### PR TITLE
fix(go2): add lidar.py and pointcloud_utils.py to Dockerfile

### DIFF
--- a/unitree/go2/Dockerfile
+++ b/unitree/go2/Dockerfile
@@ -64,6 +64,8 @@ COPY device.py /work/device.py
 COPY rpc_proxy.py /work/rpc_proxy.py
 COPY controlled_spatial.py /work/controlled_spatial.py
 COPY ext_devices.py /work/ext_devices.py
+COPY lidar.py /work/lidar.py
+COPY pointcloud_utils.py /work/pointcloud_utils.py
 COPY config.yaml /work/config.yaml
 COPY deploy/     /deploy/
 


### PR DESCRIPTION
## Summary
- Add missing `lidar.py` and `pointcloud_utils.py` to Dockerfile COPY list
- Fixes `ModuleNotFoundError: No module named 'lidar'` on container startup

## Test plan
- [x] Verified files exist in source directory
- [ ] Rebuild image and confirm container starts without import error

🤖 Generated with [Claude Code](https://claude.com/claude-code)