### PR TITLE
feat(unitree-go1): add Unitree Go1 quadruped driver

### DIFF
--- a/unitree/go1/Dockerfile
+++ b/unitree/go1/Dockerfile
@@ -1,0 +1,29 @@
+# drivers/unitree/go1/Dockerfile — Go1 只读传感器卡驱动(loco_state / imu / feet)
+#
+# 仅 3 张只读状态卡,不含运动 → 无需 py3.7 运动子进程;py3.10 主环境跑 MCP + rclpy 数据面。
+# 数据源后端:mt.backend=factory(狗上工厂高层 .so 读真实 HighState);Mac/无 .so 自动降 fake。
+
+ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base:latest
+ARG PYPI_MIRROR=https://pypi.org/simple/
+FROM ${ROS_BASE_IMAGE}
+ARG PYPI_MIRROR
+
+WORKDIR /work
+
+# 依赖极简:配置解析用 pyyaml;rclpy 来自基础镜像
+RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} pyyaml
+
+# ROS2 数据面:与 agent-core 对齐(FastDDS + domain 42)
+ENV ROS_DOMAIN_ID=42
+ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+ENV FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
+
+# ── 拷贝驱动代码(只含这 3 张卡所需) ────────────────────────────────────────
+COPY resource/  /work/resource/
+COPY plugins/   /work/plugins/
+COPY main.py go1_ctrl.py go1_hl.py ros_bridge.py config.yaml driver.yaml requirements.txt /work/
+
+ENV PYTHONUNBUFFERED=1
+EXPOSE 15704
+
+CMD ["/bin/bash", "-c", "source /opt/ros/humble/setup.bash && python3 /work/main.py ${NETWORK_INTERFACE:-eth0}"]

--- a/unitree/go1/README.md
+++ b/unitree/go1/README.md
@@ -1,0 +1,88 @@
+# Unitree Go1 Sensor Driver (PhanthyMotus)
+
+Unitree Go1 四足机器狗的 PhanthyMotus 传感器驱动。以 `unitree/go2/` 为模板、**MCP 对外接口对齐 Go2**;
+只暴露 **3 张已实机验证的只读状态卡**,用「离线 fake 自动降级」让整套代码在没有 ROS2/SDK/硬件的
+开发机上也能 import / 运行 / 测试。
+
+**卡片(全部 sensor,只读):`loco_state` · `imu` · `feet`。** MCP over HTTP,端口 `15704`。
+
+---
+
+## 1. 卡片一览
+
+| 卡片 | 类型 | 频率 | topic | 内容 |
+|---|---|---|---|---|
+| `loco_state` | sensor | 10Hz | `/{ns}/loco/state` | 模式/步态/里程 position/机身高度/速度 |
+| `imu` | sensor | 20Hz | `/{ns}/state/imu` | 四元数(wxyz)/角速度/加速度/欧拉角/温度 |
+| `feet` | sensor | 10Hz | `/{ns}/state/feet` | 四足足底力原始值(高层另带足端相对机身位姿) |
+
+读取方式:`tools/call` → `{"name":"<卡>","arguments":{"action":"read"}}`(纯只读,core 只出数据流、不给执行按钮)。
+另有一个 `model`(resource)工具返回 `resource/go1_model.urdf` 供网页骨架渲染。
+
+---
+
+## 2. 架构
+
+```
+   LLM / Dashboard ──HTTP JSON-RPC──►  Agent Core (:15678) ──ROS2──► 前端
+                                            ▲ 注册/心跳        ▲ topic 中继(数据面)
+                              ┌─────────────┴───────────────────┴──────────┐
+                              │            go1 驱动 (:15704)                 │
+                              │  main.py ── Bundle + MCP server + 注册        │
+                              │     ├── plugins/mt_state.py  3 张只读卡        │
+                              │     ├── go1_ctrl.py  数据后端(读真实 HighState)│
+                              │     └── ros_bridge.py  rclpy 隔离(有/无都能跑) │
+                              └──────────────────────│──────────────────────┘
+                                        后台线程读取  │ UDP HighState
+                                                      ▼   Unitree Go1
+```
+
+**两个关键机制**
+- **离线 fake 自动降级**:数据后端 `mt.backend=factory`(狗上工厂高层 `.so` 读真实 `HighState`);
+  开发机 import 不到 `.so` → 自动降 fake,整套照跑、离线可测。
+- **rclpy 隔离(`ros_bridge.py`)**:除它外无任何模块顶层 import rclpy;无 ROS2 时发布变 no-op +
+  线程定时器。→ 无 ROS2 的开发机也能起。
+
+> 本驱动只读、不下发运动。数据面经 Agent Core 的 ROS2 topic 中继呈现到前端 DATA STREAMS。
+
+---
+
+## 3. 文件清单
+
+| 文件/目录 | 作用 |
+|---|---|
+| `main.py` | 入口:读 config → 起数据后端 + ros_bridge → 注册 3 张卡 → MCP server + 注册 Agent Core |
+| `go1_ctrl.py` | Go1 经典 SDK 控制/状态后端(本驱动只用其状态读取;factory 读真实 HighState,无 SDK 降 fake) |
+| `go1_hl.py` | Go1 高层客户端(框架依赖,保留;本传感器驱动不下发运动) |
+| `ros_bridge.py` | rclpy 隔离层(real 发 topic / 无 rclpy 离线 no-op) |
+| `plugins/mt_state.py` | 状态卡实现(本驱动注册 `LocoStateCard`/`ImuCard`/`FeetCard`) |
+| `plugins/mt_base.py` `plugins/base.py` | 卡片基类 / 返回包络 |
+| `config.yaml` | 端口、后端、卡片参数 |
+| `driver.yaml` `Dockerfile` `requirements.txt` `resource/` | 元数据 / 构建 / 依赖 / URDF |
+
+---
+
+## 4. 运行
+
+```bash
+# 开发机离线跑(无 ROS2/SDK/硬件,自动 fake)
+python3 main.py
+
+# 查工具
+curl -s http://localhost:15704/mcp -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+
+# 读一张卡
+curl -s http://localhost:15704/mcp -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"feet","arguments":{"action":"read"}}}'
+```
+
+狗上运行:`mt.backend=factory` 需要工厂高层 `.so`(`robot_interface_high_level`,cpython-37);
+容器构建见 `Dockerfile`(`../../build.sh unitree/go1`)。
+
+---
+
+## 5. 与 Go2 的关系
+
+以 `unitree/go2/` 为模板,MCP 接口对齐;通信底层换成 Go1 的高层 UDP(读 `HighState`)。
+本驱动聚焦 3 张实机验证过的只读传感器卡;运动/避障/语音/视频/导航等能力不在本次范围。

--- a/unitree/go1/config.yaml
+++ b/unitree/go1/config.yaml
@@ -1,0 +1,149 @@
+mcp_port: 15704
+ros_namespace: ""          # 留空则自动用主机名
+name: "Unitree Go1"
+
+# ── Go1 高层控制:三后端(auto 依次尝试 programming → subproc → legged_sdk) ─────────
+# backend = auto|programming|subproc|legged_sdk
+#   programming : robot_interface_high_level(Pi py3.7 直跑,已实机验证能驱动这条狗)。
+#   subproc     : ★卡片(容器 py3.10)用这个。py3.10 import 不了 py3.7 的 .so,故把运动隔离到
+#                 motion_worker.py(python3.7 子进程)跑同一个已验证 .so,主进程经 stdin/stdout 通信。
+#   legged_sdk  : 标准 unitree_legged_sdk 的 UDP HighCmd。⚠️实测被这条狗的 Legged_sport 静默丢弃
+#                 (Recv 恒 -1,协议/版本不匹配),暂不可用;保留待将来匹配固件 SDK 版本。
+robot:
+  backend: auto
+  # programming / subproc 共用:工厂 py3.7 绑定路径与模块名
+  sdk_build_path: "/home/pi/Unitree/autostart/programming/build"
+  sdk_module: "robot_interface_high_level"
+  modes: {idle: 0, stand: 1, walk: 2, stand_up: 6, stand_down: 5, damp: 7}
+  gaits: {trot: 1}
+  # subproc 后端参数(容器里 python3.7 可执行名 / worker 脚本路径,worker 默认取同目录)
+  py37_bin: "python3.7"
+  # worker_path: "/work/motion_worker.py"   # 默认 = go1_hl.py 同目录,一般不用填
+  # 容器里 worker 子进程的额外 LD 路径(挂载的 liblcm 等;宿主直跑留空,目录不存在会被忽略)
+  worker_ld_path: "/opt/go1_libs"
+  # legged_sdk 后端参数(暂不可用,见上)
+  legged_sdk_module: "robot_interface"
+  robot_ip: "192.168.123.161"
+  local_port: 8080
+  target_port: 8082
+  # 公共
+  rate_hz: 100
+  move_timeout: 1.0
+
+# ── MT 卡片(经典 SDK 14 卡)：与上面 robot(proprietary)互斥,同时只启一个核心 ──────
+# enabled: true 时改用 Go1Control(标准 unitree_legged_sdk v3.8.6:UDP HighCmd/LowCmd),
+# 提供 loco/switch_gait/body_pose/special_motion/joint_control/power_control + 8 状态卡。
+# 另含 6 张驱动增值卡(非 MT 14 卡,便于大模型自然语言指挥;实机只读已验证):
+#   perform      —— 表情/复合动作(点头/摇头/鞠躬/摇摆/伸懒腰/左顾右盼/打招呼/开心/抖/蹲/站高 + 转圈spin)
+#   robot_status —— 一键态势快照(后端/链路/站没站/在不在动/位置/宏进度/电量/能否运动+人话提示)
+#   fall_alarm   —— 跌倒/侧翻告警(IMU roll/pitch 幅度 → ok/tilted/fallen + 倾角)
+#   net          —— 网络健康(主机名/IPv4/Wi-Fi 信号;实机读到 wlan0 link 85)
+#   odometry     —— 里程计(position/yaw/累计路程/相对起点位移;reset_origin 重置)
+#   speed_gear   —— 速度档位(slow/normal/fast;闭环便捷动作 move_distance/turn_angle 缺省速度跟随)
+# ⚠️ 启用 MT 模式时,请把上面 plugins.* 里与之重复的 loco/state 关掉(enabled:false),避免重名工具。
+mt:
+  enabled: true                     # 开 MT 卡片
+  control_level: HIGHLEVEL          # HIGHLEVEL | LOWLEVEL(启动定,不运行时切)
+  # 数据源后端:auto|standard|factory|fake(见 go1_ctrl 注释)
+  #   本机实测:standard(标准UDP)Recv 恒 -1 不可用;factory(工厂高层.so)可读真实 HighState。
+  #   factory 只高层 → joints/obstacle_range/battery 残缺(卡片自动标 available:false)。
+  #   Mac 开发机:factory import 失败 → 自动降 fake(离线全绿)。
+  backend: factory
+  factory_module: robot_interface_high_level             # 工厂高层绑定真名(绕开坏软链 robot_interface)
+  factory_build_path: "/home/pi/Unitree/autostart/programming/build"
+  sdk_module: robot_interface       # standard 后端用(标准 SDK 绑定名;本机暂不可用)
+  sdk_build_path: ""                # standard 绑定 .so 所在目录(留空=系统路径)
+  robot_ip: "192.168.123.161"
+  local_port: 8080
+  target_port: 8082
+  send_period_s: 0.002              # 2ms 持续下发(MT §8)
+  move_timeout_s: 0.5               # 高层 move 看门狗
+  # 低层安全(LOWLEVEL)
+  power_protect_factor: 1           # 1~10(默认 1=10%)
+  position_protect_limit_rad: 0.087
+  joint_control:                    # 未配速度/力矩上限前不开放(MT §5.1)
+    allow_velocity: false
+    allow_torque: false
+  # ── 里程计闭环导航卡(nav;无需 LiDAR,航点用 sqlite 存;走位靠里程计+闭环运动宏) ──
+  nav:
+    db_path: "/tmp/go1_nav.db"      # 航点库(容器部署改 /opt/phanthy-motus/data/go1_nav.db)
+  # ── 媒体卡(buzzer/camera/mic,ANY 级;无设备自动降 fake、诚实 available:false) ──
+  buzzer:                           # 蜂鸣器/提示音:纯软件音调 → 扬声器 aplay
+    mode: auto                      # 无 aplay(开发机)自动降 fake;接扬声器即真
+    device: "default"               # ALSA 播放设备(aplay -D,按 aplay -l 填)
+  camera:                           # 摄像头:USB/V4L2
+    mode: auto                      # 无 cv2/相机自动降 fake;插 USB 相机后即真
+    device_index: 0                 # /dev/videoN 的 N(按 ls /dev/video* 填)
+    width: 640
+    height: 480
+    fps: 15
+  mic:                              # 麦克风:USB/ALSA 采集
+    mode: auto                      # 无 pyalsaaudio/麦自动降 fake;插麦+装库即真
+    device: "default"               # ALSA 采集设备(arecord -l)
+    sample_rate: 16000
+    channels: 1
+  led:                              # 胸口 RGB 灯:走标准 SDK HighCmd.led(经 deploy/set_led.sh 容器发)
+    mode: auto                      # auto/real=真发(需狗+docker+标准绑定);fake=不真发(开发机/离线测试)
+    set_led_sh: "/home/pi/go1-driver/go1/deploy/set_led.sh"
+  # battery/joints 经低层 SDK 复活:lowstate_reader(连主控板 192.168.123.10 读 LowState.bms/motorState)
+  # 写共享文件,卡片读它。起读取器:bash deploy/run_lowstate_reader.sh。无 reader 供数时卡自标 available:false。
+  battery:
+    lowstate_file: "/tmp/go1_lowstate.json"
+  joints:
+    lowstate_file: "/tmp/go1_lowstate.json"
+
+# ── 插件开关 ────────────────────────────────────────────────────────────────
+# mode: auto|real|fake。auto = 先试 real,失败自动降 fake(开发机无硬件时全降 fake)。
+# 标 TODO 的参数明天连硬件后按实机填。
+plugins:
+  # ⚠️ MT 模式(mt.enabled:true)下:loco/state 与 MT 卡重名、tricks 依赖 go1_hl(MT 模式不启)→ 全关。
+  # 运动 + 状态(已具备真实实现,经 go1_hl)
+  loco:
+    enabled: false
+  state:
+    enabled: false
+
+  # 组合动作库(点头/摇头/鞠躬/摇摆… 复合动作,只调 go1_hl 原语)
+  tricks:
+    enabled: false
+
+  # 避障:real 需机器人已连接;避障方式(固件模式?超声?)明天确认
+  obstacle:
+    enabled: false           # go2 模板遗留,非 MT 卡;MT 用 obstacle_range 状态卡
+
+  # 视频:外接 USB 相机(V4L2)。⚠️ 当前 Pi 上无 USB 相机(/dev/video10-23 是树莓派编解码,非采集)。
+  #      插上 USB 相机后把 mode 改回 auto,device_index 按 `ls /dev/video*` 填(通常 0)。
+  ext_camera:
+    enabled: false           # go2 模板遗留,非 MT 卡(MT 视觉卡=camera_rgb/depth/pointcloud,另做)
+    mode: fake               # 插 USB 相机后改 auto
+    device_index: 0
+    width: 640
+    height: 480
+    fps: 15
+
+  # 语音输入:外接 USB 麦(ALSA)。⚠️ 当前 Pi 上无麦(arecord 采集列表为空)且无 pyalsaaudio。
+  #      插上 USB 麦 + `pip3 install pyalsaaudio` 后改 auto,device 按 `arecord -l` 填。
+  ext_mic:
+    enabled: false           # go2 模板遗留,非 MT 卡(MT 麦克风卡=ext_mic MT规格版,另做)
+    mode: fake               # 插 USB 麦 + 装 pyalsaaudio 后改 auto
+    device: "default"
+    sample_rate: 16000
+    channels: 1
+
+  # 语音输出:扬声器(ALSA aplay)。⚠️ 当前 Pi 只有 HDMI 音频,无独立喇叭。
+  speaker:
+    enabled: false           # go2 模板遗留,非 MT 卡
+    mode: fake               # 插 USB 音箱后改 auto,device 按 `aplay -l` 填
+    device: "default"
+
+  # 音量/LED:amixer 'Master' 存在(控 HDMI 音量),可真调
+  vui:
+    enabled: false           # go2 模板遗留,非 MT 卡
+    mode: auto
+    mixer_control: "Master"
+
+  # 导航:本机无 LiDAR → stub(POI 增删查可用,建图/导航返回未装 LiDAR)
+  navigation:
+    enabled: false           # go2 模板遗留(lidar_cloud/controlled_spatial/model),非 MT 卡
+    mode: auto
+    db_path: "/tmp/go1_nav.db"     # 开发/直跑用 /tmp(容器部署改 /opt/phanthy-motus/data/go1_nav.db)

--- a/unitree/go1/driver.yaml
+++ b/unitree/go1/driver.yaml
@@ -1,0 +1,9 @@
+id: go1-driver
+name: Unitree Go1 Bundle
+category: driver
+hardware_provider: unitree
+hardware_model: "go1"
+image_name: go1
+port: 15704
+mcp_url: "http://localhost:15704/mcp"
+description: "Unitree Go1 — 运动控制 + 避障 + 语音 + 视频 + 导航"

--- a/unitree/go1/go1_ctrl.py
+++ b/unitree/go1/go1_ctrl.py
@@ -1,0 +1,944 @@
+#!/usr/bin/env python3
+"""
+go1_ctrl.py — Go1 经典 SDK 控制核心(MT 卡片专用,单一硬件入口)。
+
+依据 MT《Go1 动作/运控能力卡片》与官方 unitree_legged_sdk Go1(v3.8.6)的
+comm.h / joystick.h / safety.h / example_walk.cpp。与旧 go1_hl(proprietary
+robot_interface_high_level 后端)不同:本核心走**标准经典 UDP** 绑定
+(module `robot_interface`,导出 UDP/HighCmd/HighState/LowCmd/LowState/Safety/BmsCmd),
+拿得到 motorState/footForce/rangeObstacle/bms/wirelessRemote 全量状态,并支持低层关节控制。
+
+设计(对齐 MT §8 Driver 实现要求):
+  • 单一 UDP 收发线程 + 单一命令状态机;卡片只更新"期望命令",不各自建 UDP。
+  • 按 1~10ms 周期持续发送(默认 2ms);启动 InitCmdData;校验收到状态包后才 ready。
+  • loco/switch_gait/body_pose/special_motion 共享同一份 HighCmd,加锁由状态机合成。
+  • 高层 move 看门狗:超保活时间速度清零 + mode=0。
+  • 低层 joint_control 独占 LOWLEVEL;安全(PositionLimit/PowerProtect/PositionProtect/温度/超时)
+    任一异常 → 全关节 Damping。
+  • control_level 由启动配置定(HIGHLEVEL|LOWLEVEL),不运行中切换。
+  • 无 SDK(开发 Mac / import 失败)→ 离线 fake:MCP 照常起,状态为合成数据、控制为回显。
+
+⚠️ 经典 UDP 能否驱动本机 Legged_sport 尚待实机复核(见 memory go1-driver-project);
+   LowCmd/Safety 细节按官方 API 编写,标 VERIFY 处连狗核对。Python 3.7 兼容。
+"""
+from __future__ import annotations
+
+import importlib
+import math
+import struct
+import sys
+import threading
+import time
+
+HIGHLEVEL = 0xee
+LOWLEVEL = 0xff
+
+# 高层运动模式(comm.h / example_walk / MT)
+MODE_IDLE = 0        # idle, default stand
+MODE_FORCE_STAND = 1  # forced stand(姿态/高度在此模式下调)
+MODE_WALK = 2
+MODE_STAND_DOWN = 5
+MODE_STAND_UP = 6
+MODE_DAMP = 7
+MODE_RECOVERY = 8
+MODE_JUMP_YAW_LEFT = 10
+MODE_STRAIGHT_HAND = 11
+
+# 步态
+GAITS = {"idle": 0, "trot": 1, "trot_run": 2, "climb_stair": 3, "trot_obstacle": 4}
+GAIT_NAMES = {v: k for k, v in GAITS.items()}
+MODE_NAMES = {0: "idle", 1: "force_stand", 2: "walk", 5: "stand_down",
+              6: "stand_up", 7: "damp", 8: "recovery_stand",
+              10: "jump_yaw_left", 11: "straight_hand"}
+
+# 速度档位(speed_gear 卡:自然语言"走快点/慢点"→ 档位)。映射到闭环便捷动作
+# (move_distance/turn_angle/spin)缺省速度;直接 move 显式给速度时不受影响。
+SPEED_GEARS = {"slow":   {"linear_mps": 0.15, "yaw_rad_s": 0.3},
+               "normal": {"linear_mps": 0.3,  "yaw_rad_s": 0.6},
+               "fast":   {"linear_mps": 0.6,  "yaw_rad_s": 1.0}}
+
+
+def _wrap_pi(a):
+    """把角度归一化到 [-pi, pi](闭环导航算朝向误差用)。"""
+    a = float(a)
+    while a > math.pi:
+        a -= 2 * math.pi
+    while a < -math.pi:
+        a += 2 * math.pi
+    return a
+
+# 12 关节名与索引(MT 卡片映射;SDK 数组长 20,Go1 只用 0~11)
+JOINT_NAMES = ["FR_hip", "FR_thigh", "FR_calf", "FL_hip", "FL_thigh", "FL_calf",
+               "RR_hip", "RR_thigh", "RR_calf", "RL_hip", "RL_thigh", "RL_calf"]
+JOINT_INDEX = {n: i for i, n in enumerate(JOINT_NAMES)}
+
+# 关节位置硬限制(rad),按关节类型(MT §5.1)
+JOINT_LIMIT = {"hip": (-1.047, 1.047), "thigh": (-0.663, 2.966), "calf": (-2.721, -0.837)}
+
+# 低层电机模式常量(comm.h)
+MOTOR_SERVO = 0x0A
+MOTOR_DAMPING = 0x00
+POS_STOP_F = 2.146e9    # PosStopF:关闭位置环
+VEL_STOP_F = 16000.0    # VelStopF:关闭速度环
+FEET_ORDER = ["FR", "FL", "RR", "RL"]
+BMS_STATUS = {0: "wakeup", 1: "discharge", 2: "charge", 3: "charger", 4: "precharge",
+              5: "charge_error", 6: "waterfall_light", 7: "self_discharge", 8: "junk"}
+
+
+def _joint_kind(idx: int) -> str:
+    return ("hip", "thigh", "calf")[idx % 3]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  wirelessRemote(40 字节)→ 按键 / 摇杆(joystick.h 布局)
+# ══════════════════════════════════════════════════════════════════════════════
+_BTN_ORDER = ["R1", "L1", "start", "select", "R2", "L2", "F1", "F2",
+              "A", "B", "X", "Y", "up", "right", "down", "left"]
+
+
+def parse_wireless_remote(arr):
+    """arr: 长度 40 的 int(字节)序列 → {buttons, axes}。解析失败给全 0。"""
+    try:
+        b = bytes(int(x) & 0xFF for x in list(arr)[:40])
+        if len(b) < 24:
+            b = b + b"\x00" * (24 - len(b))
+        btn = struct.unpack_from("<H", b, 2)[0]          # 2 字节位掩码
+        lx, rx, ry, l2, ly = struct.unpack_from("<5f", b, 4)
+        buttons = {name: bool(btn & (1 << i)) for i, name in enumerate(_BTN_ORDER)}
+        axes = {"lx": round(lx, 4), "rx": round(rx, 4), "ry": round(ry, 4),
+                "L2": round(l2, 4), "ly": round(ly, 4)}
+        return {"buttons": buttons, "axes": axes}
+    except Exception:  # noqa: BLE001
+        return {"buttons": {n: False for n in _BTN_ORDER},
+                "axes": {"lx": 0.0, "rx": 0.0, "ry": 0.0, "L2": 0.0, "ly": 0.0}}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  防御性取值
+# ══════════════════════════════════════════════════════════════════════════════
+def _get(obj, name, default=None):
+    try:
+        return getattr(obj, name)
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def _num(obj, name, default=0.0):
+    try:
+        return float(_get(obj, name, default))
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def _flist(v, n):
+    try:
+        return [round(float(x), 6) for x in list(v)[:n]]
+    except Exception:  # noqa: BLE001
+        return [0.0] * n
+
+
+def _ilist(v, n):
+    try:
+        return [int(x) for x in list(v)[:n]]
+    except Exception:  # noqa: BLE001
+        return [0] * n
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  HighState / LowState → dict
+# ══════════════════════════════════════════════════════════════════════════════
+def snapshot_high(s) -> dict:
+    imu = _get(s, "imu")
+    imu_d = {
+        "quaternion_wxyz": _flist(_get(imu, "quaternion", []), 4) if imu is not None else [1.0, 0, 0, 0],
+        "gyroscope_rad_s": _flist(_get(imu, "gyroscope", []), 3) if imu is not None else [0, 0, 0],
+        "accelerometer_m_s2": _flist(_get(imu, "accelerometer", []), 3) if imu is not None else [0, 0, 0],
+        "rpy_rad": _flist(_get(imu, "rpy", []), 3) if imu is not None else [0, 0, 0],
+        "temperature_c": int(_num(imu, "temperature", 0)) if imu is not None else 0,
+    }
+    motors = []
+    ms = _get(s, "motorState", []) or []
+    for i in range(min(12, len(ms))):
+        m = ms[i]
+        motors.append({"q_rad": round(_num(m, "q"), 6), "dq_rad_s": round(_num(m, "dq"), 6),
+                       "ddq_rad_s2": round(_num(m, "ddq"), 6),
+                       "tau_est_nm": round(_num(m, "tauEst", _num(m, "tau")), 5),
+                       "temperature_c": int(_num(m, "temperature", 0)),
+                       "mode": int(_num(m, "mode", 0))})
+    foot_pos = []
+    foot_spd = []
+    fp = _get(s, "footPosition2Body", []) or []
+    fs = _get(s, "footSpeed2Body", []) or []
+    for i in range(4):
+        p = fp[i] if i < len(fp) else None
+        v = fs[i] if i < len(fs) else None
+        foot_pos.append({"x": round(_num(p, "x"), 5), "y": round(_num(p, "y"), 5), "z": round(_num(p, "z"), 5)})
+        foot_spd.append({"x": round(_num(v, "x"), 5), "y": round(_num(v, "y"), 5), "z": round(_num(v, "z"), 5)})
+    return {
+        "mode": int(_num(s, "mode", 0)),
+        "gait_type": int(_num(s, "gaitType", 0)),
+        "body_height_m": round(_num(s, "bodyHeight", 0), 5),
+        "foot_raise_height_m": round(_num(s, "footRaiseHeight", 0), 5),
+        "position_m": _flist(_get(s, "position", []), 3),
+        "velocity": _flist(_get(s, "velocity", []), 3),
+        "yaw_speed_rad_s": round(_num(s, "yawSpeed", 0), 5),
+        "imu": imu_d,
+        "motors": motors,
+        "foot_force_raw": _ilist(_get(s, "footForce", []), 4),
+        "foot_position_to_body": foot_pos,
+        "foot_speed_to_body": foot_spd,
+        "range_obstacle_raw": _flist(_get(s, "rangeObstacle", []), 4),
+        "wireless_remote": parse_wireless_remote(_get(s, "wirelessRemote", []) or []),
+        "bms": _snapshot_bms(_get(s, "bms")),
+    }
+
+
+def _snapshot_bms(bms) -> dict:
+    if bms is None:
+        return {}
+    ver = _get(bms, "version_high", _get(bms, "version_h"))
+    status = int(_num(bms, "bms_status", _num(bms, "status", 0)))
+    return {
+        "version": {"high": int(_num(bms, "version_high", 0)), "low": int(_num(bms, "version_low", 0))}
+        if ver is not None else {},
+        "status_code": status,
+        "status_name": BMS_STATUS.get(status, "unknown"),
+        "soc_percent": int(_num(bms, "SOC", _num(bms, "soc", 0))),
+        "current_ma": int(_num(bms, "current", 0)),
+        "cycle_count": int(_num(bms, "cycle", 0)),
+        "bq_ntc_c": _ilist(_get(bms, "BQ_NTC", []), 2),
+        "mcu_ntc_c": _ilist(_get(bms, "MCU_NTC", []), 2),
+        "cell_voltage_mv": _ilist(_get(bms, "cell_vol", []), 10),
+    }
+
+
+def snapshot_low(s) -> dict:
+    motors = []
+    ms = _get(s, "motorState", []) or []
+    for i in range(min(12, len(ms))):
+        m = ms[i]
+        motors.append({"index": i, "name": JOINT_NAMES[i], "mode": int(_num(m, "mode", 0)),
+                       "q_rad": round(_num(m, "q"), 6), "dq_rad_s": round(_num(m, "dq"), 6),
+                       "ddq_rad_s2": round(_num(m, "ddq"), 6),
+                       "tau_est_nm": round(_num(m, "tauEst", _num(m, "tau")), 5),
+                       "temperature_c": int(_num(m, "temperature", 0))})
+    imu = _get(s, "imu")
+    return {
+        "motors": motors,
+        "foot_force_raw": _ilist(_get(s, "footForce", []), 4),
+        "imu": {
+            "quaternion_wxyz": _flist(_get(imu, "quaternion", []), 4) if imu is not None else [1.0, 0, 0, 0],
+            "gyroscope_rad_s": _flist(_get(imu, "gyroscope", []), 3) if imu is not None else [0, 0, 0],
+            "accelerometer_m_s2": _flist(_get(imu, "accelerometer", []), 3) if imu is not None else [0, 0, 0],
+            "rpy_rad": _flist(_get(imu, "rpy", []), 3) if imu is not None else [0, 0, 0],
+            "temperature_c": int(_num(imu, "temperature", 0)) if imu is not None else 0,
+        },
+        "bms": _snapshot_bms(_get(s, "bms")),
+        "wireless_remote": parse_wireless_remote(_get(s, "wirelessRemote", []) or []),
+    }
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  Go1Control:控制核心
+# ══════════════════════════════════════════════════════════════════════════════
+class Go1Control:
+    def __init__(self, cfg: dict):
+        self._cfg = cfg or {}
+        self.control_level = str(self._cfg.get("control_level", "HIGHLEVEL")).upper()
+        self._module = self._cfg.get("sdk_module", "robot_interface")
+        self._build_path = self._cfg.get("sdk_build_path", "")
+        # 后端选择:auto|standard|factory|fake。
+        #   standard = 标准 unitree_legged_sdk UDP(HighCmd/HighState,本机 Recv 恒 -1 暂不可用)
+        #   factory  = 工厂 robot_interface_high_level(RobotInterface,已验证能读本机真实 HighState;
+        #              只高层、无 motorState/rangeObstacle/BmsState → joints/obstacle_range/battery 残缺)
+        #   fake     = 离线合成。auto = 先试 standard 再 factory,都不行则 fake。
+        self._backend = str(self._cfg.get("backend", "auto")).lower()
+        self._factory_module = self._cfg.get("factory_module", "robot_interface_high_level")
+        self._factory_build_path = self._cfg.get(
+            "factory_build_path", "/home/pi/Unitree/autostart/programming/build")
+        self._mode_backend = None      # 实际生效后端:standard|factory|fake
+        self._robot = None             # factory 后端的 RobotInterface 实例
+        self._ip = self._cfg.get("robot_ip", "192.168.123.161")
+        self._local_port = int(self._cfg.get("local_port", 8080))
+        self._target_port = int(self._cfg.get("target_port", 8082))
+        self._dt = float(self._cfg.get("send_period_s", 0.002))       # 默认 2ms
+        self._move_timeout = float(self._cfg.get("move_timeout_s", 0.5))
+        self._power_factor = int(self._cfg.get("power_protect_factor", 1))  # 1~10
+        self._pos_err_limit = float(self._cfg.get("position_protect_limit_rad", 0.087))
+
+        self._lock = threading.Lock()
+        self._sdk = None
+        self._udp = None
+        self._cmd = None
+        self._state = None
+        self._connected = False
+        self._running = False
+        self._thread = None
+        self._level_flag = HIGHLEVEL if self.control_level == "HIGHLEVEL" else LOWLEVEL
+
+        # 高层期望(状态机合成用)
+        self._hi = {"mode": MODE_IDLE, "gaitType": 0, "speedLevel": 0,
+                    "footRaiseHeight": 0.0, "bodyHeight": 0.0,
+                    "euler": [0.0, 0.0, 0.0], "velocity": [0.0, 0.0], "yawSpeed": 0.0,
+                    "move_deadline": 0.0}
+        # special_motion 序列器:None 或 {"mode":10/11,"phase":"stabilize|active","deadline":t}
+        self._special = None
+        self._special_stabilize_s = float(self._cfg.get("special_stabilize_s", 1.0))
+        self._special_active_s = float(self._cfg.get("special_active_s", 4.0))
+        self._seq_id = 0
+
+        # 闭环运动宏(move_distance/turn_angle):后台线程读里程计/yaw,走够即停。
+        # 供大模型下"向前走2米/左转90度"这种单条指令(不用它自己拿速度+看门狗凑)。
+        self._macro_cancel = threading.Event()
+        self._macro_thread = None
+        self._macro_status = {"active": False}
+
+        # 里程计累加(odometry 卡):收发循环内按 position 水平增量累计总路程(防跳变)。
+        self._odometer_m = 0.0
+        self._odo_last = None
+        # 速度档位(speed_gear 卡):闭环便捷动作缺省速度取此档;可 config 预设。
+        self._speed_gear = str(self._cfg.get("speed_gear", "normal")).lower()
+        if self._speed_gear not in SPEED_GEARS:
+            self._speed_gear = "normal"
+
+        # 低层期望:每关节 MotorCmd 目标(默认全 damping)
+        self._lo = [dict(q=POS_STOP_F, dq=VEL_STOP_F, Kp=0.0, Kd=0.0, tau=0.0, mode=MOTOR_DAMPING)
+                    for _ in range(12)]
+        self._power_off_pending = False
+
+        # UDP 诊断计数
+        self._diag = {"total_count": 0, "send_count": 0, "recv_count": 0, "send_error": 0,
+                      "flag_error": 0, "recv_crc_error": 0, "recv_lose_error": 0, "accessible": False}
+        self._last_state_mono = 0.0
+        self._safety_tripped = False
+
+    # ── 生命周期 ──────────────────────────────────────────────────────────────
+    def start(self):
+        order = {"auto": ["standard", "factory"], "standard": ["standard"],
+                 "factory": ["factory"], "fake": []}.get(self._backend, ["standard", "factory"])
+        for name in order:
+            try:
+                if name == "standard":
+                    self._start_standard()
+                else:
+                    self._start_factory()
+                self._mode_backend = name
+                self._connected = True
+                print(f"[go1_ctrl] ✓ 后端={name} level={self.control_level}", flush=True)
+                break
+            except Exception as e:  # noqa: BLE001
+                print(f"[go1_ctrl] 后端 {name} 不可用: {e}", flush=True)
+                self._connected = False
+        if not self._connected:
+            self._mode_backend = "fake"
+            print("[go1_ctrl] → 离线 fake(MCP 照常起,状态合成/控制回显)", flush=True)
+        self._running = True
+        self._thread = threading.Thread(target=self._loop, daemon=True, name="go1_ctrl")
+        self._thread.start()
+
+    def _start_standard(self):
+        """标准 unitree_legged_sdk:UDP + HighCmd/HighState(或 LowCmd/LowState)。"""
+        if self._build_path and self._build_path not in sys.path:
+            sys.path.append(self._build_path)
+        self._sdk = importlib.import_module(self._module)
+        self._udp = self._sdk.UDP(self._level_flag, self._local_port, self._ip, self._target_port)
+        if self.control_level == "HIGHLEVEL":
+            self._cmd = self._sdk.HighCmd()
+            self._state = self._sdk.HighState()
+        else:
+            self._cmd = self._sdk.LowCmd()
+            self._state = self._sdk.LowState()
+            self._safety = self._sdk.Safety(self._sdk.LeggedType.Go1)
+        self._udp.InitCmdData(self._cmd)
+
+    def _start_factory(self):
+        """工厂 robot_interface_high_level:RobotInterface(robotControl/UDPSend/UDPRecv/getState)。
+        只高层,无 LowState/关节/BmsState → joints/obstacle_range/battery 由 capabilities() 标残缺。"""
+        if self.control_level != "HIGHLEVEL":
+            raise RuntimeError("factory 后端仅支持 HIGHLEVEL(工厂 .so 无 LowState/关节控制)")
+        if self._factory_build_path and self._factory_build_path not in sys.path:
+            sys.path.append(self._factory_build_path)
+        self._sdk = importlib.import_module(self._factory_module)
+        self._robot = self._sdk.RobotInterface()
+        self._state = self._robot.getState()      # 首帧(验证能读)
+
+    def stop(self):
+        self.cancel_macro()
+        self._running = False
+        if self._thread:
+            self._thread.join(timeout=2)
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    # ── 控制循环(唯一 UDP 收发处) ─────────────────────────────────────────────
+    def _loop(self):
+        while self._running:
+            t0 = time.monotonic()
+            if self._mode_backend == "standard":
+                self._loop_standard(t0)
+            elif self._mode_backend == "factory":
+                self._loop_factory(t0)
+            else:
+                self._fake_step(t0)
+            dt = self._dt - (time.monotonic() - t0)
+            if dt > 0:
+                time.sleep(dt)
+
+    def _loop_standard(self, t0):
+        try:
+            self._diag["total_count"] += 1
+            r = self._udp.Recv()
+            self._udp.GetRecv(self._state)
+            if isinstance(r, int) and r > 0:
+                self._diag["recv_count"] += 1
+                self._last_state_mono = t0
+                self._diag["accessible"] = True
+                self._accum_odo()
+            with self._lock:
+                self._compose_cmd(t0)
+            self._udp.SetSend(self._cmd)
+            s = self._udp.Send()
+            self._diag["send_count"] += 1
+            if isinstance(s, int) and s < 0:
+                self._diag["send_error"] += 1
+            # 反馈超时判定
+            if self._last_state_mono and (t0 - self._last_state_mono) > 0.5:
+                self._diag["accessible"] = False
+        except Exception as e:  # noqa: BLE001
+            self._diag["send_error"] += 1
+            print(f"[go1_ctrl] loop err: {e}", flush=True)
+
+    def _loop_factory(self, t0):
+        # 工厂只高层:合成目标 → robotControl → UDPSend/UDPRecv → getState(读真实 HighState)。
+        # 状态卡阶段 self._hi 默认 idle(mode=0),下发中性命令不会让狗动。
+        try:
+            self._diag["total_count"] += 1
+            with self._lock:
+                mode, gait, speed, foot_raise, body_h, euler, vel, yaw = self._resolve_high(t0)
+            self._robot.robotControl(int(mode), int(gait), int(speed), float(foot_raise), float(body_h),
+                                     float(euler[0]), float(euler[1]), float(euler[2]),
+                                     float(vel[0]), float(vel[1]), float(yaw))
+            self._robot.UDPSend()
+            self._diag["send_count"] += 1
+            self._robot.UDPRecv()
+            st = self._robot.getState()
+            if st is not None:
+                self._state = st
+                self._diag["recv_count"] += 1
+                self._last_state_mono = t0
+                self._diag["accessible"] = True
+                self._accum_odo()
+            if self._last_state_mono and (t0 - self._last_state_mono) > 0.5:
+                self._diag["accessible"] = False
+        except Exception as e:  # noqa: BLE001
+            self._diag["send_error"] += 1
+            print(f"[go1_ctrl] factory loop err: {e}", flush=True)
+
+    def _compose_cmd(self, now):
+        c = self._cmd
+        if self.control_level == "HIGHLEVEL":
+            self._compose_high(c, now)
+        else:
+            self._compose_low(c, now)
+
+    def _resolve_high(self, now):
+        """期望 + special 序列器 + move 看门狗 → 实际下发目标(standard/factory 共用)。
+        返回 (mode, gait, speed, foot_raise, body_h, euler[3], vel[2], yaw)。"""
+        h = self._hi
+        # special_motion 序列器优先
+        if self._special is not None:
+            sp = self._special
+            if now >= sp["deadline"]:
+                if sp["phase"] == "stabilize":
+                    sp["phase"] = "active"; sp["deadline"] = now + self._special_active_s
+                else:
+                    self._special = None                       # 超时回落
+            mode = MODE_FORCE_STAND if (self._special and self._special["phase"] == "stabilize") \
+                else (self._special["mode"] if self._special else MODE_FORCE_STAND)
+            return (mode, 0, 0, 0.0, 0.0, [0.0, 0.0, 0.0], [0.0, 0.0], 0.0)
+        # move 看门狗
+        mode = h["mode"]
+        vel = list(h["velocity"]); yaw = h["yawSpeed"]
+        if mode == MODE_WALK and now > h["move_deadline"]:
+            mode = MODE_IDLE                    # 保活超时 → 回 idle
+        # 速度只在 WALK 模式有意义;其余模式一律清零,防陈旧速度泄漏到
+        # 站立/姿态/特殊动作(set_attitude 后 velocity 仍留在 _hi)。
+        if mode != MODE_WALK:
+            vel = [0.0, 0.0]; yaw = 0.0
+        return (mode, h["gaitType"], h["speedLevel"], h["footRaiseHeight"], h["bodyHeight"],
+                list(h["euler"]), vel, yaw)
+
+    def _compose_high(self, c, now):
+        mode, gait, speed, foot_raise, body_h, euler, vel, yaw = self._resolve_high(now)
+        self._write_high(c, mode=mode, gait=gait, speed=speed, foot_raise=foot_raise,
+                         body_h=body_h, euler=euler, vel=vel, yaw=yaw)
+
+    def _write_high(self, c, mode=0, gait=0, speed=0, foot_raise=0.0, body_h=0.0,
+                    euler=(0.0, 0.0, 0.0), vel=(0.0, 0.0), yaw=0.0):
+        try:
+            c.mode = int(mode); c.gaitType = int(gait); c.speedLevel = int(speed)
+            c.footRaiseHeight = float(foot_raise); c.bodyHeight = float(body_h)
+            c.euler = [float(euler[0]), float(euler[1]), float(euler[2])]
+            c.velocity = [float(vel[0]), float(vel[1])]; c.yawSpeed = float(yaw)
+            if self._power_off_pending:
+                try:
+                    c.bms.off = 0xA5
+                except Exception:  # noqa: BLE001
+                    pass
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _compose_low(self, c, now):
+        # 安全:反馈超时 → 全关节 damping
+        if self._last_state_mono and (now - self._last_state_mono) > 0.5:
+            self._safety_tripped = True
+        for i in range(12):
+            j = self._lo[i]
+            try:
+                mc = c.motorCmd[i]
+                if self._safety_tripped:
+                    mc.q = POS_STOP_F; mc.dq = VEL_STOP_F; mc.Kp = 0.0; mc.Kd = 0.0; mc.tau = 0.0; mc.mode = MOTOR_DAMPING
+                else:
+                    mc.q = float(j["q"]); mc.dq = float(j["dq"]); mc.Kp = float(j["Kp"])
+                    mc.Kd = float(j["Kd"]); mc.tau = float(j["tau"]); mc.mode = int(j["mode"])
+            except Exception:  # noqa: BLE001
+                pass
+        # 安全函数(按官方 API;VERIFY 实机)
+        try:
+            self._safety.PositionLimit(c)
+            self._safety.PowerProtect(c, self._state, self._power_factor)
+            self._safety.PositionProtect(c, self._state, self._pos_err_limit)
+        except Exception:  # noqa: BLE001
+            pass
+        if self._power_off_pending:
+            try:
+                c.bms.off = 0xA5
+            except Exception:  # noqa: BLE001
+                pass
+
+    # ── 离线 fake ──────────────────────────────────────────────────────────────
+    def _fake_step(self, now):
+        wob = 0.02 * math.sin(now)
+        motors = [{"q_rad": round(0.05 * math.sin(now + i), 4), "dq_rad_s": 0.0, "ddq_rad_s2": 0.0,
+                   "tau_est_nm": 0.0, "temperature_c": 34, "mode": MOTOR_SERVO} for i in range(12)]
+        self._fake = {
+            "mode": self._hi["mode"], "gait_type": self._hi["gaitType"],
+            "body_height_m": 0.28 + self._hi["bodyHeight"],
+            "foot_raise_height_m": 0.08 + self._hi["footRaiseHeight"],
+            "position_m": [0.0, 0.0, 0.0],
+            "velocity": [self._hi["velocity"][0], self._hi["velocity"][1], 0.0],
+            "yaw_speed_rad_s": self._hi["yawSpeed"],
+            "imu": {"quaternion_wxyz": [1.0, round(wob, 4), 0.0, 0.0], "gyroscope_rad_s": [0, 0, 0],
+                    "accelerometer_m_s2": [0, 0, 9.81], "rpy_rad": [round(wob, 4), 0.0, 0.0], "temperature_c": 35},
+            "motors": motors, "foot_force_raw": [90, 92, 88, 91],
+            "foot_position_to_body": [{"x": 0.18, "y": -0.13, "z": -0.28}] * 4,
+            "foot_speed_to_body": [{"x": 0.0, "y": 0.0, "z": 0.0}] * 4,
+            "range_obstacle_raw": [0.0, 0.0, 0.0, 0.0],
+            "wireless_remote": parse_wireless_remote([0] * 40),
+            "bms": {"version": {"high": 1, "low": 0}, "status_code": 1, "status_name": "discharge",
+                    "soc_percent": 82, "current_ma": -1500, "cycle_count": 42,
+                    "bq_ntc_c": [30, 31], "mcu_ntc_c": [33, 34], "cell_voltage_mv": [3900] * 10},
+            "_offline": True,
+        }
+        self._diag["total_count"] += 1
+        self._diag["accessible"] = False
+
+    # ── 状态读取 ────────────────────────────────────────────────────────────────
+    def get_high_state(self) -> dict:
+        if not self._connected:
+            return getattr(self, "_fake", None) or {"_offline": True}
+        with self._lock:
+            return snapshot_high(self._state)
+
+    def get_low_state(self) -> dict:
+        if not self._connected:
+            f = getattr(self, "_fake", None) or {}
+            fm = f.get("motors", [])
+            motors = []
+            for i in range(12):
+                src = fm[i] if i < len(fm) else {}
+                motors.append({"index": i, "name": JOINT_NAMES[i], "mode": src.get("mode", MOTOR_SERVO),
+                               "q_rad": src.get("q_rad", 0.0), "dq_rad_s": src.get("dq_rad_s", 0.0),
+                               "ddq_rad_s2": src.get("ddq_rad_s2", 0.0),
+                               "tau_est_nm": src.get("tau_est_nm", 0.0),
+                               "temperature_c": src.get("temperature_c", 34)})
+            return {"motors": motors, "foot_force_raw": f.get("foot_force_raw", [0, 0, 0, 0]),
+                    "imu": f.get("imu", {}), "bms": f.get("bms", {}),
+                    "wireless_remote": f.get("wireless_remote", parse_wireless_remote([0] * 40)),
+                    "_offline": True}
+        with self._lock:
+            return snapshot_low(self._state)
+
+    def get_state(self) -> dict:
+        """按 control_level 返回对应快照(状态卡通用)。"""
+        return self.get_high_state() if self.control_level == "HIGHLEVEL" else self.get_low_state()
+
+    def _accum_odo(self):
+        """收发循环内调:按 position 水平增量累计总路程;单帧跳变(>0.5m)丢弃防污染。"""
+        try:
+            p = _flist(_get(self._state, "position", []), 3)
+        except Exception:  # noqa: BLE001
+            return
+        if self._odo_last is not None:
+            d = math.hypot(p[0] - self._odo_last[0], p[1] - self._odo_last[1])
+            if d < 0.5:
+                self._odometer_m += d
+        self._odo_last = p
+
+    def get_odometry(self) -> dict:
+        """里程计快照:当前 position/yaw + 累计总路程(total_distance_m 由收发循环累加)。"""
+        s = self.get_high_state()
+        pos = s.get("position_m", [0.0, 0.0, 0.0])
+        yaw = s.get("imu", {}).get("rpy_rad", [0.0, 0.0, 0.0])[2]
+        return {"position_m": pos, "yaw_rad": round(float(yaw), 5),
+                "total_distance_m": round(self._odometer_m, 3),
+                "offline": bool(s.get("_offline"))}
+
+    def get_diagnostics(self) -> dict:
+        d = dict(self._diag)
+        d["accessible"] = bool(d["accessible"]) and self._connected
+        return d
+
+    def capabilities(self) -> dict:
+        """各状态卡的数据源是否可用(供状态卡诚实标注,避免把"无数据"伪装成真实值)。
+        factory(工厂高层 .so):无 motorState/rangeObstacle/BmsState → joints/obstacle_range/battery 残缺。
+        standard(标准 SDK):全字段可用。fake:合成数据,视作全可用。"""
+        caps = {"loco_state": True, "imu": True, "feet": True, "remote_controller": True,
+                "udp_diagnostics": True, "joints": True, "obstacle_range": True, "battery": True}
+        if self._mode_backend == "factory":
+            caps["joints"] = False        # 工厂 HighState 无 motorState
+            caps["obstacle_range"] = False  # 工厂 HighState 无 rangeObstacle
+            caps["battery"] = False       # 工厂 BmsState 未注册,读取抛异常
+        return caps
+
+    def backend_name(self) -> str:
+        return self._mode_backend or "fake"
+
+    def state_fresh(self) -> bool:
+        """是否在超时内收到过有效状态包(NO_FEEDBACK 判定用)。"""
+        if not self._connected:
+            return True   # fake 恒有合成数据
+        return bool(self._last_state_mono) and (time.monotonic() - self._last_state_mono) <= 0.5
+
+    # ── HIGHLEVEL 期望设定(卡片调用;仅更新目标,由 loop 合成下发) ────────────
+    def set_move(self, vx, vy, vyaw):
+        with self._lock:
+            self._hi.update(mode=MODE_WALK, velocity=[float(vx), float(vy)], yawSpeed=float(vyaw),
+                            move_deadline=time.monotonic() + self._move_timeout)
+
+    def stop_move(self):
+        with self._lock:
+            self._hi.update(mode=MODE_IDLE, velocity=[0.0, 0.0], yawSpeed=0.0)
+
+    def set_simple_mode(self, mode):
+        with self._lock:
+            self._hi.update(mode=int(mode), velocity=[0.0, 0.0], yawSpeed=0.0)
+
+    def set_gait(self, gait_type):
+        with self._lock:
+            self._hi["gaitType"] = int(gait_type)
+
+    def current_gait(self) -> int:
+        return int(self._hi["gaitType"])
+
+    def set_speed_gear(self, gear) -> bool:
+        """设速度档位 slow|normal|fast(speed_gear 卡)。未知档位返回 False。"""
+        g = str(gear).lower()
+        if g not in SPEED_GEARS:
+            return False
+        with self._lock:
+            self._speed_gear = g
+        return True
+
+    def speed_gear(self) -> str:
+        return self._speed_gear
+
+    def gear_speed(self) -> dict:
+        """当前档位对应的缺省线速/转速(闭环便捷动作用)。"""
+        return dict(SPEED_GEARS[self._speed_gear])
+
+    def is_moving(self) -> bool:
+        """当前是否在运动(只读,不推进任何状态机):运动宏(walk/turn/perform)进行中、
+        special 进行中,或未超看门狗的有效 move。非 WALK 模式速度已在合成时清零,故仅
+        WALK+未超时算 move。供 power_control 静止前置 / robot_status 用。"""
+        if self._macro_status.get("active"):   # walk_distance/turn_angle/perform 后台宏
+            return True
+        with self._lock:
+            if self._special is not None:
+                return True
+            h = self._hi
+            return h["mode"] == MODE_WALK and time.monotonic() <= h["move_deadline"]
+
+    def is_standing(self) -> bool:
+        """粗判是否站立态(供 robot_status/大模型判断能否运动):
+        IDLE(默认站)/FORCE_STAND/WALK/RECOVERY 视作站立;stand_down/damp 视作未站立。"""
+        m = int(self.get_high_state().get("mode", 0))
+        return m in (MODE_IDLE, MODE_FORCE_STAND, MODE_WALK, MODE_RECOVERY)
+
+    def set_attitude(self, roll, pitch, yaw):
+        with self._lock:
+            self._hi.update(mode=MODE_FORCE_STAND, euler=[float(roll), float(pitch), float(yaw)])
+
+    def set_body_height(self, off):
+        with self._lock:
+            self._hi["bodyHeight"] = float(off)
+
+    def set_foot_raise_height(self, off):
+        with self._lock:
+            self._hi["footRaiseHeight"] = float(off)
+
+    def pose_reset(self):
+        with self._lock:
+            self._hi.update(euler=[0.0, 0.0, 0.0], bodyHeight=0.0, footRaiseHeight=0.0)
+
+    def trigger_special(self, mode) -> int:
+        with self._lock:
+            self._seq_id += 1
+            self._special = {"mode": int(mode), "phase": "stabilize",
+                             "deadline": time.monotonic() + self._special_stabilize_s}
+            return self._seq_id
+
+    def special_state(self):
+        with self._lock:
+            if self._special is None:
+                return {"active": False}
+            return {"active": True, "phase": self._special["phase"], "mode": self._special["mode"]}
+
+    # ── 闭环运动宏(供大模型下"走2米/转90度"单指令;异步后台线程,读里程计/yaw) ──────
+    def cancel_macro(self):
+        """打断正在跑的运动宏。任何手动运动指令/急停都应先调它。可跨线程调(防 join 自身)。"""
+        self._macro_cancel.set()
+        t = self._macro_thread
+        if t is not None and t.is_alive() and t is not threading.current_thread():
+            t.join(timeout=1.5)
+
+    def macro_status(self) -> dict:
+        return dict(self._macro_status)
+
+    def _start_macro(self, kind, target, loop_fn):
+        self.cancel_macro()                       # 先取消上一个宏
+        self._macro_cancel.clear()
+        self._macro_status = {"active": True, "kind": kind, "target": round(float(target), 4), "progress": 0.0}
+
+        def run():
+            try:
+                loop_fn()
+            except Exception as e:  # noqa: BLE001
+                print(f"[go1_ctrl] macro {kind} err: {e}", flush=True)
+            finally:
+                cancelled = self._macro_cancel.is_set()
+                if not cancelled:
+                    self.stop_move()              # 正常完成主动停;被取消则保留取消者(如 damp)的设定
+                self._macro_status = {"active": False, "kind": kind, "target": round(float(target), 4),
+                                      "progress": self._macro_status.get("progress", 0.0), "cancelled": cancelled}
+
+        self._macro_thread = threading.Thread(target=run, daemon=True, name="go1_macro")
+        self._macro_thread.start()
+
+    def walk_distance(self, distance_m, speed_mps=0.3, max_time_s=20.0):
+        """闭环前进/后退 distance_m(读里程计位移,走够即停)。异步:立即返回,后台执行。
+        负值后退。speed 限 0.05~0.8。看门狗兜底(线程停发 move → 狗 0.5s 内自停)。"""
+        target = abs(float(distance_m))
+        sgn = 1.0 if distance_m >= 0 else -1.0
+        sp = min(max(abs(float(speed_mps)), 0.05), 0.8) * sgn
+        start = list(self.get_high_state().get("position_m", [0.0, 0.0, 0.0]))
+        # 到达提前量:补偿里程上报延迟 + 停下滑行(实测 0.3m/s 无补偿过冲 ~0.15m,约目标的 30%)。
+        lead = min(abs(sp) * 0.5, target * 0.5)
+
+        def loop():
+            self.set_gait(GAITS["trot"])
+            t0 = time.monotonic()
+            while not self._macro_cancel.is_set() and (time.monotonic() - t0) < max_time_s:
+                pos = self.get_high_state().get("position_m", [0.0, 0.0, 0.0])
+                travelled = math.hypot(pos[0] - start[0], pos[1] - start[1])
+                self._macro_status["progress"] = round(travelled, 3)
+                if travelled >= target - lead:
+                    break
+                self.set_move(sp, 0.0, 0.0)       # 持续刷新看门狗
+                time.sleep(0.05)
+
+        self._start_macro("walk_distance", target, loop)
+        return {"started": True, "target_m": round(target, 3), "speed_mps": round(abs(sp), 3)}
+
+    def turn_angle(self, angle_rad, yaw_rate=0.5, max_time_s=15.0):
+        """闭环旋转 angle_rad(读 IMU yaw 累计,含 unwrap,转够即停)。异步。左正右负。
+        yaw_rate 限 0.1~1.5。闭环读 yaw 用 signed 累计(噪声正负抵消,大角度不虚高提前停/少转)。"""
+        target = abs(float(angle_rad))
+        sgn = 1.0 if angle_rad >= 0 else -1.0
+        rate = min(max(abs(float(yaw_rate)), 0.1), 1.5) * sgn
+
+        def _yaw():
+            return self.get_high_state().get("imu", {}).get("rpy_rad", [0.0, 0.0, 0.0])[2]
+
+        def loop():
+            self.set_gait(GAITS["trot"])
+            prev = _yaw(); acc = 0.0; t0 = time.monotonic()
+            while not self._macro_cancel.is_set() and (time.monotonic() - t0) < max_time_s:
+                if abs(acc) >= target:
+                    break
+                self.set_move(0.0, 0.0, rate)
+                time.sleep(0.05)
+                cur = _yaw(); d = cur - prev
+                if d > math.pi:
+                    d -= 2 * math.pi
+                elif d < -math.pi:
+                    d += 2 * math.pi
+                acc += d; prev = cur      # signed 累计:yaw 噪声正负抵消,不虚高(修大角度少转)
+                self._macro_status["progress"] = round(abs(acc), 3)
+
+        self._start_macro("turn_angle", target, loop)
+        return {"started": True, "target_rad": round(target, 3), "yaw_rate": round(abs(rate), 3)}
+
+    # ── 闭环导航(nav 卡:里程计世界系走到 (x,y);单后台槽、异步、可打断) ────────────
+    def _turn_to_yaw(self, target_yaw, rate=0.5, tol=0.1, max_time_s=8.0):
+        """闭环转到里程计绝对 yaw=target_yaw(在宏内跑,cancel 可打断)。逐帧读绝对 yaw 误差,
+        进 tol 即停。用于 go_to 的终点朝向对齐。"""
+        t0 = time.monotonic()
+        while not self._macro_cancel.is_set() and (time.monotonic() - t0) < max_time_s:
+            cur = self.get_odometry().get("yaw_rad", 0.0)
+            err = _wrap_pi(target_yaw - cur)
+            if abs(err) <= tol:
+                return
+            self.set_move(0.0, 0.0, (abs(rate) if err > 0 else -abs(rate)))
+            time.sleep(0.05)
+
+    def _goto_segment(self, x, y, speed, tol, final_yaw=None, max_time_s=30.0):
+        """朝里程计世界坐标 (x,y) 走过去的比例控制器(在宏内同步跑,cancel 可打断)。
+        朝向误差大 → 原地转对准;对准 → 带小转向分量前进;进 tol 米即到,
+        可选到点后对齐 final_yaw。返回 True=到达 / False=被取消或超时。"""
+        self.set_gait(GAITS["trot"])
+        t0 = time.monotonic()
+        reached = False
+        while not self._macro_cancel.is_set() and (time.monotonic() - t0) < max_time_s:
+            odo = self.get_odometry()
+            pos = odo.get("position_m", [0.0, 0.0, 0.0])
+            cur_yaw = odo.get("yaw_rad", 0.0)
+            dx = x - pos[0]
+            dy = y - pos[1]
+            dist = math.hypot(dx, dy)
+            self._macro_status["progress"] = round(dist, 3)   # 剩余距离(越小越近)
+            if dist <= tol:
+                reached = True
+                break
+            err = _wrap_pi(math.atan2(dy, dx) - cur_yaw)
+            if abs(err) > 0.35:
+                self.set_move(0.0, 0.0, 0.6 if err > 0 else -0.6)   # 原地转对准
+            else:
+                steer = max(-0.6, min(0.6, 1.5 * err))               # 带转向前进
+                self.set_move(float(speed), 0.0, steer)
+            time.sleep(0.05)
+        if reached and final_yaw is not None and not self._macro_cancel.is_set():
+            self._turn_to_yaw(final_yaw)
+        return reached
+
+    def nav_goto(self, x, y, yaw=None, speed=None, tol=None, max_time_s=30.0):
+        """闭环走到里程计世界坐标 (x,y)(可选终点朝向 yaw)。异步:立即返回、后台执行、可打断。
+        speed 缺省跟随 speed_gear;看门狗兜底(线程停发 move → 狗 0.5s 内自停)。"""
+        tx, ty = float(x), float(y)
+        fy = None if yaw is None else float(yaw)
+        sp = self.gear_speed().get("linear_mps", 0.3) if speed is None else float(speed)
+        sp = min(max(abs(sp), 0.05), 0.8)
+        tl = 0.15 if tol is None else max(0.05, float(tol))
+
+        def loop():
+            self._goto_segment(tx, ty, sp, tl, final_yaw=fy, max_time_s=max_time_s)
+
+        self._start_macro("nav_goto", math.hypot(tx, ty), loop)
+        return {"started": True, "target_m": [round(tx, 3), round(ty, 3)],
+                "final_yaw_rad": (round(fy, 3) if fy is not None else None),
+                "speed_mps": round(sp, 3), "tol_m": round(tl, 3)}
+
+    def patrol_points(self, points, loops=1, speed=None, tol=None, max_time_s=30.0):
+        """依次巡逻一串航点(可多圈)。异步、单宏、可打断;任一段被取消/超时即终止整程。
+        points: [{"x":float, "y":float, "yaw":float|None, "name":str}, ...]。"""
+        pts = list(points or [])
+        n = max(1, int(loops))
+        sp = self.gear_speed().get("linear_mps", 0.3) if speed is None else float(speed)
+        sp = min(max(abs(sp), 0.05), 0.8)
+        tl = 0.2 if tol is None else max(0.05, float(tol))
+
+        def loop():
+            for _ in range(n):
+                for p in pts:
+                    if self._macro_cancel.is_set():
+                        return
+                    fy = p.get("yaw")
+                    ok = self._goto_segment(float(p["x"]), float(p["y"]), sp, tl,
+                                            final_yaw=(None if fy is None else float(fy)),
+                                            max_time_s=max_time_s)
+                    if not ok:
+                        return
+
+        self._start_macro("patrol", len(pts) * n, loop)
+        return {"started": True, "points": [p.get("name") for p in pts],
+                "count": len(pts), "loops": n, "speed_mps": round(sp, 3), "tol_m": round(tl, 3)}
+
+    # ── 姿态时间线(表情/复合动作;供 perform 卡与大模型下"打招呼/点头/开心"这类指令) ──────
+    def _sleep_cancellable(self, dur):
+        """分片睡 dur 秒,期间可被 cancel_macro 打断;被打断返回 False,否则 True。"""
+        end = time.monotonic() + max(0.0, float(dur))
+        while time.monotonic() < end:
+            if self._macro_cancel.is_set():
+                return False
+            time.sleep(0.02)
+        return not self._macro_cancel.is_set()
+
+    def play_routine(self, name, steps, settle_s=0.4):
+        """播放一段"姿态时间线"复合动作。steps: 有序列表,每步
+        {roll,pitch,yaw (rad), body_height,foot_raise (偏移 m), dur (秒)}。
+        异步:立即返回,后台线程逐步 set_attitude/高度;与 walk/turn 宏共用**唯一后台槽**
+        (同时只一个动作);任何手动运动指令/damp/perform stop 都能打断;结束自动归中性站好。
+        ⚠️ 需狗已站立(软件无法从地面起立,靠遥控)。幅值内部再夹一层,防越硬件安全区。"""
+        def _c(v, lo, hi):
+            try:
+                v = float(v)
+            except (TypeError, ValueError):
+                return 0.0
+            return lo if v < lo else hi if v > hi else v
+
+        steps = list(steps or [])
+
+        def loop():
+            for i, st in enumerate(steps):
+                if self._macro_cancel.is_set():
+                    return
+                self.set_attitude(_c(st.get("roll", 0.0), -0.5, 0.5),
+                                  _c(st.get("pitch", 0.0), -0.5, 0.5),
+                                  _c(st.get("yaw", 0.0), -0.5, 0.5))
+                if "body_height" in st:
+                    self.set_body_height(_c(st["body_height"], -0.1, 0.03))
+                if "foot_raise" in st:
+                    self.set_foot_raise_height(_c(st["foot_raise"], -0.05, 0.03))
+                self._macro_status["progress"] = i + 1
+                self._sleep_cancellable(st.get("dur", settle_s))
+            self.pose_reset()      # 归中性姿态;_start_macro 收尾 stop_move → IDLE 站好
+
+        self._start_macro("perform:" + str(name), len(steps), loop)
+        return {"started": True, "routine": name, "steps": len(steps)}
+
+    # ── LOWLEVEL 期望设定 ──────────────────────────────────────────────────────
+    def set_joint(self, idx, q=None, dq=None, kp=0.0, kd=0.0, tau=0.0, mode=MOTOR_SERVO):
+        with self._lock:
+            j = self._lo[idx]
+            j.update(q=(POS_STOP_F if q is None else float(q)),
+                     dq=(VEL_STOP_F if dq is None else float(dq)),
+                     Kp=float(kp), Kd=float(kd), tau=float(tau), mode=int(mode))
+
+    def set_joint_damping(self, idxs):
+        with self._lock:
+            for i in idxs:
+                self._lo[i].update(q=POS_STOP_F, dq=VEL_STOP_F, Kp=0.0, Kd=0.0, tau=0.0, mode=MOTOR_DAMPING)
+
+    def joint_feedback(self, idx) -> dict:
+        st = self.get_low_state()
+        for m in st.get("motors", []):
+            if m.get("index") == idx:
+                return {"q_rad": m.get("q_rad", 0.0), "dq_rad_s": m.get("dq_rad_s", 0.0),
+                        "tau_est_nm": m.get("tau_est_nm", 0.0), "temperature_c": m.get("temperature_c", 0)}
+        return {"q_rad": 0.0, "dq_rad_s": 0.0, "tau_est_nm": 0.0, "temperature_c": 0}
+
+    # ── 电源 ────────────────────────────────────────────────────────────────────
+    def request_power_off(self):
+        with self._lock:
+            self._power_off_pending = True

--- a/unitree/go1/go1_hl.py
+++ b/unitree/go1/go1_hl.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""
+go1_hl.py — Unitree Go1 高层控制客户端(双后端)。
+
+对外语义 API 不变(move/stop_move/stand_up/stand_down/damp/balance_stand/euler/body_height/
+get_state + 运动仲裁 acquire/release/motion_owner)。内部把"目标"交给当前后端翻译成各自 SDK 调用。
+
+两个后端(config: robot.backend = auto|programming|legged_sdk;auto 依次尝试):
+  • programming  : robot_interface_high_level(Go1 "programming" pybind,**py3.7**,Pi 直跑,已实机验证)。
+                   HighState 无 motorState、BmsState 取不到 → joints 空、电量 None。
+  • legged_sdk   : 标准 unitree_legged_sdk 的 UDP HighCmd/HighState(**可在 py3.10 容器重编**)。
+                   HighState 带 motorState(关节角)、rangeObstacle(超声避障)、bms(电量)→ 状态更全。
+                   ★ 这是"卡片"(容器 py3.10)能真正运动 + 拿全状态的关键后端。
+
+⚠️ legged_sdk 后端按标准 unitree_legged_sdk v3.8.0 API 编写,**需连狗后对着实机 SDK 版本核对**
+   (HighCmd 字段名、mode 语义、python 绑定模块名 robot_interface、UDP 端口)。已标 VERIFY。
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import math
+import select
+import subprocess
+import sys
+import threading
+import time
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  后端 A:programming(robot_interface_high_level,Pi py3.7,已验证)
+# ══════════════════════════════════════════════════════════════════════════════
+
+class _ProgrammingBackend:
+    name = "programming"
+
+    def __init__(self, cfg):
+        self._build_path = cfg.get("sdk_build_path", "/home/pi/Unitree/autostart/programming/build")
+        self._module = cfg.get("sdk_module", "robot_interface_high_level")
+        m = cfg.get("modes", {}) or {}
+        self.M_IDLE = int(m.get("idle", 0)); self.M_STAND = int(m.get("stand", 1)); self.M_WALK = int(m.get("walk", 2))
+        # 从趴/阻尼态"起立"必须用 position-stand-up(mode 6);mode 1 只在已站立时力控调姿。
+        # position-stand-down = mode 5;damping(急停软腿)= mode 7。实机 2026-07-10 验证。
+        self.M_STANDUP = int(m.get("stand_up", 6)); self.M_STANDDOWN = int(m.get("stand_down", 5)); self.M_DAMP = int(m.get("damp", 7))
+        self.G_TROT = int((cfg.get("gaits", {}) or {}).get("trot", 1))
+        self._robot = None
+
+    def connect(self):
+        if self._build_path and self._build_path not in sys.path:
+            sys.path.append(self._build_path)
+        mod = importlib.import_module(self._module)
+        self._robot = mod.RobotInterface()
+
+    def step(self, t) -> dict:
+        mode, gait = self.M_IDLE, 0
+        roll = pitch = yaw = fwd = side = rot = bh = 0.0
+        a = t["action"]
+        if a == "walk":
+            mode, gait = self.M_WALK, self.G_TROT; fwd, side, rot = t["vx"], t["vy"], t["vyaw"]
+        elif a in ("stand", "balance"):
+            mode = self.M_STAND
+        elif a == "stand_up":
+            mode = self.M_STANDUP          # 6 = position stand up(从趴/阻尼起立)
+        elif a == "stand_down":
+            mode = self.M_STANDDOWN        # 5 = position stand down(趴下)
+        elif a == "euler":
+            mode = self.M_STAND; roll, pitch, yaw = t["roll"], t["pitch"], t["yaw"]
+        elif a == "body_height":
+            mode = self.M_STAND; bh = t["height"]
+        elif a == "damp":
+            mode = self.M_DAMP             # 7 = damping(急停软腿)
+        else:  # idle
+            mode = self.M_IDLE
+        self._robot.robotControl(mode, gait, 0, 0.0, bh, roll, pitch, yaw, fwd, side, rot)
+        self._robot.UDPSend()
+        self._robot.UDPRecv()
+        return _normalize(self._robot.getState(), with_motors=False)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  后端 B:legged_sdk(标准 unitree_legged_sdk,UDP HighCmd,容器 py3.10)
+# ══════════════════════════════════════════════════════════════════════════════
+
+class _LeggedSdkBackend:
+    name = "legged_sdk"
+    HIGHLEVEL = 0xee
+
+    def __init__(self, cfg):
+        self._module = cfg.get("legged_sdk_module", "robot_interface")   # unitree_legged_sdk 的 py 绑定
+        self._ip = cfg.get("robot_ip", "192.168.123.161")
+        self._local_port = int(cfg.get("local_port", 8080))
+        self._target_port = int(cfg.get("target_port", 8082))
+        self._sdk = None; self._udp = None; self._cmd = None; self._hs = None
+
+    def connect(self):
+        self._sdk = importlib.import_module(self._module)          # VERIFY: 绑定模块名
+        self._udp = self._sdk.UDP(self.HIGHLEVEL, self._local_port, self._ip, self._target_port)
+        self._cmd = self._sdk.HighCmd()
+        self._hs = self._sdk.HighState()
+        self._udp.InitCmdData(self._cmd)
+
+    def step(self, t) -> dict:
+        # 先收状态
+        self._udp.Recv()
+        self._udp.GetRecv(self._hs)
+        # 目标 → HighCmd(VERIFY: 字段名/ mode 语义按实机 SDK 核对)
+        c = self._cmd
+        c.mode = 0; c.gaitType = 0; c.speedLevel = 0
+        c.footRaiseHeight = 0.0; c.bodyHeight = 0.0
+        c.euler = [0.0, 0.0, 0.0]; c.velocity = [0.0, 0.0]; c.yawSpeed = 0.0
+        a = t["action"]
+        if a == "walk":
+            c.mode = 2; c.gaitType = 1; c.velocity = [float(t["vx"]), float(t["vy"])]; c.yawSpeed = float(t["vyaw"])
+        elif a in ("stand", "balance"):
+            c.mode = 1
+        elif a == "stand_up":
+            c.mode = 1; c.bodyHeight = 0.1
+        elif a == "stand_down":
+            c.mode = 1; c.bodyHeight = -0.1
+        elif a == "euler":
+            c.mode = 1; c.euler = [float(t["roll"]), float(t["pitch"]), float(t["yaw"])]
+        elif a == "body_height":
+            c.mode = 1; c.bodyHeight = float(t["height"])
+        elif a == "damp":
+            c.mode = 7    # VERIFY: 标准 SDK 阻尼模式
+        else:
+            c.mode = 0    # idle / default stand
+        self._udp.SetSend(c)
+        self._udp.Send()
+        return _normalize(self._hs, with_motors=True)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  后端 C:subproc(py3.7 子进程跑 programming .so,给 py3.10 卡片容器用)
+# ══════════════════════════════════════════════════════════════════════════════
+# 卡片容器是 py3.10,import 不了工厂 py3.7 的 robot_interface_high_level.so;而标准 UDP
+# 后端实测被这条狗的 Legged_sport 静默丢弃(Recv 恒 -1,协议/版本不匹配)。所以容器运动
+# = 把"能驱动这条狗的那个 py3.7 .so"隔离到 motion_worker.py 子进程,主进程经 stdin/stdout
+# 同步 lockstep 下发目标/读状态(类比 go2 rpc_proxy 的子进程隔离,这里隔离的是 python 版本)。
+# 用户 2026-07-10 拍板走此路。
+
+class _SubprocBackend:
+    name = "subproc"
+
+    def __init__(self, cfg):
+        from pathlib import Path
+        self._py = cfg.get("py37_bin", "python3.7")
+        self._worker = cfg.get("worker_path", str(Path(__file__).parent / "motion_worker.py"))
+        self._build_path = cfg.get("sdk_build_path", "/home/pi/Unitree/autostart/programming/build")
+        self._module = cfg.get("sdk_module", "robot_interface_high_level")
+        m = cfg.get("modes", {}) or {}
+        g = cfg.get("gaits", {}) or {}
+        # mode 语义与 _ProgrammingBackend 一致,整包传给 worker(worker 负责 action→mode 映射)
+        self._modes = {"idle": int(m.get("idle", 0)), "stand": int(m.get("stand", 1)),
+                       "walk": int(m.get("walk", 2)), "stand_up": int(m.get("stand_up", 6)),
+                       "stand_down": int(m.get("stand_down", 5)), "damp": int(m.get("damp", 7)),
+                       "trot": int(g.get("trot", 1))}
+        # 容器里:.so 是 buster 编的,依赖 liblcm/glib 等——给 worker 单独的 LD_LIBRARY_PATH
+        # (挂载的宿主库),隔离到子进程,不污染 py3.10 主进程。宿主直跑时留空即可。
+        self._ld = cfg.get("worker_ld_path", "")
+        self._proc = None
+
+    def connect(self):
+        import os
+        args = [self._py, self._worker, self._build_path, self._module, json.dumps(self._modes)]
+        env = dict(os.environ)
+        if self._ld:
+            prev = env.get("LD_LIBRARY_PATH", "")
+            env["LD_LIBRARY_PATH"] = self._ld + ((":" + prev) if prev else "")
+        # stderr 直通父进程 → driver.log;stdout 只走状态 JSON
+        self._proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                      stderr=None, bufsize=1, universal_newlines=True, env=env)
+        line = self._read_line(15.0)                 # 等 worker 的 READY 握手
+        if line is None:
+            self._kill(); raise RuntimeError("motion_worker 15s 内无响应(py3.7? .so?)")
+        if "READY" not in line:
+            self._kill(); raise RuntimeError("motion_worker 未就绪: %s" % line.strip())
+
+    def _read_line(self, timeout):
+        """带超时读一行 stdout;None = 超时或 worker 已退出(EOF)。"""
+        try:
+            r, _, _ = select.select([self._proc.stdout], [], [], timeout)
+        except Exception:  # noqa: BLE001
+            return None
+        if not r:
+            return None
+        line = self._proc.stdout.readline()
+        return None if line == "" else line
+
+    def step(self, t) -> dict:
+        p = self._proc
+        if p is None or p.poll() is not None:
+            raise RuntimeError("motion_worker 已退出")
+        p.stdin.write(json.dumps(t) + "\n"); p.stdin.flush()
+        line = self._read_line(2.0)
+        if line is None:
+            raise RuntimeError("motion_worker 读状态超时/退出")
+        try:
+            return json.loads(line)
+        except Exception:  # noqa: BLE001
+            return {}
+
+    def _kill(self):
+        try:
+            if self._proc:
+                self._proc.kill()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def close(self):
+        try:
+            if self._proc and self._proc.poll() is None:
+                try:
+                    self._proc.stdin.close()
+                except Exception:  # noqa: BLE001
+                    pass
+                self._proc.terminate()
+                self._proc.wait(timeout=2)
+        except Exception:  # noqa: BLE001
+            self._kill()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  HighState → dict(两后端共用;逐字段防御)
+# ══════════════════════════════════════════════════════════════════════════════
+
+def _normalize(s, with_motors: bool) -> dict:
+    def _list(v, n):
+        try:
+            return [round(float(x), 5) for x in list(v)[:n]]
+        except Exception:  # noqa: BLE001
+            return [0.0] * n
+
+    def _get(obj, name, default=None):
+        try:
+            return getattr(obj, name)
+        except Exception:  # noqa: BLE001
+            return default
+
+    def _num(obj, name, default=0.0):
+        try:
+            return float(_get(obj, name, default))
+        except Exception:  # noqa: BLE001
+            return default
+
+    imu = _get(s, "imu")
+    imu_d = {
+        "quaternion":    _list(_get(imu, "quaternion", []), 4) if imu is not None else [1, 0, 0, 0],
+        "gyroscope":     _list(_get(imu, "gyroscope", []), 3) if imu is not None else [0, 0, 0],
+        "accelerometer": _list(_get(imu, "accelerometer", []), 3) if imu is not None else [0, 0, 0],
+        "rpy":           _list(_get(imu, "rpy", []), 3) if imu is not None else [0, 0, 0],
+        "temperature":   int(_num(imu, "temperature", 0)) if imu is not None else 0,
+    }
+
+    # 电量:bms.SOC(programming 的 BmsState 取不到 → None;legged_sdk 一般可取)
+    soc = None
+    try:
+        bms = getattr(s, "bms")
+        soc = int(getattr(bms, "SOC", getattr(bms, "soc", 0)))
+    except Exception:  # noqa: BLE001
+        soc = None
+
+    try:
+        foot = [int(x) for x in list(_get(s, "footForce", []) or [])[:4]] or [0, 0, 0, 0]
+    except Exception:  # noqa: BLE001
+        foot = [0, 0, 0, 0]
+
+    # 关节:仅 legged_sdk 有 motorState(前 12 个为腿部电机);programming 无 → 空
+    motors = []
+    if with_motors:
+        try:
+            ms = _get(s, "motorState", []) or []
+            for i in range(min(12, len(ms))):
+                m = ms[i]
+                motors.append({"q": round(_num(m, "q"), 5), "dq": round(_num(m, "dq"), 5),
+                               "tau": round(_num(m, "tauEst", _num(m, "tau")), 4),
+                               "temperature": int(_num(m, "temperature", 0))})
+        except Exception:  # noqa: BLE001
+            motors = []
+
+    # 超声避障距离:仅 legged_sdk 有 rangeObstacle[4](m)
+    obstacles = None
+    if with_motors:
+        r = _list(_get(s, "rangeObstacle", []), 4)
+        if any(r):
+            obstacles = {"front": r[0], "left": r[1], "right": r[2], "rear": r[3]}
+
+    out = {
+        "mode":        int(_num(s, "mode", 0)),
+        "gait":        int(_num(s, "gaitType", 0)),
+        "body_height": round(_num(s, "bodyHeight", 0), 4),
+        "position":    _list(_get(s, "position", []), 3),
+        "velocity":    _list(_get(s, "velocity", []), 3),
+        "yaw_speed":   round(_num(s, "yawSpeed", 0), 4),
+        "foot_force":  foot,
+        "imu":         imu_d,
+        "battery_soc": soc,
+        "motors":      motors,
+    }
+    if obstacles is not None:
+        out["obstacles_m"] = obstacles
+    return out
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  Go1HighLevel:对外唯一入口(公共 API 不变)
+# ══════════════════════════════════════════════════════════════════════════════
+
+class Go1HighLevel:
+    def __init__(self, robot_cfg: dict):
+        self._cfg = robot_cfg or {}
+        self._backend_pref = (self._cfg.get("backend", "auto") or "auto").lower()
+        self._rate_hz = float(self._cfg.get("rate_hz", 100))
+        self._move_timeout = float(self._cfg.get("move_timeout", 1.0))
+
+        self._lock = threading.Lock()
+        self._running = False
+        self._connected = False
+        self._thread: threading.Thread | None = None
+        self._backend = None
+        self._state = None          # 最新 normalized dict
+        self._motion_owner = None   # None | "avoid" | "nav"(运动仲裁)
+
+        # 语义目标(后端无关)
+        self._t = {"action": "idle", "vx": 0.0, "vy": 0.0, "vyaw": 0.0,
+                   "roll": 0.0, "pitch": 0.0, "yaw": 0.0, "height": 0.0, "move_deadline": 0.0}
+
+    # ── 生命周期 ────────────────────────────────────────────────────────────
+    def start(self) -> None:
+        order = {"auto": ["programming", "subproc", "legged_sdk"],
+                 "programming": ["programming"],
+                 "subproc": ["subproc"],
+                 "legged_sdk": ["legged_sdk"]}.get(self._backend_pref, ["programming", "subproc", "legged_sdk"])
+        for name in order:
+            try:
+                if name == "programming":
+                    b = _ProgrammingBackend(self._cfg)
+                elif name == "subproc":
+                    b = _SubprocBackend(self._cfg)
+                else:
+                    b = _LeggedSdkBackend(self._cfg)
+                b.connect()
+                self._backend = b; self._connected = True
+                print(f"[go1_hl] ✓ backend={name} 就绪", flush=True)
+                break
+            except Exception as e:  # noqa: BLE001
+                print(f"[go1_hl] backend '{name}' 不可用: {e}", flush=True)
+        if not self._connected:
+            print("[go1_hl] ⚠️  无可用后端 → 离线模式:MCP 照常起,控制/状态为合成数据。", flush=True)
+
+        self._running = True
+        self._thread = threading.Thread(target=self._loop, daemon=True, name="go1_hl")
+        self._thread.start()
+
+    def stop(self) -> None:
+        try:
+            self.stop_move(); time.sleep(0.1)
+        except Exception:  # noqa: BLE001
+            pass
+        self._running = False
+        if self._thread:
+            self._thread.join(timeout=2)
+        # 关闭后端子进程(subproc 后端)
+        b = self._backend
+        if b is not None and hasattr(b, "close"):
+            try:
+                b.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    # ── 后台收发循环(唯一调 SDK 的地方) ──────────────────────────────────
+    def _loop(self) -> None:
+        dt = 1.0 / self._rate_hz
+        while self._running:
+            t0 = time.monotonic()
+            if self._connected and self._backend is not None:
+                try:
+                    with self._lock:
+                        t = dict(self._t)
+                    # move 看门狗:行走超时 → 转为站立(防失控续跑)
+                    if t["action"] == "walk" and time.monotonic() > t["move_deadline"]:
+                        t["action"] = "stand"; t["vx"] = t["vy"] = t["vyaw"] = 0.0
+                    st = self._backend.step(t)
+                    with self._lock:
+                        self._state = st
+                except Exception as e:  # noqa: BLE001
+                    print(f"[go1_hl] loop error: {e}", flush=True)
+            sleep = dt - (time.monotonic() - t0)
+            if sleep > 0:
+                time.sleep(sleep)
+
+    # ── 运动仲裁 ──────────────────────────────────────────────────────────
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def acquire_motion(self, owner: str) -> bool:
+        with self._lock:
+            if self._motion_owner in (None, owner):
+                self._motion_owner = owner
+                return True
+            return False
+
+    def release_motion(self, owner: str) -> None:
+        with self._lock:
+            if self._motion_owner == owner:
+                self._motion_owner = None
+
+    def motion_owner(self) -> str | None:
+        with self._lock:
+            return self._motion_owner
+
+    # ── 语义 API(只改目标) ──────────────────────────────────────────────
+    def _set(self, action, **kw) -> int:
+        base = {"action": action, "vx": 0.0, "vy": 0.0, "vyaw": 0.0,
+                "roll": 0.0, "pitch": 0.0, "yaw": 0.0, "height": 0.0}
+        base.update(kw)
+        with self._lock:
+            self._t.update(base)
+            if action != "walk":
+                self._t["move_deadline"] = 0.0
+        return 0 if self._connected else 3104
+
+    def move(self, vx: float, vy: float, vyaw: float) -> int:
+        return self._set("walk", vx=vx, vy=vy, vyaw=vyaw,
+                         move_deadline=time.monotonic() + self._move_timeout)
+
+    def stop_move(self) -> int:
+        return self._set("stand")
+
+    def stand_up(self) -> int:
+        return self._set("stand_up")
+
+    def stand_down(self) -> int:
+        return self._set("stand_down")
+
+    def damp(self) -> int:
+        return self._set("damp")
+
+    def balance_stand(self) -> int:
+        return self._set("stand")
+
+    def euler(self, roll: float, pitch: float, yaw: float) -> int:
+        return self._set("euler", roll=roll, pitch=pitch, yaw=yaw)
+
+    def body_height(self, h: float) -> int:
+        return self._set("body_height", height=h)
+
+    # ── 状态读取 ──────────────────────────────────────────────────────────
+    def get_state(self) -> dict | None:
+        if not self._connected:
+            return self._fake_state()
+        with self._lock:
+            return self._state
+
+    def _fake_state(self) -> dict:
+        """离线(无后端)时的合成状态。忠实保留高层无关节角(motors 空)。"""
+        t = time.monotonic()
+        wobble = 0.02 * math.sin(t)
+        return {
+            "mode": 1, "gait": 0, "body_height": 0.0,
+            "position": [0.0, 0.0, 0.0], "velocity": [0.0, 0.0, 0.0], "yaw_speed": 0.0,
+            "foot_force": [90, 90, 90, 90],
+            "imu": {"quaternion": [1.0, 0.0, 0.0, round(wobble, 4)],
+                    "gyroscope": [0.0, 0.0, 0.0], "accelerometer": [0.0, 0.0, 9.81],
+                    "rpy": [round(wobble, 4), 0.0, 0.0], "temperature": 35},
+            "battery_soc": 88, "motors": [], "_offline": True,
+        }

--- a/unitree/go1/main.py
+++ b/unitree/go1/main.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+#!/usr/bin/env python3
+"""
+drivers/unitree/go1/main.py — Unitree Go1 四足机器狗 设备 bundle 统一入口。
+
+结构对齐 go2(MCP HTTP server + 插件聚合 + 自动注册/心跳),但:
+  • 去掉 DDS/RpcProxy,改用本地 Go1 高层客户端 Go1HighLevel(go1_hl.py,唯一硬件写入口)。
+  • rclpy 全部隔离到 ros_bridge.py:有 rclpy 真发 topic,无 rclpy(开发 Mac)自动降级离线。
+  • 插件模块化到 plugins/,硬件访问经 adapters/(real/fake 自动选择)。
+
+用法:  python3 main.py <networkInterface>      # networkInterface 目前仅用于日志
+环境变量:CONFIG_PATH(config.yaml 路径)、AGENT_CORE_URL(默认 https://localhost:15678)、
+         ROS_MODE(auto|real|fake,覆盖 bridge 模式;默认 auto)。
+"""
+import json
+import os
+import re
+import signal
+import socket
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from go1_hl import Go1HighLevel
+from ros_bridge import RosBridge
+
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+def _load_config() -> dict:
+    import yaml  # 惰性:开发机离线测试不走这里(smoke 直接喂 dict)
+    config_path = os.environ.get("CONFIG_PATH", str(Path(__file__).parent / "config.yaml"))
+    with open(config_path) as f:
+        return yaml.safe_load(f)
+
+
+def _resolve_namespace(cfg: dict) -> str:
+    ns = cfg.get("ros_namespace", "").strip()
+    if ns:
+        return re.sub(r"[^a-zA-Z0-9_]", "_", ns)
+    return re.sub(r"[^a-zA-Z0-9_]", "_", socket.gethostname())
+
+
+# ── 插件注册表(config 驱动;供 main 与 smoke 复用) ───────────────────────────
+
+def build_plugins(cfg: dict, namespace: str, bridge: RosBridge, hl: Go1HighLevel, ctrl=None) -> list:
+    """只装配 3 张已实机验证的只读状态卡:loco_state / imu / feet(MT 状态卡)。
+    需 mt.enabled 且 ctrl(Go1Control)就绪;单卡失败只跳过它,不拖垮 bundle。"""
+    plugins = []
+    mt = cfg.get("mt", {}) or {}
+    if mt.get("enabled") and ctrl is not None:
+        from plugins.mt_state import LocoStateCard, ImuCard, FeetCard
+        for cardcls in (LocoStateCard, ImuCard, FeetCard):
+            try:
+                plugins.append(cardcls(mt.get(cardcls.CARD, {}) or {}, namespace, bridge, ctrl))
+                print(f"[bundle] MT card '{cardcls.CARD}' loaded", flush=True)
+            except Exception as e:  # noqa: BLE001
+                print(f"[bundle] MT card '{cardcls.CARD}' FAILED: {e}", flush=True)
+    return plugins
+
+
+# ── Bundle:聚合插件,提供 tools/list 与 dispatch ─────────────────────────────
+
+class Go1DeviceBundle:
+    def __init__(self, plugins: list):
+        self._plugins = plugins
+
+    def start_all(self):
+        for p in self._plugins:
+            try:
+                p.start()
+            except Exception as e:  # noqa: BLE001
+                print(f"[bundle] {type(p).__name__}.start() FAILED: {e}", flush=True)
+                import traceback; traceback.print_exc()
+        print(f"[bundle] {len(self._plugins)} plugins started", flush=True)
+
+    def stop_all(self):
+        for p in self._plugins:
+            try:
+                p.stop()
+            except Exception:  # noqa: BLE001
+                pass
+        print("[bundle] all plugins stopped", flush=True)
+
+    def _model_tool(self):
+        return {"name": "model", "type": "resource",
+                "description": "Go1 quadruped robot URDF model for skeleton renderer",
+                "inputSchema": {"type": "object", "properties": {}}}
+
+    def get_all_tools(self):
+        tools = [self._model_tool()]
+        for p in self._plugins:
+            tools.extend(p.get_tools() if hasattr(p, "get_tools") else [p.get_tool()])
+        return tools
+
+    def dispatch(self, tool_name, args):
+        if tool_name == "model":
+            urdf_path = Path(__file__).parent / "resource" / "go1_model.urdf"
+            return {"urdf": urdf_path.read_text()}
+        for p in self._plugins:
+            tool_defs = p.get_tools() if hasattr(p, "get_tools") else [p.get_tool()]
+            for td in tool_defs:
+                if td["name"] == tool_name:
+                    if td["type"] == "resource":
+                        return p.dispatch(tool_name, args)
+                    action = args.pop("action", tool_name)
+                    args["_tool_name"] = tool_name
+                    return p.dispatch(action, args)
+        return None
+
+
+# ── MCP HTTP server(JSON-RPC 2.0,与 go2 一致) ───────────────────────────────
+
+_bundle: "Go1DeviceBundle | None" = None
+
+
+def make_handler():
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):
+            msg = fmt % args
+            if '"POST /mcp' in msg and '200' in msg:
+                return
+            print(f"[mcp] {self.address_string()} {msg}")
+
+        def _send(self, status, body):
+            enc = body.encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(enc)))
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type, Accept")
+            self.end_headers()
+            self.wfile.write(enc)
+
+        def do_GET(self):
+            self.send_response(404); self.end_headers()
+
+        def do_OPTIONS(self):
+            self.send_response(204)
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type, Accept")
+            self.end_headers()
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0))
+            raw = self.rfile.read(length)
+            try:
+                rpc = json.loads(raw)
+            except Exception:
+                self._send(400, json.dumps({"jsonrpc": "2.0", "id": None,
+                                            "error": {"code": -32700, "message": "Parse error"}}))
+                return
+            rid = rpc.get("id"); method = rpc.get("method", ""); params = rpc.get("params") or {}
+            if rid is None:
+                self.send_response(202); self.end_headers(); return
+
+            def ok(result): self._send(200, json.dumps({"jsonrpc": "2.0", "id": rid, "result": result}))
+            def err(code, msg): self._send(200, json.dumps({"jsonrpc": "2.0", "id": rid,
+                                                            "error": {"code": code, "message": msg}}))
+            try:
+                if method == "initialize":
+                    ok({"protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "go1-hcl", "version": "1.0.0"}})
+                elif method == "tools/list":
+                    ok({"tools": _bundle.get_all_tools()})
+                elif method == "tools/call":
+                    name = params.get("name", ""); a = params.get("arguments") or {}
+                    result = _bundle.dispatch(name, a)
+                    if result is None:
+                        err(-32601, f"Unknown tool: {name}")
+                    else:
+                        ok({"content": [{"type": "text", "text": json.dumps(result)}]})
+                else:
+                    err(-32601, f"Method not found: {method}")
+            except Exception as e:  # noqa: BLE001
+                err(-32603, str(e))
+    return Handler
+
+
+# ── 向 Agent Core 注册 + 30s 心跳 ────────────────────────────────────────────
+
+def _start_registration(mcp_port, name, category):
+    import urllib.request as _urllib
+    import ssl as _ssl
+    agent_core_url = os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+    payload = json.dumps({"name": name, "url": f"http://localhost:{mcp_port}/mcp",
+                          "category": category}).encode()
+    _ctx = _ssl.create_default_context(); _ctx.check_hostname = False; _ctx.verify_mode = _ssl.CERT_NONE
+
+    def _run():
+        import time as _t
+        while True:
+            try:
+                req = _urllib.Request(f"{agent_core_url}/api/mcp", data=payload,
+                                      headers={"Content-Type": "application/json"}, method="POST")
+                with _urllib.urlopen(req, timeout=3, context=_ctx):
+                    pass
+                _t.sleep(30)
+            except Exception as e:  # noqa: BLE001
+                print(f"[register] failed: {e}, retry in 5s")
+                _t.sleep(5)
+    threading.Thread(target=_run, daemon=True, name="register").start()
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def main():
+    global _bundle
+    network_iface = sys.argv[1] if len(sys.argv) >= 2 else ""
+    cfg = _load_config()
+    # 环境变量覆盖后端(便于测试/容器显式指定,如 GO1_BACKEND=subproc)
+    _be = os.environ.get("GO1_BACKEND")
+    if _be:
+        cfg.setdefault("robot", {})["backend"] = _be
+    namespace = _resolve_namespace(cfg)
+    mcp_port = int(cfg.get("mcp_port", 15704))
+    print(f"[bundle] namespace={namespace} mcp_port={mcp_port} iface={network_iface or '(auto)'}")
+
+    hl = Go1HighLevel(cfg.get("robot", {}))
+    ctrl = None
+    mt_on = bool((cfg.get("mt", {}) or {}).get("enabled"))
+    # 高低层单核心互斥:mt 模式用 Go1Control(经典 SDK 14 卡),否则用 Go1HighLevel(proprietary)。
+    # 两者都会开高层 UDP 通道,绝不同时 start(否则争用同一 Legged_sport 通道)。
+    if mt_on:
+        from go1_ctrl import Go1Control
+        ctrl = Go1Control(cfg.get("mt", {}))
+        ctrl.start()
+        print(f"[bundle] MT 模式 control_level={ctrl.control_level}", flush=True)
+    else:
+        hl.start()
+
+    bridge = RosBridge(force_mode=os.environ.get("ROS_MODE", "auto"))
+    bridge.start()
+
+    _bundle = Go1DeviceBundle(build_plugins(cfg, namespace, bridge, hl, ctrl))
+    _bundle.start_all()
+    bridge.spin_background()
+
+    _start_registration(mcp_port, cfg.get("name", "Unitree Go1"), "driver")
+
+    # accept 队列调大:默认 backlog=5,多客户端(ROS 转发器串行读 + core 轮询 + 人工 call)
+    # 并发连接稍一叠加就溢出 → Connection refused。128 足够吸收突发。
+    ThreadingHTTPServer.request_queue_size = 128
+    server = ThreadingHTTPServer(("", mcp_port), make_handler())
+    print(f"[bundle] MCP server → http://localhost:{mcp_port}")
+
+    def _shutdown(signum, frame):
+        print(f"[bundle] signal {signum}, shutting down")
+        _bundle.stop_all()
+        if ctrl is not None:
+            ctrl.stop()
+        hl.stop()
+        bridge.shutdown()
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+    try:
+        server.serve_forever()
+    finally:
+        _bundle.stop_all()
+        if ctrl is not None:
+            ctrl.stop()
+        hl.stop()
+        bridge.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/unitree/go1/plugins/__init__.py
+++ b/unitree/go1/plugins/__init__.py
@@ -1,0 +1,10 @@
+"""plugins — Go1 设备插件(每功能一个模块)。
+
+每个插件遵循统一契约:
+    __init__(cfg, namespace, bridge, hl)   # cfg=该插件配置段, bridge=RosBridge, hl=Go1HighLevel
+    get_tool() -> dict   或   get_tools() -> list[dict]   # MCP tool schema
+    start()  / stop()
+    dispatch(action, args) -> dict | None                 # 必须处理 start/stop/info
+sensor 插件用 bridge.add_sensor 发数据到 ROS2 topic;actuator 在 dispatch 里调 hl/adapter。
+所有 dispatch 返回 plain dict,由 main.py 的 HTTP handler 包成 MCP content。
+"""

--- a/unitree/go1/plugins/base.py
+++ b/unitree/go1/plugins/base.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+#!/usr/bin/env python3
+"""
+plugins/base.py — 插件公共基类与 helper。
+
+提供:
+  • BasePlugin:统一 start/stop 空实现 + 生命周期动作(start/stop/info)默认处理。
+  • clamp():参数范围保护。
+子类覆写 get_tool()/get_tools() 与 dispatch();dispatch 里先调 self._lifecycle(action),
+非生命周期动作(返回 None)再走自己的业务分支。
+"""
+
+
+def clamp(v, lo, hi, default=0.0):
+    try:
+        return max(lo, min(hi, float(v)))
+    except (TypeError, ValueError):
+        return default
+
+
+class BasePlugin:
+    #: 子类可覆写:info/start 返回的 state 文案
+    RUNNING_STATE = "running"
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def _lifecycle(self, action, extra=None):
+        """处理 start/stop/info 通用动作;不是这三者返回 None。extra: info 附加字段(dict)。"""
+        if action == "start":
+            return {"state": self.RUNNING_STATE}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "info":
+            out = {"state": self.RUNNING_STATE}
+            if extra:
+                out.update(extra)
+            return out
+        return None

--- a/unitree/go1/plugins/mt_base.py
+++ b/unitree/go1/plugins/mt_base.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+#!/usr/bin/env python3
+"""
+plugins/mt_base.py — MT 卡片公共层(返回包络、错误码、控制等级校验、状态卡基类)。
+
+依据 MT《Go1 动作/运控能力卡片》§3 统一接口约定:
+  • 控制卡成功:{ok, card, action, control_level, applied, timestamp_ms}
+    失败:{ok:false, code, message}(不允许静默裁剪后继续)。
+  • 状态卡:无业务输入,支持 start/stop/info;消息含 timestamp_ms/control_level/最新数据。
+所有 MT 卡片通过本层与 go1_ctrl(唯一硬件入口)交互。
+"""
+import time
+
+from plugins.base import BasePlugin, clamp  # noqa: F401  (clamp 供子类 import)
+
+# 错误码(MT §3.1)
+INVALID_ARGUMENT = "INVALID_ARGUMENT"
+WRONG_CONTROL_LEVEL = "WRONG_CONTROL_LEVEL"
+PRECONDITION_FAILED = "PRECONDITION_FAILED"
+NO_FEEDBACK = "NO_FEEDBACK"
+SAFETY_LIMIT = "SAFETY_LIMIT"
+COMMUNICATION_ERROR = "COMMUNICATION_ERROR"
+
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+class MtCard(BasePlugin):
+    """MT 卡片基类。子类设 CARD;控制卡设 CONTROL_LEVEL(HIGHLEVEL|LOWLEVEL|ANY)。"""
+    CARD = ""
+    CONTROL_LEVEL = "ANY"
+
+    def __init__(self, cfg, namespace, bridge, ctrl):
+        self._cfg = cfg or {}
+        self._ns = namespace
+        self._bridge = bridge
+        self._ctrl = ctrl
+
+    # ── 返回包络 ────────────────────────────────────────────────────────────
+    def _ok(self, action, applied=None):
+        return {"ok": True, "card": self.CARD, "action": action,
+                "control_level": self._ctrl.control_level,
+                "applied": applied or {}, "timestamp_ms": now_ms()}
+
+    def _err(self, code, message):
+        return {"ok": False, "code": code, "message": message,
+                "card": self.CARD, "timestamp_ms": now_ms()}
+
+    # ── 前置校验 ────────────────────────────────────────────────────────────
+    def _level_error(self):
+        """卡片控制等级与 Driver 当前等级不符 → WRONG_CONTROL_LEVEL;否则 None。"""
+        if self.CONTROL_LEVEL != "ANY" and self._ctrl.control_level != self.CONTROL_LEVEL:
+            return self._err(WRONG_CONTROL_LEVEL,
+                             "card '%s' needs %s but driver is %s"
+                             % (self.CARD, self.CONTROL_LEVEL, self._ctrl.control_level))
+        return None
+
+    def _require_confirm(self, args, action):
+        if args.get("confirm") is not True:
+            return self._err(PRECONDITION_FAILED, "action '%s' requires confirm=true" % action)
+        return None
+
+    @staticmethod
+    def _num(args, key):
+        """取数值;缺失/非数返回 (None, err_msg)。"""
+        v = args.get(key)
+        if v is None:
+            return None, "missing '%s'" % key
+        try:
+            return float(v), None
+        except (TypeError, ValueError):
+            return None, "'%s' must be a number" % key
+
+    def _ranged(self, args, key, lo, hi):
+        """取并校验范围;越界不静默裁剪,返回 (val, err_dict|None)。"""
+        v, msg = self._num(args, key)
+        if msg:
+            return None, self._err(INVALID_ARGUMENT, msg)
+        if v < lo or v > hi:
+            return None, self._err(INVALID_ARGUMENT,
+                                   "'%s'=%s out of range [%s, %s]" % (key, v, lo, hi))
+        return v, None
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  状态卡基类
+# ══════════════════════════════════════════════════════════════════════════════
+class MtStateCard(MtCard):
+    """状态 sensor 卡:子类设 CARD/TOPIC/FORMAT/HZ,实现 _payload()。"""
+    TOPIC = ""            # 相对路径,如 "state/imu"(会拼成 /{ns}/state/imu)
+    FMT = "data/json"
+    HZ = 10.0
+    DESC = ""
+
+    def __init__(self, cfg, namespace, bridge, ctrl):
+        super().__init__(cfg, namespace, bridge, ctrl)
+        self._topic = "/%s/%s" % (namespace, self.TOPIC)
+        try:
+            bridge.add_sensor("go1_%s" % self.CARD, self._topic, self.HZ, self._produce)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _payload(self):
+        raise NotImplementedError
+
+    def _produce(self):
+        # 连接态但无新包 → 不伪造时间戳,跳过本次发布(MT §3.2)
+        if self._ctrl.is_connected() and not self._ctrl.state_fresh():
+            return None
+        d = self._payload()
+        if d is None:
+            return None
+        d = dict(d)
+        d["timestamp_ms"] = now_ms()
+        d["control_level"] = self._ctrl.control_level
+        return d
+
+    def get_tool(self):
+        # 纯状态卡:只出数据流(topic_out),**不暴露可执行 action** → core 不渲染"执行"按钮
+        # (MT 要求:状态卡去掉执行按钮,只看数据流)。read/start/stop/info 仍可经 MCP 调用
+        # (转发器就是直接 tools/call read,不走此 schema),仅是不在 UI 上给按钮。
+        return {
+            "name": self.CARD, "type": "sensor", "multiInstance": False,
+            "readOnly": True,
+            "description": self.DESC or ("Go1 %s state → %s" % (self.CARD, self._topic)),
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._topic, "format": self.FMT}],
+        }
+
+    def dispatch(self, action, args):
+        if action == "read":
+            d = self._produce()
+            return d if d is not None else self._err(NO_FEEDBACK, "no fresh state packet")
+        if action == "info":
+            return {"state": "running", "control_level": self._ctrl.control_level,
+                    "topic_out": [{"topic": self._topic, "format": self.FMT}]}
+        if action in ("start", "stop"):
+            return self._lifecycle(action)
+        return self._err(INVALID_ARGUMENT, "unknown action '%s'" % action)

--- a/unitree/go1/plugins/mt_state.py
+++ b/unitree/go1/plugins/mt_state.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+#!/usr/bin/env python3
+"""
+plugins/mt_state.py — MT 8 张状态卡:
+  loco_state / imu / joints / feet / obstacle_range / remote_controller / battery / udp_diagnostics
+
+全部只读,数据取自 go1_ctrl(唯一硬件入口)的快照;按 MT §6 的字段命名与单位。
+"""
+import json
+import math
+import os
+
+from go1_ctrl import MODE_NAMES, GAIT_NAMES, GAITS, JOINT_NAMES, FEET_ORDER  # noqa: F401
+from plugins.mt_base import MtStateCard, now_ms  # noqa: F401
+
+# lowstate_reader(低层 SDK 连主控板 192.168.123.10)写的共享文件 —— battery/joints 从这取真数据。
+_LOWSTATE_FILE_DEFAULT = "/tmp/go1_lowstate.json"
+_LOWSTATE_MAX_AGE_S = 5.0
+
+
+def _read_lowstate(path):
+    """读 lowstate_reader 写的共享文件;不存在/过期/损坏 → None(卡片据此标 available:false)。"""
+    try:
+        age = (now_ms() / 1000.0) - os.path.getmtime(path)
+        if age > _LOWSTATE_MAX_AGE_S:
+            return None
+        with open(path) as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return None
+
+
+class LocoStateCard(MtStateCard):
+    CARD = "loco_state"; CONTROL_LEVEL = "HIGHLEVEL"
+    TOPIC = "loco/state"; FMT = "data/json"; HZ = 10.0
+    DESC = "Go1 运动状态 —— 模式/步态/里程/速度/机身高度。10Hz。"
+
+    def _payload(self):
+        s = self._ctrl.get_high_state()
+        vel = s.get("velocity", [0.0, 0.0, 0.0])
+        return {
+            "mode": s.get("mode", 0), "mode_name": MODE_NAMES.get(s.get("mode", 0), "unknown"),
+            "gait_type": s.get("gait_type", 0), "gait_name": GAIT_NAMES.get(s.get("gait_type", 0), "unknown"),
+            "foot_raise_height_m": s.get("foot_raise_height_m", 0.0),
+            "position_m": s.get("position_m", [0.0, 0.0, 0.0]),
+            "body_height_m": s.get("body_height_m", 0.0),
+            "velocity_body_mps": {"forward": vel[0] if len(vel) > 0 else 0.0,
+                                  "lateral": vel[1] if len(vel) > 1 else 0.0},
+            # 官方 velocity[2] 语义与独立 yawSpeed 冲突 → 只保留原始值,不命名(MT §6.1)
+            "velocity_index_2_raw": vel[2] if len(vel) > 2 else 0.0,
+            "yaw_speed_rad_s": s.get("yaw_speed_rad_s", 0.0),
+        }
+
+
+class ImuCard(MtStateCard):
+    CARD = "imu"; CONTROL_LEVEL = "ANY"
+    TOPIC = "state/imu"; FMT = "data/json"; HZ = 20.0
+    DESC = "Go1 IMU —— 四元数(wxyz)/角速度/加速度/欧拉角/温度。20Hz。"
+
+    def _payload(self):
+        imu = self._ctrl.get_state().get("imu", {})
+        d = dict(imu)
+        d["attitude_may_drift"] = True   # 加速运动时姿态漂移,提示上层(MT §6.2)
+        return d
+
+
+class JointsCard(MtStateCard):
+    CARD = "joints"; CONTROL_LEVEL = "ANY"
+    TOPIC = "state/joints"; FMT = "sensor/skeleton"; HZ = 5.0
+    DESC = ("Go1 12 关节 —— 角度/角速度/力矩/温度。经**低层 SDK**(连主控板 192.168.123.10)读 "
+            "LowState.motorState,由 lowstate_reader 供数(高层 factory 绑定读不到关节)。")
+
+    def __init__(self, cfg, namespace, bridge, ctrl):
+        super().__init__(cfg, namespace, bridge, ctrl)
+        self._file = self._cfg.get("lowstate_file", _LOWSTATE_FILE_DEFAULT)
+
+    def _produce(self):
+        # 读低层共享文件(不受 factory 高层通道新鲜度抑制;与运动不冲突)
+        ls = _read_lowstate(self._file)
+        if ls and ls.get("joints"):
+            d = {"available": True, "joints": ls["joints"], "source": "lowlevel_sdk"}
+        else:
+            d = {"available": False, "joints": [],
+                 "reason": "无低层数据(需 lowstate_reader 连主控板 192.168.123.10 供数)"}
+        d["timestamp_ms"] = now_ms()
+        d["control_level"] = self._ctrl.control_level
+        return d
+
+
+class FeetCard(MtStateCard):
+    CARD = "feet"; CONTROL_LEVEL = "ANY"
+    TOPIC = "state/feet"; FMT = "data/json"; HZ = 10.0
+    DESC = "Go1 足端 —— 足底力原始值(高层控制时另有足端相对机身的位置/速度)。"
+
+    def _payload(self):
+        s = self._ctrl.get_state()
+        out = {"order": FEET_ORDER, "foot_force_raw": s.get("foot_force_raw", [0, 0, 0, 0])}
+        # 足端相对机身位置/速度仅高层提供(MT §6.4)
+        if "foot_position_to_body" in s:
+            out["position_to_body"] = s["foot_position_to_body"]
+            out["speed_to_body"] = s.get("foot_speed_to_body", [])
+        return out
+
+
+class ObstacleRangeCard(MtStateCard):
+    CARD = "obstacle_range"; CONTROL_LEVEL = "HIGHLEVEL"
+    TOPIC = "state/obstacle_range"; FMT = "data/json"; HZ = 10.0
+    DESC = "Go1 最近障碍距离原始值[4](方向/单位官方未定义 —— 仅只读状态,非避障)。"
+
+    def _payload(self):
+        # 工厂高层 .so 无 rangeObstacle 字段 → 诚实标注,不输出误导性的 [0,0,0,0]
+        if not self._ctrl.capabilities().get("obstacle_range", True):
+            return {"available": False, "range_raw": None,
+                    "reason": "高层 .so 无 rangeObstacle 字段;需标准 SDK"}
+        s = self._ctrl.get_high_state()
+        # 官方未定义四项方向顺序与单位 → 原样输出,不命名前后左右(MT §6.5)
+        return {"range_raw": s.get("range_obstacle_raw", [0.0, 0.0, 0.0, 0.0]),
+                "direction_mapping": "undocumented", "unit": "undocumented", "available": True}
+
+
+class RemoteControllerCard(MtStateCard):
+    CARD = "remote_controller"; CONTROL_LEVEL = "ANY"
+    TOPIC = "state/remote_controller"; FMT = "data/json"; HZ = 10.0
+    DESC = "Go1 无线遥控器 —— 16 个按键 + 5 个摇杆轴(来自 wirelessRemote[40])。"
+
+    def _payload(self):
+        wr = self._ctrl.get_state().get("wireless_remote", {})
+        return {"buttons": wr.get("buttons", {}), "axes": wr.get("axes", {})}
+
+
+class BatteryCard(MtStateCard):
+    CARD = "battery"; CONTROL_LEVEL = "ANY"
+    TOPIC = "state/battery"; FMT = "data/json"; HZ = 1.0
+    DESC = ("Go1 电池 —— SOC 电量%/状态/电流/温度/循环次数。经**低层 SDK**(连主控板 192.168.123.10)读 "
+            "LowState.bms,由 lowstate_reader 供数(高层 factory 绑定读不到电量)。")
+
+    def __init__(self, cfg, namespace, bridge, ctrl):
+        super().__init__(cfg, namespace, bridge, ctrl)
+        self._file = self._cfg.get("lowstate_file", _LOWSTATE_FILE_DEFAULT)
+
+    def _produce(self):
+        ls = _read_lowstate(self._file)
+        if ls and ls.get("bms"):
+            b = ls["bms"]
+            d = {"available": True, "soc_percent": b.get("soc"), "status": b.get("status"),
+                 "current_a": b.get("current_a"), "cycle": b.get("cycle"),
+                 "temperatures_c": b.get("temps_c"), "source": "lowlevel_sdk"}
+        else:
+            d = {"available": False, "soc_percent": None,
+                 "reason": "无低层数据(需 lowstate_reader 连主控板 192.168.123.10 供数)"}
+        d["timestamp_ms"] = now_ms()
+        d["control_level"] = self._ctrl.control_level
+        return d
+
+
+class UdpDiagnosticsCard(MtStateCard):
+    CARD = "udp_diagnostics"; CONTROL_LEVEL = "ANY"
+    TOPIC = "state/udp_diagnostics"; FMT = "data/json"; HZ = 2.0
+    DESC = "Go1 驱动 UDP 链路健康 —— 发送/接收/错误/CRC/丢包计数 + 可达性。"
+
+    def _payload(self):
+        return dict(self._ctrl.get_diagnostics())
+
+
+class RobotStatusCard(MtStateCard):
+    """驱动增值卡(非 MT 8 卡之一):把散在多张状态卡里的信息汇成一条给大模型的态势快照,
+    让它一次调用就知道:后端/链路、模式/步态、站没站、在不在动、位置、正在跑的宏进度、
+    电量、以及能不能立刻接受运动指令(ready_for_motion + 人话 hint)。只读、安全。"""
+    CARD = "robot_status"; CONTROL_LEVEL = "ANY"
+    TOPIC = "state/robot_status"; FMT = "data/json"; HZ = 2.0
+    DESC = ("Go1 一键态势快照,供高层规划一次调用即掌握:后端/链路、模式/步态、站立/移动状态、"
+            "位置、正在运行的宏(walk_distance/turn_angle/perform)、电量(若可用),以及 ready_for_motion"
+            "(能否立即运动)+ 一句人话提示下一步该做什么。")
+
+    def _payload(self):
+        s = self._ctrl.get_high_state()
+        mode = int(s.get("mode", 0))
+        macro = self._ctrl.macro_status()
+        moving = self._ctrl.is_moving()
+        standing = self._ctrl.is_standing()
+        link_ok = self._ctrl.is_connected() and self._ctrl.state_fresh()
+        batt = {"available": False, "soc_percent": None}
+        if self._ctrl.capabilities().get("battery", False):
+            b = s.get("bms", {})
+            if b:
+                batt = {"available": True, "soc_percent": b.get("soc_percent")}
+        ready = bool(standing and not moving and link_ok)
+        if not link_ok:
+            hint = "无新状态/离线 —— 请检查驱动与 Legged_sport 通道"
+        elif not standing:
+            hint = "狗未站立 —— 运动前需人用遥控器把它扶起来"
+        elif moving:
+            hint = "忙碌 —— 有运动/宏正在执行(用 perform 的 stop 或 loco 的 stop_move 打断)"
+        else:
+            hint = "就绪 —— 现在可以调用 loco / perform"
+        return {
+            "backend": self._ctrl.backend_name(), "offline": bool(s.get("_offline")),
+            "link_ok": link_ok, "mode": mode, "mode_name": MODE_NAMES.get(mode, "unknown"),
+            "gait_type": s.get("gait_type", 0),
+            "gait_name": GAIT_NAMES.get(s.get("gait_type", 0), "unknown"),
+            "standing": standing, "moving": moving,
+            "position_m": s.get("position_m", [0.0, 0.0, 0.0]),
+            "body_height_m": s.get("body_height_m", 0.0),
+            "macro": (macro if macro.get("active") else None),
+            "battery": batt, "ready_for_motion": ready, "hint": hint,
+        }
+
+
+class FallAlarmCard(MtStateCard):
+    """跌倒/侧翻告警(驱动增值卡,非 MT 14 卡之一):由 IMU 的 roll/pitch 幅度判定
+    ok/tilted/fallen,给运动安全兜底。阈值可 config(tilt_warn_rad/fall_rad)。
+    依赖 IMU 帧,连接后无新帧则按 NO_FEEDBACK 抑制(不误报)。"""
+    CARD = "fall_alarm"; CONTROL_LEVEL = "ANY"
+    TOPIC = "state/fall_alarm"; FMT = "data/json"; HZ = 10.0
+    DESC = "Go1 跌倒/侧翻告警 —— 由 IMU 的 roll/pitch 幅度判定 ok/tilted/fallen + 倾角。10Hz。"
+
+    def _payload(self):
+        imu = self._ctrl.get_state().get("imu", {})
+        rpy = imu.get("rpy_rad", [0.0, 0.0, 0.0]) or [0.0, 0.0, 0.0]
+        roll = float(rpy[0]) if len(rpy) > 0 else 0.0
+        pitch = float(rpy[1]) if len(rpy) > 1 else 0.0
+        warn = float(self._cfg.get("tilt_warn_rad", 0.6))   # ≈34°
+        fall = float(self._cfg.get("fall_rad", 1.2))        # ≈69°
+        tilt = max(abs(roll), abs(pitch))
+        if tilt >= fall:
+            status, hint = "fallen", "已跌倒/翻倒 —— 立即停止运动,需人工扶正后再操作"
+        elif tilt >= warn:
+            status, hint = "tilted", "机身明显倾斜 —— 谨慎,可能即将失稳"
+        else:
+            status, hint = "ok", "姿态正常"
+        return {"status": status, "roll_rad": round(roll, 4), "pitch_rad": round(pitch, 4),
+                "roll_deg": round(math.degrees(roll), 1), "pitch_deg": round(math.degrees(pitch), 1),
+                "tilt_warn_rad": warn, "fall_rad": fall, "hint": hint}
+
+
+class NetCard(MtStateCard):
+    """网络健康(驱动增值卡):主机名/IPv4/Wi-Fi 信号。联调时无线易掉,这张卡让大模型/人
+    一眼看清链路。纯系统读(不经硬件)→ 不套硬件状态新鲜度抑制,始终可读。"""
+    CARD = "net"; CONTROL_LEVEL = "ANY"
+    TOPIC = "state/net"; FMT = "data/json"; HZ = 0.5
+    DESC = "Go1 网络健康 —— 主机名/IPv4/Wi-Fi 信号强度(联调掉线排查用)。"
+
+    def _produce(self):
+        # 系统级读取,不依赖硬件帧 → 不套 MtStateCard 的 fresh 抑制
+        d = self._payload()
+        d["timestamp_ms"] = now_ms()
+        d["control_level"] = self._ctrl.control_level
+        return d
+
+    def _payload(self):
+        import socket
+        out = {"available": True, "hostname": None, "ipv4": None, "wifi": {"available": False}}
+        try:
+            out["hostname"] = socket.gethostname()
+        except Exception:  # noqa: BLE001
+            pass
+        out["ipv4"] = self._primary_ipv4()
+        out["wifi"] = self._wifi_stats()
+        return out
+
+    @staticmethod
+    def _primary_ipv4():
+        import socket
+        s = None
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.connect(("8.8.8.8", 80))    # 不真发包,只用于选默认出口网卡
+            return s.getsockname()[0]
+        except Exception:  # noqa: BLE001
+            return None
+        finally:
+            if s is not None:
+                try:
+                    s.close()
+                except Exception:  # noqa: BLE001
+                    pass
+
+    @staticmethod
+    def _wifi_stats():
+        # Linux(狗)读 /proc/net/wireless;Mac/无该文件 → available:false(诚实标注)
+        try:
+            with open("/proc/net/wireless") as f:
+                lines = f.read().splitlines()
+        except Exception:  # noqa: BLE001
+            return {"available": False, "reason": "无 /proc/net/wireless(非 Linux 或无无线网卡)"}
+        for ln in lines[2:]:
+            parts = ln.split()
+            if len(parts) >= 4 and parts[0].endswith(":"):
+                iface = parts[0].rstrip(":")
+                try:
+                    link = float(parts[2].rstrip("."))
+                    level = float(parts[3].rstrip("."))
+                except (ValueError, IndexError):
+                    link, level = None, None
+                return {"available": True, "iface": iface,
+                        "link_quality": link, "signal_dbm": level}
+        return {"available": False, "reason": "无活动无线网卡"}
+
+
+class OdometryCard(MtStateCard):
+    """里程计(驱动增值卡):当前 position/yaw + 累计总路程 + 相对起点位移。
+    起点默认取首帧,可用 reset_origin 动作重置。仅高层有 position(HIGHLEVEL)。"""
+    CARD = "odometry"; CONTROL_LEVEL = "HIGHLEVEL"
+    TOPIC = "state/odometry"; FMT = "data/json"; HZ = 5.0
+    DESC = ("Go1 里程计 —— 当前 position/yaw、累计总路程 total_distance_m、相对起点位移 displacement"
+            "(read 读取;reset_origin 重置起点)。让高层规划知道'走了多远/在哪'。")
+
+    def __init__(self, cfg, namespace, bridge, ctrl):
+        super().__init__(cfg, namespace, bridge, ctrl)
+        self._origin = None    # [x, y] 起点;首次读或 reset_origin 时设
+
+    # get_tool 用基类(只读、无执行按钮,与其它状态卡一致;reset_origin 仍可经 MCP 调用)
+
+    def _payload(self):
+        odo = self._ctrl.get_odometry()
+        pos = odo.get("position_m", [0.0, 0.0, 0.0])
+        if self._origin is None:
+            self._origin = [pos[0], pos[1]]
+        dx = pos[0] - self._origin[0]
+        dy = pos[1] - self._origin[1]
+        return {"position_m": pos, "yaw_rad": odo.get("yaw_rad", 0.0),
+                "total_distance_m": odo.get("total_distance_m", 0.0),
+                "origin_m": list(self._origin),
+                "displacement_m": {"dx": round(dx, 3), "dy": round(dy, 3),
+                                   "distance": round(math.hypot(dx, dy), 3)},
+                "offline": odo.get("offline", False)}
+
+    def dispatch(self, action, args):
+        if action == "reset_origin":
+            pos = self._ctrl.get_odometry().get("position_m", [0.0, 0.0, 0.0])
+            self._origin = [pos[0], pos[1]]
+            return self._ok("reset_origin", {"origin_m": list(self._origin)})
+        return super().dispatch(action, args)

--- a/unitree/go1/requirements.txt
+++ b/unitree/go1/requirements.txt
@@ -1,0 +1,9 @@
+# Go1 驱动 Python 依赖(rclpy / std_msgs / sensor_msgs / audio_msgs 由 ROS base 镜像提供)。
+# robot_interface(unitree_legged_sdk 的 python 绑定)由 Dockerfile 编译并加入 PYTHONPATH。
+# 离线单元测试(tests/)只用标准库,无需安装任何依赖。
+pyyaml
+netifaces
+numpy                       # 音频重采样
+opencv-python-headless      # ext_camera(V4L2 抓帧)
+pyalsaaudio                 # ext_mic(ALSA 采集)
+sounddevice                 # ext_mic 回退枚举/采集

--- a/unitree/go1/resource/go1_model.urdf
+++ b/unitree/go1/resource/go1_model.urdf
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  go1_model.urdf — Unitree Go1 精简骨架模型,仅供 PhanthyMotus 骨骼渲染器画 stick figure。
+
+  渲染器只用运动学链(joint 的 origin/axis/parent-child),**不需要 mesh**。
+  关节名必须与 device.py 的 _GO1_JOINT_NAMES 精确一致(FR/FL/RR/RL × hip/thigh/calf)。
+
+  ⚠️ 这里的几何尺寸是 Go1 的近似值;要精确渲染可替换为 unitree_ros 的官方 go1_description。
+     腿序/关节名是对的,尺寸差一点只影响骨架比例,不影响功能。
+-->
+<robot name="go1_description">
+
+  <link name="base"/>
+
+  <!-- ============ FR(右前) ============ -->
+  <link name="FR_hip"/>
+  <link name="FR_thigh"/>
+  <link name="FR_calf"/>
+  <link name="FR_foot"/>
+  <joint name="FR_hip_joint" type="revolute">
+    <parent link="base"/><child link="FR_hip"/>
+    <origin xyz="0.1881 -0.04675 0" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/><limit lower="-1.0" upper="1.0" effort="33" velocity="20"/>
+  </joint>
+  <joint name="FR_thigh_joint" type="revolute">
+    <parent link="FR_hip"/><child link="FR_thigh"/>
+    <origin xyz="0 -0.08 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/><limit lower="-3" upper="3" effort="33" velocity="20"/>
+  </joint>
+  <joint name="FR_calf_joint" type="revolute">
+    <parent link="FR_thigh"/><child link="FR_calf"/>
+    <origin xyz="0 0 -0.213" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/><limit lower="-3" upper="3" effort="33" velocity="20"/>
+  </joint>
+  <joint name="FR_foot_joint" type="fixed">
+    <parent link="FR_calf"/><child link="FR_foot"/>
+    <origin xyz="0 0 -0.213" rpy="0 0 0"/>
+  </joint>
+
+  <!-- ============ FL(左前) ============ -->
+  <link name="FL_hip"/>
+  <link name="FL_thigh"/>
+  <link name="FL_calf"/>
+  <link name="FL_foot"/>
+  <joint name="FL_hip_joint" type="revolute">
+    <parent link="base"/><child link="FL_hip"/>
+    <origin xyz="0.1881 0.04675 0" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/><limit lower="-1.0" upper="1.0" effort="33" velocity="20"/>
+  </joint>
+  <joint name="FL_thigh_joint" type="revolute">
+    <parent link="FL_hip"/><child link="FL_thigh"/>
+    <origin xyz="0 0.08 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/><limit lower="-3" upper="3" effort="33" velocity="20"/>
+  </joint>
+  <joint name="FL_calf_joint" type="revolute">
+    <parent link="FL_thigh"/><child link="FL_calf"/>
+    <origin xyz="0 0 -0.213" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/><limit lower="-3" upper="3" effort="33" velocity="20"/>
+  </joint>
+  <joint name="FL_foot_joint" type="fixed">
+    <parent link="FL_calf"/><child link="FL_foot"/>
+    <origin xyz="0 0 -0.213" rpy="0 0 0"/>
+  </joint>
+
+  <!-- ============ RR(右后) ============ -->
+  <link name="RR_hip"/>
+  <link name="RR_thigh"/>
+  <link name="RR_calf"/>
+  <link name="RR_foot"/>
+  <joint name="RR_hip_joint" type="revolute">
+    <parent link="base"/><child link="RR_hip"/>
+    <origin xyz="-0.1881 -0.04675 0" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/><limit lower="-1.0" upper="1.0" effort="33" velocity="20"/>
+  </joint>
+  <joint name="RR_thigh_joint" type="revolute">
+    <parent link="RR_hip"/><child link="RR_thigh"/>
+    <origin xyz="0 -0.08 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/><limit lower="-3" upper="3" effort="33" velocity="20"/>
+  </joint>
+  <joint name="RR_calf_joint" type="revolute">
+    <parent link="RR_thigh"/><child link="RR_calf"/>
+    <origin xyz="0 0 -0.213" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/><limit lower="-3" upper="3" effort="33" velocity="20"/>
+  </joint>
+  <joint name="RR_foot_joint" type="fixed">
+    <parent link="RR_calf"/><child link="RR_foot"/>
+    <origin xyz="0 0 -0.213" rpy="0 0 0"/>
+  </joint>
+
+  <!-- ============ RL(左后) ============ -->
+  <link name="RL_hip"/>
+  <link name="RL_thigh"/>
+  <link name="RL_calf"/>
+  <link name="RL_foot"/>
+  <joint name="RL_hip_joint" type="revolute">
+    <parent link="base"/><child link="RL_hip"/>
+    <origin xyz="-0.1881 0.04675 0" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/><limit lower="-1.0" upper="1.0" effort="33" velocity="20"/>
+  </joint>
+  <joint name="RL_thigh_joint" type="revolute">
+    <parent link="RL_hip"/><child link="RL_thigh"/>
+    <origin xyz="0 0.08 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/><limit lower="-3" upper="3" effort="33" velocity="20"/>
+  </joint>
+  <joint name="RL_calf_joint" type="revolute">
+    <parent link="RL_thigh"/><child link="RL_calf"/>
+    <origin xyz="0 0 -0.213" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/><limit lower="-3" upper="3" effort="33" velocity="20"/>
+  </joint>
+  <joint name="RL_foot_joint" type="fixed">
+    <parent link="RL_calf"/><child link="RL_foot"/>
+    <origin xyz="0 0 -0.213" rpy="0 0 0"/>
+  </joint>
+
+</robot>

--- a/unitree/go1/ros_bridge.py
+++ b/unitree/go1/ros_bridge.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+#!/usr/bin/env python3
+"""
+ros_bridge.py — 把 rclpy(ROS2)隔离在这一个文件里。
+
+设计目的:除本文件外,**任何驱动模块都不得在顶层 import rclpy**。
+  • 有 rclpy(机器狗镜像)   → 真发 ROS2 topic(std_msgs/String 装 JSON)。
+  • 无 rclpy(开发 Mac 等)  → 发布变 no-op,用普通线程定时器跑 producer。
+这样整套驱动代码能在没装 ROS2 的机器上直接 import / 跑 / 测。
+
+sensor 插件统一用法:
+    node = bridge.add_sensor(name, topic, hz, producer)   # producer() -> dict | None
+    ...                                                     # node.last 缓存最近一次数据(测试可读)
+actuator 插件不需要 bridge(直接在 dispatch 里调 go1_hl / adapter)。
+
+生命周期(由 main.py 调):
+    bridge = RosBridge(force_mode)      # auto|real|fake
+    bridge.start()                      # real: rclpy.init() + 建 executor
+    ... 构造插件(内部 add_sensor) ...
+    bridge.spin_background()            # real: 后台 spin;fake: 启动各 sensor 线程
+    bridge.shutdown()
+"""
+import json
+import threading
+import time
+
+try:
+    import rclpy
+    from rclpy.node import Node
+    from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
+    from std_msgs.msg import String
+    _HAVE_RCLPY = True
+except Exception:
+    _HAVE_RCLPY = False
+
+
+def have_rclpy() -> bool:
+    return _HAVE_RCLPY
+
+
+# ── 真实模式:rclpy Node(每个 sensor 一个 node + timer) ─────────────────────
+if _HAVE_RCLPY:
+    # 低延迟 QoS:best-effort、只留最近、易失(与 go2 一致)
+    _LOW_LAT_QOS = QoSProfile(
+        reliability=ReliabilityPolicy.BEST_EFFORT,
+        history=HistoryPolicy.KEEP_LAST,
+        depth=200,
+        durability=DurabilityPolicy.VOLATILE,
+    )
+
+    class _RealSensor(Node):
+        def __init__(self, name, topic, hz, producer):
+            super().__init__(name)
+            self._topic = topic
+            self._producer = producer
+            self.last = None
+            self._pub = self.create_publisher(String, topic, _LOW_LAT_QOS)
+            self.create_timer(1.0 / max(float(hz), 0.001), self.tick)
+
+        def tick(self):
+            try:
+                data = self._producer()
+                if data is None:
+                    return
+                self.last = data
+                msg = String(); msg.data = json.dumps(data)
+                self._pub.publish(msg)
+            except Exception as e:  # noqa: BLE001
+                self.get_logger().error(f"[{self._topic}] publish error: {e}")
+
+
+# ── 离线模式:线程定时器 + no-op 发布 ────────────────────────────────────────
+class _FakeSensor:
+    """无 rclpy 时的替身:同样的 add_sensor 契约,tick() 缓存最近数据供测试/离线读取。"""
+
+    def __init__(self, name, topic, hz, producer):
+        self.name = name
+        self._topic = topic
+        self._hz = float(hz)
+        self._producer = producer
+        self.last = None
+        self._running = False
+        self._thread = None
+        self._err_shown = False
+
+    def tick(self):
+        try:
+            data = self._producer()
+            self._err_shown = False
+            if data is None:
+                return
+            self.last = data
+        except Exception as e:  # noqa: BLE001
+            if not self._err_shown:   # 去重:同一错误只打一次,不刷屏
+                print(f"[ros_bridge/fake] {self._topic} producer error: {e}", flush=True)
+                self._err_shown = True
+
+    def _loop(self):
+        dt = 1.0 / max(self._hz, 0.001)
+        while self._running:
+            t0 = time.monotonic()
+            self.tick()
+            s = dt - (time.monotonic() - t0)
+            if s > 0:
+                time.sleep(s)
+
+    def start(self):
+        if self._running:
+            return
+        self._running = True
+        self._thread = threading.Thread(target=self._loop, daemon=True, name=self.name)
+        self._thread.start()
+
+    def stop(self):
+        self._running = False
+        if self._thread:
+            self._thread.join(timeout=1)
+
+
+class RosBridge:
+    def __init__(self, force_mode: str = "auto"):
+        mode = (force_mode or "auto").lower()
+        if mode == "fake":
+            self.real = False
+        elif mode == "real":
+            if not _HAVE_RCLPY:
+                raise RuntimeError("force_mode=real 但 rclpy 不可用")
+            self.real = True
+        else:  # auto
+            self.real = _HAVE_RCLPY
+        self._sensors = []
+        self._executor = None
+        self._spin_thread = None
+        self._started = False
+
+    def start(self) -> None:
+        if self.real:
+            rclpy.init()
+            from rclpy.executors import MultiThreadedExecutor
+            self._executor = MultiThreadedExecutor()
+        self._started = True
+        print(f"[ros_bridge] mode={'real(rclpy)' if self.real else 'fake(offline)'}", flush=True)
+
+    def add_sensor(self, name: str, topic: str, hz: float, producer):
+        """注册一个周期性 sensor。producer()->dict|None,返回值发到 topic(JSON)。"""
+        if self.real:
+            node = _RealSensor(name, topic, hz, producer)
+            if self._executor is not None:
+                self._executor.add_node(node)
+        else:
+            node = _FakeSensor(name, topic, hz, producer)
+        self._sensors.append(node)
+        return node
+
+    def spin_background(self) -> None:
+        if self.real:
+            def _spin():
+                while rclpy.ok():
+                    self._executor.spin_once(timeout_sec=0.1)
+            self._spin_thread = threading.Thread(target=_spin, daemon=True, name="ros_spin")
+            self._spin_thread.start()
+        else:
+            for s in self._sensors:
+                s.start()
+
+    def shutdown(self) -> None:
+        if self.real:
+            try:
+                if self._executor is not None:
+                    self._executor.shutdown()
+                rclpy.shutdown()
+            except Exception:  # noqa: BLE001
+                pass
+        else:
+            for s in self._sensors:
+                s.stop()


### PR DESCRIPTION
新增 Unitree Go1 四足驱动，以 unitree/go2 为模板、MCP 接口对齐 go2；含运动/避障/语音/视频/导航五类能力，MCP :15704。开发机可离线跑测：bash unitree/go1/tests/run_all.sh。请 MT 审核。