### PR TITLE
feat(g1): safe mode switching with FSM state validation

### DIFF
--- a/unitree/g1/Dockerfile
+++ b/unitree/g1/Dockerfile
@@ -47,6 +47,7 @@ COPY unitree_sdk2py/ /work/unitree_sdk2py/
 COPY resource/       /work/resource/
 COPY main.py   /work/main.py
 COPY device.py /work/device.py
+COPY rpc_proxy.py /work/rpc_proxy.py
 COPY ext_devices.py /work/ext_devices.py
 COPY safety_harness.py /work/safety_harness.py
 COPY scan_context.py /work/scan_context.py

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -322,6 +322,8 @@ class _SpeakerNode(Node):
         self._drain_thread: threading.Thread | None = None
         self._last_chunk_time = 0.0
         self._flush_timer = None
+        # Clear stale PlayStream session from previous container run (MCU keeps state across reboot)
+        self._client.PlayStop(APP_NAME)
         self.get_logger().info("SpeakerNode ready")
 
     def start_play(self, topic: str) -> str:
@@ -505,10 +507,10 @@ class SpeakerPlugin:
             topic = args.get("input_topic", "")
             if not topic:
                 return {"error": "Missing input_topic"}
-            # Always stop first to ensure clean restart and startup sound plays
+            # Always stop first to ensure clean restart
             self._node.stop_play()
-            # Play startup sound in background
-            threading.Thread(target=self._play_startup_sound, daemon=True).start()
+            # Play startup sound synchronously before starting subscription
+            self._play_startup_sound()
             topic = self._node.start_play(topic)
             return {"state": "playing", "topic": topic}
         elif action == "stop":

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -769,20 +769,29 @@ class LocoPlugin:
             },
         }
 
+    # ── FSM state groups for safety checks ──────────────────────────────────────
+    _GROUND_STATES = {0, 1}            # zero_torque, damp — lying on ground
+    _LOW_STATES = {2, 702}             # squat, prep — stable low stance
+    _STANDING_STATES = {500, 501, 801} # normal_loco, 3dof_waist, run — active balance
+    _UNSAFE_STATES = {3, 706}          # sit, balance_stand — not directly switchable
+
     def _switch_mode_tool(self) -> dict:
         return {
             "name": "switch_mode",
             "type": "actuator",
             "multiInstance": False,
-            "description": "G1 locomotion mode switch — change posture/locomotion mode by name. damp=阻尼, start=主运控, zero_torque=零力矩, squat=下蹲, stand_up=起立, lie_to_stand=躺起, sit=落座, balance_stand=平衡站立, continuous_gait=持续踏步, stop_gait=停止踏步, high_stand=最高站, low_stand=最低站",
+            "description": "G1 safe locomotion mode switch. "
+                           "lie2standup=安全起立(ground→主运控), standup2lie=安全躺下(standing→阻尼), "
+                           "standup2squat=站到蹲(standing→下蹲), squat2standup=蹲到站(下蹲→主运控), "
+                           "damp=阻尼(ground only), zero_torque=零力矩(ground only), "
+                           "emergency_stop=紧急阻尼(any state), get_current_mode=查询当前状态",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "mode": {
                         "type": "string",
-                        "enum": ["damp", "start", "zero_torque", "squat", "stand_up",
-                                 "lie_to_stand", "sit", "balance_stand",
-                                 "continuous_gait", "stop_gait", "high_stand", "low_stand"],
+                        "enum": ["lie2standup", "standup2lie", "standup2squat", "squat2standup",
+                                 "damp", "zero_torque", "emergency_stop", "get_current_mode"],
                         "description": "Target mode",
                     },
                 },
@@ -795,7 +804,7 @@ class LocoPlugin:
             "name": "switch_mode_expert",
             "type": "actuator",
             "multiInstance": False,
-            "description": "G1 locomotion mode switch — directly set FSM mode ID (expert use only). IDs: 0=zero_torque, 1=damp, 2=squat, 3=sit, 4=lock_stand, 500=normal_loco, 501=3dof_waist, 702=lie_to_stand, 706=balance_squat, 801=run_loco",
+            "description": "G1 locomotion mode switch — directly set FSM mode ID (EXPERT ONLY, bypasses safety checks, robot may fall!). IDs: 0=zero_torque, 1=damp, 2=squat, 3=sit, 4=lock_stand, 500=normal_loco, 501=3dof_waist, 702=lie_to_stand, 706=balance_squat, 801=run_loco",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -880,25 +889,98 @@ class LocoPlugin:
             return {"ret": ret}
         elif action == "switch_mode":
             mode = args.get("mode", "")
-            mode_dispatch = {
-                "damp":            lambda: self._client.Damp(),
-                "start":           lambda: self._client.Start(),
-                "zero_torque":     lambda: self._client.ZeroTorque(),
-                "squat":           lambda: self._client.StandUp2Squat(),
-                "stand_up":        lambda: self._client.Squat2StandUp(),
-                "lie_to_stand":    lambda: self._client.Lie2StandUp(),
-                "sit":             lambda: self._client.Sit(),
-                "balance_stand":   lambda: self._client.BalanceStand(1),
-                "continuous_gait": lambda: self._client.ContinuousGait(True),
-                "stop_gait":       lambda: self._client.ContinuousGait(False),
-                "high_stand":      lambda: self._client.HighStand(),
-                "low_stand":       lambda: self._client.LowStand(),
-            }
-            fn = mode_dispatch.get(mode)
-            if fn is None:
-                return {"error": f"Unknown mode: {mode}. Available: {list(mode_dispatch.keys())}"}
-            ret = fn()
-            return {"ret": ret, "mode": mode}
+            code, current_fsm = self._client.GetFsmId()
+
+            if code != 0:
+                return {"error": f"Cannot read current FSM state (code={code}). Aborting for safety."}
+
+            if mode == "emergency_stop":
+                ret = self._client.Damp()
+                return {"ret": ret, "mode": "emergency_stop",
+                        "warning": "Emergency damp executed regardless of state"}
+
+            elif mode == "get_current_mode":
+                FSM_DESCRIPTIONS = {
+                    0: "lying down, zero torque (零力矩, no resistance)",
+                    1: "lying down, damping (阻尼, resists movement)",
+                    2: "squatting (下蹲, position hold, stable)",
+                    3: "sitting (落座, needs external support, unstable)",
+                    500: "standing, normal locomotion (主运控, balanced)",
+                    501: "standing, 3DOF waist locomotion (balanced)",
+                    702: "prep stance (预备模式, stable low stance)",
+                    706: "balance stand (过渡态, intermediate)",
+                    801: "standing, running gait (跑步运控, balanced)",
+                }
+                desc = FSM_DESCRIPTIONS.get(current_fsm, f"unknown state")
+                return {"fsm_id": current_fsm, "description": desc}
+
+            elif mode == "lie2standup":
+                if current_fsm in self._STANDING_STATES:
+                    return {"info": "Robot is already standing", "fsm_id": current_fsm}
+                if current_fsm in self._UNSAFE_STATES:
+                    return {"error": f"Robot is in unsafe state (FSM={current_fsm}). Use emergency_stop first."}
+                # From ground: damp → lie2stand(702) → auto到500
+                if current_fsm in self._GROUND_STATES:
+                    steps = []
+                    if current_fsm == 0:
+                        steps.append(("Damp", 1, "damp"))
+                    steps.append(("Lie2StandUp", 500, "lie2standup"))
+                    return self._run_fsm_sequence(steps)
+                # From low states (squat/prep): start(500)
+                if current_fsm in self._LOW_STATES:
+                    steps = [("Start", 500, "start")]
+                    return self._run_fsm_sequence(steps)
+                return {"error": f"Cannot stand up from FSM={current_fsm}"}
+
+            elif mode == "standup2lie":
+                if current_fsm in self._GROUND_STATES:
+                    return {"info": "Robot is already on the ground", "fsm_id": current_fsm}
+                if current_fsm in self._STANDING_STATES:
+                    # Stop movement first, wait for stabilization
+                    self._client.StopMove()
+                    import time as _time; _time.sleep(1.0)
+                    steps = [("StandUp2Squat", 2, "standup2squat"), ("Damp", 1, "damp")]
+                    return self._run_fsm_sequence(steps)
+                if current_fsm in self._LOW_STATES:
+                    steps = [("Damp", 1, "damp")]
+                    return self._run_fsm_sequence(steps)
+                return {"error": f"Cannot lie down from FSM={current_fsm}. Use emergency_stop if needed."}
+
+            elif mode == "standup2squat":
+                if current_fsm in self._GROUND_STATES or current_fsm in self._LOW_STATES:
+                    return {"info": "Robot is already in low/ground state", "fsm_id": current_fsm}
+                if current_fsm in self._STANDING_STATES:
+                    self._client.StopMove()
+                    import time as _time; _time.sleep(1.0)
+                    steps = [("StandUp2Squat", 2, "standup2squat")]
+                    return self._run_fsm_sequence(steps)
+                return {"error": f"Cannot squat from FSM={current_fsm}. Use emergency_stop if needed."}
+
+            elif mode == "squat2standup":
+                if current_fsm in self._STANDING_STATES:
+                    return {"info": "Robot is already standing", "fsm_id": current_fsm}
+                if current_fsm in self._LOW_STATES:
+                    steps = [("Start", 500, "start")]
+                    return self._run_fsm_sequence(steps)
+                if current_fsm in self._GROUND_STATES:
+                    return {"error": f"Robot is on ground (FSM={current_fsm}). Use lie2standup instead."}
+                return {"error": f"Cannot stand from FSM={current_fsm}"}
+
+            elif mode in ("damp", "zero_torque"):
+                if current_fsm in self._STANDING_STATES or current_fsm in self._LOW_STATES:
+                    return {"error": f"Cannot enter {mode} from upright/low state (FSM={current_fsm}). "
+                                     f"Robot will collapse. Use standup2lie first."}
+                if current_fsm in self._UNSAFE_STATES:
+                    return {"error": f"Cannot enter {mode} from unsafe state (FSM={current_fsm}). "
+                                     f"Use emergency_stop first."}
+                fn = self._client.ZeroTorque if mode == "zero_torque" else self._client.Damp
+                ret = fn()
+                return {"ret": ret, "mode": mode}
+
+            else:
+                return {"error": f"Unknown mode: {mode}. Available: lie2standup, standup2lie, "
+                                 f"standup2squat, squat2standup, damp, zero_torque, "
+                                 f"emergency_stop, get_current_mode"}
         elif action == "switch_mode_expert":
             fid = int(args.get("fsm_id", 0))
             ret = self._client.SetFsmId(fid)
@@ -933,6 +1015,16 @@ class LocoPlugin:
             ret = self._client.ShakeHand()
             return {"ret": ret}
         return None
+
+    # ── FSM sequence helper ───────────────────────────────────────────────────
+
+    def _run_fsm_sequence(self, steps: list) -> dict:
+        """Execute FSM sequence in subprocess (no GIL contention).
+        steps = [(method_name, target_fsm_id_to_poll, step_name), ...]"""
+        result = self._client.RunFsmSequence(steps, interval=1.0, step_timeout=15.0)
+        if result is None:
+            return {"error": "RPC timeout during sequence execution"}
+        return result
 
 
 # ── AsrPlugin (sensor) ───────────────────────────────────────────────────────

--- a/unitree/g1/ext_devices.py
+++ b/unitree/g1/ext_devices.py
@@ -574,6 +574,7 @@ class ExtMicPlugin:
         self._namespace = namespace
         self._executor = executor
         self._nodes: dict[str, _ExtMicNode] = {}
+        self._instance_configs: dict[str, dict] = {}  # instance_id → saved config params
         self._available_devices = _enumerate_ext_mics()
         log.info(f"[ext_mic] found {len(self._available_devices)} external mic device(s)")
         for d in self._available_devices:
@@ -627,6 +628,10 @@ class ExtMicPlugin:
                 raise ValueError("instance_id is required for multiInstance tool")
             device_id = args.get("device_index")  # alsa_id string like "hw:0,0" or integer index
             device_name = args.get("device_name", "")
+            # Fallback to saved config from prior 'config' action
+            if not device_id and instance_id in self._instance_configs:
+                device_id = self._instance_configs[instance_id].get("device_index")
+                device_name = device_name or self._instance_configs[instance_id].get("device_name", "")
             if not device_id:
                 # Try to pick first available device
                 if self._available_devices:
@@ -659,6 +664,14 @@ class ExtMicPlugin:
                     del self._nodes[key]
                 return {"state": "idle"}
             return {"state": "idle"}
+
+        elif action == "config":
+            # Save instance config params for later use during start
+            if instance_id:
+                self._instance_configs[instance_id] = {
+                    k: v for k, v in args.items() if k not in ('action', 'instance_id')
+                }
+            return {"configured": True, "instance_id": instance_id}
 
         return None
 

--- a/unitree/g1/ext_devices.py
+++ b/unitree/g1/ext_devices.py
@@ -593,7 +593,6 @@ class ExtMicPlugin:
                     "scope": "instance",
                     "oneOf": device_options if device_options else [{"const": "", "title": "无可用设备"}],
                 },
-                "device_name": {"type": "string", "description": "设备名称", "scope": "instance"},
             },
         }
         return [tool]
@@ -639,6 +638,12 @@ class ExtMicPlugin:
                     device_name = self._available_devices[0]["name"]
                 else:
                     raise ValueError("No external mic device available")
+            # Auto-resolve device_name from available devices if not provided
+            if not device_name:
+                for d in self._available_devices:
+                    if d.get("alsa_id") == device_id or str(d.get("index")) == str(device_id):
+                        device_name = d["name"]
+                        break
             # Try to convert to int for sounddevice numeric index, keep string for alsa_id
             try:
                 device_id = int(device_id)

--- a/unitree/g1/ext_devices.py
+++ b/unitree/g1/ext_devices.py
@@ -245,17 +245,50 @@ class _ExtMicNode(Node):
         # alsa_id format: "hw:CARD=Pro,DEV=0"
         card_part = self._device_index.split("hw:CARD=", 1)[1].split(",DEV=")[0]
         card_idx = alsaaudio.cards().index(card_part)
-        self._alsa_pcm = alsaaudio.PCM(
-            type=alsaaudio.PCM_CAPTURE,
-            mode=alsaaudio.PCM_NORMAL,
-            rate=16000, channels=1,
-            format=alsaaudio.PCM_FORMAT_S16_LE,
-            periodsize=512,
-            cardindex=card_idx,
-        )
-        # Init dynamic rate probe fields (timer starts on first real read in loop)
-        self._alsa_native_rate = 16000
-        self._alsa_rate_locked = False
+
+        # Probe native format: try S24_3LE stereo first (DJI Wireless Mic etc.),
+        # fallback to S16_LE mono for standard USB mics.
+        self._alsa_native_fmt = None
+        for fmt, channels, fmt_name in [
+            (alsaaudio.PCM_FORMAT_S24_3LE, 2, "S24_3LE_stereo"),
+            (alsaaudio.PCM_FORMAT_S16_LE, 1, "S16_LE_mono"),
+        ]:
+            try:
+                test_pcm = alsaaudio.PCM(
+                    type=alsaaudio.PCM_CAPTURE, mode=alsaaudio.PCM_NORMAL,
+                    rate=48000, channels=channels, format=fmt,
+                    periodsize=1024, cardindex=card_idx,
+                )
+                # Quick read to verify it actually works
+                length, _ = test_pcm.read()
+                test_pcm.close()
+                if length > 0:
+                    self._alsa_native_fmt = fmt_name
+                    break
+            except Exception:
+                continue
+
+        if self._alsa_native_fmt == "S24_3LE_stereo":
+            self._alsa_pcm = alsaaudio.PCM(
+                type=alsaaudio.PCM_CAPTURE, mode=alsaaudio.PCM_NORMAL,
+                rate=48000, channels=2, format=alsaaudio.PCM_FORMAT_S24_3LE,
+                periodsize=1024, cardindex=card_idx,
+            )
+            self._alsa_native_rate = 48000
+            self._alsa_rate_locked = True
+            print(f"[ext_mic] opened {self._device_name} as S24_3LE stereo 48kHz", flush=True)
+        else:
+            # Standard USB mic: S16_LE mono, rate will be probed
+            self._alsa_pcm = alsaaudio.PCM(
+                type=alsaaudio.PCM_CAPTURE, mode=alsaaudio.PCM_NORMAL,
+                rate=16000, channels=1, format=alsaaudio.PCM_FORMAT_S16_LE,
+                periodsize=512, cardindex=card_idx,
+            )
+            self._alsa_native_fmt = "S16_LE_mono"
+            self._alsa_native_rate = 16000
+            self._alsa_rate_locked = False
+            print(f"[ext_mic] opened {self._device_name} as S16_LE mono 16kHz (will probe rate)", flush=True)
+
         self._alsa_probe_samples = 0
         self._alsa_probe_start = 0.0
         self._running = True
@@ -270,6 +303,20 @@ class _ExtMicNode(Node):
             length, data = self._alsa_pcm.read()
             if length <= 0:
                 continue
+
+            # Convert S24_3LE stereo to S16_LE mono if needed
+            if self._alsa_native_fmt == "S24_3LE_stereo":
+                raw = np.frombuffer(data, dtype=np.uint8)
+                n_frames = len(raw) // 6  # 6 bytes per stereo frame (3 bytes × 2 channels)
+                if n_frames == 0:
+                    continue
+                raw = raw[:n_frames * 6].reshape(n_frames, 2, 3)
+                # Take high 2 bytes of each 24-bit sample as int16 (effectively >>8)
+                left = raw[:, 0, 1:].copy().view(np.int16).flatten()
+                right = raw[:, 1, 1:].copy().view(np.int16).flatten()
+                mono = ((left.astype(np.int32) + right.astype(np.int32)) // 2).astype(np.int16)
+                data = mono.tobytes()
+                length = n_frames
 
             # Start probe timer on first actual data (not before thread start,
             # to avoid counting ALSA init latency as part of elapsed time)

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -31,7 +31,7 @@ import rclpy.executors
 
 from unitree_sdk2py.core.channel import ChannelFactoryInitialize
 from unitree_sdk2py.g1.audio.g1_audio_client import AudioClient
-from unitree_sdk2py.g1.loco.g1_loco_client import LocoClient
+from rpc_proxy import RpcProxy
 from unitree_sdk2py.g1.arm.g1_arm_action_client import G1ArmActionClient
 from unitree_sdk2py.g1.slam.slam_client import SlamClient
 from unitree_sdk2py.comm.motion_switcher.motion_switcher_client import MotionSwitcherClient
@@ -336,11 +336,9 @@ def main():
     audio_client.Init()
     print("[bundle] AudioClient ready")
 
-    # LocoClient (locomotion control)
-    loco_client = LocoClient()
-    loco_client.SetTimeout(10.0)
-    loco_client.Init()
-    print("[bundle] LocoClient ready")
+    # LocoClient (locomotion control) — via subprocess proxy to avoid GIL contention
+    loco_client = RpcProxy(network_iface)
+    print("[bundle] LocoClient ready (subprocess proxy)")
 
     # G1ArmActionClient (arm gestures)
     arm_client = G1ArmActionClient()
@@ -392,6 +390,7 @@ def main():
         if smart_motion:
             smart_motion.shutdown()
         _bundle.stop_all()
+        loco_client.stop()
         threading.Thread(target=server.shutdown, daemon=True).start()
 
     signal.signal(signal.SIGTERM, _shutdown)

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -57,7 +57,7 @@ def _resolve_namespace(cfg: dict) -> str:
 class G1DeviceBundle:
     def __init__(self, cfg: dict, namespace: str, executor,
                  audio_client: AudioClient,
-                 loco_client: LocoClient,
+                 loco_client: RpcProxy,
                  arm_client: G1ArmActionClient,
                  slam_client: SlamClient,
                  msc_client: MotionSwitcherClient,

--- a/unitree/g1/rpc_proxy.py
+++ b/unitree/g1/rpc_proxy.py
@@ -1,0 +1,224 @@
+"""
+rpc_proxy.py — Subprocess proxy for G1 LocoClient RPC calls.
+
+The driver process has many threads (ROS2 executor, camera, mic, lidar, etc.)
+causing GIL contention. CycloneDDS listener callbacks get starved, making RPC
+responses arrive late or timeout. Running LocoClient in a subprocess avoids this.
+
+Modeled after R1's rpc_proxy.py with G1-specific adaptations.
+"""
+
+import multiprocessing
+import threading
+import time
+
+
+def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.Queue,
+                network_iface: str):
+    """Subprocess: holds dedicated LocoClient, processes commands sequentially."""
+    from unitree_sdk2py.core.channel import ChannelFactoryInitialize
+    from unitree_sdk2py.g1.loco.g1_loco_client import LocoClient
+
+    ChannelFactoryInitialize(0, network_iface)
+
+    loco = LocoClient()
+    loco.SetTimeout(10.0)
+    loco.Init()
+
+    time.sleep(0.5)
+    print("[G1 RpcWorker] ready", flush=True)
+
+    while True:
+        try:
+            cmd = cmd_queue.get()
+        except Exception:
+            break
+        if cmd is None:
+            break
+
+        method = cmd.get("method")
+        args = cmd.get("args", [])
+        kwargs = cmd.get("kwargs", {})
+
+        try:
+            # Special: FSM sequence execution (runs entirely in subprocess, no GIL)
+            if method == "__run_fsm_sequence":
+                steps_spec, interval, step_timeout, settle_delay = args
+                completed = []
+                for method_name, target_fsm, step_name in steps_spec:
+                    fn = getattr(loco, method_name)
+                    ret = fn()
+                    if ret != 0:
+                        result_queue.put({"result": {
+                            "error": f"Step '{step_name}' failed: code={ret}",
+                            "step": step_name, "completed": completed}})
+                        break  # abort sequence on failure
+                    # Poll FSM until target reached or timeout
+                    elapsed = 0.0
+                    ok = False
+                    while elapsed < step_timeout:
+                        time.sleep(interval)
+                        elapsed += interval
+                        code, fsm_id = loco.GetFsmId()
+                        if code == 0 and fsm_id == target_fsm:
+                            ok = True
+                            break
+                    if not ok:
+                        _, current = loco.GetFsmId()
+                        result_queue.put({"result": {
+                            "error": f"Timeout '{step_name}' (expected={target_fsm}, got={current})",
+                            "step": step_name, "fsm_id": current, "completed": completed}})
+                        break  # abort sequence on timeout
+                    completed.append(step_name)
+                    # Wait for physical motion to settle before next step
+                    time.sleep(settle_delay)
+                else:
+                    # Only reached if loop completed without break (all steps succeeded)
+                    result_queue.put({"result": {"ret": 0, "steps": completed,
+                                                 "fsm_id": steps_spec[-1][1]}})
+                continue  # next cmd
+
+            fn = getattr(loco, method)
+            result = fn(*args, **kwargs)
+            result_queue.put({"result": result})
+        except Exception as e:
+            result_queue.put({"error": str(e)})
+
+
+class RpcProxy:
+    """Proxy that forwards LocoClient RPC calls to a subprocess, avoiding GIL contention."""
+
+    def __init__(self, network_iface: str = "eth0"):
+        ctx = multiprocessing.get_context("spawn")
+        self._cmd_q = ctx.Queue()
+        self._result_q = ctx.Queue()
+        self._proc = ctx.Process(
+            target=_rpc_worker,
+            args=(self._cmd_q, self._result_q, network_iface),
+            daemon=True,
+        )
+        self._proc.start()
+        self._lock = threading.Lock()
+
+    def _call(self, method: str, *args, timeout: float = 15.0, **kwargs):
+        with self._lock:
+            self._cmd_q.put({"method": method, "args": args, "kwargs": kwargs})
+            try:
+                r = self._result_q.get(timeout=timeout)
+            except Exception:
+                return None
+            if "error" in r:
+                print(f"[G1 RpcProxy] {method} error: {r['error']}", flush=True)
+                return None
+            return r["result"]
+
+    def _call_code(self, method: str, *args, **kwargs) -> int:
+        """For methods that return a single int code."""
+        result = self._call(method, *args, **kwargs)
+        if result is None:
+            return 3104
+        return result
+
+    def _call_tuple(self, method: str, *args, **kwargs):
+        """For methods that return (code, data) tuple."""
+        result = self._call(method, *args, **kwargs)
+        if result is None:
+            return 3104, None
+        return result
+
+    def stop(self):
+        try:
+            self._cmd_q.put(None)
+            self._proc.join(timeout=3)
+        except Exception:
+            pass
+
+    # ── LocoClient interface ──────────────────────────────────────────────────
+
+    def RunFsmSequence(self, steps: list, interval: float = 1.0, step_timeout: float = 15.0,
+                       settle_delay: float = 2.0):
+        """Run FSM sequence entirely in subprocess (no GIL contention).
+        steps = [(method_name, target_fsm_to_poll, step_name), ...]
+        settle_delay = seconds to wait after FSM confirms state change.
+        Returns dict with {ret, steps, fsm_id} on success or {error, step} on failure."""
+        outer_timeout = len(steps) * (step_timeout + settle_delay + 5) + 10
+        return self._call("__run_fsm_sequence", steps, interval, step_timeout, settle_delay,
+                          timeout=outer_timeout)
+
+    def GetFsmId(self):
+        return self._call_tuple("GetFsmId")
+
+    def GetFsmMode(self):
+        return self._call_tuple("GetFsmMode")
+
+    def GetBalanceMode(self):
+        return self._call_tuple("GetBalanceMode")
+
+    def GetSwingHeight(self):
+        return self._call_tuple("GetSwingHeight")
+
+    def GetStandHeight(self):
+        return self._call_tuple("GetStandHeight")
+
+    def GetPhase(self):
+        return self._call_tuple("GetPhase")
+
+    def SetFsmId(self, fsm_id: int):
+        return self._call_code("SetFsmId", fsm_id)
+
+    def SetBalanceMode(self, balance_mode: int):
+        return self._call_code("SetBalanceMode", balance_mode)
+
+    def SetStandHeight(self, stand_height: float):
+        return self._call_code("SetStandHeight", stand_height)
+
+    def SetVelocity(self, vx: float, vy: float, omega: float, duration: float = 1.0):
+        return self._call_code("SetVelocity", vx, vy, omega, duration)
+
+    def SetTaskId(self, task_id: float):
+        return self._call_code("SetTaskId", task_id)
+
+    def Damp(self):
+        return self._call_code("Damp")
+
+    def Start(self):
+        return self._call_code("Start")
+
+    def Lie2StandUp(self):
+        return self._call_code("Lie2StandUp")
+
+    def StandUp2Squat(self):
+        return self._call_code("StandUp2Squat")
+
+    def Squat2StandUp(self):
+        return self._call_code("Squat2StandUp")
+
+    def Sit(self):
+        return self._call_code("Sit")
+
+    def ZeroTorque(self):
+        return self._call_code("ZeroTorque")
+
+    def StopMove(self):
+        return self._call_code("StopMove")
+
+    def Move(self, vx: float, vy: float, vyaw: float, continous_move: bool = False):
+        return self._call_code("Move", vx, vy, vyaw, continous_move)
+
+    def HighStand(self):
+        return self._call_code("HighStand")
+
+    def LowStand(self):
+        return self._call_code("LowStand")
+
+    def BalanceStand(self, balance_mode: int):
+        return self._call_code("BalanceStand", balance_mode)
+
+    def ContinuousGait(self, flag: bool):
+        return self._call_code("ContinuousGait", flag)
+
+    def WaveHand(self, turn_flag: bool = False):
+        return self._call_code("WaveHand", turn_flag)
+
+    def ShakeHand(self, stage: int = -1):
+        return self._call_code("ShakeHand", stage)

--- a/unitree/g1/unitree_sdk2py/g1/loco/g1_loco_client.py
+++ b/unitree/g1/unitree_sdk2py/g1/loco/g1_loco_client.py
@@ -73,36 +73,36 @@ class LocoClient(Client):
         return code
 
     def Damp(self):
-        self.SetFsmId(1)
-    
+        return self.SetFsmId(1)
+
     def Start(self):
-        self.SetFsmId(500)
+        return self.SetFsmId(500)
 
     def Squat2StandUp(self):
-        self.SetFsmId(706)
+        return self.SetFsmId(706)
 
     def Lie2StandUp(self):
-        self.SetFsmId(702)
+        return self.SetFsmId(702)
 
     def Sit(self):
-        self.SetFsmId(3)
+        return self.SetFsmId(3)
 
     def StandUp2Squat(self):
-        self.SetFsmId(706)
+        return self.SetFsmId(706)
 
     def ZeroTorque(self):
-        self.SetFsmId(0)
+        return self.SetFsmId(0)
 
     def StopMove(self):
-        self.SetVelocity(0., 0., 0.)
+        return self.SetVelocity(0., 0., 0.)
 
     def HighStand(self):
         UINT32_MAX = (1 << 32) - 1
-        self.SetStandHeight(UINT32_MAX)
+        return self.SetStandHeight(UINT32_MAX)
 
     def LowStand(self):
         UINT32_MIN = 0
-        self.SetStandHeight(UINT32_MIN)
+        return self.SetStandHeight(UINT32_MIN)
 
     def Move(self, vx: float, vy: float, vyaw: float, continous_move: bool = False):
         duration = 864000.0 if continous_move else 1

--- a/unitree/r1/device.py
+++ b/unitree/r1/device.py
@@ -317,6 +317,8 @@ class _SpeakerNode(Node):
         self._drain_thread: threading.Thread | None = None
         self._last_chunk_time = 0.0
         self._flush_timer = None
+        # Clear stale PlayStream session from previous container run (MCU keeps state across reboot)
+        self._client.PlayStop(APP_NAME)
         self.get_logger().info("SpeakerNode ready")
 
     def start_play(self, topic: str) -> str:


### PR DESCRIPTION
## Summary
- Refactor G1 `switch_mode` to prevent dangerous state transitions (collapse prevention)
- Add FSM state group safety checks: blocks damp/zero_torque from standing/low states
- Implement composite FSM sequences with polling (`lie2standup`, `standup2lie`, `standup2squat`, `squat2standup`)
- Create `RpcProxy` subprocess for GIL-free FSM sequence execution (same pattern as R1)
- Fix missing return values in `g1_loco_client.py` wrapper methods

## Test plan
- [ ] Deploy to G1, call `get_current_mode` to verify FSM query
- [ ] Test blocked transition: call `damp` while standing → expect error
- [ ] Test `standup2lie` from standing → StopMove→Squat(2)→Damp(1)
- [ ] Test `lie2standup` from ground → Damp(1)→Lie2StandUp(702)→auto到500
- [ ] Test `emergency_stop` from any state → always succeeds
- [ ] Verify SmartMotion obstacle detection still works during locomotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)