### PR TITLE
fix: G1 mic self-check uses subprocess (sync with R1)

### DIFF
--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -22,6 +22,7 @@ import json
 import queue
 import socket
 import struct
+import subprocess
 import threading
 import time
 
@@ -188,7 +189,12 @@ class MicPlugin:
         return None
 
     def _self_check(self) -> tuple[str, str]:
-        """Verify mic pipeline: multicast receiving + ROS2 topic subscribable."""
+        """Verify mic pipeline: multicast receiving + ROS2 topic subscribable.
+
+        Check 1: multicast packets arriving (in-process).
+        Check 2: ROS2 topic receivable from a subprocess (avoids same-process
+                 FastDDS intra-participant matching issues).
+        """
         import time as _t
 
         # Check 1: multicast receiving
@@ -200,19 +206,35 @@ class MicPlugin:
             self._node.state = "error"
             return "error", "no multicast packets received in 3s"
 
-        # Check 2: ROS2 topic loopback — subscribe to own topic and verify data arrives
-        received = [False]
-        def _cb(msg):
-            received[0] = True
-        test_sub = self._node.create_subscription(AudioChunk, self._topic, _cb, _LOW_LAT_QOS)
-        deadline = _t.monotonic() + 2.0
-        while _t.monotonic() < deadline and not received[0]:
-            _t.sleep(0.1)
-        self._node.destroy_subscription(test_sub)
-
-        if not received[0]:
+        # Check 2: ROS2 topic receivable — use subprocess to avoid same-process DDS issues
+        check_script = (
+            "import sys, rclpy, time;"
+            "from rclpy.node import Node;"
+            "from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy;"
+            "from audio_msgs.msg import AudioChunk;"
+            "rclpy.init();"
+            "n = Node('_mic_check');"
+            "qos = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT,"
+            "history=HistoryPolicy.KEEP_LAST, depth=10, durability=DurabilityPolicy.VOLATILE);"
+            "ok = [False];"
+            "n.create_subscription(AudioChunk, sys.argv[1], lambda m: ok.__setitem__(0, True), qos);"
+            "dl = time.monotonic() + 3.0;"
+            "\nwhile time.monotonic() < dl and not ok[0]: rclpy.spin_once(n, timeout_sec=0.1)\n"
+            "rclpy.shutdown();"
+            "sys.exit(0 if ok[0] else 1)"
+        )
+        try:
+            result = subprocess.run(
+                ["python3", "-c", check_script, self._topic],
+                timeout=5,
+                capture_output=True,
+            )
+            if result.returncode != 0:
+                self._node.state = "error"
+                return "error", "topic published but not receivable via ROS2"
+        except (subprocess.TimeoutExpired, Exception) as e:
             self._node.state = "error"
-            return "error", "topic published but not receivable via ROS2"
+            return "error", f"ROS2 subscribe check failed: {e}"
 
         self._node.state = "running"
         return "running", ""


### PR DESCRIPTION
## Summary
- Sync R1 mic self-check fix to G1: replace in-process ROS2 loopback with subprocess-based check
- Avoids FastDDS intra-participant matching delays on ARM64

🤖 Generated with [Claude Code](https://claude.com/claude-code)