### PR TITLE
fix: remove duplicate _self_check definition in R1 device.py

### DIFF
--- a/unitree/r1/device.py
+++ b/unitree/r1/device.py
@@ -184,7 +184,6 @@ class MicPlugin:
         return None
 
     def _self_check(self) -> tuple[str, str]:
-    def _self_check(self) -> tuple[str, str]:
         """Verify mic pipeline: multicast receiving + ROS2 topic subscribable.
 
         Check 1: multicast packets arriving (in-process).


### PR DESCRIPTION
## Summary
- Duplicate `def _self_check` line caused IndentationError, preventing R1 driver from starting
- Removed the duplicate line

## Test plan
- [x] Deployed to R1 and verified container starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)