### PR TITLE
fix: remove blocking print/log in G1 speaker audio hot path

### DIFF
--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -307,7 +307,7 @@ APP_NAME = "g1_speaker"
 
 
 class _SpeakerNode(Node):
-    PREFILL = 5       # buffer 5 chunks (~500ms) before starting playback
+    PREFILL = 3       # buffer 3 chunks (~300ms) before starting playback
     MERGE_BYTES = 9600  # merge into ~300ms blocks before calling PlayStream
 
     def __init__(self, audio_client: AudioClient):
@@ -369,9 +369,6 @@ class _SpeakerNode(Node):
     def _on_chunk(self, msg: AudioChunk) -> None:
         pcm = bytes(msg.data)
         self._idx += 1
-        self.get_logger().info(
-            f"[speaker] chunk #{self._idx}: {len(pcm)} bytes, format={msg.format}"
-        )
         self._buf.put(pcm)
         self._last_chunk_time = time.monotonic()
         if not self._draining.is_set() and self._buf.qsize() >= self.PREFILL:
@@ -398,11 +395,9 @@ class _SpeakerNode(Node):
         if not self._draining.is_set() and not self._buf.empty():
             idle = time.monotonic() - self._last_chunk_time
             if idle >= 0.15:
-                self.get_logger().info(f"[speaker] flush timer triggered, {self._buf.qsize()} chunks buffered")
                 self._start_drain()
 
     def _drain(self) -> None:
-        self.get_logger().info(f"[speaker] drain started, buffered {self._buf.qsize()} chunks")
         play_idx = 0
         merged = b''
         empty_count = 0

--- a/unitree/g1/unitree_sdk2py/g1/audio/g1_audio_client.py
+++ b/unitree/g1/unitree_sdk2py/g1/audio/g1_audio_client.py
@@ -63,10 +63,7 @@ class AudioClient(Client):
     def PlayStream(self, app_name: str, stream_id: str, pcm_data: bytes):
         param = json.dumps({"app_name": app_name, "stream_id": stream_id})
         pcm_list = list(pcm_data)
-        print(f"[AudioClient] PlayStream app={app_name} id={stream_id} pcm_bytes={len(pcm_data)} list_len={len(pcm_list)}")
-        result = self._CallRequestWithParamAndBin(ROBOT_API_ID_AUDIO_START_PLAY, param, pcm_list)
-        print(f"[AudioClient] PlayStream result={result}")
-        return result
+        return self._CallRequestWithParamAndBin(ROBOT_API_ID_AUDIO_START_PLAY, param, pcm_list)
     
     def PlayStop(self, app_name: str):
         parameter = json.dumps({"app_name": app_name})


### PR DESCRIPTION
## Summary
- G1 speaker had high-frequency noise/glitches during TTS playback, R1 did not
- Root cause: `print()` in `AudioClient.PlayStream` and `logger.info` in `_on_chunk` callback were blocking the audio drain thread, disrupting playback timing (`remaining = duration - elapsed - 0.08` became too small/negative)
- Removed all blocking I/O from audio hot path and reduced PREFILL from 5→3 to match R1

## Test plan
- [x] Deployed to G1 container and restarted
- [ ] Verify TTS playback no longer has high-frequency glitches

🤖 Generated with [Claude Code](https://claude.com/claude-code)