### PR TITLE
feat(r1): safe FSM switch_mode sequences

### DIFF
--- a/unitree/r1/device.py
+++ b/unitree/r1/device.py
@@ -614,7 +614,7 @@ class LocoPlugin:
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["move", "stop_move", "get_fsm_id"],
+                        "enum": ["move", "stop_move"],
                         "description": "Action to perform",
                     },
                     "vx":         {"type": "number", "description": "Forward velocity m/s [-1, 1]"},
@@ -626,7 +626,6 @@ class LocoPlugin:
                 "x-action-params": {
                     "move":             {"params": ["vx", "vy", "vyaw", "duration"], "description": "Move with specified velocities. duration>0 for timed move via SetVelocity, 0 or negative for continuous until stop."},
                     "stop_move":        {"params": [],                                 "description": "Stop all movement immediately"},
-                    "get_fsm_id":       {"params": [],                                 "description": "Get current FSM state ID"},
                 },
             },
         }
@@ -652,8 +651,8 @@ class LocoPlugin:
                         "type": "string",
                         "enum": ["damp", "zero_torque",
                                  "lie2standup", "standup2lie",
-                                 "emergency_stop"],
-                        "description": "Target mode. lie2standup/standup2lie are safe multi-step sequences with FSM polling.",
+                                 "emergency_stop", "get_current_mode"],
+                        "description": "Target mode, or get_current_mode to query current state.",
                     },
                 },
                 "required": ["mode"],
@@ -759,12 +758,20 @@ class LocoPlugin:
                 ret = fn()
                 return {"ret": ret, "mode": mode}
 
+            elif mode == "get_current_mode":
+                code, fsm_id = self._client.GetFsmId()
+                FSM_DESCRIPTIONS = {
+                    0: "lying down, zero torque mode",
+                    1: "lying down, damping mode",
+                    4: "locked standing (intermediate, unstable)",
+                    811: "standing, locomotion mode",
+                }
+                desc = FSM_DESCRIPTIONS.get(fsm_id, f"unknown state")
+                return {"fsm_id": fsm_id, "description": desc}
+
             else:
                 return {"error": f"Unknown mode: {mode}. "
-                                 f"Available: damp, zero_torque, lie2standup, standup2lie, emergency_stop"}
-        elif action == "get_fsm_id":
-            code, fsm_id = self._client.GetFsmId()
-            return {"ret": code, "fsm_id": fsm_id}
+                                 f"Available: damp, zero_torque, lie2standup, standup2lie, emergency_stop, get_current_mode"}
         # ── Arm actions (tool_name="arm", action = gesture name) ────────────────
         elif action == "release":
             # release_arm (id=99) puts hands down

--- a/unitree/r1/device.py
+++ b/unitree/r1/device.py
@@ -729,10 +729,10 @@ class LocoPlugin:
                     return {"info": "Robot is already in loco mode (standing)", "fsm_id": 811}
                 # Full sequence: zero_torque(0) → damp(1) → stance(4) → start(811)
                 all_steps = [
-                    ("ZeroTorque", 0, "zero_torque"),
-                    ("Damp",       1, "damp"),
-                    ("Stance",     4, "stance"),
-                    ("Start",    811, "start"),
+                    ("ZeroTorque",  0, "zero_torque"),
+                    ("Damp",        1, "damp"),
+                    ("Stance",      4, "stance"),
+                    ("Lie2StandUp", 811, "lie2standup"),
                 ]
                 # Skip completed steps based on current FSM
                 fsm_to_start = {0: 1, 1: 2, 4: 3}

--- a/unitree/r1/device.py
+++ b/unitree/r1/device.py
@@ -633,7 +633,8 @@ class LocoPlugin:
 
     # FSM state groups for safety checks
     _GROUND_STATES = {0, 1}       # zero_torque, damp — robot is on the ground
-    _STANDING_STATES = {4, 811}   # stance, loco_mode — robot is upright
+    _STANDING_STATES = {811}      # loco_mode — fully operational standing
+    # FSM=4 (stance) is intermediate: allow both standup (continue) and lie-down (retreat)
 
     def _switch_mode_tool(self) -> dict:
         return {
@@ -724,39 +725,34 @@ class LocoPlugin:
                         "warning": "Emergency damp executed regardless of state"}
 
             elif mode == "lie2standup":
-                if current_fsm in self._STANDING_STATES:
-                    return {"info": "Robot is already standing", "fsm_id": current_fsm}
+                if current_fsm == 811:
+                    return {"info": "Robot is already in loco mode (standing)", "fsm_id": 811}
                 # Full sequence: zero_torque(0) → damp(1) → stance(4) → start(811)
-                # Skip steps already completed based on current FSM
                 all_steps = [
-                    (self._client.ZeroTorque, 0, "zero_torque"),
-                    (self._client.Damp,       1, "damp"),
-                    (self._client.Stance,     4, "stance"),
-                    (self._client.Start,    811, "start"),
+                    ("ZeroTorque", 0, "zero_torque"),
+                    ("Damp",       1, "damp"),
+                    ("Stance",     4, "stance"),
+                    ("Start",    811, "start"),
                 ]
-                # Determine start index: skip past current state
-                fsm_to_start = {0: 1, 1: 2, 4: 3}  # at 0→start from damp, at 1→stance, at 4→start
+                # Skip completed steps based on current FSM
+                fsm_to_start = {0: 1, 1: 2, 4: 3}
                 start_idx = fsm_to_start.get(current_fsm, 0)
                 return self._run_fsm_sequence(all_steps[start_idx:])
 
             elif mode == "standup2lie":
                 if current_fsm in self._GROUND_STATES:
                     return {"info": "Robot is already lying down", "fsm_id": current_fsm}
-                # If stuck in stance(4), go to start first so StandUp2Lie works
                 if current_fsm == 4:
-                    ret = self._client.Start()
-                    ok, fsm = self._poll_fsm(811)
-                    if not ok:
-                        return {"error": f"Failed entering loco mode before lie-down, fsm={fsm}"}
-                ret = self._client.StandUp2Lie()
-                ok, fsm = self._poll_fsm(1)  # StandUp2Lie ends in damp
-                if not ok:
-                    return {"error": f"Timeout during standup2lie, fsm={fsm}"}
-                return {"ret": 0, "mode": "standup2lie", "fsm_id": 1}
+                    # From stance: enter loco first, then lie down
+                    steps = [("Start", 811, "start"), ("StandUp2Lie", 1, "standup2lie")]
+                else:
+                    # From 811 (loco mode): lie down directly
+                    steps = [("StandUp2Lie", 1, "standup2lie")]
+                return self._run_fsm_sequence(steps)
 
             elif mode in ("zero_torque", "damp"):
-                if current_fsm in self._STANDING_STATES:
-                    return {"error": f"Cannot enter {mode} from standing/walking state "
+                if current_fsm in self._STANDING_STATES or current_fsm == 4:
+                    return {"error": f"Cannot enter {mode} from upright state "
                                      f"(FSM={current_fsm}). Robot will collapse. "
                                      f"Use standup2lie first."}
                 fn = self._client.ZeroTorque if mode == "zero_torque" else self._client.Damp
@@ -789,33 +785,13 @@ class LocoPlugin:
 
     # ── FSM sequence helpers ──────────────────────────────────────────────────
 
-    def _poll_fsm(self, target_id: int, interval: float = 1.0, timeout: float = 10.0) -> tuple:
-        """Poll GetFsmId until target reached or timeout. Returns (success, current_fsm_id)."""
-        import time
-        elapsed = 0.0
-        while elapsed < timeout:
-            code, fsm_id = self._client.GetFsmId()
-            if code == 0 and fsm_id == target_id:
-                return (True, fsm_id)
-            time.sleep(interval)
-            elapsed += interval
-        # Final check
-        code, fsm_id = self._client.GetFsmId()
-        return (fsm_id == target_id, fsm_id)
-
     def _run_fsm_sequence(self, steps: list) -> dict:
-        """Execute [(fn, target_fsm, step_name), ...] sequentially with FSM polling.
-        Aborts on RPC failure or timeout."""
-        for fn, target_fsm, name in steps:
-            ret = fn()
-            if ret != 0:
-                return {"error": f"Step '{name}' RPC failed with code {ret}", "step": name}
-            ok, current = self._poll_fsm(target_fsm)
-            if not ok:
-                return {"error": f"Timeout waiting for '{name}' "
-                                 f"(expected FSM={target_fsm}, got {current})",
-                        "step": name, "fsm_id": current}
-        return {"ret": 0, "mode": steps[-1][2], "fsm_id": steps[-1][1]}
+        """Execute FSM sequence in subprocess (no GIL contention).
+        steps = [(method_name, target_fsm_id, step_name), ...]"""
+        result = self._client.RunFsmSequence(steps, interval=1.0, step_timeout=15.0)
+        if result is None:
+            return {"error": "RPC timeout during sequence execution"}
+        return result
 
     # ── Arm helpers ───────────────────────────────────────────────────────────
 

--- a/unitree/r1/device.py
+++ b/unitree/r1/device.py
@@ -631,20 +631,28 @@ class LocoPlugin:
             },
         }
 
+    # FSM state groups for safety checks
+    _GROUND_STATES = {0, 1}       # zero_torque, damp — robot is on the ground
+    _STANDING_STATES = {4, 811}   # stance, loco_mode — robot is upright
+
     def _switch_mode_tool(self) -> dict:
         return {
             "name": "switch_mode",
             "type": "actuator",
             "multiInstance": False,
-            "description": "R1 locomotion mode switch — change posture/locomotion mode by name. damp=阻尼, stance=站立(locked_stand), start=主运控(walk/run), zero_torque=零力矩, lie2standup=躺→站, standup2lie=站→躺",
+            "description": "R1 locomotion mode switch (safe). "
+                           "damp=阻尼(ground only), zero_torque=零力矩(ground only), "
+                           "lie2standup=安全起立序列(ground→运控), standup2lie=安全躺下序列(standing→阻尼), "
+                           "emergency_stop=紧急阻尼(any state, accepts fall risk)",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "mode": {
                         "type": "string",
-                        "enum": ["damp", "stance", "start", "zero_torque",
-                                 "lie2standup", "standup2lie"],
-                        "description": "Target mode",
+                        "enum": ["damp", "zero_torque",
+                                 "lie2standup", "standup2lie",
+                                 "emergency_stop"],
+                        "description": "Target mode. lie2standup/standup2lie are safe multi-step sequences with FSM polling.",
                     },
                 },
                 "required": ["mode"],
@@ -708,19 +716,56 @@ class LocoPlugin:
             return {"ret": ret}
         elif action == "switch_mode":
             mode = args.get("mode", "")
-            mode_dispatch = {
-                "damp":         lambda: self._client.Damp(),
-                "stance":       lambda: self._client.Stance(),
-                "start":        lambda: self._client.Start(),
-                "zero_torque":  lambda: self._client.ZeroTorque(),
-                "lie2standup":  lambda: self._client.Lie2StandUp(),
-                "standup2lie":  lambda: self._client.StandUp2Lie(),
-            }
-            fn = mode_dispatch.get(mode)
-            if fn is None:
-                return {"error": f"Unknown mode: {mode}. Available: {list(mode_dispatch.keys())}"}
-            ret = fn()
-            return {"ret": ret, "mode": mode}
+            code, current_fsm = self._client.GetFsmId()
+
+            if mode == "emergency_stop":
+                ret = self._client.Damp()
+                return {"ret": ret, "mode": "emergency_stop",
+                        "warning": "Emergency damp executed regardless of state"}
+
+            elif mode == "lie2standup":
+                if current_fsm in self._STANDING_STATES:
+                    return {"info": "Robot is already standing", "fsm_id": current_fsm}
+                # Full sequence: zero_torque(0) → damp(1) → stance(4) → start(811)
+                # Skip steps already completed based on current FSM
+                all_steps = [
+                    (self._client.ZeroTorque, 0, "zero_torque"),
+                    (self._client.Damp,       1, "damp"),
+                    (self._client.Stance,     4, "stance"),
+                    (self._client.Start,    811, "start"),
+                ]
+                # Determine start index: skip past current state
+                fsm_to_start = {0: 1, 1: 2, 4: 3}  # at 0→start from damp, at 1→stance, at 4→start
+                start_idx = fsm_to_start.get(current_fsm, 0)
+                return self._run_fsm_sequence(all_steps[start_idx:])
+
+            elif mode == "standup2lie":
+                if current_fsm in self._GROUND_STATES:
+                    return {"info": "Robot is already lying down", "fsm_id": current_fsm}
+                # If stuck in stance(4), go to start first so StandUp2Lie works
+                if current_fsm == 4:
+                    ret = self._client.Start()
+                    ok, fsm = self._poll_fsm(811)
+                    if not ok:
+                        return {"error": f"Failed entering loco mode before lie-down, fsm={fsm}"}
+                ret = self._client.StandUp2Lie()
+                ok, fsm = self._poll_fsm(1)  # StandUp2Lie ends in damp
+                if not ok:
+                    return {"error": f"Timeout during standup2lie, fsm={fsm}"}
+                return {"ret": 0, "mode": "standup2lie", "fsm_id": 1}
+
+            elif mode in ("zero_torque", "damp"):
+                if current_fsm in self._STANDING_STATES:
+                    return {"error": f"Cannot enter {mode} from standing/walking state "
+                                     f"(FSM={current_fsm}). Robot will collapse. "
+                                     f"Use standup2lie first."}
+                fn = self._client.ZeroTorque if mode == "zero_torque" else self._client.Damp
+                ret = fn()
+                return {"ret": ret, "mode": mode}
+
+            else:
+                return {"error": f"Unknown mode: {mode}. "
+                                 f"Available: damp, zero_torque, lie2standup, standup2lie, emergency_stop"}
         elif action == "get_fsm_id":
             code, fsm_id = self._client.GetFsmId()
             return {"ret": code, "fsm_id": fsm_id}
@@ -741,6 +786,38 @@ class LocoPlugin:
                 self._schedule_arm_release()
             return {"ret": code, "action": action, "action_id": action_id, "data": data}
         return None
+
+    # ── FSM sequence helpers ──────────────────────────────────────────────────
+
+    def _poll_fsm(self, target_id: int, interval: float = 1.0, timeout: float = 10.0) -> tuple:
+        """Poll GetFsmId until target reached or timeout. Returns (success, current_fsm_id)."""
+        import time
+        elapsed = 0.0
+        while elapsed < timeout:
+            code, fsm_id = self._client.GetFsmId()
+            if code == 0 and fsm_id == target_id:
+                return (True, fsm_id)
+            time.sleep(interval)
+            elapsed += interval
+        # Final check
+        code, fsm_id = self._client.GetFsmId()
+        return (fsm_id == target_id, fsm_id)
+
+    def _run_fsm_sequence(self, steps: list) -> dict:
+        """Execute [(fn, target_fsm, step_name), ...] sequentially with FSM polling.
+        Aborts on RPC failure or timeout."""
+        for fn, target_fsm, name in steps:
+            ret = fn()
+            if ret != 0:
+                return {"error": f"Step '{name}' RPC failed with code {ret}", "step": name}
+            ok, current = self._poll_fsm(target_fsm)
+            if not ok:
+                return {"error": f"Timeout waiting for '{name}' "
+                                 f"(expected FSM={target_fsm}, got {current})",
+                        "step": name, "fsm_id": current}
+        return {"ret": 0, "mode": steps[-1][2], "fsm_id": steps[-1][1]}
+
+    # ── Arm helpers ───────────────────────────────────────────────────────────
 
     def _schedule_arm_release(self):
         """Schedule arm SDK release after 4 seconds."""

--- a/unitree/r1/rpc_proxy.py
+++ b/unitree/r1/rpc_proxy.py
@@ -56,6 +56,40 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
 
         try:
             client = clients.get(client_name, loco)
+
+            # Special: FSM sequence execution (runs entirely in subprocess, no GIL)
+            if method == "__run_fsm_sequence":
+                steps_spec, interval, step_timeout = args
+                completed = []
+                for method_name, target_fsm, step_name in steps_spec:
+                    fn = getattr(client, method_name)
+                    ret = fn()
+                    if ret != 0:
+                        result_queue.put({"result": {
+                            "error": f"Step '{step_name}' failed: code={ret}",
+                            "step": step_name, "completed": completed}})
+                        continue  # next cmd — sequence done
+                    # Poll FSM until target reached or timeout
+                    elapsed = 0.0
+                    ok = False
+                    while elapsed < step_timeout:
+                        time.sleep(interval)
+                        elapsed += interval
+                        code, fsm_id = client.GetFsmId()
+                        if code == 0 and fsm_id == target_fsm:
+                            ok = True
+                            break
+                    if not ok:
+                        _, current = client.GetFsmId()
+                        result_queue.put({"result": {
+                            "error": f"Timeout '{step_name}' (expected={target_fsm}, got={current})",
+                            "step": step_name, "fsm_id": current, "completed": completed}})
+                        continue  # next cmd — sequence done
+                    completed.append(step_name)
+                result_queue.put({"result": {"ret": 0, "steps": completed,
+                                             "fsm_id": steps_spec[-1][1]}})
+                continue  # next cmd
+
             fn = getattr(client, method)
             result = fn(*args, **kwargs)
             result_queue.put({"result": result})
@@ -112,6 +146,14 @@ class RpcProxy:
             pass
 
     # ── LocoClient interface (sport service — legs) ───────────────────────────
+
+    def RunFsmSequence(self, steps: list, interval: float = 1.0, step_timeout: float = 15.0):
+        """Run FSM sequence entirely in subprocess (no GIL contention in main process).
+        steps = [(method_name, target_fsm_id, step_name), ...]
+        Returns dict with {ret, steps, fsm_id} on success or {error, step} on failure."""
+        outer_timeout = len(steps) * (step_timeout + 5) + 10
+        return self._call("loco", "__run_fsm_sequence", steps, interval, step_timeout,
+                          timeout=outer_timeout)
 
     def GetFsmId(self):
         return self._call_tuple("loco", "GetFsmId")

--- a/unitree/r1/rpc_proxy.py
+++ b/unitree/r1/rpc_proxy.py
@@ -59,7 +59,7 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
 
             # Special: FSM sequence execution (runs entirely in subprocess, no GIL)
             if method == "__run_fsm_sequence":
-                steps_spec, interval, step_timeout = args
+                steps_spec, interval, step_timeout, settle_delay = args
                 completed = []
                 for method_name, target_fsm, step_name in steps_spec:
                     fn = getattr(client, method_name)
@@ -86,6 +86,8 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                             "step": step_name, "fsm_id": current, "completed": completed}})
                         continue  # next cmd — sequence done
                     completed.append(step_name)
+                    # Wait for physical motion to settle before next step
+                    time.sleep(settle_delay)
                 result_queue.put({"result": {"ret": 0, "steps": completed,
                                              "fsm_id": steps_spec[-1][1]}})
                 continue  # next cmd
@@ -147,12 +149,14 @@ class RpcProxy:
 
     # ── LocoClient interface (sport service — legs) ───────────────────────────
 
-    def RunFsmSequence(self, steps: list, interval: float = 1.0, step_timeout: float = 15.0):
+    def RunFsmSequence(self, steps: list, interval: float = 1.0, step_timeout: float = 15.0,
+                       settle_delay: float = 2.0):
         """Run FSM sequence entirely in subprocess (no GIL contention in main process).
         steps = [(method_name, target_fsm_id, step_name), ...]
+        settle_delay = seconds to wait after FSM confirms state change (physical stabilization).
         Returns dict with {ret, steps, fsm_id} on success or {error, step} on failure."""
-        outer_timeout = len(steps) * (step_timeout + 5) + 10
-        return self._call("loco", "__run_fsm_sequence", steps, interval, step_timeout,
+        outer_timeout = len(steps) * (step_timeout + settle_delay + 5) + 10
+        return self._call("loco", "__run_fsm_sequence", steps, interval, step_timeout, settle_delay,
                           timeout=outer_timeout)
 
     def GetFsmId(self):


### PR DESCRIPTION
## Summary
- Redesign `switch_mode` tool to enforce safe FSM transition sequences
- `lie2standup`: multi-step ground→standing with FSM polling (1s interval, 10s timeout per step)
- `standup2lie`: safe standing→ground sequence ending in damp
- `emergency_stop`: immediate damp regardless of state (panic button)
- Block `damp`/`zero_torque` from standing states to prevent robot collapse
- Remove dangerous `stance`/`start` from user-facing enum (used internally only)

## Test plan
- [ ] Verify `get_fsm_id` returns correct state
- [ ] Test `emergency_stop` from any state
- [ ] Test `lie2standup` from ground (full sequence)
- [ ] Test `standup2lie` from LocoMode
- [ ] Verify `damp`/`zero_torque` blocked when standing
- [ ] Verify `lie2standup` no-ops when already standing

🤖 Generated with [Claude Code](https://claude.com/claude-code)