### PR TITLE
fix: speaker startup sound plays on every start

### DIFF
--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -510,6 +510,8 @@ class SpeakerPlugin:
             topic = args.get("input_topic", "")
             if not topic:
                 return {"error": "Missing input_topic"}
+            # Always stop first to ensure clean restart and startup sound plays
+            self._node.stop_play()
             # Play startup sound in background
             threading.Thread(target=self._play_startup_sound, daemon=True).start()
             topic = self._node.start_play(topic)

--- a/unitree/r1/device.py
+++ b/unitree/r1/device.py
@@ -490,6 +490,8 @@ class SpeakerPlugin:
             topic = args.get("input_topic", "")
             if not topic:
                 return {"error": "Missing input_topic"}
+            # Always stop first to ensure clean restart and startup sound plays
+            self._node.stop_play()
             # Play startup sound in background
             threading.Thread(target=self._play_startup_sound, daemon=True).start()
             topic = self._node.start_play(topic)


### PR DESCRIPTION
## Summary

- Speaker `dispatch("start")` now calls `stop_play()` before `start_play()` 
- Ensures startup beep plays every time user clicks "start project", not just the first time
- Affects R1 and G1 drivers

## Test plan

- [ ] Click start project → hear startup beep
- [ ] Click stop → click start again → hear startup beep again

🤖 Generated with [Claude Code](https://claude.com/claude-code)