### PR TITLE
fix(r1): prevent unsafe standup2lie + fix rpc_proxy sequence abort

### DIFF
--- a/unitree/r1/device.py
+++ b/unitree/r1/device.py
@@ -745,7 +745,9 @@ class LocoPlugin:
                     # From stance: enter loco first, then lie down
                     steps = [("Start", 811, "start"), ("StandUp2Lie", 1, "standup2lie")]
                 else:
-                    # From 811 (loco mode): lie down directly
+                    # From 811 (loco mode): stop movement first, then lie down safely
+                    self._client.StopMove()
+                    import time as _time; _time.sleep(1.0)
                     steps = [("StandUp2Lie", 1, "standup2lie")]
                 return self._run_fsm_sequence(steps)
 

--- a/unitree/r1/rpc_proxy.py
+++ b/unitree/r1/rpc_proxy.py
@@ -68,7 +68,7 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                         result_queue.put({"result": {
                             "error": f"Step '{step_name}' failed: code={ret}",
                             "step": step_name, "completed": completed}})
-                        continue  # next cmd — sequence done
+                        break  # abort sequence on failure
                     # Poll FSM until target reached or timeout
                     elapsed = 0.0
                     ok = False
@@ -84,12 +84,14 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                         result_queue.put({"result": {
                             "error": f"Timeout '{step_name}' (expected={target_fsm}, got={current})",
                             "step": step_name, "fsm_id": current, "completed": completed}})
-                        continue  # next cmd — sequence done
+                        break  # abort sequence on timeout
                     completed.append(step_name)
                     # Wait for physical motion to settle before next step
                     time.sleep(settle_delay)
-                result_queue.put({"result": {"ret": 0, "steps": completed,
-                                             "fsm_id": steps_spec[-1][1]}})
+                else:
+                    # Only reached if loop completed without break (all steps succeeded)
+                    result_queue.put({"result": {"ret": 0, "steps": completed,
+                                                 "fsm_id": steps_spec[-1][1]}})
                 continue  # next cmd
 
             fn = getattr(client, method)


### PR DESCRIPTION
## Summary
- Stop robot motion (`StopMove()` + 1s settle) before executing `StandUp2Lie` from FSM=811, preventing firmware from skipping lie-down animation and going directly to damp
- Fix rpc_proxy FSM sequence: `continue`→`break` on failure/timeout so sequence aborts properly and doesn't poison the result queue with a spurious success

## Test plan
- [x] Deployed to R1, container restarted
- [ ] Test standup2lie from active walking state — verify robot stops, then performs lie-down animation
- [ ] Test multi-step sequence failure — verify abort and no queue contamination

🤖 Generated with [Claude Code](https://claude.com/claude-code)