### PR TITLE
feat(tianyi2.0): add RGB-D camera geometry resource

### DIFF
--- a/x-humanoid/tianyi2.0/Dockerfile
+++ b/x-humanoid/tianyi2.0/Dockerfile
@@ -17,20 +17,21 @@ RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
     pyyaml numpy opencv-python-headless
 
-# Build tianyi ROS2 message packages (bodyctrl_msgs + lyre_msgs)
+# Build Tianyi and Orbbec ROS2 message packages.
 COPY msgs/ /tianyi_ws/src/
 RUN cd /tianyi_ws && \
     . /opt/ros/humble/setup.sh && \
-    colcon build --packages-select bodyctrl_msgs lyre_msgs || \
+    colcon build --packages-select bodyctrl_msgs lyre_msgs orbbec_camera_msgs || \
     echo "WARNING: msg build failed, will run in stub mode"
 
 ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
 ENV PYTHONUNBUFFERED=1
 
-# Ensure tianyi msg packages are on PYTHONPATH (base image entrypoint won't source them)
-ENV PYTHONPATH=/tianyi_ws/install/lyre_msgs/local/lib/python3.10/dist-packages:/tianyi_ws/install/bodyctrl_msgs/local/lib/python3.10/dist-packages:${PYTHONPATH}
-ENV AMENT_PREFIX_PATH=/tianyi_ws/install/bodyctrl_msgs:/tianyi_ws/install/lyre_msgs:${AMENT_PREFIX_PATH}
-ENV LD_LIBRARY_PATH=/tianyi_ws/install/bodyctrl_msgs/lib:/tianyi_ws/install/lyre_msgs/lib:${LD_LIBRARY_PATH}
+# Ensure bundled message packages are available even when the base entrypoint
+# does not source the overlay.
+ENV PYTHONPATH=/tianyi_ws/install/orbbec_camera_msgs/local/lib/python3.10/dist-packages:/tianyi_ws/install/lyre_msgs/local/lib/python3.10/dist-packages:/tianyi_ws/install/bodyctrl_msgs/local/lib/python3.10/dist-packages:${PYTHONPATH}
+ENV AMENT_PREFIX_PATH=/tianyi_ws/install/orbbec_camera_msgs:/tianyi_ws/install/bodyctrl_msgs:/tianyi_ws/install/lyre_msgs:${AMENT_PREFIX_PATH}
+ENV LD_LIBRARY_PATH=/tianyi_ws/install/orbbec_camera_msgs/lib:/tianyi_ws/install/bodyctrl_msgs/lib:/tianyi_ws/install/lyre_msgs/lib:${LD_LIBRARY_PATH}
 
 COPY resource/ /work/resource/
 COPY main.py device.py nav_client.py config.yaml driver.yaml /work/

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -15,7 +15,7 @@ x-humanoid/tianyi2.0/device.py — 天轶2.0 Pro 设备插件。
 
 插件列表：
   StatePlugin      (sensor, multi-tool) — 关节/电池/急停/力传感器/URDF
-  CameraPlugin     (sensor)             — Orbbec 头部相机
+  CameraPlugin     (sensor/resource)    — Orbbec 头部相机与几何标定
   AsrPlugin        (sensor)             — 语音识别结果
   NavStatePlugin   (sensor)             — 底盘导航状态
   HeadPlugin       (actuator)           — 头部3DOF控制
@@ -30,6 +30,7 @@ x-humanoid/tianyi2.0/device.py — 天轶2.0 Pro 设备插件。
 
 from __future__ import annotations
 
+import copy
 import json
 import math
 import threading
@@ -53,6 +54,13 @@ _RELIABLE_QOS = QoSProfile(
     history=HistoryPolicy.KEEP_LAST,
     depth=10,
     durability=DurabilityPolicy.VOLATILE,
+)
+
+_CAMERA_EXTRINSICS_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    durability=DurabilityPolicy.TRANSIENT_LOCAL,
 )
 
 # ── Motor ID → Joint Name 映射 ───────────────────────────────────────────────
@@ -432,18 +440,29 @@ class StatePlugin:
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# CameraPlugin (sensor)
+# CameraPlugin (sensor/resource, multi-tool)
 # ══════════════════════════════════════════════════════════════════════════════
 
 class CameraPlugin:
-    """Orbbec 头部 RGB 相机 — 独立编码线程避免阻塞executor"""
+    """Orbbec RGB stream plus calibration for RGB/point-cloud fusion."""
 
     def __init__(self, plugin_config: dict, namespace: str, ros2):
         self._ns = namespace
         self._ros2 = ros2
         self._topic = f"/{namespace}/camera/head"
         self._running = False
-        self._frame_queue = None  # Will hold latest frame only
+        self._latest_frame = None
+        self._frame_lock = threading.Lock()
+        self._subscriptions = []
+
+        # Geometry resources are populated independently by color/depth
+        # CameraInfo.  Extrinsics are optional because older Tianyi images do
+        # not install orbbec_camera_msgs in the driver container.
+        self._geometry_lock = threading.Lock()
+        self._camera_geometry = {"color": None, "depth": None}
+        self._depth_to_color = None
+        self._extrinsics_supported = None
+        self._extrinsics_reason = "plugin_not_started"
 
         self._sub_node = Node("tianyi2_camera_sub", context=ros2.ctx_tianyi)
         ros2.executor_tianyi.add_node(self._sub_node)
@@ -451,20 +470,60 @@ class CameraPlugin:
         self._pub_node = Node("tianyi2_camera_pub", context=ros2.ctx_core)
         ros2.executor_core.add_node(self._pub_node)
 
-    def get_tool(self) -> dict:
-        return {
-            "name": "camera_head",
-            "type": "sensor",
-            "description": "天轶2.0 头部相机 (Orbbec RGB) — 彩色图像流",
-            "inputSchema": {"type": "object", "properties": {}},
-            "topic_out": [{"topic": self._topic, "format": "image/jpeg"}],
-        }
+    def get_tools(self) -> list:
+        return [
+            {
+                "name": "camera_head",
+                "type": "sensor",
+                "description": "天轶2.0 头部相机 (Orbbec RGB) — 彩色图像流",
+                "inputSchema": {"type": "object", "properties": {}},
+                "topic_out": [{"topic": self._topic, "format": "image/jpeg"}],
+            },
+            {
+                "name": "camera_geometry",
+                "type": "resource",
+                "description": (
+                    "天轶2.0 RGB-D 标定参数 — 为 camera_head 与 "
+                    "camera_pointcloud 提供彩色/深度内参、畸变参数和 "
+                    "Depth→Color 外参，用于像素↔三维坐标换算、"
+                    "RGB-点云对齐/着色及标定诊断；不重复传输图像或点云"
+                ),
+                "inputSchema": {"type": "object", "properties": {}},
+            },
+        ]
 
     def start(self):
         self._running = True
 
         # Ensure Orbbec camera service is running
         self._ensure_orbbec_service()
+
+        # Camera geometry remains available even if OpenCV or NumPy is absent
+        # and the RGB encoder cannot start.
+        try:
+            from sensor_msgs.msg import CameraInfo
+
+            self._subscriptions.extend([
+                self._sub_node.create_subscription(
+                    CameraInfo,
+                    "/ob_camera_head/color/camera_info",
+                    lambda msg: self._on_camera_info("color", msg),
+                    _RELIABLE_QOS,
+                ),
+                self._sub_node.create_subscription(
+                    CameraInfo,
+                    "/ob_camera_head/depth/camera_info",
+                    lambda msg: self._on_camera_info("depth", msg),
+                    _RELIABLE_QOS,
+                ),
+            ])
+            print("[CameraPlugin] color/depth CameraInfo subscriptions created")
+        except ImportError as e:
+            print(f"[CameraPlugin] WARNING: CameraInfo import failed ({e})")
+        except Exception as e:
+            print(f"[CameraPlugin] WARNING: CameraInfo subscriptions failed ({e})")
+
+        self._subscribe_depth_to_color()
 
         try:
             from sensor_msgs.msg import Image, CompressedImage
@@ -473,15 +532,19 @@ class CameraPlugin:
 
             self._np = np
             self._cv2 = cv2
-            self._latest_frame = None  # Only keep latest frame
-            self._frame_lock = threading.Lock()
+            with self._frame_lock:
+                self._latest_frame = None
 
             # Publish JPEG as CompressedImage
             self._pub = self._pub_node.create_publisher(CompressedImage, self._topic, _LOW_LAT_QOS)
 
             # Subscribe - callback just grabs the frame, doesn't encode
-            self._sub_node.create_subscription(
-                Image, "/ob_camera_head/color/image_raw", self._on_image_grab, _RELIABLE_QOS)
+            self._subscriptions.append(self._sub_node.create_subscription(
+                Image,
+                "/ob_camera_head/color/image_raw",
+                self._on_image_grab,
+                _RELIABLE_QOS,
+            ))
 
             # Separate encoding thread - avoids blocking executor
             self._encode_thread = threading.Thread(target=self._encode_loop, daemon=True)
@@ -490,6 +553,153 @@ class CameraPlugin:
             print("[CameraPlugin] subscription + encode thread created")
         except ImportError as e:
             print(f"[CameraPlugin] WARNING: import failed ({e})")
+
+    def _subscribe_depth_to_color(self):
+        try:
+            from orbbec_camera_msgs.msg import Extrinsics
+        except ImportError:
+            reason = "orbbec_camera_msgs.msg.Extrinsics is unavailable"
+            self._set_extrinsics_unavailable(reason)
+            print(f"[CameraPlugin] WARNING: {reason}; depth_to_color omitted")
+            return
+
+        try:
+            subscription = self._sub_node.create_subscription(
+                Extrinsics,
+                "/ob_camera_head/depth_to_color",
+                self._on_depth_to_color,
+                _CAMERA_EXTRINSICS_QOS,
+            )
+            self._subscriptions.append(subscription)
+            with self._geometry_lock:
+                self._extrinsics_supported = True
+                self._extrinsics_reason = "waiting_for_depth_to_color"
+            print("[CameraPlugin] depth_to_color extrinsics subscription created")
+        except Exception as e:
+            with self._geometry_lock:
+                self._extrinsics_supported = True
+                self._extrinsics_reason = f"subscription_failed: {e}"
+            print(f"[CameraPlugin] WARNING: depth_to_color subscription failed ({e})")
+
+    @staticmethod
+    def _header_fields(msg) -> tuple:
+        header = getattr(msg, "header", None)
+        frame_id = str(getattr(header, "frame_id", ""))
+        stamp = getattr(header, "stamp", None)
+        if stamp is None:
+            return frame_id, None, None
+        sec = int(getattr(stamp, "sec", 0))
+        nanosec = int(getattr(stamp, "nanosec", 0))
+        timestamp = {"sec": sec, "nanosec": nanosec}
+        timestamp_ms = sec * 1000 + nanosec // 1_000_000
+        return frame_id, timestamp, timestamp_ms
+
+    @classmethod
+    def _camera_info_to_dict(cls, msg) -> dict:
+        frame_id, timestamp, timestamp_ms = cls._header_fields(msg)
+        k = [float(value) for value in getattr(msg, "k", ())]
+        roi = getattr(msg, "roi", None)
+        return {
+            "width": int(getattr(msg, "width", 0)),
+            "height": int(getattr(msg, "height", 0)),
+            "intrinsics": {
+                "fx": k[0] if len(k) > 0 else None,
+                "fy": k[4] if len(k) > 4 else None,
+                "cx": k[2] if len(k) > 2 else None,
+                "cy": k[5] if len(k) > 5 else None,
+            },
+            "distortion_model": str(getattr(msg, "distortion_model", "")),
+            "d": [float(value) for value in getattr(msg, "d", ())],
+            "k": k,
+            "r": [float(value) for value in getattr(msg, "r", ())],
+            "p": [float(value) for value in getattr(msg, "p", ())],
+            "binning": {
+                "x": int(getattr(msg, "binning_x", 0)),
+                "y": int(getattr(msg, "binning_y", 0)),
+            },
+            "roi": {
+                "x_offset": int(getattr(roi, "x_offset", 0)),
+                "y_offset": int(getattr(roi, "y_offset", 0)),
+                "height": int(getattr(roi, "height", 0)),
+                "width": int(getattr(roi, "width", 0)),
+                "do_rectify": bool(getattr(roi, "do_rectify", False)),
+            },
+            "frame_id": frame_id,
+            "timestamp": timestamp,
+            "timestamp_ms": timestamp_ms,
+        }
+
+    @classmethod
+    def _extrinsics_to_dict(cls, msg) -> dict:
+        frame_id, timestamp, timestamp_ms = cls._header_fields(msg)
+        return {
+            "supported": True,
+            "available": True,
+            "rotation": [float(value) for value in getattr(msg, "rotation", ())],
+            # orbbec_camera's wrapper converts SDK millimetres to metres
+            # before publishing Extrinsics.
+            "translation_m": [
+                float(value) for value in getattr(msg, "translation", ())
+            ],
+            "frame_id": frame_id,
+            "timestamp": timestamp,
+            "timestamp_ms": timestamp_ms,
+        }
+
+    def _on_camera_info(self, stream: str, msg):
+        if stream not in self._camera_geometry:
+            return
+        geometry = self._camera_info_to_dict(msg)
+        with self._geometry_lock:
+            self._camera_geometry[stream] = geometry
+
+    def _on_depth_to_color(self, msg):
+        extrinsics = self._extrinsics_to_dict(msg)
+        with self._geometry_lock:
+            self._depth_to_color = extrinsics
+            self._extrinsics_supported = True
+            self._extrinsics_reason = None
+
+    def _set_extrinsics_unavailable(self, reason: str):
+        with self._geometry_lock:
+            self._depth_to_color = None
+            self._extrinsics_supported = False
+            self._extrinsics_reason = reason
+
+    def _geometry_snapshot(self) -> dict:
+        with self._geometry_lock:
+            color = copy.deepcopy(self._camera_geometry["color"])
+            depth = copy.deepcopy(self._camera_geometry["depth"])
+            depth_to_color = copy.deepcopy(self._depth_to_color)
+            extrinsics_supported = self._extrinsics_supported
+            extrinsics_reason = self._extrinsics_reason
+
+        missing = [
+            stream for stream, value in (("color", color), ("depth", depth))
+            if value is None
+        ]
+        if depth_to_color is None:
+            depth_to_color = {
+                "supported": extrinsics_supported,
+                "available": False,
+                "reason": extrinsics_reason,
+            }
+        availability = {
+            "color": color is not None,
+            "depth": depth is not None,
+            "depth_to_color": depth_to_color["available"],
+        }
+        return {
+            "available": not missing,
+            "availability": availability,
+            "missing": missing,
+            "optional_missing": (
+                [] if depth_to_color["available"] else ["depth_to_color"]
+            ),
+            "color": color,
+            "depth": depth,
+            "depth_to_color": depth_to_color,
+        }
 
     def _ensure_orbbec_service(self):
         """Ensure orbbec_head.service is running. Use nsenter to access host systemd."""
@@ -549,12 +759,14 @@ class CameraPlugin:
             except Exception as e:
                 print(f"[CameraPlugin] encode error: {e}", flush=True)
 
-    def dispatch(self, action: str, args: dict) -> dict:
-        if action == "start":
+    def dispatch(self, action_or_tool: str, args: dict) -> dict:
+        if action_or_tool == "camera_geometry":
+            return self._geometry_snapshot()
+        if action_or_tool == "start":
             return {"state": "running"}
-        if action == "stop":
+        if action_or_tool == "stop":
             return {"state": "idle"}
-        if action == "info":
+        if action_or_tool == "info":
             return {"state": "running", "topic_out": [{"topic": self._topic, "format": "image/jpeg"}]}
         return {"state": "running"}
 

--- a/x-humanoid/tianyi2.0/msgs/orbbec_camera_msgs/CMakeLists.txt
+++ b/x-humanoid/tianyi2.0/msgs/orbbec_camera_msgs/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.8)
+project(orbbec_camera_msgs)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/Extrinsics.msg"
+  DEPENDENCIES std_msgs
+)
+
+ament_package()

--- a/x-humanoid/tianyi2.0/msgs/orbbec_camera_msgs/msg/Extrinsics.msg
+++ b/x-humanoid/tianyi2.0/msgs/orbbec_camera_msgs/msg/Extrinsics.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+float64[9] rotation
+float64[3] translation

--- a/x-humanoid/tianyi2.0/msgs/orbbec_camera_msgs/package.xml
+++ b/x-humanoid/tianyi2.0/msgs/orbbec_camera_msgs/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>orbbec_camera_msgs</name>
+  <version>2.5.4</version>
+  <description>A package containing orbbec camera messages definitions.</description>
+  <maintainer email="mocun@orbbec.com">Joe Dong</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <depend>std_msgs</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## 功能概述

本 PR 为天轶 2.0 Pro 新增 `camera_geometry` MCP resource，并集成在现有 `CameraPlugin` 中，不增加独立功能脚本。

`camera_geometry` 不重复传输 RGB 图像或点云，而是为现有 `camera_head` 与 `camera_pointcloud` 提供配套的 RGB-D 标定参数，使下游能够正确解释、对齐和组合两类数据。

## 数据接入

卡片读取天轶头部 Orbbec 相机发布的以下 ROS 2 话题：

- `/ob_camera_head/color/camera_info`：彩色相机分辨率、内参、畸变模型和校正矩阵
- `/ob_camera_head/depth/camera_info`：深度相机分辨率、内参、畸变模型和校正矩阵
- `/ob_camera_head/depth_to_color`：Depth 坐标系到 Color 坐标系的旋转和平移外参

其中 Depth→Color 外参依赖 `orbbec_camera_msgs/msg/Extrinsics`。本 PR 将官方同名消息接口随驱动镜像构建，避免容器内缺少消息定义而无法订阅。

## 返回内容

按需调用 `camera_geometry` 时返回一个 JSON 快照，包含：

- Color/Depth 的 `width`、`height`
- `fx`、`fy`、`cx`、`cy`
- 完整 `D/K/R/P` 标定矩阵
- distortion model、ROI、binning
- `frame_id` 和 ROS 时间戳
- Depth→Color 的 3×3 rotation 与米制 translation
- 各部分 `availability`、`missing` 和可选外参降级原因

彩色或深度 `CameraInfo` 尚未到达时，卡片返回明确的缺失状态；外参消息不可用时仅降级 `depth_to_color`，不会影响已有 RGB 图像流。

## 实际用途

- 将深度像素反投影为三维坐标
- 将点云投影到 RGB 图像并进行颜色关联
- 根据 RGB 检测框获取目标空间坐标和距离
- 排查 RGB、深度和点云分辨率或标定不一致导致的错位

现有点云卡可以自行使用深度内参生成 XYZ 数据；本卡不替代点云卡，而是把完整的 Color/Depth 标定关系通过 MCP 开放给需要 RGB-点云融合的下游。

## 实现方式与范围

- 复用 `CameraPlugin.get_tools()` 同时注册 `camera_head` 和 `camera_geometry`
- 复用现有 camera 插件开关和生命周期，无需新增 `config.yaml` 配置或单独 `main.py` 加载逻辑
- 保留原有 `camera_head` 名称、JPEG topic 和调用行为
- 继续使用现有 Tianyi Bundle 的驱动 ID、名称和 MCP 端口；本卡不创建独立服务，因此无需另占端口
- 本 PR 仅包含 `camera_geometry`，不包含 `bag_recorder`、`software_manifest` 或临时测试脚本

## 验证

- 基于最新 `upstream/main` 开发，分支仅领先 1 个提交
- 8 项相机几何逻辑用例通过
- Python 语法、YAML 解析及 `git diff --check` 通过
- 天轶驱动 Docker 镜像本地构建成功
- `bodyctrl_msgs`、`lyre_msgs`、`orbbec_camera_msgs` 三个 ROS 2 接口包构建成功
- 镜像内 `orbbec_camera_msgs.msg.Extrinsics` 与 `device.py` 导入成功

尚未在天轶实机上验证相机话题数据，需由主仓库管理者按上传流程进行构建、启动和画布调用测试。
