### PR TITLE
feat(tianyi2): add state monitoring and semantic action cards

### DIFF
--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -1,0 +1,43 @@
+# Tianyi 2.0 Pro Driver
+
+Phanthy Motus driver bundle for the Tianyi 2.0 Pro humanoid robot. The driver
+bridges robot-side ROS2 topics on domain 0 to Agent Core topics on domain 42 and
+exposes the capabilities as MCP tools.
+
+## Service state card
+
+`service_state` aggregates the robot's internal `NodeState` messages and reports
+the latest running/idle state for each service topic.
+
+| Item | Value |
+|---|---|
+| Tool name | `service_state` |
+| Tool type | `sensor` |
+| Robot-side inputs | `/bodycontrol_state`, `/node/status` |
+| Agent Core output | `/{namespace}/state/service_state` |
+| Output format | `data/json` |
+
+The target robot confirms both inputs as `bodyctrl_msgs/msg/NodeState` with
+RELIABLE publishers. `/node/status` continuously reports the process manager;
+`/bodycontrol_state` is an event-oriented stream published by components such as
+the power board and Bluetooth server.
+
+## Motor faults card
+
+`motor_faults` reports only motors whose vendor error code is non-zero. It does
+not duplicate the joint position, velocity, current, or temperature stream.
+
+| Item | Value |
+|---|---|
+| Tool name | `motor_faults` |
+| Tool type | `sensor` |
+| Robot-side inputs | `/head/status`, `/arm/status`, `/waist/status`, `/leg/status` |
+| Agent Core output | `/{namespace}/state/motor_faults` |
+| Output format | `data/json` |
+
+When a motor's error code returns to zero, it is removed from the active fault
+list. Error codes are preserved as vendor-provided integers; this driver does
+not invent descriptions without an authoritative error-code table.
+
+Both cards are read-only. They do not command joints, stop the robot, trigger an
+emergency stop, or modify any robot-side configuration.

--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -4,42 +4,28 @@ Phanthy Motus driver bundle for the Tianyi 2.0 Pro humanoid robot. The driver
 bridges robot-side ROS2 topics on domain 0 to Agent Core topics on domain 42 and
 exposes the capabilities as MCP tools.
 
-## Service state card
+## Robot faults card
 
-`service_state` aggregates the robot's internal `NodeState` messages and reports
-the latest running/idle state for each service topic.
-
-| Item | Value |
-|---|---|
-| Tool name | `service_state` |
-| Tool type | `sensor` |
-| Robot-side inputs | `/bodycontrol_state`, `/node/status` |
-| Agent Core output | `/{namespace}/state/service_state` |
-| Output format | `data/json` |
-
-The target robot confirms both inputs as `bodyctrl_msgs/msg/NodeState` with
-RELIABLE publishers. `/node/status` continuously reports the process manager;
-`/bodycontrol_state` is an event-oriented stream published by components such as
-the power board and Bluetooth server.
-
-## Motor faults card
-
-`motor_faults` reports only motors whose vendor error code is non-zero. It does
-not duplicate the joint position, velocity, current, or temperature stream.
+`robot_faults` aggregates verified fault signals from the robot's motors, both
+Inspire hands, and the physical/remote emergency-stop state. Input callbacks
+only update an in-memory snapshot; the Agent Core output is published at 1Hz.
 
 | Item | Value |
 |---|---|
-| Tool name | `motor_faults` |
+| Tool name | `robot_faults` |
 | Tool type | `sensor` |
-| Robot-side inputs | `/head/status`, `/arm/status`, `/waist/status`, `/leg/status` |
-| Agent Core output | `/{namespace}/state/motor_faults` |
+| Robot-side inputs | `/head/status`, `/arm/status`, `/waist/status`, `/leg/status`, `/inspire_hand/error/left_hand`, `/inspire_hand/error/right_hand`, `/power/board/key_status` |
+| Agent Core output | `/{namespace}/state/robot_faults` |
 | Output format | `data/json` |
+| Output rate | 1Hz |
 
-When a motor's error code returns to zero, it is removed from the active fault
+When an input error code returns to zero, it is removed from the active fault
 list. Error codes are preserved as vendor-provided integers; this driver does
-not invent descriptions without an authoritative error-code table.
+not invent descriptions without an authoritative error-code table. Power
+voltage, current and temperature are not classified as faults because the SDK
+does not provide authoritative alarm thresholds.
 
-Both cards are read-only. They do not command joints, stop the robot, trigger an
+The card is read-only. It does not command joints, stop the robot, trigger an
 emergency stop, or modify any robot-side configuration.
 
 ## Head gesture card
@@ -57,7 +43,18 @@ semantic sequences.
 
 Yaw, pitch and roll are clamped to the limits already documented by the raw
 `head` card. Starting a new gesture cancels the remaining frames of the previous
-gesture; `stop` cancels future frames without issuing an additional pose.
+gesture; `stop` cancels future frames without issuing an additional pose. A nod
+moves from neutral to positive pitch (down) and back to neutral; it never passes
+through negative pitch (up).
+
+| Action | Dashboard defaults | Allowed range |
+|---|---|---|
+| `nod` | cycles 2, amplitude 12°, speed 30°/s | cycles 1–5, amplitude 5–20°, speed 5–60°/s |
+| `shake` | cycles 2, amplitude 25°, speed 30°/s | cycles 1–5, amplitude 5–45°, speed 5–60°/s |
+| `scan` | cycles 2, amplitude 25°, speed 30°/s, hold 1.0s/side | cycles 1–5, amplitude 5–45°, speed 5–60°/s, hold 0.2–3.0s/side |
+| `tilt` | left, amplitude 12°, speed 30°/s, hold 0.8s | side left/right, amplitude 5–20°, speed 5–60°/s, hold 0.2–3.0s |
+| `reset` | speed 30°/s | speed 5–60°/s |
+| `stop` | no parameters | no parameters |
 
 ## Arm gesture card
 
@@ -77,3 +74,12 @@ inside the checked-in URDF limits. The preset poses still require low-speed,
 clear-area calibration on the target robot before production use. Do not run
 the raw `arm` card and `arm_gesture` concurrently because both publish to the
 same controller topic.
+
+| Action | Dashboard defaults | Allowed range |
+|---|---|---|
+| `wave` | right arm, cycles 2, speed 0.5rad/s | side left/right/both, cycles 1–5, speed 0.2–1.5rad/s |
+| `salute` | right arm, speed 0.5rad/s | side left/right/both, speed 0.2–1.5rad/s |
+| `welcome` | right arm, speed 0.5rad/s | side left/right/both, speed 0.2–1.5rad/s |
+| `raise` | right arm, speed 0.5rad/s | side left/right/both, speed 0.2–1.5rad/s |
+| `reset` | right arm, speed 0.5rad/s | side left/right/both, speed 0.2–1.5rad/s |
+| `stop` | no parameters | no parameters |

--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -41,3 +41,56 @@ not invent descriptions without an authoritative error-code table.
 
 Both cards are read-only. They do not command joints, stop the robot, trigger an
 emergency stop, or modify any robot-side configuration.
+
+## Status light card
+
+`status_light` publishes the official `PowerLightCtrl` events to
+`/power/light/ctrl`. The vendor message contains only an integer `cmd`; RGB,
+brightness and blink-frequency controls are intentionally not invented.
+
+| Item | Value |
+|---|---|
+| Tool name | `status_light` |
+| Tool type | `actuator` |
+| Robot-side output | `/power/light/ctrl` |
+| Message type | `bodyctrl_msgs/msg/PowerLightCtrl` |
+| Action | `set_event` |
+
+Supported events match `PowerLightCtrl.msg`, including power-on, service,
+self-check, fault, warning, voice, running and power-off state transitions.
+
+## Head gesture card
+
+`head_gesture` turns safe, bounded head-position commands into cancellable
+semantic sequences.
+
+| Item | Value |
+|---|---|
+| Tool name | `head_gesture` |
+| Tool type | `actuator` |
+| Robot-side output | `/head/cmd_pos` |
+| Message type | `bodyctrl_msgs/msg/CmdSetMotorPosition` |
+| Actions | `nod`, `shake`, `scan`, `tilt`, `reset`, `stop` |
+
+Yaw, pitch and roll are clamped to the limits already documented by the raw
+`head` card. Starting a new gesture cancels the remaining frames of the previous
+gesture; `stop` cancels future frames without issuing an additional pose.
+
+## Arm gesture card
+
+`arm_gesture` provides semantic arm motions on top of the existing joint-level
+`arm` card.
+
+| Item | Value |
+|---|---|
+| Tool name | `arm_gesture` |
+| Tool type | `actuator` |
+| Robot-side output | `/arm/cmd_pos` |
+| Message type | `bodyctrl_msgs/msg/CmdSetMotorPosition` |
+| Actions | `wave`, `salute`, `welcome`, `raise`, `reset`, `stop` |
+
+The right-arm poses are mirrored from the left-arm definitions and remain
+inside the checked-in URDF limits. The preset poses still require low-speed,
+clear-area calibration on the target robot before production use. Do not run
+the raw `arm` card and `arm_gesture` concurrently because both publish to the
+same controller topic.

--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -42,23 +42,6 @@ not invent descriptions without an authoritative error-code table.
 Both cards are read-only. They do not command joints, stop the robot, trigger an
 emergency stop, or modify any robot-side configuration.
 
-## Status light card
-
-`status_light` publishes the official `PowerLightCtrl` events to
-`/power/light/ctrl`. The vendor message contains only an integer `cmd`; RGB,
-brightness and blink-frequency controls are intentionally not invented.
-
-| Item | Value |
-|---|---|
-| Tool name | `status_light` |
-| Tool type | `actuator` |
-| Robot-side output | `/power/light/ctrl` |
-| Message type | `bodyctrl_msgs/msg/PowerLightCtrl` |
-| Action | `set_event` |
-
-Supported events match `PowerLightCtrl.msg`, including power-on, service,
-self-check, fault, warning, voice, running and power-off state transitions.
-
 ## Head gesture card
 
 `head_gesture` turns safe, bounded head-position commands into cancellable

--- a/x-humanoid/tianyi2.0/config.yaml
+++ b/x-humanoid/tianyi2.0/config.yaml
@@ -26,8 +26,6 @@ plugins:
     enabled: true
   nav_state:
     enabled: true
-  status_light:
-    enabled: true
   head:
     enabled: true
   head_gesture:

--- a/x-humanoid/tianyi2.0/config.yaml
+++ b/x-humanoid/tianyi2.0/config.yaml
@@ -26,9 +26,15 @@ plugins:
     enabled: true
   nav_state:
     enabled: true
+  status_light:
+    enabled: true
   head:
     enabled: true
+  head_gesture:
+    enabled: true
   arm:
+    enabled: true
+  arm_gesture:
     enabled: true
   waist:
     enabled: true

--- a/x-humanoid/tianyi2.0/config.yaml
+++ b/x-humanoid/tianyi2.0/config.yaml
@@ -8,6 +8,18 @@ slamtec:
 plugins:
   state:
     enabled: true
+  service_state:
+    enabled: true
+    source_topics:
+      - "/bodycontrol_state"
+      - "/node/status"
+  motor_faults:
+    enabled: true
+    motor_status_topics:
+      - "/head/status"
+      - "/arm/status"
+      - "/waist/status"
+      - "/leg/status"
   camera:
     enabled: true
   asr:

--- a/x-humanoid/tianyi2.0/config.yaml
+++ b/x-humanoid/tianyi2.0/config.yaml
@@ -8,18 +8,17 @@ slamtec:
 plugins:
   state:
     enabled: true
-  service_state:
-    enabled: true
-    source_topics:
-      - "/bodycontrol_state"
-      - "/node/status"
-  motor_faults:
+  robot_faults:
     enabled: true
     motor_status_topics:
       - "/head/status"
       - "/arm/status"
       - "/waist/status"
       - "/leg/status"
+    hand_error_topics:
+      left: "/inspire_hand/error/left_hand"
+      right: "/inspire_hand/error/right_hand"
+    estop_topic: "/power/board/key_status"
   camera:
     enabled: true
   asr:

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -20,8 +20,11 @@ x-humanoid/tianyi2.0/device.py — 天轶2.0 Pro 设备插件。
   CameraPlugin     (sensor)             — Orbbec 头部相机
   AsrPlugin        (sensor)             — 语音识别结果
   NavStatePlugin   (sensor)             — 底盘导航状态
+  StatusLightPlugin (actuator)          — 机器人状态灯事件
   HeadPlugin       (actuator)           — 头部3DOF控制
+  HeadGesturePlugin (actuator)          — 点头/摇头/左右观察等语义动作
   ArmPlugin        (actuator)           — 双臂14DOF控制
+  ArmGesturePlugin (actuator)           — 挥手/敬礼/欢迎等语义动作
   WaistPlugin      (actuator)           — 腰部2DOF控制
   HandPlugin       (actuator)           — 灵巧手控制
   TtsPlugin        (actuator)           — 语音合成
@@ -113,6 +116,58 @@ def _stamp_to_ms(stamp) -> int | None:
         return int(stamp.sec * 1000 + stamp.nanosec / 1_000_000)
     except (AttributeError, TypeError, ValueError):
         return None
+
+
+def _clamp(value: float, lower: float, upper: float) -> float:
+    """Clamp a numeric input to a safe, documented range."""
+    return max(lower, min(upper, float(value)))
+
+
+class _ActionSequence:
+    """Run one cancellable actuator sequence at a time."""
+
+    def __init__(self, name: str):
+        self._name = name
+        self._lock = threading.Lock()
+        self._cancel_event: threading.Event | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self, worker) -> None:
+        self.cancel()
+        cancel_event = threading.Event()
+
+        def _run():
+            try:
+                worker(cancel_event)
+            except Exception as e:
+                print(f"[{self._name}] sequence failed: {e}")
+            finally:
+                with self._lock:
+                    if self._cancel_event is cancel_event:
+                        self._cancel_event = None
+                        self._thread = None
+
+        thread = threading.Thread(
+            target=_run, name=f"{self._name}_sequence", daemon=True)
+        with self._lock:
+            self._cancel_event = cancel_event
+            self._thread = thread
+        thread.start()
+
+    def cancel(self) -> bool:
+        with self._lock:
+            cancel_event = self._cancel_event
+            thread = self._thread
+        if cancel_event is None:
+            return False
+        cancel_event.set()
+        if thread and thread is not threading.current_thread():
+            thread.join(timeout=1.0)
+        with self._lock:
+            if self._cancel_event is cancel_event:
+                self._cancel_event = None
+                self._thread = None
+        return True
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -840,8 +895,106 @@ class NavStatePlugin:
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# HeadPlugin (actuator)
+# StatusLightPlugin (actuator)
 # ══════════════════════════════════════════════════════════════════════════════
+
+class StatusLightPlugin:
+    """发布电源板定义的状态灯事件。
+
+    PowerLightCtrl 消息只包含 cmd，灯效由电源板根据事件编号决定；
+    因此这里不暴露硬件未定义的 RGB、亮度或闪烁频率参数。
+    """
+
+    _EVENTS = {
+        "battery_supply": 1,
+        "power_on_start": 2,
+        "power_on_finish": 3,
+        "service_start": 4,
+        "service_finish": 5,
+        "self_check_start": 6,
+        "self_check_failed": 7,
+        "self_check_success": 8,
+        "fault_occur": 9,
+        "fault_clear": 10,
+        "voice_wakeup": 11,
+        "voice_response": 12,
+        "voice_exit": 13,
+        "running_start": 14,
+        "running_finish": 15,
+        "power_off": 16,
+        "warn_occur": 17,
+        "warn_clear": 18,
+    }
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        self._pub_node = Node("tianyi2_status_light_pub", context=ros2.ctx_tianyi)
+        ros2.executor_tianyi.add_node(self._pub_node)
+        self._publisher = None
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "status_light",
+            "type": "actuator",
+            "description": "天轶2.0 状态灯控制 — 向电源板发送官方定义的灯光状态事件",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string", "enum": ["set_event"],
+                        "description": "发送状态灯事件",
+                    },
+                    "event": {
+                        "type": "string", "enum": list(self._EVENTS),
+                        "description": "PowerLightCtrl.msg 定义的状态事件",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "set_event": {
+                        "params": ["event"],
+                        "description": "设置状态灯事件",
+                    },
+                },
+            },
+        }
+
+    def start(self):
+        try:
+            from bodyctrl_msgs.msg import PowerLightCtrl
+            self._publisher = self._pub_node.create_publisher(
+                PowerLightCtrl, "/power/light/ctrl", _RELIABLE_QOS)
+            print("[StatusLightPlugin] publisher created")
+        except ImportError as e:
+            print(f"[StatusLightPlugin] WARNING: msg import failed ({e})")
+
+    def stop(self):
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action == "set_event":
+            event = str(args.get("event", "")).strip()
+            if event not in self._EVENTS:
+                return {"error": "event must be one of the documented PowerLightCtrl events"}
+            if not self._publisher:
+                return {"error": "publisher not initialized"}
+            try:
+                from bodyctrl_msgs.msg import PowerLightCtrl
+                msg = PowerLightCtrl()
+                msg.cmd = self._EVENTS[event]
+                self._publisher.publish(msg)
+                return {"state": "sent", "event": event, "cmd": msg.cmd}
+            except Exception as e:
+                return {"error": str(e)}
+        if action in ("start", "info"):
+            return {"state": "ready" if self._publisher else "idle"}
+        if action == "stop":
+            return {"state": "idle"}
+        return {"error": f"unknown action: {action}"}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# HeadPlugin (actuator)
+# ═════════════════════════════════════════════════════════════════════════════════
 
 class HeadPlugin:
     """头部3DOF位置控制 (roll/pitch/yaw)"""
@@ -936,8 +1089,161 @@ class HeadPlugin:
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# ArmPlugin (actuator)
+# HeadGesturePlugin (actuator)
 # ══════════════════════════════════════════════════════════════════════════════
+
+class HeadGesturePlugin:
+    """可取消的头部语义动作序列。"""
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        self._pub_node = Node("tianyi2_head_gesture_pub", context=ros2.ctx_tianyi)
+        ros2.executor_tianyi.add_node(self._pub_node)
+        self._publisher = None
+        self._sequence = _ActionSequence("HeadGesturePlugin")
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "head_gesture",
+            "type": "actuator",
+            "description": "天轶2.0 头部语义动作 — 点头、摇头、左右观察、歪头和回正",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["nod", "shake", "scan", "tilt", "reset", "stop"],
+                        "description": "头部动作",
+                    },
+                    "cycles": {
+                        "type": "integer", "minimum": 1, "maximum": 5,
+                        "default": 2, "description": "循环次数",
+                    },
+                    "amplitude": {
+                        "type": "number", "minimum": 5, "maximum": 45,
+                        "description": "动作幅度(度)，会再按各关节极限限幅",
+                    },
+                    "speed": {
+                        "type": "number", "minimum": 5, "maximum": 60,
+                        "default": 30, "description": "动作速度(度/秒)",
+                    },
+                    "side": {
+                        "type": "string", "enum": ["left", "right"],
+                        "default": "left", "description": "歪头方向",
+                    },
+                    "hold": {
+                        "type": "number", "minimum": 0.2, "maximum": 3.0,
+                        "default": 0.8, "description": "歪头保持时间(秒)",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "nod": {"params": ["cycles", "amplitude", "speed"], "description": "连续点头后回正"},
+                    "shake": {"params": ["cycles", "amplitude", "speed"], "description": "连续摇头后回正"},
+                    "scan": {"params": ["cycles", "amplitude", "speed"], "description": "左右观察后回正"},
+                    "tilt": {"params": ["side", "amplitude", "speed", "hold"], "description": "向指定方向歪头后回正"},
+                    "reset": {"params": ["speed"], "description": "取消序列并将头部回正"},
+                    "stop": {"params": [], "description": "取消尚未发送的后续动作帧"},
+                },
+            },
+        }
+
+    def start(self):
+        try:
+            from bodyctrl_msgs.msg import CmdSetMotorPosition
+            self._publisher = self._pub_node.create_publisher(
+                CmdSetMotorPosition, "/head/cmd_pos", _RELIABLE_QOS)
+            print("[HeadGesturePlugin] publisher created")
+        except ImportError as e:
+            print(f"[HeadGesturePlugin] WARNING: msg import failed ({e})")
+
+    def stop(self):
+        self._sequence.cancel()
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("start", "info"):
+            return {"state": "ready" if self._publisher else "idle"}
+        if action == "stop":
+            return {"state": "stopped", "cancelled": self._sequence.cancel()}
+        if action == "reset":
+            self._sequence.cancel()
+            return self._publish_pose(0, 0, 0, args.get("speed", 30))
+        if action not in ("nod", "shake", "scan", "tilt"):
+            return {"error": f"unknown action: {action}"}
+        if not self._publisher:
+            return {"error": "publisher not initialized"}
+
+        cycles = int(_clamp(args.get("cycles", 2), 1, 5))
+        speed = _clamp(args.get("speed", 30), 5, 60)
+        amplitude_default = 12 if action in ("nod", "tilt") else 25
+        amplitude = _clamp(args.get("amplitude", amplitude_default), 5, 45)
+
+        frames: list[tuple[float, float, float, float]] = []
+        if action == "nod":
+            amplitude = min(amplitude, 20)
+            for _ in range(cycles):
+                frames.extend([(0, amplitude, 0, amplitude / speed),
+                               (0, -amplitude, 0, 2 * amplitude / speed)])
+        elif action == "shake":
+            amplitude = min(amplitude, 45)
+            for _ in range(cycles):
+                frames.extend([(amplitude, 0, 0, amplitude / speed),
+                               (-amplitude, 0, 0, 2 * amplitude / speed)])
+        elif action == "scan":
+            amplitude = min(amplitude, 45)
+            for _ in range(cycles):
+                frames.extend([(amplitude, 0, 0, amplitude / speed),
+                               (0, 0, 0, amplitude / speed),
+                               (-amplitude, 0, 0, amplitude / speed),
+                               (0, 0, 0, amplitude / speed)])
+        else:
+            amplitude = min(amplitude, 20)
+            roll = amplitude if args.get("side", "left") == "left" else -amplitude
+            hold = _clamp(args.get("hold", 0.8), 0.2, 3.0)
+            frames.append((0, 0, roll, amplitude / speed + hold))
+        frames.append((0, 0, 0, max(0.15, amplitude / speed)))
+
+        def _worker(cancel_event: threading.Event):
+            for yaw, pitch, roll, delay in frames:
+                if cancel_event.is_set():
+                    return
+                result = self._publish_pose(yaw, pitch, roll, speed)
+                if "error" in result or cancel_event.wait(max(0.15, delay)):
+                    return
+
+        self._sequence.start(_worker)
+        return {
+            "state": "running", "gesture": action, "cycles": cycles,
+            "amplitude": amplitude, "speed": speed,
+        }
+
+    def _publish_pose(self, yaw_deg: float, pitch_deg: float,
+                      roll_deg: float, speed_deg: float) -> dict:
+        if not self._publisher:
+            return {"error": "publisher not initialized"}
+        try:
+            from bodyctrl_msgs.msg import CmdSetMotorPosition, SetMotorPosition
+            yaw_deg = _clamp(yaw_deg, -90, 90)
+            pitch_deg = _clamp(pitch_deg, -25, 25)
+            roll_deg = _clamp(roll_deg, -26, 26)
+            speed_rad = _deg2rad(_clamp(speed_deg, 5, 60))
+            msg = CmdSetMotorPosition()
+            msg.cmds = []
+            for motor_id, deg in [(1, roll_deg), (2, pitch_deg), (3, yaw_deg)]:
+                cmd = SetMotorPosition()
+                cmd.name = motor_id
+                cmd.pos = _deg2rad(deg)
+                cmd.spd = speed_rad
+                cmd.cur = 3.0
+                msg.cmds.append(cmd)
+            self._publisher.publish(msg)
+            return {"state": "moving", "yaw": yaw_deg, "pitch": pitch_deg, "roll": roll_deg}
+        except Exception as e:
+            return {"error": str(e)}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ArmPlugin (actuator)
+# ════════════════════════════════════════════════════════════════════════════════
 
 class ArmPlugin:
     """双臂14DOF控制 (位置模式 / 力位混合)"""
@@ -1076,8 +1382,158 @@ class ArmPlugin:
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# WaistPlugin (actuator)
+# ArmGesturePlugin (actuator)
 # ══════════════════════════════════════════════════════════════════════════════
+
+class ArmGesturePlugin:
+    """可取消的挥手、敬礼和欢迎手势序列。"""
+
+    _NEUTRAL = [0, 0, 0, 0, 0, 0, 0]
+    # 角度顺序：肩 pitch、肩 roll、肩 yaw、肘 pitch、腕 yaw、腕 pitch、腕 roll。
+    _GESTURES = {
+        "wave": [0, 55, 0, -85, 0, 0, 0],
+        "salute": [-20, 45, -15, -100, 0, 15, 0],
+        "welcome": [-20, 50, 0, -45, 0, 0, 0],
+        "raise": [0, 45, 0, -20, 0, 0, 0],
+    }
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        self._pub_node = Node("tianyi2_arm_gesture_pub", context=ros2.ctx_tianyi)
+        ros2.executor_tianyi.add_node(self._pub_node)
+        self._publisher = None
+        self._sequence = _ActionSequence("ArmGesturePlugin")
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "arm_gesture",
+            "type": "actuator",
+            "description": "天轶2.0 手臂语义动作 — 挥手、敬礼、欢迎、举手和回正",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["wave", "salute", "welcome", "raise", "reset", "stop"],
+                        "description": "手臂动作",
+                    },
+                    "side": {
+                        "type": "string", "enum": ["left", "right", "both"],
+                        "default": "right", "description": "执行手臂",
+                    },
+                    "cycles": {
+                        "type": "integer", "minimum": 1, "maximum": 5,
+                        "default": 2, "description": "挥手循环次数",
+                    },
+                    "speed": {
+                        "type": "number", "minimum": 0.2, "maximum": 1.5,
+                        "default": 0.5, "description": "关节速度(rad/s)",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "wave": {"params": ["side", "cycles", "speed"], "description": "举手后挥手并回到中性姿态"},
+                    "salute": {"params": ["side", "speed"], "description": "执行敬礼姿态并回正"},
+                    "welcome": {"params": ["side", "speed"], "description": "执行欢迎展示姿态并回正"},
+                    "raise": {"params": ["side", "speed"], "description": "举手并回正"},
+                    "reset": {"params": ["side", "speed"], "description": "取消序列并回到中性姿态"},
+                    "stop": {"params": [], "description": "取消尚未发送的后续动作帧"},
+                },
+            },
+        }
+
+    def start(self):
+        try:
+            from bodyctrl_msgs.msg import CmdSetMotorPosition
+            self._publisher = self._pub_node.create_publisher(
+                CmdSetMotorPosition, "/arm/cmd_pos", _RELIABLE_QOS)
+            print("[ArmGesturePlugin] publisher created")
+        except ImportError as e:
+            print(f"[ArmGesturePlugin] WARNING: msg import failed ({e})")
+
+    def stop(self):
+        self._sequence.cancel()
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("start", "info"):
+            return {"state": "ready" if self._publisher else "idle"}
+        if action == "stop":
+            return {"state": "stopped", "cancelled": self._sequence.cancel()}
+        side = args.get("side", "right")
+        if side not in ("left", "right", "both"):
+            return {"error": "side must be left, right or both"}
+        speed = _clamp(args.get("speed", 0.5), 0.2, 1.5)
+        if action == "reset":
+            self._sequence.cancel()
+            return self._publish_pose(side, self._NEUTRAL, speed)
+        if action not in self._GESTURES:
+            return {"error": f"unknown action: {action}"}
+        if not self._publisher:
+            return {"error": "publisher not initialized"}
+
+        pose = self._GESTURES[action]
+        cycles = int(_clamp(args.get("cycles", 2), 1, 5))
+        frames = [(pose, 0.8)]
+        if action == "wave":
+            for i in range(cycles * 2):
+                wave_pose = list(pose)
+                wave_pose[4] = 30 if i % 2 == 0 else -30
+                frames.append((wave_pose, 0.6))
+        frames.append((self._NEUTRAL, 1.0))
+
+        def _worker(cancel_event: threading.Event):
+            previous = self._NEUTRAL
+            for frame, hold in frames:
+                if cancel_event.is_set():
+                    return
+                result = self._publish_pose(side, frame, speed)
+                max_delta_rad = max(
+                    abs(_deg2rad(float(current) - float(old)))
+                    for current, old in zip(frame, previous)
+                )
+                transition = max_delta_rad / speed if speed > 0 else 0
+                previous = frame
+                if "error" in result or cancel_event.wait(transition + hold):
+                    return
+
+        self._sequence.start(_worker)
+        return {"state": "running", "gesture": action, "side": side,
+                "cycles": cycles, "speed": speed}
+
+    def _publish_pose(self, side: str, left_pose: list[float], speed: float) -> dict:
+        if not self._publisher:
+            return {"error": "publisher not initialized"}
+        if len(left_pose) != 7:
+            return {"error": "internal pose must have 7 values"}
+        try:
+            from bodyctrl_msgs.msg import CmdSetMotorPosition, SetMotorPosition
+            # Mirror the lateral axes for the right arm. All values remain within
+            # the URDF limits used by the existing arm card.
+            right_pose = [left_pose[0], -left_pose[1], -left_pose[2],
+                          left_pose[3], -left_pose[4], left_pose[5], -left_pose[6]]
+            selected = []
+            if side in ("left", "both"):
+                selected.append((11, left_pose))
+            if side in ("right", "both"):
+                selected.append((21, right_pose))
+            msg = CmdSetMotorPosition()
+            msg.cmds = []
+            for base_id, pose in selected:
+                for index, deg in enumerate(pose):
+                    cmd = SetMotorPosition()
+                    cmd.name = base_id + index
+                    cmd.pos = _deg2rad(float(deg))
+                    cmd.spd = speed
+                    cmd.cur = 5.0
+                    msg.cmds.append(cmd)
+            self._publisher.publish(msg)
+            return {"state": "moving", "side": side, "joints": len(msg.cmds)}
+        except Exception as e:
+            return {"error": str(e)}
+
+
+# ══════════════════════════════════════════════════════════
+# WaistPlugin (actuator)
+# ══════════════════════════════════════════════════════════════════════════
 
 class WaistPlugin:
     """腰部2DOF控制 (yaw/pitch)"""

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -15,8 +15,7 @@ x-humanoid/tianyi2.0/device.py — 天轶2.0 Pro 设备插件。
 
 插件列表：
   StatePlugin      (sensor, multi-tool) — 关节/电池/急停/力传感器/URDF
-  ServiceStatePlugin (sensor)           — ROS2 服务节点运行状态
-  MotorFaultsPlugin (sensor)            — 电机错误码汇总
+  RobotFaultsPlugin (sensor)            — 全机故障汇总
   CameraPlugin     (sensor)             — Orbbec 头部相机
   AsrPlugin        (sensor)             — 语音识别结果
   NavStatePlugin   (sensor)             — 底盘导航状态
@@ -431,144 +430,45 @@ class StatePlugin:
         return {"error": f"unknown action: {action_or_tool}"}
 
 
-# ══════════════════════════════════════════════════════════════════════════════════
-# ServiceStatePlugin (sensor)
-# ══════════════════════════════════════════════════════════════════════════════════
-
-class ServiceStatePlugin:
-    """Track the latest running/idle state for robot services or topics."""
-
-    def __init__(self, plugin_config: dict, namespace: str, ros2):
-        configured_topics = plugin_config.get("source_topics")
-        if configured_topics is None:
-            configured_topics = [plugin_config.get("source_topic", "")]
-        self._source_topics = [
-            str(topic).strip() for topic in configured_topics
-            if str(topic).strip()
-        ]
-        self._topic = f"/{namespace}/state/service_state"
-        self._running = False
-        self._services = {}
-        self._last_update_ms = None
-        self._lock = threading.Lock()
-
-        self._sub_node = Node(
-            "tianyi2_service_state_sub", context=ros2.ctx_tianyi)
-        ros2.executor_tianyi.add_node(self._sub_node)
-        self._pub_node = Node(
-            "tianyi2_service_state_pub", context=ros2.ctx_core)
-        ros2.executor_core.add_node(self._pub_node)
-        self._publisher = self._pub_node.create_publisher(
-            String, self._topic, _RELIABLE_QOS)
-
-    def get_tool(self) -> dict:
-        return {
-            "name": "service_state",
-            "type": "sensor",
-            "description": "天轶2.0 内部服务状态 — 按Topic汇总节点 running/idle 状态",
-            "inputSchema": {"type": "object", "properties": {}},
-            "topic_out": [{"topic": self._topic, "format": "data/json"}],
-        }
-
-    def start(self):
-        self._running = True
-        if not self._source_topics:
-            print("[ServiceStatePlugin] source topics not configured")
-            return
-        try:
-            from bodyctrl_msgs.msg import NodeState
-            for source_topic in self._source_topics:
-                self._sub_node.create_subscription(
-                    NodeState, source_topic,
-                    lambda msg, topic=source_topic: self._on_state(msg, topic),
-                    _RELIABLE_QOS,
-                )
-        except ImportError as e:
-            print(f"[ServiceStatePlugin] WARNING: msg import failed ({e}), running in stub mode")
-
-    def stop(self):
-        self._running = False
-
-    def _on_state(self, msg, source_topic: str = ""):
-        state_code = int(msg.state)
-        state = {0: "idle", 1: "running"}.get(state_code, "unknown")
-        now_ms = int(time.time() * 1000)
-        service_key = f"{source_topic}:{msg.topic}" if source_topic else msg.topic
-        with self._lock:
-            self._services[service_key] = {
-                "topic": msg.topic,
-                "source_topic": source_topic,
-                "state": state,
-                "state_code": state_code,
-                "timestamp_ms": _stamp_to_ms(msg.header.stamp) or now_ms,
-            }
-            self._last_update_ms = now_ms
-            payload = self._build_payload_locked()
-        if self._running:
-            self._publisher.publish(String(data=json.dumps(payload)))
-
-    def _build_payload_locked(self) -> dict:
-        services = sorted(self._services.values(), key=lambda x: x["topic"])
-        return {
-            "available": self._last_update_ms is not None,
-            "timestamp_ms": int(time.time() * 1000),
-            "last_update_ms": self._last_update_ms,
-            "service_count": len(services),
-            "running_count": sum(s["state"] == "running" for s in services),
-            "idle_count": sum(s["state"] == "idle" for s in services),
-            "unknown_count": sum(s["state"] == "unknown" for s in services),
-            "services": services,
-        }
-
-    def dispatch(self, action: str, args: dict) -> dict | None:
-        if action == "service_state":
-            with self._lock:
-                return self._build_payload_locked()
-        if action == "start":
-            return {"state": "running"}
-        if action == "stop":
-            return {"state": "idle"}
-        if action == "info":
-            return {
-                "state": "running",
-                "source_topics": self._source_topics,
-                "topic_out": [{"topic": self._topic, "format": "data/json"}],
-            }
-        return None
-
-
 # ════════════════════════════════════════════════════════════════════════════════
-# MotorFaultsPlugin (sensor)
+# RobotFaultsPlugin (sensor)
 # ═════════════════════════════════════════════════════════════════════════════════
 
-class MotorFaultsPlugin:
-    """Expose non-zero motor error codes without duplicating joint telemetry."""
+class RobotFaultsPlugin:
+    """Aggregate verified motor, hand and emergency-stop fault sources."""
 
     def __init__(self, plugin_config: dict, namespace: str, ros2):
         default_topics = [
             "/head/status", "/arm/status", "/waist/status", "/leg/status"]
-        self._source_topics = plugin_config.get(
+        self._motor_topics = plugin_config.get(
             "motor_status_topics", default_topics)
-        self._topic = f"/{namespace}/state/motor_faults"
+        self._hand_topics = plugin_config.get("hand_error_topics", {
+            "left": "/inspire_hand/error/left_hand",
+            "right": "/inspire_hand/error/right_hand",
+        })
+        self._estop_topic = plugin_config.get(
+            "estop_topic", "/power/board/key_status")
+        self._topic = f"/{namespace}/state/robot_faults"
         self._running = False
         self._faults = {}
         self._last_update_ms = None
+        self._source_updates = {}
         self._lock = threading.Lock()
 
         self._sub_node = Node(
-            "tianyi2_motor_faults_sub", context=ros2.ctx_tianyi)
+            "tianyi2_robot_faults_sub", context=ros2.ctx_tianyi)
         ros2.executor_tianyi.add_node(self._sub_node)
         self._pub_node = Node(
-            "tianyi2_motor_faults_pub", context=ros2.ctx_core)
+            "tianyi2_robot_faults_pub", context=ros2.ctx_core)
         ros2.executor_core.add_node(self._pub_node)
         self._publisher = self._pub_node.create_publisher(
             String, self._topic, _RELIABLE_QOS)
 
     def get_tool(self) -> dict:
         return {
-            "name": "motor_faults",
+            "name": "robot_faults",
             "type": "sensor",
-            "description": "天轶2.0 电机故障汇总 — 仅输出非零电机错误码及关节名",
+            "description": "天轶2.0 全机故障汇总 — 电机、左右灵巧手及急停状态，固定1Hz",
             "inputSchema": {"type": "object", "properties": {}},
             "topic_out": [{"topic": self._topic, "format": "data/json"}],
         }
@@ -576,43 +476,132 @@ class MotorFaultsPlugin:
     def start(self):
         self._running = True
         try:
-            from bodyctrl_msgs.msg import MotorStatusMsg
-            for source_topic in self._source_topics:
+            from bodyctrl_msgs.msg import MotorStatusMsg, PowerBoardKeyStatus
+            from std_msgs.msg import UInt32MultiArray
+            for source_topic in self._motor_topics:
                 self._sub_node.create_subscription(
                     MotorStatusMsg, source_topic,
-                    lambda msg, topic=source_topic: self._on_status(msg, topic),
+                    lambda msg, topic=source_topic: self._on_motor_status(
+                        msg, topic),
                     _RELIABLE_QOS,
                 )
+            for side, source_topic in self._hand_topics.items():
+                self._sub_node.create_subscription(
+                    UInt32MultiArray, source_topic,
+                    lambda msg, hand=side, topic=source_topic:
+                    self._on_hand_error(msg, hand, topic),
+                    _RELIABLE_QOS,
+                )
+            self._sub_node.create_subscription(
+                PowerBoardKeyStatus, self._estop_topic,
+                self._on_estop, _RELIABLE_QOS)
         except ImportError as e:
-            print(f"[MotorFaultsPlugin] WARNING: msg import failed ({e}), running in stub mode")
+            print(f"[RobotFaultsPlugin] WARNING: msg import failed ({e}), running in stub mode")
+        self._pub_thread = threading.Thread(
+            target=self._publish_loop,
+            name="tianyi2_robot_faults_1hz",
+            daemon=True,
+        )
+        self._pub_thread.start()
 
     def stop(self):
         self._running = False
 
-    def _on_status(self, msg, source_topic: str):
+    def _on_motor_status(self, msg, source_topic: str):
         now_ms = int(time.time() * 1000)
         with self._lock:
             for motor in msg.status:
                 motor_id = int(motor.name)
+                fault_id = f"motor:{motor_id}"
                 if int(motor.error) == 0:
-                    self._faults.pop(motor_id, None)
+                    self._faults.pop(fault_id, None)
                     continue
-                self._faults[motor_id] = {
+                self._faults[fault_id] = {
+                    "fault_id": fault_id,
+                    "category": "motor",
                     "motor_id": motor_id,
-                    "joint_name": _ALL_JOINTS.get(
+                    "component": _ALL_JOINTS.get(
                         motor_id, f"motor_{motor_id}"),
                     "error_code": int(motor.error),
+                    "severity": "error",
                     "source_topic": source_topic,
                     "timestamp_ms": _stamp_to_ms(msg.header.stamp) or now_ms,
                 }
-            self._last_update_ms = now_ms
-            payload = self._build_payload_locked()
-        if self._running:
+            self._mark_source_updated_locked(source_topic, now_ms)
+
+    def _on_hand_error(self, msg, side: str, source_topic: str):
+        now_ms = int(time.time() * 1000)
+        prefix = f"hand:{side}:"
+        with self._lock:
+            for fault_id in [
+                    key for key in self._faults if key.startswith(prefix)]:
+                self._faults.pop(fault_id, None)
+            for index, error_code in enumerate(msg.data, start=1):
+                error_code = int(error_code)
+                if error_code == 0:
+                    continue
+                fault_id = f"{prefix}{index}"
+                self._faults[fault_id] = {
+                    "fault_id": fault_id,
+                    "category": "hand",
+                    "component": f"{side}_hand_error_channel_{index}",
+                    "error_code": error_code,
+                    "severity": "error",
+                    "source_topic": source_topic,
+                    "timestamp_ms": now_ms,
+                }
+            self._mark_source_updated_locked(source_topic, now_ms)
+
+    def _on_estop(self, msg):
+        now_ms = int(time.time() * 1000)
+        states = {
+            "physical": bool(msg.is_estop.data),
+            "remote": bool(msg.is_remote_estop.data),
+        }
+        with self._lock:
+            for kind, active in states.items():
+                fault_id = f"estop:{kind}"
+                if not active:
+                    self._faults.pop(fault_id, None)
+                    continue
+                self._faults[fault_id] = {
+                    "fault_id": fault_id,
+                    "category": "estop",
+                    "component": f"{kind}_estop",
+                    "error_code": 1,
+                    "severity": "fatal",
+                    "source_topic": self._estop_topic,
+                    "timestamp_ms": _stamp_to_ms(msg.header.stamp) or now_ms,
+                }
+            self._mark_source_updated_locked(self._estop_topic, now_ms)
+
+    def _mark_source_updated_locked(
+            self, source_topic: str, timestamp_ms: int) -> None:
+        self._source_updates[source_topic] = timestamp_ms
+        self._last_update_ms = timestamp_ms
+
+    def _publish_loop(self):
+        while self._running:
+            with self._lock:
+                payload = self._build_payload_locked()
             self._publisher.publish(String(data=json.dumps(payload)))
+            time.sleep(1.0)
 
     def _build_payload_locked(self) -> dict:
         faults = sorted(
-            self._faults.values(), key=lambda item: item["motor_id"])
+            self._faults.values(), key=lambda item: item["fault_id"])
+        expected_sources = (
+            list(self._motor_topics)
+            + list(self._hand_topics.values())
+            + [self._estop_topic]
+        )
+        sources = {
+            topic: {
+                "available": topic in self._source_updates,
+                "last_update_ms": self._source_updates.get(topic),
+            }
+            for topic in expected_sources
+        }
         return {
             "available": self._last_update_ms is not None,
             "timestamp_ms": int(time.time() * 1000),
@@ -620,16 +609,17 @@ class MotorFaultsPlugin:
             "healthy": self._last_update_ms is not None and not faults,
             "fault_count": len(faults),
             "summary": (
-                "尚未收到电机状态数据"
+                "尚未收到全机故障源数据"
                 if self._last_update_ms is None
-                else (f"检测到{len(faults)}个电机故障" if faults
-                      else "当前没有非零电机错误码")
+                else (f"检测到{len(faults)}个全机故障" if faults
+                      else "当前没有已知故障")
             ),
+            "sources": sources,
             "faults": faults,
         }
 
     def dispatch(self, action: str, args: dict) -> dict | None:
-        if action == "motor_faults":
+        if action == "robot_faults":
             with self._lock:
                 return self._build_payload_locked()
         if action == "start":
@@ -639,7 +629,12 @@ class MotorFaultsPlugin:
         if action == "info":
             return {
                 "state": "running",
-                "source_topics": self._source_topics,
+                "source_topics": (
+                    list(self._motor_topics)
+                    + list(self._hand_topics.values())
+                    + [self._estop_topic]
+                ),
+                "publish_rate_hz": 1,
                 "topic_out": [{"topic": self._topic, "format": "data/json"}],
             }
         return None
@@ -1013,35 +1008,60 @@ class HeadGesturePlugin:
                     "action": {
                         "type": "string",
                         "enum": ["nod", "shake", "scan", "tilt", "reset", "stop"],
-                        "description": "头部动作",
+                        "default": "nod",
+                        "description": "头部动作，可选[nod, shake, scan, tilt, reset, stop]",
                     },
                     "cycles": {
                         "type": "integer", "minimum": 1, "maximum": 5,
-                        "default": 2, "description": "循环次数",
+                        "default": 2, "description": "循环次数，范围[1, 5]，默认2",
                     },
-                    "amplitude": {
+                    "nod_amplitude": {
+                        "type": "number", "minimum": 5, "maximum": 20,
+                        "default": 12,
+                        "description": "点头向下幅度(度)，范围[5, 20]，默认12",
+                    },
+                    "shake_amplitude": {
                         "type": "number", "minimum": 5, "maximum": 45,
-                        "description": "动作幅度(度)，会再按各关节极限限幅",
+                        "default": 25,
+                        "description": "摇头左右幅度(度)，范围[5, 45]，默认25",
+                    },
+                    "scan_amplitude": {
+                        "type": "number", "minimum": 5, "maximum": 45,
+                        "default": 25,
+                        "description": "左右观察幅度(度)，范围[5, 45]，默认25",
+                    },
+                    "scan_hold": {
+                        "type": "number", "minimum": 0.2, "maximum": 3.0,
+                        "default": 1.0,
+                        "description": "左右观察时每侧停留时间(秒)，范围[0.2, 3.0]，默认1.0",
+                    },
+                    "tilt_amplitude": {
+                        "type": "number", "minimum": 5, "maximum": 20,
+                        "default": 12,
+                        "description": "歪头幅度(度)，范围[5, 20]，默认12",
                     },
                     "speed": {
                         "type": "number", "minimum": 5, "maximum": 60,
-                        "default": 30, "description": "动作速度(度/秒)",
+                        "default": 30,
+                        "description": "动作速度(度/秒)，范围[5, 60]，默认30",
                     },
                     "side": {
                         "type": "string", "enum": ["left", "right"],
-                        "default": "left", "description": "歪头方向",
+                        "default": "left",
+                        "description": "歪头方向，可选[left, right]，默认left",
                     },
                     "hold": {
                         "type": "number", "minimum": 0.2, "maximum": 3.0,
-                        "default": 0.8, "description": "歪头保持时间(秒)",
+                        "default": 0.8,
+                        "description": "歪头保持时间(秒)，范围[0.2, 3.0]，默认0.8",
                     },
                 },
                 "required": ["action"],
                 "x-action-params": {
-                    "nod": {"params": ["cycles", "amplitude", "speed"], "description": "连续点头后回正"},
-                    "shake": {"params": ["cycles", "amplitude", "speed"], "description": "连续摇头后回正"},
-                    "scan": {"params": ["cycles", "amplitude", "speed"], "description": "左右观察后回正"},
-                    "tilt": {"params": ["side", "amplitude", "speed", "hold"], "description": "向指定方向歪头后回正"},
+                    "nod": {"params": ["cycles", "nod_amplitude", "speed"], "description": "向下点头后回正，不经过抬头姿态"},
+                    "shake": {"params": ["cycles", "shake_amplitude", "speed"], "description": "在左右方向之间连续摇头后回正"},
+                    "scan": {"params": ["cycles", "scan_amplitude", "speed", "scan_hold"], "description": "依次观察左侧并停留、回中、观察右侧并停留、回中"},
+                    "tilt": {"params": ["side", "tilt_amplitude", "speed", "hold"], "description": "向指定方向歪头、保持后回正"},
                     "reset": {"params": ["speed"], "description": "取消序列并将头部回正"},
                     "stop": {"params": [], "description": "取消尚未发送的后续动作帧"},
                 },
@@ -1075,29 +1095,33 @@ class HeadGesturePlugin:
 
         cycles = int(_clamp(args.get("cycles", 2), 1, 5))
         speed = _clamp(args.get("speed", 30), 5, 60)
-        amplitude_default = 12 if action in ("nod", "tilt") else 25
-        amplitude = _clamp(args.get("amplitude", amplitude_default), 5, 45)
+        amplitude_specs = {
+            "nod": ("nod_amplitude", 12, 20),
+            "shake": ("shake_amplitude", 25, 45),
+            "scan": ("scan_amplitude", 25, 45),
+            "tilt": ("tilt_amplitude", 12, 20),
+        }
+        amplitude_key, amplitude_default, amplitude_max = amplitude_specs[action]
+        amplitude = _clamp(
+            args.get(amplitude_key, amplitude_default), 5, amplitude_max)
 
         frames: list[tuple[float, float, float, float]] = []
         if action == "nod":
-            amplitude = min(amplitude, 20)
             for _ in range(cycles):
                 frames.extend([(0, amplitude, 0, amplitude / speed),
-                               (0, -amplitude, 0, 2 * amplitude / speed)])
+                               (0, 0, 0, amplitude / speed)])
         elif action == "shake":
-            amplitude = min(amplitude, 45)
             for _ in range(cycles):
                 frames.extend([(amplitude, 0, 0, amplitude / speed),
                                (-amplitude, 0, 0, 2 * amplitude / speed)])
         elif action == "scan":
-            amplitude = min(amplitude, 45)
+            scan_hold = _clamp(args.get("scan_hold", 1.0), 0.2, 3.0)
             for _ in range(cycles):
-                frames.extend([(amplitude, 0, 0, amplitude / speed),
+                frames.extend([(amplitude, 0, 0, amplitude / speed + scan_hold),
                                (0, 0, 0, amplitude / speed),
-                               (-amplitude, 0, 0, amplitude / speed),
+                               (-amplitude, 0, 0, amplitude / speed + scan_hold),
                                (0, 0, 0, amplitude / speed)])
         else:
-            amplitude = min(amplitude, 20)
             roll = amplitude if args.get("side", "left") == "left" else -amplitude
             hold = _clamp(args.get("hold", 0.8), 0.2, 3.0)
             frames.append((0, 0, roll, amplitude / speed + hold))
@@ -1315,19 +1339,23 @@ class ArmGesturePlugin:
                     "action": {
                         "type": "string",
                         "enum": ["wave", "salute", "welcome", "raise", "reset", "stop"],
-                        "description": "手臂动作",
+                        "default": "wave",
+                        "description": "手臂动作，可选[wave, salute, welcome, raise, reset, stop]",
                     },
                     "side": {
                         "type": "string", "enum": ["left", "right", "both"],
-                        "default": "right", "description": "执行手臂",
+                        "default": "right",
+                        "description": "执行手臂，可选[left, right, both]，默认right",
                     },
                     "cycles": {
                         "type": "integer", "minimum": 1, "maximum": 5,
-                        "default": 2, "description": "挥手循环次数",
+                        "default": 2,
+                        "description": "挥手循环次数，范围[1, 5]，默认2",
                     },
                     "speed": {
                         "type": "number", "minimum": 0.2, "maximum": 1.5,
-                        "default": 0.5, "description": "关节速度(rad/s)",
+                        "default": 0.5,
+                        "description": "关节速度(rad/s)，范围[0.2, 1.5]，默认0.5",
                     },
                 },
                 "required": ["action"],

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -15,6 +15,8 @@ x-humanoid/tianyi2.0/device.py — 天轶2.0 Pro 设备插件。
 
 插件列表：
   StatePlugin      (sensor, multi-tool) — 关节/电池/急停/力传感器/URDF
+  ServiceStatePlugin (sensor)           — ROS2 服务节点运行状态
+  MotorFaultsPlugin (sensor)            — 电机错误码汇总
   CameraPlugin     (sensor)             — Orbbec 头部相机
   AsrPlugin        (sensor)             — 语音识别结果
   NavStatePlugin   (sensor)             — 底盘导航状态
@@ -26,6 +28,8 @@ x-humanoid/tianyi2.0/device.py — 天轶2.0 Pro 设备插件。
   NavPlugin        (actuator)           — 底盘导航控制
   ChatPlugin       (actuator)           — 语音交互开关
 """
+
+from __future__ import annotations
 
 import json
 import math
@@ -99,6 +103,16 @@ def _deg2rad(deg: float) -> float:
 
 def _rad2deg(rad: float) -> float:
     return rad * 180.0 / math.pi
+
+
+def _stamp_to_ms(stamp) -> int | None:
+    """Convert a ROS2 builtin_interfaces/Time-like object to milliseconds."""
+    if stamp is None:
+        return None
+    try:
+        return int(stamp.sec * 1000 + stamp.nanosec / 1_000_000)
+    except (AttributeError, TypeError, ValueError):
+        return None
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -361,6 +375,220 @@ class StatePlugin:
             fmt = "sensor/skeleton" if tool_name == "joints" else "data/json"
             return {"state": "running", "topic_out": [{"topic": topic, "format": fmt}]}
         return {"error": f"unknown action: {action_or_tool}"}
+
+
+# ══════════════════════════════════════════════════════════════════════════════════
+# ServiceStatePlugin (sensor)
+# ══════════════════════════════════════════════════════════════════════════════════
+
+class ServiceStatePlugin:
+    """Track the latest running/idle state for robot services or topics."""
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        configured_topics = plugin_config.get("source_topics")
+        if configured_topics is None:
+            configured_topics = [plugin_config.get("source_topic", "")]
+        self._source_topics = [
+            str(topic).strip() for topic in configured_topics
+            if str(topic).strip()
+        ]
+        self._topic = f"/{namespace}/state/service_state"
+        self._running = False
+        self._services = {}
+        self._last_update_ms = None
+        self._lock = threading.Lock()
+
+        self._sub_node = Node(
+            "tianyi2_service_state_sub", context=ros2.ctx_tianyi)
+        ros2.executor_tianyi.add_node(self._sub_node)
+        self._pub_node = Node(
+            "tianyi2_service_state_pub", context=ros2.ctx_core)
+        ros2.executor_core.add_node(self._pub_node)
+        self._publisher = self._pub_node.create_publisher(
+            String, self._topic, _RELIABLE_QOS)
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "service_state",
+            "type": "sensor",
+            "description": "天轶2.0 内部服务状态 — 按Topic汇总节点 running/idle 状态",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+        }
+
+    def start(self):
+        self._running = True
+        if not self._source_topics:
+            print("[ServiceStatePlugin] source topics not configured")
+            return
+        try:
+            from bodyctrl_msgs.msg import NodeState
+            for source_topic in self._source_topics:
+                self._sub_node.create_subscription(
+                    NodeState, source_topic,
+                    lambda msg, topic=source_topic: self._on_state(msg, topic),
+                    _RELIABLE_QOS,
+                )
+        except ImportError as e:
+            print(f"[ServiceStatePlugin] WARNING: msg import failed ({e}), running in stub mode")
+
+    def stop(self):
+        self._running = False
+
+    def _on_state(self, msg, source_topic: str = ""):
+        state_code = int(msg.state)
+        state = {0: "idle", 1: "running"}.get(state_code, "unknown")
+        now_ms = int(time.time() * 1000)
+        service_key = f"{source_topic}:{msg.topic}" if source_topic else msg.topic
+        with self._lock:
+            self._services[service_key] = {
+                "topic": msg.topic,
+                "source_topic": source_topic,
+                "state": state,
+                "state_code": state_code,
+                "timestamp_ms": _stamp_to_ms(msg.header.stamp) or now_ms,
+            }
+            self._last_update_ms = now_ms
+            payload = self._build_payload_locked()
+        if self._running:
+            self._publisher.publish(String(data=json.dumps(payload)))
+
+    def _build_payload_locked(self) -> dict:
+        services = sorted(self._services.values(), key=lambda x: x["topic"])
+        return {
+            "available": self._last_update_ms is not None,
+            "timestamp_ms": int(time.time() * 1000),
+            "last_update_ms": self._last_update_ms,
+            "service_count": len(services),
+            "running_count": sum(s["state"] == "running" for s in services),
+            "idle_count": sum(s["state"] == "idle" for s in services),
+            "unknown_count": sum(s["state"] == "unknown" for s in services),
+            "services": services,
+        }
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "service_state":
+            with self._lock:
+                return self._build_payload_locked()
+        if action == "start":
+            return {"state": "running"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "info":
+            return {
+                "state": "running",
+                "source_topics": self._source_topics,
+                "topic_out": [{"topic": self._topic, "format": "data/json"}],
+            }
+        return None
+
+
+# ════════════════════════════════════════════════════════════════════════════════
+# MotorFaultsPlugin (sensor)
+# ═════════════════════════════════════════════════════════════════════════════════
+
+class MotorFaultsPlugin:
+    """Expose non-zero motor error codes without duplicating joint telemetry."""
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        default_topics = [
+            "/head/status", "/arm/status", "/waist/status", "/leg/status"]
+        self._source_topics = plugin_config.get(
+            "motor_status_topics", default_topics)
+        self._topic = f"/{namespace}/state/motor_faults"
+        self._running = False
+        self._faults = {}
+        self._last_update_ms = None
+        self._lock = threading.Lock()
+
+        self._sub_node = Node(
+            "tianyi2_motor_faults_sub", context=ros2.ctx_tianyi)
+        ros2.executor_tianyi.add_node(self._sub_node)
+        self._pub_node = Node(
+            "tianyi2_motor_faults_pub", context=ros2.ctx_core)
+        ros2.executor_core.add_node(self._pub_node)
+        self._publisher = self._pub_node.create_publisher(
+            String, self._topic, _RELIABLE_QOS)
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "motor_faults",
+            "type": "sensor",
+            "description": "天轶2.0 电机故障汇总 — 仅输出非零电机错误码及关节名",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+        }
+
+    def start(self):
+        self._running = True
+        try:
+            from bodyctrl_msgs.msg import MotorStatusMsg
+            for source_topic in self._source_topics:
+                self._sub_node.create_subscription(
+                    MotorStatusMsg, source_topic,
+                    lambda msg, topic=source_topic: self._on_status(msg, topic),
+                    _RELIABLE_QOS,
+                )
+        except ImportError as e:
+            print(f"[MotorFaultsPlugin] WARNING: msg import failed ({e}), running in stub mode")
+
+    def stop(self):
+        self._running = False
+
+    def _on_status(self, msg, source_topic: str):
+        now_ms = int(time.time() * 1000)
+        with self._lock:
+            for motor in msg.status:
+                motor_id = int(motor.name)
+                if int(motor.error) == 0:
+                    self._faults.pop(motor_id, None)
+                    continue
+                self._faults[motor_id] = {
+                    "motor_id": motor_id,
+                    "joint_name": _ALL_JOINTS.get(
+                        motor_id, f"motor_{motor_id}"),
+                    "error_code": int(motor.error),
+                    "source_topic": source_topic,
+                    "timestamp_ms": _stamp_to_ms(msg.header.stamp) or now_ms,
+                }
+            self._last_update_ms = now_ms
+            payload = self._build_payload_locked()
+        if self._running:
+            self._publisher.publish(String(data=json.dumps(payload)))
+
+    def _build_payload_locked(self) -> dict:
+        faults = sorted(
+            self._faults.values(), key=lambda item: item["motor_id"])
+        return {
+            "available": self._last_update_ms is not None,
+            "timestamp_ms": int(time.time() * 1000),
+            "last_update_ms": self._last_update_ms,
+            "healthy": self._last_update_ms is not None and not faults,
+            "fault_count": len(faults),
+            "summary": (
+                "尚未收到电机状态数据"
+                if self._last_update_ms is None
+                else (f"检测到{len(faults)}个电机故障" if faults
+                      else "当前没有非零电机错误码")
+            ),
+            "faults": faults,
+        }
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "motor_faults":
+            with self._lock:
+                return self._build_payload_locked()
+        if action == "start":
+            return {"state": "running"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "info":
+            return {
+                "state": "running",
+                "source_topics": self._source_topics,
+                "topic_out": [{"topic": self._topic, "format": "data/json"}],
+            }
+        return None
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -20,7 +20,6 @@ x-humanoid/tianyi2.0/device.py — 天轶2.0 Pro 设备插件。
   CameraPlugin     (sensor)             — Orbbec 头部相机
   AsrPlugin        (sensor)             — 语音识别结果
   NavStatePlugin   (sensor)             — 底盘导航状态
-  StatusLightPlugin (actuator)          — 机器人状态灯事件
   HeadPlugin       (actuator)           — 头部3DOF控制
   HeadGesturePlugin (actuator)          — 点头/摇头/左右观察等语义动作
   ArmPlugin        (actuator)           — 双臂14DOF控制
@@ -892,104 +891,6 @@ class NavStatePlugin:
             return {"state": "running" if self._running else "idle",
                     "topic_out": [{"topic": self._topic, "format": "data/json"}]}
         return {"state": "running"}
-
-
-# ══════════════════════════════════════════════════════════════════════════════
-# StatusLightPlugin (actuator)
-# ══════════════════════════════════════════════════════════════════════════════
-
-class StatusLightPlugin:
-    """发布电源板定义的状态灯事件。
-
-    PowerLightCtrl 消息只包含 cmd，灯效由电源板根据事件编号决定；
-    因此这里不暴露硬件未定义的 RGB、亮度或闪烁频率参数。
-    """
-
-    _EVENTS = {
-        "battery_supply": 1,
-        "power_on_start": 2,
-        "power_on_finish": 3,
-        "service_start": 4,
-        "service_finish": 5,
-        "self_check_start": 6,
-        "self_check_failed": 7,
-        "self_check_success": 8,
-        "fault_occur": 9,
-        "fault_clear": 10,
-        "voice_wakeup": 11,
-        "voice_response": 12,
-        "voice_exit": 13,
-        "running_start": 14,
-        "running_finish": 15,
-        "power_off": 16,
-        "warn_occur": 17,
-        "warn_clear": 18,
-    }
-
-    def __init__(self, plugin_config: dict, namespace: str, ros2):
-        self._pub_node = Node("tianyi2_status_light_pub", context=ros2.ctx_tianyi)
-        ros2.executor_tianyi.add_node(self._pub_node)
-        self._publisher = None
-
-    def get_tool(self) -> dict:
-        return {
-            "name": "status_light",
-            "type": "actuator",
-            "description": "天轶2.0 状态灯控制 — 向电源板发送官方定义的灯光状态事件",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string", "enum": ["set_event"],
-                        "description": "发送状态灯事件",
-                    },
-                    "event": {
-                        "type": "string", "enum": list(self._EVENTS),
-                        "description": "PowerLightCtrl.msg 定义的状态事件",
-                    },
-                },
-                "required": ["action"],
-                "x-action-params": {
-                    "set_event": {
-                        "params": ["event"],
-                        "description": "设置状态灯事件",
-                    },
-                },
-            },
-        }
-
-    def start(self):
-        try:
-            from bodyctrl_msgs.msg import PowerLightCtrl
-            self._publisher = self._pub_node.create_publisher(
-                PowerLightCtrl, "/power/light/ctrl", _RELIABLE_QOS)
-            print("[StatusLightPlugin] publisher created")
-        except ImportError as e:
-            print(f"[StatusLightPlugin] WARNING: msg import failed ({e})")
-
-    def stop(self):
-        pass
-
-    def dispatch(self, action: str, args: dict) -> dict:
-        if action == "set_event":
-            event = str(args.get("event", "")).strip()
-            if event not in self._EVENTS:
-                return {"error": "event must be one of the documented PowerLightCtrl events"}
-            if not self._publisher:
-                return {"error": "publisher not initialized"}
-            try:
-                from bodyctrl_msgs.msg import PowerLightCtrl
-                msg = PowerLightCtrl()
-                msg.cmd = self._EVENTS[event]
-                self._publisher.publish(msg)
-                return {"state": "sent", "event": event, "cmd": msg.cmd}
-            except Exception as e:
-                return {"error": str(e)}
-        if action in ("start", "info"):
-            return {"state": "ready" if self._publisher else "idle"}
-        if action == "stop":
-            return {"state": "idle"}
-        return {"error": f"unknown action: {action}"}
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -129,15 +129,33 @@ class TianyiDeviceBundle:
             self._plugins.append(NavStatePlugin(plugins_cfg["nav_state"], namespace, ros2, slamtec_client))
             print("[bundle] NavStatePlugin loaded")
 
+        if plugins_cfg.get("status_light", {}).get("enabled", False):
+            from device import StatusLightPlugin
+            self._plugins.append(StatusLightPlugin(
+                plugins_cfg["status_light"], namespace, ros2))
+            print("[bundle] StatusLightPlugin loaded")
+
         if plugins_cfg.get("head", {}).get("enabled", False):
             from device import HeadPlugin
             self._plugins.append(HeadPlugin(plugins_cfg["head"], namespace, ros2))
             print("[bundle] HeadPlugin loaded")
 
+        if plugins_cfg.get("head_gesture", {}).get("enabled", False):
+            from device import HeadGesturePlugin
+            self._plugins.append(HeadGesturePlugin(
+                plugins_cfg["head_gesture"], namespace, ros2))
+            print("[bundle] HeadGesturePlugin loaded")
+
         if plugins_cfg.get("arm", {}).get("enabled", False):
             from device import ArmPlugin
             self._plugins.append(ArmPlugin(plugins_cfg["arm"], namespace, ros2))
             print("[bundle] ArmPlugin loaded")
+
+        if plugins_cfg.get("arm_gesture", {}).get("enabled", False):
+            from device import ArmGesturePlugin
+            self._plugins.append(ArmGesturePlugin(
+                plugins_cfg["arm_gesture"], namespace, ros2))
+            print("[bundle] ArmGesturePlugin loaded")
 
         if plugins_cfg.get("waist", {}).get("enabled", False):
             from device import WaistPlugin

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -102,6 +102,18 @@ class TianyiDeviceBundle:
             self._plugins.append(StatePlugin(plugins_cfg["state"], namespace, ros2))
             print("[bundle] StatePlugin loaded")
 
+        if plugins_cfg.get("service_state", {}).get("enabled", False):
+            from device import ServiceStatePlugin
+            self._plugins.append(ServiceStatePlugin(
+                plugins_cfg["service_state"], namespace, ros2))
+            print("[bundle] ServiceStatePlugin loaded")
+
+        if plugins_cfg.get("motor_faults", {}).get("enabled", False):
+            from device import MotorFaultsPlugin
+            self._plugins.append(MotorFaultsPlugin(
+                plugins_cfg["motor_faults"], namespace, ros2))
+            print("[bundle] MotorFaultsPlugin loaded")
+
         if plugins_cfg.get("camera", {}).get("enabled", False):
             from device import CameraPlugin
             self._plugins.append(CameraPlugin(plugins_cfg["camera"], namespace, ros2))

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -129,12 +129,6 @@ class TianyiDeviceBundle:
             self._plugins.append(NavStatePlugin(plugins_cfg["nav_state"], namespace, ros2, slamtec_client))
             print("[bundle] NavStatePlugin loaded")
 
-        if plugins_cfg.get("status_light", {}).get("enabled", False):
-            from device import StatusLightPlugin
-            self._plugins.append(StatusLightPlugin(
-                plugins_cfg["status_light"], namespace, ros2))
-            print("[bundle] StatusLightPlugin loaded")
-
         if plugins_cfg.get("head", {}).get("enabled", False):
             from device import HeadPlugin
             self._plugins.append(HeadPlugin(plugins_cfg["head"], namespace, ros2))

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -102,17 +102,11 @@ class TianyiDeviceBundle:
             self._plugins.append(StatePlugin(plugins_cfg["state"], namespace, ros2))
             print("[bundle] StatePlugin loaded")
 
-        if plugins_cfg.get("service_state", {}).get("enabled", False):
-            from device import ServiceStatePlugin
-            self._plugins.append(ServiceStatePlugin(
-                plugins_cfg["service_state"], namespace, ros2))
-            print("[bundle] ServiceStatePlugin loaded")
-
-        if plugins_cfg.get("motor_faults", {}).get("enabled", False):
-            from device import MotorFaultsPlugin
-            self._plugins.append(MotorFaultsPlugin(
-                plugins_cfg["motor_faults"], namespace, ros2))
-            print("[bundle] MotorFaultsPlugin loaded")
+        if plugins_cfg.get("robot_faults", {}).get("enabled", False):
+            from device import RobotFaultsPlugin
+            self._plugins.append(RobotFaultsPlugin(
+                plugins_cfg["robot_faults"], namespace, ros2))
+            print("[bundle] RobotFaultsPlugin loaded")
 
         if plugins_cfg.get("camera", {}).get("enabled", False):
             from device import CameraPlugin


### PR DESCRIPTION
## Summary

为天轶 2.0 Pro Driver 提交卡片开发，新增两类能力：

- 状态监控卡片：`service_state`、`motor_faults`
- 语义动作卡片：`head_gesture`、`arm_gesture`

`service_state` 用于汇总机器人内部 ROS2 服务节点的最新运行状态；`motor_faults` 用于发现头部、手臂、腰部和腿部电机的非零故障码。`head_gesture` 提供点头、摇头、左右观察等头部语义动作；`arm_gesture` 提供挥手、敬礼、欢迎、抬臂和回零等手臂语义动作。

## Changed files

- `x-humanoid/tianyi2.0/device.py`
  - 新增 `ServiceStatePlugin` 与 `MotorFaultsPlugin`，订阅并整理机器人状态与电机故障信息。
  - 新增 `HeadGesturePlugin` 与 `ArmGesturePlugin`，将语义动作转换为 ROS2 关节位置控制消息。
  - 为动作序列加入取消机制；`stop` 仅取消未发送的后续动作帧，不作为物理急停使用。

- `x-humanoid/tianyi2.0/main.py`
  - 根据配置加载上述四个卡片插件。

- `x-humanoid/tianyi2.0/config.yaml`
  - 新增四个卡片的启用配置与状态卡片对应的 ROS2 Topic 配置。

- `x-humanoid/tianyi2.0/README.md`
  - 补充四张卡片的用途、输入/输出 Topic、MCP Tool 类型和使用边界说明。