### PR TITLE
feat: heyangyang add Tianyi hand, depth, and remote sensor cards

### DIFF
--- a/x-humanoid/tianyi2.0/Dockerfile
+++ b/x-humanoid/tianyi2.0/Dockerfile
@@ -33,7 +33,7 @@ ENV AMENT_PREFIX_PATH=/tianyi_ws/install/bodyctrl_msgs:/tianyi_ws/install/lyre_m
 ENV LD_LIBRARY_PATH=/tianyi_ws/install/bodyctrl_msgs/lib:/tianyi_ws/install/lyre_msgs/lib:${LD_LIBRARY_PATH}
 
 COPY resource/ /work/resource/
-COPY main.py device.py nav_client.py config.yaml driver.yaml /work/
+COPY main.py device.py nav_client.py hand_state.py camera_depth.py remote_controller.py config.yaml driver.yaml /work/
 
 EXPOSE 15707
 

--- a/x-humanoid/tianyi2.0/camera_depth.py
+++ b/x-humanoid/tianyi2.0/camera_depth.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""天轶2.0 Orbbec 深度相机原子卡片。
+
+机器人在 ROS domain 0 发布深度帧。本插件仅保留最新帧，
+Agent Core domain 上发布紧密排列、小端的 ``sensor_msgs/Image``。
+``image/depth-z16`` 消费者可将 data 直接解读为以毫米为单位的
+uint16 数组。
+"""
+
+import threading
+import time
+
+from rclpy.node import Node
+from rclpy.qos import (
+    DurabilityPolicy,
+    HistoryPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+from sensor_msgs.msg import Image
+
+
+_DEPTH_SOURCE_TOPIC = "/ob_camera_head/depth/image_raw"
+_DEPTH_ENCODINGS = {"16uc1", "mono16"}
+
+_DEPTH_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+
+class CameraDepthPlugin:
+    """将天轶 Orbbec 最新 Z16 深度帧转发给 Agent Core。"""
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        del plugin_config
+        self._topic = f"/{namespace}/camera/depth"
+        self._sub_node = Node(
+            "tianyi2_camera_depth_sub", context=ros2.ctx_tianyi
+        )
+        ros2.executor_tianyi.add_node(self._sub_node)
+        self._pub_node = Node(
+            "tianyi2_camera_depth_pub", context=ros2.ctx_core
+        )
+        ros2.executor_core.add_node(self._pub_node)
+
+        self._running = False
+        self._subscription = None
+        self._publisher = None
+        self._worker = None
+        self._worker_stop = None
+
+        self._lifecycle_lock = threading.Lock()
+        self._frame_lock = threading.Lock()
+        self._frame_ready = threading.Event()
+        self._latest_frame = None
+        self._last_warning_at = 0.0
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "camera_depth",
+            "type": "sensor",
+            "multiInstance": False,
+            "description": (
+                "天轶2.0 头部 Orbbec 深度相机 — 16位深度图，"
+                "每个像素表示毫米距离"
+            ),
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [
+                {"topic": self._topic, "format": "image/depth-z16"}
+            ],
+        }
+
+    def start(self) -> None:
+        """启动深度桥接；重复调用不会创建重复资源。"""
+        with self._lifecycle_lock:
+            if self._running:
+                return
+
+            self._publisher = self._pub_node.create_publisher(
+                Image, self._topic, _DEPTH_QOS
+            )
+            self._subscription = self._sub_node.create_subscription(
+                Image,
+                _DEPTH_SOURCE_TOPIC,
+                self._on_depth_frame,
+                _DEPTH_QOS,
+            )
+            self._running = True
+            self._worker_stop = threading.Event()
+            self._worker = threading.Thread(
+                target=self._publish_loop,
+                args=(self._worker_stop,),
+                name="tianyi2_camera_depth",
+                daemon=True,
+            )
+            self._worker.start()
+
+        print(
+            f"[CameraDepthPlugin] {_DEPTH_SOURCE_TOPIC} -> {self._topic}",
+            flush=True,
+        )
+
+    def stop(self) -> None:
+        """停止发布，并释放本卡片创建的订阅和发布器。"""
+        with self._lifecycle_lock:
+            if not self._running:
+                return
+            self._running = False
+            self._worker_stop.set()
+            self._frame_ready.set()
+            if self._worker is not None:
+                self._worker.join()
+            if self._subscription is not None:
+                self._sub_node.destroy_subscription(self._subscription)
+                self._subscription = None
+            if self._publisher is not None:
+                self._pub_node.destroy_publisher(self._publisher)
+                self._publisher = None
+            self._worker = None
+            self._worker_stop = None
+
+        with self._frame_lock:
+            self._latest_frame = None
+        self._frame_ready.clear()
+
+    def _on_depth_frame(self, msg: Image) -> None:
+        """回调只替换最新帧，格式转换留给后台线程。"""
+        with self._frame_lock:
+            if not self._running:
+                return
+            self._latest_frame = msg
+        self._frame_ready.set()
+
+    def _publish_loop(self, worker_stop: threading.Event) -> None:
+        while not worker_stop.is_set():
+            if not self._frame_ready.wait(timeout=0.25):
+                continue
+            self._frame_ready.clear()
+            if worker_stop.is_set():
+                return
+
+            with self._frame_lock:
+                frame = self._latest_frame
+                self._latest_frame = None
+            if frame is None:
+                continue
+
+            try:
+                output = self._to_depth_z16(frame)
+                if worker_stop.is_set():
+                    return
+                publisher = self._publisher
+                if output is not None and publisher is not None:
+                    publisher.publish(output)
+            except Exception as exc:
+                self._warn(f"depth frame conversion failed: {exc}")
+
+    def _to_depth_z16(self, source: Image):
+        """返回紧密小端 16UC1 图像；无效时返回 None。"""
+        encoding = source.encoding.strip().lower()
+        if encoding not in _DEPTH_ENCODINGS:
+            self._warn(
+                f"unsupported depth encoding {source.encoding!r}; "
+                "expected 16UC1 or mono16"
+            )
+            return None
+
+        width = int(source.width)
+        height = int(source.height)
+        row_bytes = width * 2
+        source_step = int(source.step)
+        if width <= 0 or height <= 0 or source_step < row_bytes:
+            self._warn(
+                f"invalid depth layout: {width}x{height}, step={source_step}"
+            )
+            return None
+
+        raw = bytes(source.data)
+        required_bytes = source_step * height
+        if len(raw) < required_bytes:
+            self._warn(
+                f"short depth frame: got {len(raw)} bytes, "
+                f"need {required_bytes}"
+            )
+            return None
+
+        if source_step == row_bytes:
+            packed = raw[:required_bytes]
+        else:
+            packed_buffer = bytearray(row_bytes * height)
+            for row in range(height):
+                src_start = row * source_step
+                dst_start = row * row_bytes
+                packed_buffer[dst_start : dst_start + row_bytes] = raw[
+                    src_start : src_start + row_bytes
+                ]
+            packed = bytes(packed_buffer)
+
+        if bool(source.is_bigendian):
+            little_endian = bytearray(packed)
+            little_endian[0::2], little_endian[1::2] = (
+                little_endian[1::2],
+                little_endian[0::2],
+            )
+            packed = bytes(little_endian)
+
+        output = Image()
+        output.header.stamp = source.header.stamp
+        output.header.frame_id = source.header.frame_id
+        output.height = height
+        output.width = width
+        output.encoding = "16UC1"
+        output.is_bigendian = 0
+        output.step = row_bytes
+        output.data = packed
+        return output
+
+    def _warn(self, message: str) -> None:
+        """限制重复相机错误的日志频率。"""
+        now = time.monotonic()
+        if now - self._last_warning_at < 5.0:
+            return
+        self._last_warning_at = now
+        self._sub_node.get_logger().warning(f"[CameraDepthPlugin] {message}")
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        del args
+        if action == "start":
+            self.start()
+            return self._status()
+        if action == "stop":
+            self.stop()
+            return {"state": "idle"}
+        if action in {"info", "camera_depth"}:
+            return self._status()
+        return {"error": f"unknown action: {action}"}
+
+    def _status(self) -> dict:
+        return {
+            "state": "running" if self._running else "idle",
+            "topic_out": [
+                {"topic": self._topic, "format": "image/depth-z16"}
+            ],
+        }

--- a/x-humanoid/tianyi2.0/config.yaml
+++ b/x-humanoid/tianyi2.0/config.yaml
@@ -8,9 +8,15 @@ slamtec:
 plugins:
   state:
     enabled: true
+  hand_state:
+    enabled: true
   camera:
     enabled: true
+  camera_depth:
+    enabled: true
   asr:
+    enabled: true
+  remote_controller:
     enabled: true
   nav_state:
     enabled: true

--- a/x-humanoid/tianyi2.0/hand_state.py
+++ b/x-humanoid/tianyi2.0/hand_state.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""天轶2.0 Inspire 灵巧手状态原子卡片。"""
+
+import copy
+import json
+import threading
+import time
+
+from rclpy.node import Node
+from rclpy.qos import (
+    DurabilityPolicy,
+    HistoryPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+from std_msgs.msg import String
+
+
+_RELIABLE_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=10,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+
+def _empty_hand_state() -> dict:
+    return {
+        "name": [],
+        "position": [],
+        "velocity": [],
+        "effort": [],
+        "timestamp": None,
+    }
+
+
+class HandStatePlugin:
+    """转发左右 Inspire 灵巧手的关节位置、速度和力反馈。"""
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        del plugin_config
+        self._topic = f"/{namespace}/state/hand"
+        self._running = False
+        self._subscriptions = []
+        self._lock = threading.Lock()
+        self._state = {
+            "updated_at": None,
+            "left": _empty_hand_state(),
+            "right": _empty_hand_state(),
+        }
+
+        self._sub_node = Node(
+            "tianyi2_hand_state_sub", context=ros2.ctx_tianyi
+        )
+        ros2.executor_tianyi.add_node(self._sub_node)
+
+        self._pub_node = Node("tianyi2_hand_state_pub", context=ros2.ctx_core)
+        ros2.executor_core.add_node(self._pub_node)
+        self._pub = self._pub_node.create_publisher(
+            String, self._topic, _RELIABLE_QOS
+        )
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "hand_state",
+            "type": "sensor",
+            "description": (
+                "天轶2.0 Inspire灵巧手状态 — "
+                "左右手关节名称、位置、速度和力反馈"
+            ),
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        """开始转发状态；重复调用不会创建重复订阅。"""
+        with self._lock:
+            self._running = True
+            if self._subscriptions:
+                return
+
+            try:
+                from sensor_msgs.msg import JointState
+
+                self._subscriptions = [
+                    self._sub_node.create_subscription(
+                        JointState,
+                        "/inspire_hand/state/left_hand",
+                        lambda msg: self._on_hand_state("left", msg),
+                        _RELIABLE_QOS,
+                    ),
+                    self._sub_node.create_subscription(
+                        JointState,
+                        "/inspire_hand/state/right_hand",
+                        lambda msg: self._on_hand_state("right", msg),
+                        _RELIABLE_QOS,
+                    ),
+                ]
+                print("[HandStatePlugin] subscriptions created")
+            except ImportError as exc:
+                self._running = False
+                print(
+                    f"[HandStatePlugin] WARNING: msg import failed ({exc}), "
+                    "sensor is idle"
+                )
+
+    def stop(self) -> None:
+        """暂停状态转发，保留最近一次双手状态供查询。"""
+        with self._lock:
+            self._running = False
+
+    def _on_hand_state(self, side: str, msg) -> None:
+        received_at = time.time()
+        state = {
+            "name": list(msg.name),
+            "position": list(msg.position),
+            "velocity": list(msg.velocity),
+            "effort": list(msg.effort),
+            "timestamp": {
+                "sec": int(msg.header.stamp.sec),
+                "nanosec": int(msg.header.stamp.nanosec),
+                "received_at": received_at,
+            },
+        }
+
+        with self._lock:
+            if not self._running:
+                return
+            self._state[side] = state
+            self._state["updated_at"] = received_at
+            payload = copy.deepcopy(self._state)
+            out = String()
+            out.data = json.dumps(payload, ensure_ascii=False)
+            self._pub.publish(out)
+
+    def dispatch(self, action_or_tool: str, args: dict) -> dict:
+        del args
+        if action_or_tool == "hand_state":
+            with self._lock:
+                return copy.deepcopy(self._state)
+
+        if action_or_tool == "start":
+            self.start()
+        elif action_or_tool == "stop":
+            self.stop()
+        elif action_or_tool != "info":
+            return {"error": f"unknown action: {action_or_tool}"}
+
+        return {
+            "state": "running" if self._is_running() else "idle",
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+        }
+
+    def _is_running(self) -> bool:
+        with self._lock:
+            return self._running

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -102,15 +102,38 @@ class TianyiDeviceBundle:
             self._plugins.append(StatePlugin(plugins_cfg["state"], namespace, ros2))
             print("[bundle] StatePlugin loaded")
 
+        if plugins_cfg.get("hand_state", {}).get("enabled", False):
+            from hand_state import HandStatePlugin
+            self._plugins.append(
+                HandStatePlugin(plugins_cfg["hand_state"], namespace, ros2)
+            )
+            print("[bundle] HandStatePlugin loaded")
+
         if plugins_cfg.get("camera", {}).get("enabled", False):
             from device import CameraPlugin
             self._plugins.append(CameraPlugin(plugins_cfg["camera"], namespace, ros2))
             print("[bundle] CameraPlugin loaded")
 
+        if plugins_cfg.get("camera_depth", {}).get("enabled", False):
+            from camera_depth import CameraDepthPlugin
+            self._plugins.append(
+                CameraDepthPlugin(plugins_cfg["camera_depth"], namespace, ros2)
+            )
+            print("[bundle] CameraDepthPlugin loaded")
+
         if plugins_cfg.get("asr", {}).get("enabled", False):
             from device import AsrPlugin
             self._plugins.append(AsrPlugin(plugins_cfg["asr"], namespace, ros2))
             print("[bundle] AsrPlugin loaded")
+
+        if plugins_cfg.get("remote_controller", {}).get("enabled", False):
+            from remote_controller import RemoteControllerPlugin
+            self._plugins.append(
+                RemoteControllerPlugin(
+                    plugins_cfg["remote_controller"], namespace, ros2
+                )
+            )
+            print("[bundle] RemoteControllerPlugin loaded")
 
         if plugins_cfg.get("nav_state", {}).get("enabled", False):
             from device import NavStatePlugin

--- a/x-humanoid/tianyi2.0/remote_controller.py
+++ b/x-humanoid/tianyi2.0/remote_controller.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""天轶2.0 遥控器状态原子卡片。"""
+
+import copy
+import json
+import threading
+import time
+
+from rclpy.node import Node
+from rclpy.qos import (
+    DurabilityPolicy,
+    HistoryPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+from std_msgs.msg import String
+
+
+_RELIABLE_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=10,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+_KEY_EVENT_NAMES = {
+    0: "none",
+    1: "a_up",
+    2: "a_down",
+    3: "b_up",
+    4: "b_down",
+    5: "c_up",
+    6: "c_down",
+    7: "d_up",
+    8: "d_down",
+    9: "e_up",
+    10: "e_mid",
+    11: "e_down",
+    12: "f_up",
+    13: "f_mid",
+    14: "f_down",
+    15: "g_left",
+    16: "g_mid",
+    17: "g_right",
+    18: "h_left",
+    19: "h_mid",
+    20: "h_right",
+}
+
+
+class RemoteControllerPlugin:
+    """转发 SBUS 遥控器按键、拨杆和摇杆状态。"""
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        del plugin_config
+        self._topic = f"/{namespace}/state/remote_controller"
+        self._running = False
+        self._subscription = None
+        self._latest = None
+        self._lock = threading.Lock()
+
+        self._sub_node = Node(
+            "tianyi2_remote_controller_sub", context=ros2.ctx_tianyi
+        )
+        ros2.executor_tianyi.add_node(self._sub_node)
+
+        self._pub_node = Node(
+            "tianyi2_remote_controller_pub", context=ros2.ctx_core
+        )
+        ros2.executor_core.add_node(self._pub_node)
+        self._pub = self._pub_node.create_publisher(
+            String, self._topic, _RELIABLE_QOS
+        )
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "remote_controller",
+            "type": "sensor",
+            "description": (
+                "天轶2.0 SBUS遥控器状态 — "
+                "按键事件、A-H拨杆状态及双摇杆位置"
+            ),
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        """开始转发事件；重复调用不会重复创建 ROS 订阅。"""
+        with self._lock:
+            self._running = True
+            if self._subscription is not None:
+                return
+
+            try:
+                from bodyctrl_msgs.msg import SbusData
+
+                self._subscription = self._sub_node.create_subscription(
+                    SbusData,
+                    "/sbus_data/event",
+                    self._on_remote_controller,
+                    _RELIABLE_QOS,
+                )
+                print("[RemoteControllerPlugin] subscription created")
+            except ImportError as exc:
+                self._running = False
+                warning = (
+                    "[RemoteControllerPlugin] WARNING: "
+                    f"msg import failed ({exc}), sensor is idle"
+                )
+                print(warning)
+
+    def stop(self) -> None:
+        """暂停事件转发，保留最近状态供查询。"""
+        with self._lock:
+            self._running = False
+
+    def _on_remote_controller(self, msg) -> None:
+        key_event_new = int(msg.key_event_new)
+        key_event_old = int(msg.key_event_old)
+        received_at = time.time()
+        payload = {
+            "header": {
+                "stamp": {
+                    "sec": int(msg.header.stamp.sec),
+                    "nanosec": int(msg.header.stamp.nanosec),
+                },
+                "frame_id": msg.header.frame_id,
+            },
+            "received_at": received_at,
+            "key_event_new": key_event_new,
+            "key_event_new_name": _KEY_EVENT_NAMES.get(
+                key_event_new, f"unknown_{key_event_new}"
+            ),
+            "key_event_old": key_event_old,
+            "key_event_old_name": _KEY_EVENT_NAMES.get(
+                key_event_old, f"unknown_{key_event_old}"
+            ),
+            "button_a": int(msg.button_a),
+            "button_b": int(msg.button_b),
+            "button_c": int(msg.button_c),
+            "button_d": int(msg.button_d),
+            "button_e": int(msg.button_e),
+            "button_f": int(msg.button_f),
+            "button_g": int(msg.button_g),
+            "button_h": int(msg.button_h),
+            "x1": float(msg.x1),
+            "y1": float(msg.y1),
+            "x2": float(msg.x2),
+            "y2": float(msg.y2),
+        }
+
+        with self._lock:
+            if not self._running:
+                return
+            self._latest = payload
+            out = String()
+            out.data = json.dumps(payload, ensure_ascii=False)
+            self._pub.publish(out)
+
+    def dispatch(self, action_or_tool: str, args: dict) -> dict:
+        del args
+        if action_or_tool == "remote_controller":
+            with self._lock:
+                if self._latest is None:
+                    return {"state": "no_data"}
+                return copy.deepcopy(self._latest)
+
+        if action_or_tool == "start":
+            self.start()
+        elif action_or_tool == "stop":
+            self.stop()
+        elif action_or_tool != "info":
+            return {"error": f"unknown action: {action_or_tool}"}
+
+        return {
+            "state": "running" if self._is_running() else "idle",
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+        }
+
+    def _is_running(self) -> bool:
+        with self._lock:
+            return self._running

--- a/x-humanoid/tianyi2.0/tests/test_atomic_sensors.py
+++ b/x-humanoid/tianyi2.0/tests/test_atomic_sensors.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""不依赖 ROS 安装的天轶2.0 原子传感器单元测试。"""
+
+import importlib
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+class _Stamp:
+    def __init__(self, sec=0, nanosec=0):
+        self.sec = sec
+        self.nanosec = nanosec
+
+
+class _Header:
+    def __init__(self, sec=0, nanosec=0, frame_id=""):
+        self.stamp = _Stamp(sec, nanosec)
+        self.frame_id = frame_id
+
+
+class _String:
+    def __init__(self):
+        self.data = ""
+
+
+class _Image:
+    def __init__(self):
+        self.header = _Header()
+        self.height = 0
+        self.width = 0
+        self.encoding = ""
+        self.is_bigendian = 0
+        self.step = 0
+        self.data = b""
+
+
+class _Publisher:
+    def __init__(self, msg_type, topic):
+        self.msg_type = msg_type
+        self.topic = topic
+        self.messages = []
+
+    def publish(self, msg):
+        self.messages.append(msg)
+
+
+class _Subscription:
+    def __init__(self, msg_type, topic, callback):
+        self.msg_type = msg_type
+        self.topic = topic
+        self.callback = callback
+
+
+class _Logger:
+    def warning(self, _message):
+        pass
+
+
+class _Node:
+    def __init__(self, name, context=None):
+        self.name = name
+        self.context = context
+        self.publishers = []
+        self.subscriptions = []
+
+    def create_publisher(self, msg_type, topic, _qos):
+        publisher = _Publisher(msg_type, topic)
+        self.publishers.append(publisher)
+        return publisher
+
+    def create_subscription(self, msg_type, topic, callback, _qos):
+        subscription = _Subscription(msg_type, topic, callback)
+        self.subscriptions.append(subscription)
+        return subscription
+
+    def destroy_publisher(self, publisher):
+        self.publishers.remove(publisher)
+
+    def destroy_subscription(self, subscription):
+        self.subscriptions.remove(subscription)
+
+    def get_logger(self):
+        return _Logger()
+
+
+class _QoSProfile:
+    def __init__(self, **kwargs):
+        self.settings = kwargs
+
+
+class _Policy:
+    RELIABLE = "reliable"
+    BEST_EFFORT = "best_effort"
+    KEEP_LAST = "keep_last"
+    VOLATILE = "volatile"
+
+
+class _Executor:
+    def __init__(self):
+        self.nodes = []
+
+    def add_node(self, node):
+        self.nodes.append(node)
+
+
+class _Ros2:
+    def __init__(self):
+        self.ctx_tianyi = object()
+        self.ctx_core = object()
+        self.executor_tianyi = _Executor()
+        self.executor_core = _Executor()
+
+
+def _install_ros_stubs():
+    rclpy = types.ModuleType("rclpy")
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_qos = types.ModuleType("rclpy.qos")
+    std_msgs = types.ModuleType("std_msgs")
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    sensor_msgs = types.ModuleType("sensor_msgs")
+    sensor_msgs_msg = types.ModuleType("sensor_msgs.msg")
+
+    rclpy_node.Node = _Node
+    rclpy_qos.QoSProfile = _QoSProfile
+    rclpy_qos.ReliabilityPolicy = _Policy
+    rclpy_qos.HistoryPolicy = _Policy
+    rclpy_qos.DurabilityPolicy = _Policy
+    std_msgs_msg.String = _String
+    sensor_msgs_msg.Image = _Image
+
+    sys.modules.update(
+        {
+            "rclpy": rclpy,
+            "rclpy.node": rclpy_node,
+            "rclpy.qos": rclpy_qos,
+            "std_msgs": std_msgs,
+            "std_msgs.msg": std_msgs_msg,
+            "sensor_msgs": sensor_msgs,
+            "sensor_msgs.msg": sensor_msgs_msg,
+        }
+    )
+
+
+_install_ros_stubs()
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+camera_depth = importlib.import_module("camera_depth")
+hand_state = importlib.import_module("hand_state")
+remote_controller = importlib.import_module("remote_controller")
+
+
+class AtomicSensorTests(unittest.TestCase):
+    def test_tool_names_and_formats(self):
+        ros2 = _Ros2()
+        cases = [
+            (
+                hand_state.HandStatePlugin({}, "robot", ros2),
+                "hand_state",
+                "data/json",
+            ),
+            (
+                camera_depth.CameraDepthPlugin({}, "robot", ros2),
+                "camera_depth",
+                "image/depth-z16",
+            ),
+            (
+                remote_controller.RemoteControllerPlugin({}, "robot", ros2),
+                "remote_controller",
+                "data/json",
+            ),
+        ]
+
+        for plugin, name, output_format in cases:
+            with self.subTest(name=name):
+                tool = plugin.get_tool()
+                self.assertEqual(tool["name"], name)
+                self.assertEqual(tool["type"], "sensor")
+                self.assertEqual(tool["topic_out"][0]["format"], output_format)
+
+    def test_hand_state_aggregates_both_hands(self):
+        plugin = hand_state.HandStatePlugin({}, "robot", _Ros2())
+        plugin._running = True
+        left = types.SimpleNamespace(
+            header=_Header(1, 2, "left"),
+            name=["finger_1"],
+            position=[0.25],
+            velocity=[0.5],
+            effort=[0.75],
+        )
+        right = types.SimpleNamespace(
+            header=_Header(3, 4, "right"),
+            name=["finger_2"],
+            position=[0.4],
+            velocity=[0.6],
+            effort=[0.8],
+        )
+
+        plugin._on_hand_state("left", left)
+        plugin._on_hand_state("right", right)
+
+        payload = plugin.dispatch("hand_state", {})
+        self.assertEqual(payload["left"]["position"], [0.25])
+        self.assertEqual(payload["right"]["effort"], [0.8])
+        published = json.loads(plugin._pub.messages[-1].data)
+        self.assertEqual(published["left"]["name"], ["finger_1"])
+        self.assertEqual(published["right"]["name"], ["finger_2"])
+
+        published_count = len(plugin._pub.messages)
+        plugin.stop()
+        plugin._on_hand_state("left", left)
+        self.assertEqual(len(plugin._pub.messages), published_count)
+
+    def test_remote_controller_preserves_values_and_key_name(self):
+        plugin = remote_controller.RemoteControllerPlugin({}, "robot", _Ros2())
+        plugin._running = True
+        msg = types.SimpleNamespace(
+            header=_Header(10, 20, "sbus"),
+            key_event_new=17,
+            key_event_old=16,
+            button_a=1,
+            button_b=2,
+            button_c=3,
+            button_d=4,
+            button_e=5,
+            button_f=6,
+            button_g=7,
+            button_h=8,
+            x1=0.1,
+            y1=-0.2,
+            x2=0.3,
+            y2=-0.4,
+        )
+
+        plugin._on_remote_controller(msg)
+        payload = plugin.dispatch("remote_controller", {})
+        self.assertEqual(payload["key_event_new"], 17)
+        self.assertEqual(payload["key_event_new_name"], "g_right")
+        self.assertEqual(payload["button_h"], 8)
+        self.assertAlmostEqual(payload["y2"], -0.4)
+
+        published_count = len(plugin._pub.messages)
+        plugin.stop()
+        plugin._on_remote_controller(msg)
+        self.assertEqual(len(plugin._pub.messages), published_count)
+
+    def test_depth_conversion_removes_padding(self):
+        plugin = camera_depth.CameraDepthPlugin({}, "robot", _Ros2())
+        source = _Image()
+        source.header = _Header(5, 6, "depth")
+        source.width = 2
+        source.height = 2
+        source.encoding = "16UC1"
+        source.step = 6
+        source.data = b"\x01\x00\x02\x00xx\x03\x00\x04\x00yy"
+
+        output = plugin._to_depth_z16(source)
+        self.assertEqual(output.encoding, "16UC1")
+        self.assertEqual(output.step, 4)
+        self.assertEqual(output.data, b"\x01\x00\x02\x00\x03\x00\x04\x00")
+
+    def test_depth_conversion_swaps_big_endian_pixels(self):
+        plugin = camera_depth.CameraDepthPlugin({}, "robot", _Ros2())
+        source = _Image()
+        source.width = 2
+        source.height = 1
+        source.encoding = "mono16"
+        source.is_bigendian = 1
+        source.step = 4
+        source.data = b"\x00\x01\x00\x02"
+
+        output = plugin._to_depth_z16(source)
+        self.assertEqual(output.is_bigendian, 0)
+        self.assertEqual(output.data, b"\x01\x00\x02\x00")
+
+    def test_depth_lifecycle_releases_resources_before_restart(self):
+        plugin = camera_depth.CameraDepthPlugin({}, "robot", _Ros2())
+
+        plugin.start()
+        first_publisher = plugin._publisher
+        plugin.stop()
+        self.assertEqual(plugin._pub_node.publishers, [])
+        self.assertEqual(plugin._sub_node.subscriptions, [])
+
+        plugin.start()
+        self.assertIsNot(plugin._publisher, first_publisher)
+        self.assertEqual(len(plugin._pub_node.publishers), 1)
+        self.assertEqual(len(plugin._sub_node.subscriptions), 1)
+        plugin.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
本 PR 为天轶 2.0 Pro 驱动新增三张原子传感器卡片：
hand_state：订阅左右 Inspire 灵巧手状态，输出关节名称、位置、速度和力反馈，为抓取闭环控制提供状态数据。
camera_depth：转发 Orbbec 头部相机深度图，支持 16UC1/mono16，统一输出紧密排列的小端 Z16 毫米深度数据。
remote_controller：订阅 SBUS 遥控器事件，输出按键、拨杆、双摇杆及按键事件名称。
三张卡片均已集成至 Tianyi MCP Bundle，完成 config.yaml 默认启用、main.py 注册及 Docker 镜像打包。实现包含线程安全缓存、完整的 start/stop/info 生命周期和跨 ROS Domain 数据转发，并新增 6 项单元测试，覆盖数据转换、状态聚合、停止后禁止发布及深度卡资源释放与重启。ARM64 镜像已在本地构建验证通过。