### PR TITLE
fix(tianyi2): repair raw arm joint control card

### DIFF
--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -20,7 +20,15 @@ input is never mirrored automatically. To create a mirrored right-arm pose manua
 shoulder roll, shoulder yaw, wrist yaw, and wrist roll (indices 1, 2, 4, and 6)
 from the left pose. Right-arm motor IDs are 21-27 and left-arm IDs are 11-17.
 `move_pos` accepts speed [0.2, 1.5] rad/s. `move_ctrl` accepts seven-element
-`kp` [0, 2000] and `kd` [0, 300] arrays shared by the selected arms.
+`kp` [5, 100] and `kd` [5, 30] arrays shared by both arms. Conservative raw
+control defaults are `kp=10` and `kd=8` for every joint; these are test
+starting points, not vendor-certified gains.
+
+`move_ctrl` sends a position step with target speed and feed-forward torque set
+to zero. The vendor-side controller applies `kp` and `kd`; this driver does not
+calculate the PD output or impose a trajectory speed limit. Use small target
+changes, begin with low gains, keep the emergency stop available, and use
+`move_pos` when bounded motion speed is required.
 
 Both modes reject malformed arrays and poses outside the checked-in URDF
 limits. They check fresh `/arm/status`, selected motor faults, emergency stop,

--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -20,9 +20,11 @@ input is never mirrored automatically. To create a mirrored right-arm pose manua
 shoulder roll, shoulder yaw, wrist yaw, and wrist roll (indices 1, 2, 4, and 6)
 from the left pose. Right-arm motor IDs are 21-27 and left-arm IDs are 11-17.
 `move_pos` accepts speed [0.2, 1.5] rad/s. `move_ctrl` accepts seven-element
-`kp` [0, 2000] and `kd` [0, 300] arrays shared by both arms. The original raw
-control defaults are `kp=200` and `kd=20` for every joint; these are not
-vendor-certified gains.
+`kp` [10, 200] and `kd` [5, 50] arrays shared by both arms. Raw-control defaults
+are `kp=50` and `kd=20` for every joint. The bounded tuning range includes the
+tested lower-gain and original-default combinations while excluding zero
+position stiffness and the previous unverified extreme upper bounds. These are
+still not vendor-certified gains.
 
 `move_ctrl` sends a position step with target speed and feed-forward torque set
 to zero. The vendor-side controller applies `kp` and `kd`; this driver does not

--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -27,6 +27,10 @@ and power state before publishing, then wait for newer feedback. Do not command
 the raw `arm` and `arm_gesture` cards concurrently because both can publish to
 `/arm/cmd_pos`.
 
+For compatibility with dashboard array fields, `positions`, `kp`, and `kd`
+accept either native JSON arrays or strings containing a JSON array. Both forms
+are decoded into seven numeric values before the same range and URDF checks run.
+
 ## Head gesture card
 
 `head_gesture` turns safe, bounded head-position commands into cancellable

--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -13,11 +13,10 @@ exposes the capabilities as MCP tools.
  elbow_pitch, wrist_yaw, wrist_pitch, wrist_roll]
 ```
 
-The card exposes separate `left_positions` and `right_positions` arrays in
-degrees. Selecting `left` reads only the left array, selecting `right` reads
-only the right array, and selecting `both` publishes both arrays in one command
-so the arms can move to different poses simultaneously. Raw arm input is never
-mirrored automatically. To create a mirrored right-arm pose manually, negate
+The card always exposes separate `left_positions` and `right_positions` arrays
+in degrees and publishes both arrays in one 14-joint command, so the arms can
+move to different poses simultaneously. There is no `side` selector. Raw arm
+input is never mirrored automatically. To create a mirrored right-arm pose manually, negate
 shoulder roll, shoulder yaw, wrist yaw, and wrist roll (indices 1, 2, 4, and 6)
 from the left pose. Right-arm motor IDs are 21-27 and left-arm IDs are 11-17.
 `move_pos` accepts speed [0.2, 1.5] rad/s. `move_ctrl` accepts seven-element
@@ -33,8 +32,8 @@ For compatibility with dashboard array fields, `left_positions`,
 `right_positions`, `kp`, and `kd` accept either native JSON arrays or strings
 containing a JSON array. Both forms are decoded into seven numeric values before
 the same range and URDF checks run. Direct callers using the former `positions`
-field remain supported as a fallback, but its values are sent unchanged to each
-selected arm and are no longer mirrored.
+field remain supported as a fallback, but its values are sent unchanged to both
+arms and are no longer mirrored.
 
 ## Head gesture card
 

--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -42,6 +42,18 @@ calculate the PD output or impose a trajectory speed limit. Use small target
 changes, begin with low gains, keep the emergency stop available, and use
 `move_pos` when bounded motion speed is required.
 
+In practical terms, `move_ctrl` is intended for controller commissioning,
+pose holding and already-validated compliant interaction where the operator
+needs to tune joint stiffness and damping. Higher `kp` generally increases
+position response and holding stiffness but can increase impact and overshoot;
+lower `kp` is more compliant but can leave a larger load-dependent position
+error. Higher `kd` generally adds damping, while insufficient `kd` can allow
+overshoot or oscillation. The exact control law runs in the vendor controller,
+so these effects are guidance rather than a driver-side torque calculation.
+The same seven-element gain arrays are applied to corresponding joints on both
+arms. Do not use `move_ctrl` as a substitute for `move_pos` for routine poses,
+large position steps or semantic gestures.
+
 Both modes reject malformed arrays and poses outside the checked-in URDF
 limits. They check fresh `/arm/status`, selected motor faults, emergency stop,
 and power state before publishing, then wait for newer feedback. Do not command

--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -26,6 +26,16 @@ tested lower-gain and original-default combinations while excluding zero
 position stiffness and the previous unverified extreme upper bounds. These are
 still not vendor-certified gains.
 
+`move_pos` uses the rated-current limits from the Tianyi joint specification
+table instead of one fixed current for every arm motor. In joint order, each
+arm uses `[35, 23, 8, 8, 8, 5, 5]` A for shoulder pitch, shoulder roll,
+shoulder yaw, elbow pitch, wrist yaw, wrist pitch, and wrist roll. The same
+limits apply to left motor IDs 11-17 and right motor IDs 21-27. Raw and semantic
+head position commands use 5 A for motor IDs 1-3. `move_ctrl` has no current
+field and is unaffected by this mapping. Do not increase these values beyond
+the specification; clear the workspace and keep the emergency stop available
+when validating the higher-current shoulder joints.
+
 `move_ctrl` sends a position step with target speed and feed-forward torque set
 to zero. The vendor-side controller applies `kp` and `kd`; this driver does not
 calculate the PD output or impose a trajectory speed limit. Use small target

--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -13,13 +13,15 @@ exposes the capabilities as MCP tools.
  elbow_pitch, wrist_yaw, wrist_pitch, wrist_roll]
 ```
 
-The input pose is a left-arm canonical pose in degrees. Selecting `right` or
-`both` mirrors shoulder roll, shoulder yaw, wrist yaw, and wrist roll before
-publishing to right-arm motor IDs 21-27; left-arm IDs are 11-17. This makes a
-single pose produce symmetric bilateral motion and keeps right-arm lateral
-axes consistent with the semantic arm card. `move_pos` accepts speed
-[0.2, 1.5] rad/s. `move_ctrl` accepts seven-element `kp` [0, 2000] and `kd`
-[0, 300] arrays.
+The card exposes separate `left_positions` and `right_positions` arrays in
+degrees. Selecting `left` reads only the left array, selecting `right` reads
+only the right array, and selecting `both` publishes both arrays in one command
+so the arms can move to different poses simultaneously. Raw arm input is never
+mirrored automatically. To create a mirrored right-arm pose manually, negate
+shoulder roll, shoulder yaw, wrist yaw, and wrist roll (indices 1, 2, 4, and 6)
+from the left pose. Right-arm motor IDs are 21-27 and left-arm IDs are 11-17.
+`move_pos` accepts speed [0.2, 1.5] rad/s. `move_ctrl` accepts seven-element
+`kp` [0, 2000] and `kd` [0, 300] arrays shared by the selected arms.
 
 Both modes reject malformed arrays and poses outside the checked-in URDF
 limits. They check fresh `/arm/status`, selected motor faults, emergency stop,
@@ -27,9 +29,12 @@ and power state before publishing, then wait for newer feedback. Do not command
 the raw `arm` and `arm_gesture` cards concurrently because both can publish to
 `/arm/cmd_pos`.
 
-For compatibility with dashboard array fields, `positions`, `kp`, and `kd`
-accept either native JSON arrays or strings containing a JSON array. Both forms
-are decoded into seven numeric values before the same range and URDF checks run.
+For compatibility with dashboard array fields, `left_positions`,
+`right_positions`, `kp`, and `kd` accept either native JSON arrays or strings
+containing a JSON array. Both forms are decoded into seven numeric values before
+the same range and URDF checks run. Direct callers using the former `positions`
+field remain supported as a fallback, but its values are sent unchanged to each
+selected arm and are no longer mirrored.
 
 ## Head gesture card
 

--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -4,22 +4,6 @@ Phanthy Motus driver bundle for the Tianyi 2.0 Pro humanoid robot. The driver
 bridges robot-side ROS2 topics on domain 0 to Agent Core topics on domain 42 and
 exposes the capabilities as MCP tools.
 
-## Raw head joint card
-
-`head` directly commands the three head joints in degrees on `/head/cmd_pos`.
-The motor order is roll (ID 1), pitch (ID 2), and yaw (ID 3), while dashboard
-parameters are named `yaw`, `pitch`, and `roll`. `move_pos` accepts yaw
-[-90, 90], pitch [-25, 25], roll [-26, 26], and speed [5, 60] degrees/second.
-`look_at` provides forward, left, right, up, and down presets using the same
-speed range.
-
-Before publishing, the card rejects non-numeric, non-finite, or out-of-range
-inputs and checks fresh `/head/status`, all head motor fault codes, emergency
-stop, and power state. It waits up to two seconds for newer status and reports
-`feedback_verified: true` only after observing motion or confirming that the
-head was already at the target. Controller/status failures are returned as
-stable error codes instead of incorrectly reporting `moving` immediately.
-
 ## Raw arm joint card
 
 `arm` directly commands seven joints per selected arm in this canonical order:

--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -20,9 +20,9 @@ input is never mirrored automatically. To create a mirrored right-arm pose manua
 shoulder roll, shoulder yaw, wrist yaw, and wrist roll (indices 1, 2, 4, and 6)
 from the left pose. Right-arm motor IDs are 21-27 and left-arm IDs are 11-17.
 `move_pos` accepts speed [0.2, 1.5] rad/s. `move_ctrl` accepts seven-element
-`kp` [5, 100] and `kd` [5, 30] arrays shared by both arms. Conservative raw
-control defaults are `kp=10` and `kd=8` for every joint; these are test
-starting points, not vendor-certified gains.
+`kp` [0, 2000] and `kd` [0, 300] arrays shared by both arms. The original raw
+control defaults are `kp=200` and `kd=20` for every joint; these are not
+vendor-certified gains.
 
 `move_ctrl` sends a position step with target speed and feed-forward torque set
 to zero. The vendor-side controller applies `kp` and `kd`; this driver does not

--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -4,6 +4,45 @@ Phanthy Motus driver bundle for the Tianyi 2.0 Pro humanoid robot. The driver
 bridges robot-side ROS2 topics on domain 0 to Agent Core topics on domain 42 and
 exposes the capabilities as MCP tools.
 
+## Raw head joint card
+
+`head` directly commands the three head joints in degrees on `/head/cmd_pos`.
+The motor order is roll (ID 1), pitch (ID 2), and yaw (ID 3), while dashboard
+parameters are named `yaw`, `pitch`, and `roll`. `move_pos` accepts yaw
+[-90, 90], pitch [-25, 25], roll [-26, 26], and speed [5, 60] degrees/second.
+`look_at` provides forward, left, right, up, and down presets using the same
+speed range.
+
+Before publishing, the card rejects non-numeric, non-finite, or out-of-range
+inputs and checks fresh `/head/status`, all head motor fault codes, emergency
+stop, and power state. It waits up to two seconds for newer status and reports
+`feedback_verified: true` only after observing motion or confirming that the
+head was already at the target. Controller/status failures are returned as
+stable error codes instead of incorrectly reporting `moving` immediately.
+
+## Raw arm joint card
+
+`arm` directly commands seven joints per selected arm in this canonical order:
+
+```text
+[shoulder_pitch, shoulder_roll, shoulder_yaw,
+ elbow_pitch, wrist_yaw, wrist_pitch, wrist_roll]
+```
+
+The input pose is a left-arm canonical pose in degrees. Selecting `right` or
+`both` mirrors shoulder roll, shoulder yaw, wrist yaw, and wrist roll before
+publishing to right-arm motor IDs 21-27; left-arm IDs are 11-17. This makes a
+single pose produce symmetric bilateral motion and keeps right-arm lateral
+axes consistent with the semantic arm card. `move_pos` accepts speed
+[0.2, 1.5] rad/s. `move_ctrl` accepts seven-element `kp` [0, 2000] and `kd`
+[0, 300] arrays.
+
+Both modes reject malformed arrays and poses outside the checked-in URDF
+limits. They check fresh `/arm/status`, selected motor faults, emergency stop,
+and power state before publishing, then wait for newer feedback. Do not command
+the raw `arm` and `arm_gesture` cards concurrently because both can publish to
+`/arm/cmd_pos`.
+
 ## Head gesture card
 
 `head_gesture` turns safe, bounded head-position commands into cancellable

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -170,6 +170,222 @@ class _ActionSequence:
         return True
 
 
+class _JointCommandFeedback:
+    """Shared status, safety preflight, and motion feedback for raw joint cards."""
+
+    _STATUS_MAX_AGE = 2.0
+    _FEEDBACK_TIMEOUT = 2.0
+    _MOVE_THRESHOLD_RAD = _deg2rad(0.5)
+    _TARGET_TOLERANCE_RAD = _deg2rad(3.0)
+
+    def __init__(self, subsystem: str, status_topic: str):
+        self._subsystem = subsystem
+        self._status_topic = status_topic
+        self._condition = threading.Condition()
+        self._status: dict[int, dict] = {}
+        self._status_seq = 0
+        self._status_time: float | None = None
+        self._power_status: dict = {}
+        self._power_status_time: float | None = None
+
+    def create_subscriptions(self, node: Node) -> None:
+        from bodyctrl_msgs.msg import MotorStatusMsg, PowerBoardKeyStatus
+        node.create_subscription(
+            MotorStatusMsg, self._status_topic,
+            self._on_motor_status, _RELIABLE_QOS)
+        node.create_subscription(
+            PowerBoardKeyStatus, "/power/board/key_status",
+            self._on_power_status, _RELIABLE_QOS)
+
+    def _on_motor_status(self, msg) -> None:
+        now = time.monotonic()
+        with self._condition:
+            self._status = {
+                int(motor.name): {
+                    "pos": float(motor.pos),
+                    "speed": float(motor.speed),
+                    "current": float(motor.current),
+                    "temperature": float(motor.temperature),
+                    "error": int(motor.error),
+                }
+                for motor in msg.status
+            }
+            self._status_seq += 1
+            self._status_time = now
+            self._condition.notify_all()
+
+    def _on_power_status(self, msg) -> None:
+        now = time.monotonic()
+        with self._condition:
+            self._power_status = {
+                "is_estop": bool(msg.is_estop.data),
+                "is_remote_estop": bool(msg.is_remote_estop.data),
+                "is_power_on": bool(msg.is_power_on.data),
+            }
+            self._power_status_time = now
+            self._condition.notify_all()
+
+    @staticmethod
+    def _error(code: str, message: str, **details) -> dict:
+        result = {"state": "error", "error": message, "code": code}
+        result.update(details)
+        return result
+
+    def _faults(self, motor_ids: list[int]) -> list[dict]:
+        faults = []
+        for motor_id in motor_ids:
+            status = self._status.get(motor_id)
+            if status is None or status["error"] == 0:
+                continue
+            error_code = status["error"]
+            faults.append({
+                "motor_id": motor_id,
+                "joint": _ALL_JOINTS.get(motor_id, f"motor_{motor_id}"),
+                "error_code": error_code,
+                "description": _MOTOR_ERROR_DESCRIPTIONS.get(
+                    error_code, "unknown_vendor_error"),
+            })
+        return faults
+
+    def preflight(self, publisher, motor_ids: list[int]) -> dict | None:
+        if not publisher:
+            return self._error(
+                "publisher_not_initialized",
+                f"{self._subsystem} command publisher is not initialized")
+        now = time.monotonic()
+        with self._condition:
+            if self._status_time is None:
+                return self._error(
+                    f"{self._subsystem}_status_unavailable",
+                    f"No {self._status_topic} received; "
+                    f"{self._subsystem} controller may not be running",
+                    diagnosis=[
+                        "check robot body-control program",
+                        "complete robot self-check and confirm Ready state",
+                        f"check ROS_DOMAIN_ID and {self._status_topic}",
+                    ],
+                )
+            status_age = now - self._status_time
+            if status_age > self._STATUS_MAX_AGE:
+                return self._error(
+                    f"{self._subsystem}_status_stale",
+                    f"{self._status_topic} is stale ({status_age:.2f}s)",
+                    diagnosis=[
+                        "check robot body-control program",
+                        "check ROS communication",
+                    ],
+                )
+            missing = [
+                motor_id for motor_id in motor_ids
+                if motor_id not in self._status
+            ]
+            if missing:
+                return self._error(
+                    f"{self._subsystem}_motors_missing",
+                    f"Selected {self._subsystem} motors are missing from "
+                    f"{self._status_topic}",
+                    missing_motor_ids=missing,
+                )
+            faults = self._faults(motor_ids)
+            if faults:
+                return self._error(
+                    f"{self._subsystem}_motor_fault",
+                    f"Selected {self._subsystem} has active motor faults",
+                    faults=faults,
+                )
+            if (self._power_status_time is not None
+                    and now - self._power_status_time <= self._STATUS_MAX_AGE):
+                if (self._power_status.get("is_estop")
+                        or self._power_status.get("is_remote_estop")):
+                    return self._error(
+                        "emergency_stop_active",
+                        "Physical or remote emergency stop is active",
+                        power_status=dict(self._power_status),
+                    )
+                if not self._power_status.get("is_power_on", True):
+                    return self._error(
+                        "robot_power_off",
+                        "Robot power board reports power off",
+                        power_status=dict(self._power_status),
+                    )
+        return None
+
+    def snapshot(self, motor_ids: list[int]) -> tuple[int, dict[int, float]]:
+        with self._condition:
+            return self._status_seq, {
+                motor_id: self._status[motor_id]["pos"]
+                for motor_id in motor_ids
+                if motor_id in self._status
+            }
+
+    def wait_for_motion(
+            self, targets: dict[int, float], baseline_seq: int,
+            baseline: dict[int, float]) -> dict:
+        motor_ids = list(targets)
+        deadline = time.monotonic() + self._FEEDBACK_TIMEOUT
+        received_new_status = False
+        with self._condition:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                if self._status_seq <= baseline_seq:
+                    self._condition.wait(remaining)
+                    continue
+                received_new_status = True
+                faults = self._faults(motor_ids)
+                if faults:
+                    return self._error(
+                        f"{self._subsystem}_motor_fault_after_command",
+                        f"{self._subsystem.capitalize()} motor fault appeared "
+                        "after command",
+                        faults=faults,
+                    )
+                positions = {
+                    motor_id: self._status[motor_id]["pos"]
+                    for motor_id in motor_ids
+                }
+                moved = max(
+                    abs(positions[motor_id] - baseline[motor_id])
+                    for motor_id in motor_ids
+                )
+                target_error = max(
+                    abs(positions[motor_id] - targets[motor_id])
+                    for motor_id in motor_ids
+                )
+                if (moved >= self._MOVE_THRESHOLD_RAD
+                        or target_error <= self._TARGET_TOLERANCE_RAD):
+                    return {
+                        "state": "moving",
+                        "status_topic": self._status_topic,
+                        "max_movement_deg": round(_rad2deg(moved), 2),
+                        "max_target_error_deg": round(
+                            _rad2deg(target_error), 2),
+                    }
+                self._condition.wait(0.05)
+        if not received_new_status:
+            return self._error(
+                f"{self._subsystem}_feedback_timeout",
+                f"Command was published but no new {self._status_topic} "
+                "was received",
+                diagnosis=[
+                    f"check {self._subsystem} controller and ROS communication",
+                    "confirm robot self-check completed and robot is Ready",
+                ],
+            )
+        return self._error(
+            f"{self._subsystem}_no_motion",
+            f"Command was published and {self._subsystem} status updated, "
+            "but no selected joint moved",
+            diagnosis=[
+                "robot may not be Ready or self-check may be incomplete",
+                f"{self._subsystem} controller may be disabled or rejecting commands",
+                f"another node may be publishing competing "
+                f"/{self._subsystem}/cmd_pos commands",
+            ],
+        )
+
+
 # ══════════════════════════════════════════════════════════════════════════════
 # StatePlugin (sensor, multi-tool)
 # ══════════════════════════════════════════════════════════════════════════════
@@ -692,7 +908,8 @@ class HeadPlugin:
         self._ros2 = ros2
         self._pub_node = Node("tianyi2_head_pub", context=ros2.ctx_tianyi)
         ros2.executor_tianyi.add_node(self._pub_node)
-        self._publisher = None  # Lazy init
+        self._publisher = None
+        self._feedback = _JointCommandFeedback("head", "/head/status")
 
     def get_tool(self) -> dict:
         return {
@@ -703,18 +920,26 @@ class HeadPlugin:
                 "type": "object",
                 "properties": {
                     "action": {"type": "string", "enum": ["move_pos", "look_at"],
+                               "default": "move_pos",
                                "description": "控制动作"},
-                    "yaw": {"type": "number", "description": "偏航角(度), 左正右负, 范围[-90, 90]"},
-                    "pitch": {"type": "number", "description": "俯仰角(度), 下正上负, 范围[-25, 25]"},
-                    "roll": {"type": "number", "description": "翻滚角(度), 范围[-26, 26]"},
+                    "yaw": {"type": "number", "minimum": -90, "maximum": 90,
+                            "default": 0, "description": "偏航角(度), 左正右负, 范围[-90, 90]"},
+                    "pitch": {"type": "number", "minimum": -25, "maximum": 25,
+                              "default": 0, "description": "俯仰角(度), 下正上负, 范围[-25, 25]"},
+                    "roll": {"type": "number", "minimum": -26, "maximum": 26,
+                             "default": 0, "description": "翻滚角(度), 范围[-26, 26]"},
+                    "speed": {"type": "number", "minimum": 5, "maximum": 60,
+                              "default": 30,
+                              "description": "头部运动速度(度/秒), 范围[5, 60], 默认30"},
                     "target": {"type": "string", "enum": ["forward", "left", "right", "up", "down"],
+                               "default": "forward",
                                "description": "预设方向"},
                 },
                 "required": ["action"],
                 "x-action-params": {
-                    "move_pos": {"params": ["yaw", "pitch", "roll"],
+                    "move_pos": {"params": ["yaw", "pitch", "roll", "speed"],
                                  "description": "移动头部到指定角度(度)"},
-                    "look_at": {"params": ["target"],
+                    "look_at": {"params": ["target", "speed"],
                                 "description": "看向预设方向"},
                 },
             },
@@ -725,7 +950,8 @@ class HeadPlugin:
             from bodyctrl_msgs.msg import CmdSetMotorPosition
             self._publisher = self._pub_node.create_publisher(
                 CmdSetMotorPosition, "/head/cmd_pos", _RELIABLE_QOS)
-            print("[HeadPlugin] publisher created")
+            self._feedback.create_subscriptions(self._pub_node)
+            print("[HeadPlugin] publisher and feedback subscriptions created")
         except ImportError as e:
             print(f"[HeadPlugin] WARNING: msg import failed ({e})")
 
@@ -734,10 +960,9 @@ class HeadPlugin:
 
     def dispatch(self, action: str, args: dict) -> dict:
         if action == "move_pos":
-            yaw = args.get("yaw", 0)
-            pitch = args.get("pitch", 0)
-            roll = args.get("roll", 0)
-            return self._send_head_pos(roll, pitch, yaw)
+            return self._move_to(
+                args.get("yaw", 0), args.get("pitch", 0),
+                args.get("roll", 0), args.get("speed", 30))
         elif action == "look_at":
             target = args.get("target", "forward")
             presets = {
@@ -747,15 +972,68 @@ class HeadPlugin:
                 "up": (0, -20, 0),
                 "down": (0, 20, 0),
             }
-            yaw, pitch, roll = presets.get(target, (0, 0, 0))
-            return self._send_head_pos(roll, pitch, yaw)
+            if target not in presets:
+                return {"state": "error", "error": "unknown head target",
+                        "code": "invalid_head_target", "target": target}
+            yaw, pitch, roll = presets[target]
+            return self._move_to(
+                yaw, pitch, roll, args.get("speed", 30))
         elif action in ("start", "info"):
-            return {"state": "ready"}
+            return {
+                "state": "ready" if self._publisher else "idle",
+                "feedback_supported": True,
+                "feedback_topic": "/head/status",
+            }
         elif action == "stop":
             return {"state": "idle"}
         return {"error": f"unknown action: {action}"}
 
-    def _send_head_pos(self, roll_deg: float, pitch_deg: float, yaw_deg: float) -> dict:
+    def _move_to(self, yaw, pitch, roll, speed) -> dict:
+        try:
+            yaw = float(yaw)
+            pitch = float(pitch)
+            roll = float(roll)
+            speed = float(speed)
+        except (TypeError, ValueError):
+            return {"state": "error", "error": "head angles and speed must be numeric",
+                    "code": "invalid_head_parameters"}
+        if not all(math.isfinite(value) for value in (yaw, pitch, roll, speed)):
+            return {"state": "error", "error": "head angles and speed must be finite",
+                    "code": "invalid_head_parameters"}
+        limits = {
+            "yaw": (yaw, -90, 90),
+            "pitch": (pitch, -25, 25),
+            "roll": (roll, -26, 26),
+            "speed": (speed, 5, 60),
+        }
+        violations = [
+            {"parameter": name, "value": value, "minimum": lower, "maximum": upper}
+            for name, (value, lower, upper) in limits.items()
+            if value < lower or value > upper
+        ]
+        if violations:
+            return {"state": "error", "error": "Head command exceeds allowed range",
+                    "code": "head_command_out_of_range", "violations": violations}
+        motor_ids = [1, 2, 3]
+        check = self._feedback.preflight(self._publisher, motor_ids)
+        if check is not None:
+            return check
+        baseline_seq, baseline = self._feedback.snapshot(motor_ids)
+        result = self._send_head_pos(roll, pitch, yaw, speed)
+        if "error" in result:
+            return result
+        targets = {1: _deg2rad(roll), 2: _deg2rad(pitch), 3: _deg2rad(yaw)}
+        feedback = self._feedback.wait_for_motion(
+            targets, baseline_seq, baseline)
+        if feedback.get("state") == "error":
+            return feedback
+        result["feedback_verified"] = True
+        result["feedback"] = feedback
+        return result
+
+    def _send_head_pos(
+            self, roll_deg: float, pitch_deg: float,
+            yaw_deg: float, speed_deg: float) -> dict:
         if not self._publisher:
             return {"error": "publisher not initialized"}
         try:
@@ -766,7 +1044,7 @@ class HeadPlugin:
                 cmd = SetMotorPosition()
                 cmd.name = motor_id
                 cmd.pos = _deg2rad(deg)
-                cmd.spd = 1.0  # rad/s
+                cmd.spd = _deg2rad(speed_deg)
                 cmd.cur = 3.0  # A (max current)
                 cmds.append(cmd)
             msg.cmds = cmds
@@ -1195,6 +1473,19 @@ class HeadGesturePlugin:
 class ArmPlugin:
     """双臂14DOF控制 (位置模式 / 力位混合)"""
 
+    _JOINT_NAMES = [
+        "shoulder_pitch", "shoulder_roll", "shoulder_yaw",
+        "elbow_pitch", "wrist_yaw", "wrist_pitch", "wrist_roll",
+    ]
+    _LEFT_POSE_LIMITS = [
+        (-170, 170), (-15, 150), (-170, 170), (-150, 15),
+        (-170, 170), (-45, 60), (-95, 75),
+    ]
+    _RIGHT_POSE_LIMITS = [
+        (-170, 170), (-150, 15), (-170, 170), (-150, 15),
+        (-170, 170), (-45, 60), (-75, 95),
+    ]
+
     def __init__(self, plugin_config: dict, namespace: str, ros2):
         self._ns = namespace
         self._ros2 = ros2
@@ -1202,6 +1493,7 @@ class ArmPlugin:
         ros2.executor_tianyi.add_node(self._pub_node)
         self._pos_publisher = None
         self._ctrl_publisher = None
+        self._feedback = _JointCommandFeedback("arm", "/arm/status")
 
     def get_tool(self) -> dict:
         return {
@@ -1212,15 +1504,27 @@ class ArmPlugin:
                 "type": "object",
                 "properties": {
                     "action": {"type": "string", "enum": ["move_pos", "move_ctrl"],
+                               "default": "move_pos",
                                "description": "控制模式"},
                     "side": {"type": "string", "enum": ["left", "right", "both"],
-                             "description": "控制哪只手臂"},
-                    "positions": {"type": "array", "items": {"type": "number"},
-                                  "description": "7个关节角度(度): [肩pitch, 肩roll, 肩yaw, 肘pitch, 腕yaw, 腕pitch, 腕roll]"},
-                    "speed": {"type": "number", "description": "运动速度(rad/s), 默认1.0"},
-                    "kp": {"type": "array", "items": {"type": "number"},
+                             "default": "left",
+                             "description": "控制哪只手臂；right/both会自动镜像横向关节"},
+                    "positions": {
+                        "type": "array", "items": {"type": "number", "minimum": -170, "maximum": 170},
+                        "minItems": 7, "maxItems": 7,
+                        "default": [0, 0, 0, 0, 0, 0, 0],
+                        "description": "左臂基准的7个关节角度(度): [肩pitch, 肩roll, 肩yaw, 肘pitch, 腕yaw, 腕pitch, 腕roll]；right/both自动镜像roll/yaw轴"
+                    },
+                    "speed": {"type": "number", "minimum": 0.2, "maximum": 1.5,
+                              "default": 0.5,
+                              "description": "运动速度(rad/s), 范围[0.2, 1.5], 默认0.5"},
+                    "kp": {"type": "array", "items": {"type": "number", "minimum": 0, "maximum": 2000},
+                           "minItems": 7, "maxItems": 7,
+                           "default": [200, 200, 200, 200, 200, 200, 200],
                            "description": "位置增益(7个), 范围[0,2000]"},
-                    "kd": {"type": "array", "items": {"type": "number"},
+                    "kd": {"type": "array", "items": {"type": "number", "minimum": 0, "maximum": 300},
+                           "minItems": 7, "maxItems": 7,
+                           "default": [20, 20, 20, 20, 20, 20, 20],
                            "description": "速度增益(7个), 范围[0,300]"},
                 },
                 "required": ["action"],
@@ -1240,7 +1544,8 @@ class ArmPlugin:
                 CmdSetMotorPosition, "/arm/cmd_pos", _RELIABLE_QOS)
             self._ctrl_publisher = self._pub_node.create_publisher(
                 CmdMotorCtrl, "/arm/cmd_ctrl", _RELIABLE_QOS)
-            print("[ArmPlugin] publishers created")
+            self._feedback.create_subscriptions(self._pub_node)
+            print("[ArmPlugin] publishers and feedback subscriptions created")
         except ImportError as e:
             print(f"[ArmPlugin] WARNING: msg import failed ({e})")
 
@@ -1250,24 +1555,177 @@ class ArmPlugin:
     def dispatch(self, action: str, args: dict) -> dict:
         if action == "move_pos":
             side = args.get("side", "left")
-            positions = args.get("positions", [])
-            speed = args.get("speed", 1.0)
-            if len(positions) != 7:
-                return {"error": "positions must have exactly 7 values (degrees)"}
-            return self._send_pos(side, positions, speed)
+            positions = args.get("positions", [0] * 7)
+            speed = args.get("speed", 0.5)
+            validated = self._validate_command(side, positions, speed=speed)
+            if isinstance(validated, dict):
+                return validated
+            canonical_pose, speed = validated
+            motor_ids = self._motor_ids(side)
+            check = self._feedback.preflight(self._pos_publisher, motor_ids)
+            if check is not None:
+                return check
+            baseline_seq, baseline = self._feedback.snapshot(motor_ids)
+            result = self._send_pos(side, canonical_pose, speed)
+            if "error" in result:
+                return result
+            feedback = self._feedback.wait_for_motion(
+                self._target_positions(side, canonical_pose),
+                baseline_seq, baseline)
+            if feedback.get("state") == "error":
+                return feedback
+            result["feedback_verified"] = True
+            result["feedback"] = feedback
+            return result
         elif action == "move_ctrl":
             side = args.get("side", "left")
-            positions = args.get("positions", [])
+            positions = args.get("positions", [0] * 7)
             kp = args.get("kp", [200] * 7)
             kd = args.get("kd", [20] * 7)
-            if len(positions) != 7:
-                return {"error": "positions must have exactly 7 values (degrees)"}
-            return self._send_ctrl(side, positions, kp, kd)
+            validated = self._validate_command(
+                side, positions, kp=kp, kd=kd)
+            if isinstance(validated, dict):
+                return validated
+            canonical_pose, kp, kd = validated
+            motor_ids = self._motor_ids(side)
+            check = self._feedback.preflight(self._ctrl_publisher, motor_ids)
+            if check is not None:
+                return check
+            baseline_seq, baseline = self._feedback.snapshot(motor_ids)
+            result = self._send_ctrl(side, canonical_pose, kp, kd)
+            if "error" in result:
+                return result
+            feedback = self._feedback.wait_for_motion(
+                self._target_positions(side, canonical_pose),
+                baseline_seq, baseline)
+            if feedback.get("state") == "error":
+                return feedback
+            result["feedback_verified"] = True
+            result["feedback"] = feedback
+            return result
         elif action in ("start", "info"):
-            return {"state": "ready"}
+            return {
+                "state": "ready" if self._pos_publisher else "idle",
+                "feedback_supported": True,
+                "feedback_topic": "/arm/status",
+                "right_arm_mirrored": True,
+            }
         elif action == "stop":
             return {"state": "idle"}
         return {"error": f"unknown action: {action}"}
+
+    @staticmethod
+    def _mirror_pose(left_pose: list[float]) -> list[float]:
+        return [
+            left_pose[0], -left_pose[1], -left_pose[2],
+            left_pose[3], -left_pose[4], left_pose[5], -left_pose[6],
+        ]
+
+    @staticmethod
+    def _motor_ids(side: str) -> list[int]:
+        motor_ids = []
+        if side in ("left", "both"):
+            motor_ids.extend(range(11, 18))
+        if side in ("right", "both"):
+            motor_ids.extend(range(21, 28))
+        return motor_ids
+
+    @classmethod
+    def _pose_violations(cls, side: str, left_pose: list[float]) -> list[dict]:
+        selected = []
+        if side in ("left", "both"):
+            selected.append(("left", left_pose, cls._LEFT_POSE_LIMITS))
+        if side in ("right", "both"):
+            selected.append((
+                "right", cls._mirror_pose(left_pose), cls._RIGHT_POSE_LIMITS))
+        violations = []
+        for arm_side, pose, limits in selected:
+            for index, (value, bounds) in enumerate(zip(pose, limits)):
+                lower, upper = bounds
+                if value < lower or value > upper:
+                    violations.append({
+                        "side": arm_side,
+                        "joint": cls._JOINT_NAMES[index],
+                        "value_deg": value,
+                        "minimum_deg": lower,
+                        "maximum_deg": upper,
+                    })
+        return violations
+
+    @classmethod
+    def _target_positions(
+            cls, side: str, left_pose: list[float]) -> dict[int, float]:
+        right_pose = cls._mirror_pose(left_pose)
+        targets = {}
+        if side in ("left", "both"):
+            targets.update({
+                11 + index: _deg2rad(deg)
+                for index, deg in enumerate(left_pose)
+            })
+        if side in ("right", "both"):
+            targets.update({
+                21 + index: _deg2rad(deg)
+                for index, deg in enumerate(right_pose)
+            })
+        return targets
+
+    @classmethod
+    def _validate_command(
+            cls, side, positions, speed=None, kp=None, kd=None):
+        if side not in ("left", "right", "both"):
+            return {"state": "error", "error": "side must be left, right or both",
+                    "code": "invalid_arm_side"}
+        if not isinstance(positions, (list, tuple)) or len(positions) != 7:
+            return {"state": "error",
+                    "error": "positions must have exactly 7 values (degrees)",
+                    "code": "invalid_arm_positions"}
+        try:
+            pose = [float(value) for value in positions]
+        except (TypeError, ValueError):
+            return {"state": "error", "error": "positions must be numeric",
+                    "code": "invalid_arm_positions"}
+        if not all(math.isfinite(value) for value in pose):
+            return {"state": "error", "error": "positions must be finite",
+                    "code": "invalid_arm_positions"}
+        violations = cls._pose_violations(side, pose)
+        if violations:
+            return {"state": "error", "error": "Arm pose exceeds URDF joint limits",
+                    "code": "arm_pose_out_of_range", "violations": violations}
+        if speed is not None:
+            try:
+                speed = float(speed)
+            except (TypeError, ValueError):
+                return {"state": "error", "error": "speed must be numeric",
+                        "code": "invalid_arm_speed"}
+            if not math.isfinite(speed):
+                return {"state": "error", "error": "speed must be finite",
+                        "code": "invalid_arm_speed"}
+            if speed < 0.2 or speed > 1.5:
+                return {"state": "error", "error": "speed must be in [0.2, 1.5] rad/s",
+                        "code": "arm_speed_out_of_range", "speed": speed}
+            return pose, speed
+        for name, values, lower, upper in (
+                ("kp", kp, 0, 2000), ("kd", kd, 0, 300)):
+            if not isinstance(values, (list, tuple)) or len(values) != 7:
+                return {"state": "error", "error": f"{name} must have exactly 7 values",
+                        "code": f"invalid_arm_{name}"}
+            try:
+                converted = [float(value) for value in values]
+            except (TypeError, ValueError):
+                return {"state": "error", "error": f"{name} must be numeric",
+                        "code": f"invalid_arm_{name}"}
+            if not all(math.isfinite(value) for value in converted):
+                return {"state": "error", "error": f"{name} must be finite",
+                        "code": f"invalid_arm_{name}"}
+            bad = [value for value in converted if value < lower or value > upper]
+            if bad:
+                return {"state": "error", "error": f"{name} values must be in [{lower}, {upper}]",
+                        "code": f"arm_{name}_out_of_range", "values": bad}
+            if name == "kp":
+                kp = converted
+            else:
+                kd = converted
+        return pose, kp, kd
 
     def _send_pos(self, side: str, positions_deg: list, speed: float) -> dict:
         if not self._pos_publisher:
@@ -1278,12 +1736,12 @@ class ArmPlugin:
             cmds = []
             sides = []
             if side in ("left", "both"):
-                sides.append(("left", 11))
+                sides.append((11, positions_deg))
             if side in ("right", "both"):
-                sides.append(("right", 21))
+                sides.append((21, self._mirror_pose(positions_deg)))
 
-            for side_name, base_id in sides:
-                for i, deg in enumerate(positions_deg):
+            for base_id, pose in sides:
+                for i, deg in enumerate(pose):
                     cmd = SetMotorPosition()
                     cmd.name = base_id + i
                     cmd.pos = _deg2rad(deg)
@@ -1306,12 +1764,12 @@ class ArmPlugin:
             cmds = []
             sides = []
             if side in ("left", "both"):
-                sides.append(("left", 11))
+                sides.append((11, positions_deg))
             if side in ("right", "both"):
-                sides.append(("right", 21))
+                sides.append((21, self._mirror_pose(positions_deg)))
 
-            for side_name, base_id in sides:
-                for i, deg in enumerate(positions_deg):
+            for base_id, pose in sides:
+                for i, deg in enumerate(pose):
                     cmd = MotorCtrl()
                     cmd.name = base_id + i
                     cmd.pos = _deg2rad(deg)

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -1444,20 +1444,17 @@ class ArmPlugin:
                     "action": {"type": "string", "enum": ["move_pos", "move_ctrl"],
                                "default": "move_pos",
                                "description": "控制模式"},
-                    "side": {"type": "string", "enum": ["left", "right", "both"],
-                             "default": "left",
-                             "description": "控制哪只手臂；角度均按所选手臂的实际关节方向输入，不自动镜像"},
                     "left_positions": {
                         "type": "array", "items": {"type": "number", "minimum": -170, "maximum": 170},
                         "minItems": 7, "maxItems": 7,
                         "default": [0, 0, 0, 0, 0, 0, 0],
-                        "description": "左臂实际7关节角度(度)，用于left/both: [肩pitch, 肩roll, 肩yaw, 肘pitch, 腕yaw, 腕pitch, 腕roll]"
+                        "description": "左臂实际7关节角度(度): [肩pitch, 肩roll, 肩yaw, 肘pitch, 腕yaw, 腕pitch, 腕roll]"
                     },
                     "right_positions": {
                         "type": "array", "items": {"type": "number", "minimum": -170, "maximum": 170},
                         "minItems": 7, "maxItems": 7,
                         "default": [0, 0, 0, 0, 0, 0, 0],
-                        "description": "右臂实际7关节角度(度)，用于right/both，顺序同左臂；若要镜像左臂姿态，请将肩roll、肩yaw、腕yaw、腕roll（索引1/2/4/6）取反"
+                        "description": "右臂实际7关节角度(度)，顺序同左臂；若要镜像左臂姿态，请将肩roll、肩yaw、腕yaw、腕roll（索引1/2/4/6）取反"
                     },
                     "speed": {"type": "number", "minimum": 0.2, "maximum": 1.5,
                               "default": 0.5,
@@ -1465,18 +1462,18 @@ class ArmPlugin:
                     "kp": {"type": "array", "items": {"type": "number", "minimum": 0, "maximum": 2000},
                            "minItems": 7, "maxItems": 7,
                            "default": [200, 200, 200, 200, 200, 200, 200],
-                           "description": "位置增益(7个), 范围[0,2000]"},
+                           "description": "位置增益(7个), 范围[0,2000], 默认值200"},
                     "kd": {"type": "array", "items": {"type": "number", "minimum": 0, "maximum": 300},
                            "minItems": 7, "maxItems": 7,
                            "default": [20, 20, 20, 20, 20, 20, 20],
-                           "description": "速度增益(7个), 范围[0,300]"},
+                           "description": "速度增益(7个), 范围[0,300], 默认值20"},
                 },
                 "required": ["action"],
                 "x-action-params": {
-                    "move_pos": {"params": ["side", "left_positions", "right_positions", "speed"],
-                                 "description": "位置模式: 分别输入左右臂实际关节角度；both可同时执行两组不同姿态"},
-                    "move_ctrl": {"params": ["side", "left_positions", "right_positions", "kp", "kd"],
-                                  "description": "力位混合模式: 分别输入左右臂实际位置和共用增益；both可同时执行两组不同姿态"},
+                    "move_pos": {"params": ["left_positions", "right_positions", "speed"],
+                                 "description": "位置模式: 同时输入并执行左右臂两组实际关节角度"},
+                    "move_ctrl": {"params": ["left_positions", "right_positions", "kp", "kd"],
+                                  "description": "力位混合模式: 同时输入并执行左右臂实际位置和共用增益"},
                 },
             },
         }
@@ -1498,14 +1495,13 @@ class ArmPlugin:
 
     def dispatch(self, action: str, args: dict) -> dict:
         if action == "move_pos":
-            side = args.get("side", "left")
-            poses = self._requested_poses(side, args)
+            poses = self._requested_poses(args)
             speed = args.get("speed", 0.5)
-            validated = self._validate_command(side, poses, speed=speed)
+            validated = self._validate_command(poses, speed=speed)
             if isinstance(validated, dict):
                 return validated
             poses, speed = validated
-            motor_ids = self._motor_ids(side)
+            motor_ids = self._motor_ids()
             check = self._feedback.preflight(self._pos_publisher, motor_ids)
             if check is not None:
                 return check
@@ -1522,16 +1518,15 @@ class ArmPlugin:
             result["feedback"] = feedback
             return result
         elif action == "move_ctrl":
-            side = args.get("side", "left")
-            poses = self._requested_poses(side, args)
+            poses = self._requested_poses(args)
             kp = args.get("kp", [200] * 7)
             kd = args.get("kd", [20] * 7)
             validated = self._validate_command(
-                side, poses, kp=kp, kd=kd)
+                poses, kp=kp, kd=kd)
             if isinstance(validated, dict):
                 return validated
             poses, kp, kd = validated
-            motor_ids = self._motor_ids(side)
+            motor_ids = self._motor_ids()
             check = self._feedback.preflight(self._ctrl_publisher, motor_ids)
             if check is not None:
                 return check
@@ -1560,24 +1555,17 @@ class ArmPlugin:
         return {"error": f"unknown action: {action}"}
 
     @staticmethod
-    def _requested_poses(side: str, args: dict) -> dict[str, object]:
+    def _requested_poses(args: dict) -> dict[str, object]:
         """Resolve visible per-arm fields, with legacy `positions` fallback."""
         legacy = args.get("positions", [0] * 7)
-        poses = {}
-        if side in ("left", "both"):
-            poses["left"] = args.get("left_positions", legacy)
-        if side in ("right", "both"):
-            poses["right"] = args.get("right_positions", legacy)
-        return poses
+        return {
+            "left": args.get("left_positions", legacy),
+            "right": args.get("right_positions", legacy),
+        }
 
     @staticmethod
-    def _motor_ids(side: str) -> list[int]:
-        motor_ids = []
-        if side in ("left", "both"):
-            motor_ids.extend(range(11, 18))
-        if side in ("right", "both"):
-            motor_ids.extend(range(21, 28))
-        return motor_ids
+    def _motor_ids() -> list[int]:
+        return [*range(11, 18), *range(21, 28)]
 
     @classmethod
     def _pose_violations(cls, poses: dict[str, list[float]]) -> list[dict]:
@@ -1640,10 +1628,7 @@ class ArmPlugin:
 
     @classmethod
     def _validate_command(
-            cls, side, poses, speed=None, kp=None, kd=None):
-        if side not in ("left", "right", "both"):
-            return {"state": "error", "error": "side must be left, right or both",
-                    "code": "invalid_arm_side"}
+            cls, poses, speed=None, kp=None, kd=None):
         converted_poses = {}
         for arm_side, values in poses.items():
             name = f"{arm_side}_positions"
@@ -1727,8 +1712,7 @@ class ArmPlugin:
 
             msg.cmds = cmds
             self._pos_publisher.publish(msg)
-            return {"state": "moving", "side": self._side_from_poses(poses),
-                    "joints": len(cmds)}
+            return {"state": "moving", "side": "both", "joints": len(cmds)}
         except Exception as e:
             return {"error": str(e)}
 
@@ -1755,14 +1739,10 @@ class ArmPlugin:
 
             msg.cmds = cmds
             self._ctrl_publisher.publish(msg)
-            return {"state": "moving", "side": self._side_from_poses(poses),
+            return {"state": "moving", "side": "both",
                     "mode": "force_position"}
         except Exception as e:
             return {"error": str(e)}
-
-    @staticmethod
-    def _side_from_poses(poses: dict[str, list[float]]) -> str:
-        return "both" if len(poses) == 2 else next(iter(poses))
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -1411,12 +1411,13 @@ class HeadGesturePlugin:
 class ArmPlugin:
     """双臂14DOF控制 (位置模式 / 力位混合)"""
 
-    # Original raw-control gains and accepted ranges. The vendor-side
-    # controller applies them; this driver does not rate-limit the position step.
-    _DEFAULT_KP = 200.0
+    # Raw-control defaults and a deliberately bounded tuning range. The
+    # vendor-side controller applies them; this driver does not rate-limit the
+    # position step.
+    _DEFAULT_KP = 50.0
     _DEFAULT_KD = 20.0
-    _KP_RANGE = (0.0, 2000.0)
-    _KD_RANGE = (0.0, 300.0)
+    _KP_RANGE = (10.0, 200.0)
+    _KD_RANGE = (5.0, 50.0)
 
     _JOINT_NAMES = [
         "shoulder_pitch", "shoulder_roll", "shoulder_yaw",
@@ -1466,14 +1467,14 @@ class ArmPlugin:
                     "speed": {"type": "number", "minimum": 0.2, "maximum": 1.5,
                               "default": 0.5,
                               "description": "运动速度(rad/s), 范围[0.2, 1.5], 默认0.5"},
-                    "kp": {"type": "array", "items": {"type": "number", "minimum": 0, "maximum": 2000},
+                    "kp": {"type": "array", "items": {"type": "number", "minimum": 10, "maximum": 200},
                            "minItems": 7, "maxItems": 7,
-                           "default": [200, 200, 200, 200, 200, 200, 200],
-                           "description": "位置增益(7个), 范围[0,2000], 默认200；move_ctrl无速度限制，仅建议小角度目标调试"},
-                    "kd": {"type": "array", "items": {"type": "number", "minimum": 0, "maximum": 300},
+                           "default": [50, 50, 50, 50, 50, 50, 50],
+                           "description": "位置增益(7个), 范围[10,200], 默认50；move_ctrl无速度限制，仅建议小角度目标调试"},
+                    "kd": {"type": "array", "items": {"type": "number", "minimum": 5, "maximum": 50},
                            "minItems": 7, "maxItems": 7,
                            "default": [20, 20, 20, 20, 20, 20, 20],
-                           "description": "速度阻尼增益(7个), 范围[0,300], 默认20"},
+                           "description": "速度阻尼增益(7个), 范围[5,50], 默认20"},
                 },
                 "required": ["action"],
                 "x-action-params": {

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -84,6 +84,16 @@ _ARM_RIGHT_JOINTS = {
     27: "right_wrist_roll_joint",
 }
 
+# Rated motor currents from the Tianyi 2.0 joint specification table. These
+# values are used as the current limits in CmdSetMotorPosition commands.
+_RATED_MOTOR_CURRENT_A = {
+    1: 5.0, 2: 5.0, 3: 5.0,
+    11: 35.0, 12: 23.0, 13: 8.0, 14: 8.0,
+    15: 8.0, 16: 5.0, 17: 5.0,
+    21: 35.0, 22: 23.0, 23: 8.0, 24: 8.0,
+    25: 8.0, 26: 5.0, 27: 5.0,
+}
+
 _WAIST_JOINTS = {
     31: "waist_yaw_joint",
     32: "waist_pitch_joint",
@@ -983,7 +993,7 @@ class HeadPlugin:
                 cmd.name = motor_id
                 cmd.pos = _deg2rad(deg)
                 cmd.spd = 1.0  # rad/s
-                cmd.cur = 3.0  # A (max current)
+                cmd.cur = _RATED_MOTOR_CURRENT_A[motor_id]
                 cmds.append(cmd)
             msg.cmds = cmds
             self._publisher.publish(msg)
@@ -1396,7 +1406,7 @@ class HeadGesturePlugin:
                 cmd.name = motor_id
                 cmd.pos = _deg2rad(deg)
                 cmd.spd = speed_rad
-                cmd.cur = 3.0
+                cmd.cur = _RATED_MOTOR_CURRENT_A[motor_id]
                 msg.cmds.append(cmd)
             self._publisher.publish(msg)
             return {"state": "moving", "yaw": yaw_deg, "pitch": pitch_deg, "roll": roll_deg}
@@ -1713,10 +1723,11 @@ class ArmPlugin:
             for base_id, pose in sides:
                 for i, deg in enumerate(pose):
                     cmd = SetMotorPosition()
-                    cmd.name = base_id + i
+                    motor_id = base_id + i
+                    cmd.name = motor_id
                     cmd.pos = _deg2rad(deg)
                     cmd.spd = speed
-                    cmd.cur = 5.0
+                    cmd.cur = _RATED_MOTOR_CURRENT_A[motor_id]
                     cmds.append(cmd)
 
             msg.cmds = cmds
@@ -2244,7 +2255,7 @@ class ArmGesturePlugin:
                 "robot may not be Ready or self-check may be incomplete",
                 "arm controller may be disabled or rejecting commands",
                 "another node may be publishing competing /arm/cmd_pos commands",
-                "the configured 5A maximum current may be insufficient; verify with the robot vendor before increasing it",
+                "check joint load and mechanical interference; do not exceed the mapped vendor-rated current",
             ],
         )
 
@@ -2275,10 +2286,11 @@ class ArmGesturePlugin:
             for base_id, pose in selected:
                 for index, deg in enumerate(pose):
                     cmd = SetMotorPosition()
-                    cmd.name = base_id + index
+                    motor_id = base_id + index
+                    cmd.name = motor_id
                     cmd.pos = _deg2rad(float(deg))
                     cmd.spd = speed
-                    cmd.cur = 5.0
+                    cmd.cur = _RATED_MOTOR_CURRENT_A[motor_id]
                     msg.cmds.append(cmd)
             self._publisher.publish(msg)
             return {"state": "moving", "side": side, "joints": len(msg.cmds)}

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -1486,13 +1486,21 @@ class ArmPlugin:
         return {
             "name": "arm",
             "type": "actuator",
-            "description": "天轶2.0 双臂控制 — 每臂7DOF (肩3+肘1+腕3), 位置/力位混合模式",
+            "description": (
+                "天轶2.0 双臂14关节控制。move_pos按给定速度执行常规位置运动，"
+                "适合日常调姿；move_ctrl把目标角度和KP/KD下发给机器人侧控制器，"
+                "用于调节关节刚度、阻尼及经过验证的柔顺/保持实验。move_ctrl没有"
+                "轨迹速度限制，不适合直接执行大角度动作或普通语义手势。"
+            ),
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "action": {"type": "string", "enum": ["move_pos", "move_ctrl"],
                                "default": "move_pos",
-                               "description": "控制模式"},
+                               "description": (
+                                   "控制模式：日常移动和大角度调姿选择move_pos；"
+                                   "只有需要调整PD刚度/阻尼并理解增益风险时才选择move_ctrl"
+                               )},
                     "left_positions": {
                         "type": "array", "items": {"type": "number", "minimum": -170, "maximum": 170},
                         "minItems": 7, "maxItems": 7,
@@ -1507,22 +1515,43 @@ class ArmPlugin:
                     },
                     "speed": {"type": "number", "minimum": 0.2, "maximum": 1.5,
                               "default": 0.5,
-                              "description": "运动速度(rad/s), 范围[0.2, 1.5], 默认0.5"},
+                              "description": (
+                                  "仅move_pos使用的关节运动速度(rad/s)，范围[0.2,1.5]，"
+                                  "默认0.5；move_ctrl不读取此参数，也没有等效速度限制"
+                              )},
                     "kp": {"type": "array", "items": {"type": "number", "minimum": 10, "maximum": 200},
                            "minItems": 7, "maxItems": 7,
                            "default": [50, 50, 50, 50, 50, 50, 50],
-                           "description": "位置增益(7个), 范围[10,200], 默认50；move_ctrl无速度限制，仅建议小角度目标调试"},
+                           "description": (
+                               "仅move_ctrl使用的位置增益，按[肩pitch,肩roll,肩yaw,肘pitch,"
+                               "腕yaw,腕pitch,腕roll]填写7项，范围[10,200]，默认50；同一数组"
+                               "分别用于左右臂对应关节。KP越高通常响应和保持刚度越强，但冲击、"
+                               "超调风险越大；KP较低更柔顺，也可能因负载而达不到目标角度"
+                           )},
                     "kd": {"type": "array", "items": {"type": "number", "minimum": 5, "maximum": 50},
                            "minItems": 7, "maxItems": 7,
                            "default": [20, 20, 20, 20, 20, 20, 20],
-                           "description": "速度阻尼增益(7个), 范围[5,50], 默认20"},
+                           "description": (
+                               "仅move_ctrl使用的速度阻尼增益，关节顺序同KP，共7项，"
+                               "范围[5,50]，默认20；同一数组分别用于左右臂对应关节。"
+                               "KD越高通常抑制振荡更强但动作更迟钝，KD过低可能产生超调或抖动"
+                           )},
                 },
                 "required": ["action"],
                 "x-action-params": {
                     "move_pos": {"params": ["left_positions", "right_positions", "speed"],
-                                 "description": "位置模式: 同时输入并执行左右臂两组实际关节角度"},
+                                 "description": (
+                                     "常规位置模式：按speed限制运动速度，同时执行左右臂目标角度。"
+                                     "适用于日常调姿、大角度运动和需要可控速度的场景，通常优先选择此模式"
+                                 )},
                     "move_ctrl": {"params": ["left_positions", "right_positions", "kp", "kd"],
-                                  "description": "力位混合模式: 同时输入并执行左右臂实际位置和共用增益"},
+                                  "description": (
+                                      "PD力位控制模式：将左右臂目标角度和一组共用KP/KD发布到"
+                                      "/arm/cmd_ctrl，由机器人侧控制器计算控制输出；驱动固定目标速度"
+                                      "和前馈力矩为0，不计算PD，也不限制轨迹速度。用于小角度、低风险的"
+                                      "刚度/阻尼调试、姿态保持或已验证的柔顺交互；最终角度会受增益、"
+                                      "负载和摩擦影响。普通动作或大幅移动请使用move_pos"
+                                  )},
                 },
             },
         }

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -1487,10 +1487,10 @@ class ArmPlugin:
             "name": "arm",
             "type": "actuator",
             "description": (
-                "天轶2.0 双臂14关节控制。move_pos按给定速度执行常规位置运动，"
-                "适合日常调姿；move_ctrl把目标角度和KP/KD下发给机器人侧控制器，"
-                "用于调节关节刚度、阻尼及经过验证的柔顺/保持实验。move_ctrl没有"
-                "轨迹速度限制，不适合直接执行大角度动作或普通语义手势。"
+                "控制左右手臂的各关节角度。不确定选哪个模式时，请使用move_pos："
+                "它适合抬手、弯肘、摆姿势和回到初始位置。move_ctrl是高级调试模式，"
+                "用于调整手臂保持姿势时有多用力、到位后是否容易晃动，以及已确认安全的"
+                "轻推柔顺实验；它不是慢速模式，不适合普通动作或大幅移动。"
             ),
             "inputSchema": {
                 "type": "object",
@@ -1498,8 +1498,8 @@ class ArmPlugin:
                     "action": {"type": "string", "enum": ["move_pos", "move_ctrl"],
                                "default": "move_pos",
                                "description": (
-                                   "控制模式：日常移动和大角度调姿选择move_pos；"
-                                   "只有需要调整PD刚度/阻尼并理解增益风险时才选择move_ctrl"
+                                   "模式选择：抬手、弯肘、摆姿势、回零等普通操作选move_pos；"
+                                   "只有需要调节手臂保持力度或减少晃动时才选move_ctrl"
                                )},
                     "left_positions": {
                         "type": "array", "items": {"type": "number", "minimum": -170, "maximum": 170},
@@ -1516,41 +1516,40 @@ class ArmPlugin:
                     "speed": {"type": "number", "minimum": 0.2, "maximum": 1.5,
                               "default": 0.5,
                               "description": (
-                                  "仅move_pos使用的关节运动速度(rad/s)，范围[0.2,1.5]，"
-                                  "默认0.5；move_ctrl不读取此参数，也没有等效速度限制"
+                                  "仅move_pos使用：决定手臂移动到目标姿势时有多快。"
+                                  "范围[0.2,1.5]rad/s，默认0.5。move_ctrl不能用它来减速"
                               )},
                     "kp": {"type": "array", "items": {"type": "number", "minimum": 10, "maximum": 200},
                            "minItems": 7, "maxItems": 7,
                            "default": [50, 50, 50, 50, 50, 50, 50],
                            "description": (
-                               "仅move_ctrl使用的位置增益，按[肩pitch,肩roll,肩yaw,肘pitch,"
-                               "腕yaw,腕pitch,腕roll]填写7项，范围[10,200]，默认50；同一数组"
-                               "分别用于左右臂对应关节。KP越高通常响应和保持刚度越强，但冲击、"
-                               "超调风险越大；KP较低更柔顺，也可能因负载而达不到目标角度"
+                               "仅move_ctrl使用，可理解为关节偏离目标后“拉回去的力度”。"
+                               "按[肩pitch,肩roll,肩yaw,肘pitch,腕yaw,腕pitch,腕roll]填写7项，"
+                               "范围[10,200]，默认50，左右臂共用。调高会保持得更硬、更有力，"
+                               "但可能动作突然或冲过目标；调低会更柔和，但手臂可能被负载压偏"
                            )},
                     "kd": {"type": "array", "items": {"type": "number", "minimum": 5, "maximum": 50},
                            "minItems": 7, "maxItems": 7,
                            "default": [20, 20, 20, 20, 20, 20, 20],
                            "description": (
-                               "仅move_ctrl使用的速度阻尼增益，关节顺序同KP，共7项，"
-                               "范围[5,50]，默认20；同一数组分别用于左右臂对应关节。"
-                               "KD越高通常抑制振荡更强但动作更迟钝，KD过低可能产生超调或抖动"
+                               "仅move_ctrl使用，可理解为关节的“减震力度”。关节顺序同KP，"
+                               "共7项，范围[5,50]，默认20，左右臂共用。调高通常更不容易晃，"
+                               "但反应可能变慢；调得太低，手臂到位后可能来回抖动"
                            )},
                 },
                 "required": ["action"],
                 "x-action-params": {
                     "move_pos": {"params": ["left_positions", "right_positions", "speed"],
                                  "description": (
-                                     "常规位置模式：按speed限制运动速度，同时执行左右臂目标角度。"
-                                     "适用于日常调姿、大角度运动和需要可控速度的场景，通常优先选择此模式"
+                                     "普通动作首选：填写左右臂目标角度和移动速度。适合抬手、弯肘、"
+                                     "摆出指定姿势、回到初始位置，以及其他希望控制移动快慢的场景"
                                  )},
                     "move_ctrl": {"params": ["left_positions", "right_positions", "kp", "kd"],
                                   "description": (
-                                      "PD力位控制模式：将左右臂目标角度和一组共用KP/KD发布到"
-                                      "/arm/cmd_ctrl，由机器人侧控制器计算控制输出；驱动固定目标速度"
-                                      "和前馈力矩为0，不计算PD，也不限制轨迹速度。用于小角度、低风险的"
-                                      "刚度/阻尼调试、姿态保持或已验证的柔顺交互；最终角度会受增益、"
-                                      "负载和摩擦影响。普通动作或大幅移动请使用move_pos"
+                                      "高级调试模式：目标角度决定手臂想停在哪里，KP决定偏离后拉回的"
+                                      "力度，KD决定减少晃动的力度。适用于手臂被负载压偏、到位后晃动，"
+                                      "或已确认安全的轻推柔顺实验。它没有可设置的移动速度，同一角度在"
+                                      "不同KP/KD下也可能停在不同位置；普通摆姿势或大幅移动请用move_pos"
                                   )},
                 },
             },

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -1411,12 +1411,12 @@ class HeadGesturePlugin:
 class ArmPlugin:
     """双臂14DOF控制 (位置模式 / 力位混合)"""
 
-    # Conservative raw-control starting gains. The vendor-side controller
-    # applies these gains; this driver does not rate-limit the position step.
-    _DEFAULT_KP = 10.0
-    _DEFAULT_KD = 8.0
-    _KP_RANGE = (5.0, 100.0)
-    _KD_RANGE = (5.0, 30.0)
+    # Original raw-control gains and accepted ranges. The vendor-side
+    # controller applies them; this driver does not rate-limit the position step.
+    _DEFAULT_KP = 200.0
+    _DEFAULT_KD = 20.0
+    _KP_RANGE = (0.0, 2000.0)
+    _KD_RANGE = (0.0, 300.0)
 
     _JOINT_NAMES = [
         "shoulder_pitch", "shoulder_roll", "shoulder_yaw",
@@ -1466,14 +1466,14 @@ class ArmPlugin:
                     "speed": {"type": "number", "minimum": 0.2, "maximum": 1.5,
                               "default": 0.5,
                               "description": "运动速度(rad/s), 范围[0.2, 1.5], 默认0.5"},
-                    "kp": {"type": "array", "items": {"type": "number", "minimum": 5, "maximum": 100},
+                    "kp": {"type": "array", "items": {"type": "number", "minimum": 0, "maximum": 2000},
                            "minItems": 7, "maxItems": 7,
-                           "default": [10, 10, 10, 10, 10, 10, 10],
-                           "description": "位置增益(7个), 范围[5,100], 默认10；move_ctrl无速度限制，仅建议小角度低增益调试"},
-                    "kd": {"type": "array", "items": {"type": "number", "minimum": 5, "maximum": 30},
+                           "default": [200, 200, 200, 200, 200, 200, 200],
+                           "description": "位置增益(7个), 范围[0,2000], 默认200；move_ctrl无速度限制，仅建议小角度目标调试"},
+                    "kd": {"type": "array", "items": {"type": "number", "minimum": 0, "maximum": 300},
                            "minItems": 7, "maxItems": 7,
-                           "default": [8, 8, 8, 8, 8, 8, 8],
-                           "description": "速度阻尼增益(7个), 范围[5,30], 默认8"},
+                           "default": [20, 20, 20, 20, 20, 20, 20],
+                           "description": "速度阻尼增益(7个), 范围[0,300], 默认20"},
                 },
                 "required": ["action"],
                 "x-action-params": {

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -1446,12 +1446,18 @@ class ArmPlugin:
                                "description": "控制模式"},
                     "side": {"type": "string", "enum": ["left", "right", "both"],
                              "default": "left",
-                             "description": "控制哪只手臂；right/both会自动镜像横向关节"},
-                    "positions": {
+                             "description": "控制哪只手臂；角度均按所选手臂的实际关节方向输入，不自动镜像"},
+                    "left_positions": {
                         "type": "array", "items": {"type": "number", "minimum": -170, "maximum": 170},
                         "minItems": 7, "maxItems": 7,
                         "default": [0, 0, 0, 0, 0, 0, 0],
-                        "description": "左臂基准的7个关节角度(度): [肩pitch, 肩roll, 肩yaw, 肘pitch, 腕yaw, 腕pitch, 腕roll]；right/both自动镜像roll/yaw轴"
+                        "description": "左臂实际7关节角度(度)，用于left/both: [肩pitch, 肩roll, 肩yaw, 肘pitch, 腕yaw, 腕pitch, 腕roll]"
+                    },
+                    "right_positions": {
+                        "type": "array", "items": {"type": "number", "minimum": -170, "maximum": 170},
+                        "minItems": 7, "maxItems": 7,
+                        "default": [0, 0, 0, 0, 0, 0, 0],
+                        "description": "右臂实际7关节角度(度)，用于right/both，顺序同左臂；若要镜像左臂姿态，请将肩roll、肩yaw、腕yaw、腕roll（索引1/2/4/6）取反"
                     },
                     "speed": {"type": "number", "minimum": 0.2, "maximum": 1.5,
                               "default": 0.5,
@@ -1467,10 +1473,10 @@ class ArmPlugin:
                 },
                 "required": ["action"],
                 "x-action-params": {
-                    "move_pos": {"params": ["side", "positions", "speed"],
-                                 "description": "位置模式: 移动手臂关节到指定角度(度)"},
-                    "move_ctrl": {"params": ["side", "positions", "kp", "kd"],
-                                  "description": "力位混合模式: 指定位置+增益"},
+                    "move_pos": {"params": ["side", "left_positions", "right_positions", "speed"],
+                                 "description": "位置模式: 分别输入左右臂实际关节角度；both可同时执行两组不同姿态"},
+                    "move_ctrl": {"params": ["side", "left_positions", "right_positions", "kp", "kd"],
+                                  "description": "力位混合模式: 分别输入左右臂实际位置和共用增益；both可同时执行两组不同姿态"},
                 },
             },
         }
@@ -1493,22 +1499,22 @@ class ArmPlugin:
     def dispatch(self, action: str, args: dict) -> dict:
         if action == "move_pos":
             side = args.get("side", "left")
-            positions = args.get("positions", [0] * 7)
+            poses = self._requested_poses(side, args)
             speed = args.get("speed", 0.5)
-            validated = self._validate_command(side, positions, speed=speed)
+            validated = self._validate_command(side, poses, speed=speed)
             if isinstance(validated, dict):
                 return validated
-            canonical_pose, speed = validated
+            poses, speed = validated
             motor_ids = self._motor_ids(side)
             check = self._feedback.preflight(self._pos_publisher, motor_ids)
             if check is not None:
                 return check
             baseline_seq, baseline = self._feedback.snapshot(motor_ids)
-            result = self._send_pos(side, canonical_pose, speed)
+            result = self._send_pos(poses, speed)
             if "error" in result:
                 return result
             feedback = self._feedback.wait_for_motion(
-                self._target_positions(side, canonical_pose),
+                self._target_positions(poses),
                 baseline_seq, baseline)
             if feedback.get("state") == "error":
                 return feedback
@@ -1517,24 +1523,24 @@ class ArmPlugin:
             return result
         elif action == "move_ctrl":
             side = args.get("side", "left")
-            positions = args.get("positions", [0] * 7)
+            poses = self._requested_poses(side, args)
             kp = args.get("kp", [200] * 7)
             kd = args.get("kd", [20] * 7)
             validated = self._validate_command(
-                side, positions, kp=kp, kd=kd)
+                side, poses, kp=kp, kd=kd)
             if isinstance(validated, dict):
                 return validated
-            canonical_pose, kp, kd = validated
+            poses, kp, kd = validated
             motor_ids = self._motor_ids(side)
             check = self._feedback.preflight(self._ctrl_publisher, motor_ids)
             if check is not None:
                 return check
             baseline_seq, baseline = self._feedback.snapshot(motor_ids)
-            result = self._send_ctrl(side, canonical_pose, kp, kd)
+            result = self._send_ctrl(poses, kp, kd)
             if "error" in result:
                 return result
             feedback = self._feedback.wait_for_motion(
-                self._target_positions(side, canonical_pose),
+                self._target_positions(poses),
                 baseline_seq, baseline)
             if feedback.get("state") == "error":
                 return feedback
@@ -1546,18 +1552,23 @@ class ArmPlugin:
                 "state": "ready" if self._pos_publisher else "idle",
                 "feedback_supported": True,
                 "feedback_topic": "/arm/status",
-                "right_arm_mirrored": True,
+                "right_arm_mirrored": False,
+                "independent_bilateral_positions": True,
             }
         elif action == "stop":
             return {"state": "idle"}
         return {"error": f"unknown action: {action}"}
 
     @staticmethod
-    def _mirror_pose(left_pose: list[float]) -> list[float]:
-        return [
-            left_pose[0], -left_pose[1], -left_pose[2],
-            left_pose[3], -left_pose[4], left_pose[5], -left_pose[6],
-        ]
+    def _requested_poses(side: str, args: dict) -> dict[str, object]:
+        """Resolve visible per-arm fields, with legacy `positions` fallback."""
+        legacy = args.get("positions", [0] * 7)
+        poses = {}
+        if side in ("left", "both"):
+            poses["left"] = args.get("left_positions", legacy)
+        if side in ("right", "both"):
+            poses["right"] = args.get("right_positions", legacy)
+        return poses
 
     @staticmethod
     def _motor_ids(side: str) -> list[int]:
@@ -1569,13 +1580,12 @@ class ArmPlugin:
         return motor_ids
 
     @classmethod
-    def _pose_violations(cls, side: str, left_pose: list[float]) -> list[dict]:
-        selected = []
-        if side in ("left", "both"):
-            selected.append(("left", left_pose, cls._LEFT_POSE_LIMITS))
-        if side in ("right", "both"):
-            selected.append((
-                "right", cls._mirror_pose(left_pose), cls._RIGHT_POSE_LIMITS))
+    def _pose_violations(cls, poses: dict[str, list[float]]) -> list[dict]:
+        selected = [
+            (arm_side, pose,
+             cls._LEFT_POSE_LIMITS if arm_side == "left" else cls._RIGHT_POSE_LIMITS)
+            for arm_side, pose in poses.items()
+        ]
         violations = []
         for arm_side, pose, limits in selected:
             for index, (value, bounds) in enumerate(zip(pose, limits)):
@@ -1592,18 +1602,17 @@ class ArmPlugin:
 
     @classmethod
     def _target_positions(
-            cls, side: str, left_pose: list[float]) -> dict[int, float]:
-        right_pose = cls._mirror_pose(left_pose)
+            cls, poses: dict[str, list[float]]) -> dict[int, float]:
         targets = {}
-        if side in ("left", "both"):
+        if "left" in poses:
             targets.update({
                 11 + index: _deg2rad(deg)
-                for index, deg in enumerate(left_pose)
+                for index, deg in enumerate(poses["left"])
             })
-        if side in ("right", "both"):
+        if "right" in poses:
             targets.update({
                 21 + index: _deg2rad(deg)
-                for index, deg in enumerate(right_pose)
+                for index, deg in enumerate(poses["right"])
             })
         return targets
 
@@ -1631,26 +1640,30 @@ class ArmPlugin:
 
     @classmethod
     def _validate_command(
-            cls, side, positions, speed=None, kp=None, kd=None):
+            cls, side, poses, speed=None, kp=None, kd=None):
         if side not in ("left", "right", "both"):
             return {"state": "error", "error": "side must be left, right or both",
                     "code": "invalid_arm_side"}
-        positions, error = cls._decode_array_argument(positions, "positions")
-        if error is not None:
-            return error
-        if not isinstance(positions, (list, tuple)) or len(positions) != 7:
-            return {"state": "error",
-                    "error": "positions must have exactly 7 values (degrees)",
-                    "code": "invalid_arm_positions"}
-        try:
-            pose = [float(value) for value in positions]
-        except (TypeError, ValueError):
-            return {"state": "error", "error": "positions must be numeric",
-                    "code": "invalid_arm_positions"}
-        if not all(math.isfinite(value) for value in pose):
-            return {"state": "error", "error": "positions must be finite",
-                    "code": "invalid_arm_positions"}
-        violations = cls._pose_violations(side, pose)
+        converted_poses = {}
+        for arm_side, values in poses.items():
+            name = f"{arm_side}_positions"
+            values, error = cls._decode_array_argument(values, name)
+            if error is not None:
+                return error
+            if not isinstance(values, (list, tuple)) or len(values) != 7:
+                return {"state": "error",
+                        "error": f"{name} must have exactly 7 values (degrees)",
+                        "code": f"invalid_arm_{name}"}
+            try:
+                pose = [float(value) for value in values]
+            except (TypeError, ValueError):
+                return {"state": "error", "error": f"{name} must be numeric",
+                        "code": f"invalid_arm_{name}"}
+            if not all(math.isfinite(value) for value in pose):
+                return {"state": "error", "error": f"{name} must be finite",
+                        "code": f"invalid_arm_{name}"}
+            converted_poses[arm_side] = pose
+        violations = cls._pose_violations(converted_poses)
         if violations:
             return {"state": "error", "error": "Arm pose exceeds URDF joint limits",
                     "code": "arm_pose_out_of_range", "violations": violations}
@@ -1666,7 +1679,7 @@ class ArmPlugin:
             if speed < 0.2 or speed > 1.5:
                 return {"state": "error", "error": "speed must be in [0.2, 1.5] rad/s",
                         "code": "arm_speed_out_of_range", "speed": speed}
-            return pose, speed
+            return converted_poses, speed
         for name, values, lower, upper in (
                 ("kp", kp, 0, 2000), ("kd", kd, 0, 300)):
             values, error = cls._decode_array_argument(values, name)
@@ -1691,20 +1704,17 @@ class ArmPlugin:
                 kp = converted
             else:
                 kd = converted
-        return pose, kp, kd
+        return converted_poses, kp, kd
 
-    def _send_pos(self, side: str, positions_deg: list, speed: float) -> dict:
+    def _send_pos(self, poses: dict[str, list[float]], speed: float) -> dict:
         if not self._pos_publisher:
             return {"error": "publisher not initialized"}
         try:
             from bodyctrl_msgs.msg import CmdSetMotorPosition, SetMotorPosition
             msg = CmdSetMotorPosition()
             cmds = []
-            sides = []
-            if side in ("left", "both"):
-                sides.append((11, positions_deg))
-            if side in ("right", "both"):
-                sides.append((21, self._mirror_pose(positions_deg)))
+            sides = [(11 if arm_side == "left" else 21, pose)
+                     for arm_side, pose in poses.items()]
 
             for base_id, pose in sides:
                 for i, deg in enumerate(pose):
@@ -1717,22 +1727,20 @@ class ArmPlugin:
 
             msg.cmds = cmds
             self._pos_publisher.publish(msg)
-            return {"state": "moving", "side": side, "joints": len(cmds)}
+            return {"state": "moving", "side": self._side_from_poses(poses),
+                    "joints": len(cmds)}
         except Exception as e:
             return {"error": str(e)}
 
-    def _send_ctrl(self, side: str, positions_deg: list, kp: list, kd: list) -> dict:
+    def _send_ctrl(self, poses: dict[str, list[float]], kp: list, kd: list) -> dict:
         if not self._ctrl_publisher:
             return {"error": "publisher not initialized"}
         try:
             from bodyctrl_msgs.msg import CmdMotorCtrl, MotorCtrl
             msg = CmdMotorCtrl()
             cmds = []
-            sides = []
-            if side in ("left", "both"):
-                sides.append((11, positions_deg))
-            if side in ("right", "both"):
-                sides.append((21, self._mirror_pose(positions_deg)))
+            sides = [(11 if arm_side == "left" else 21, pose)
+                     for arm_side, pose in poses.items()]
 
             for base_id, pose in sides:
                 for i, deg in enumerate(pose):
@@ -1747,9 +1755,14 @@ class ArmPlugin:
 
             msg.cmds = cmds
             self._ctrl_publisher.publish(msg)
-            return {"state": "moving", "side": side, "mode": "force_position"}
+            return {"state": "moving", "side": self._side_from_poses(poses),
+                    "mode": "force_position"}
         except Exception as e:
             return {"error": str(e)}
+
+    @staticmethod
+    def _side_from_poses(poses: dict[str, list[float]]) -> str:
+        return "both" if len(poses) == 2 else next(iter(poses))
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -1607,12 +1607,37 @@ class ArmPlugin:
             })
         return targets
 
+    @staticmethod
+    def _decode_array_argument(value, name: str):
+        """Accept native arrays and JSON-array strings emitted by the dashboard."""
+        if not isinstance(value, str):
+            return value, None
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError as exc:
+            return None, {
+                "state": "error",
+                "error": f"{name} must be a valid JSON array",
+                "code": f"invalid_arm_{name}",
+                "parse_error": str(exc),
+            }
+        if not isinstance(decoded, list):
+            return None, {
+                "state": "error",
+                "error": f"{name} JSON value must be an array",
+                "code": f"invalid_arm_{name}",
+            }
+        return decoded, None
+
     @classmethod
     def _validate_command(
             cls, side, positions, speed=None, kp=None, kd=None):
         if side not in ("left", "right", "both"):
             return {"state": "error", "error": "side must be left, right or both",
                     "code": "invalid_arm_side"}
+        positions, error = cls._decode_array_argument(positions, "positions")
+        if error is not None:
+            return error
         if not isinstance(positions, (list, tuple)) or len(positions) != 7:
             return {"state": "error",
                     "error": "positions must have exactly 7 values (degrees)",
@@ -1644,6 +1669,9 @@ class ArmPlugin:
             return pose, speed
         for name, values, lower, upper in (
                 ("kp", kp, 0, 2000), ("kd", kd, 0, 300)):
+            values, error = cls._decode_array_argument(values, name)
+            if error is not None:
+                return error
             if not isinstance(values, (list, tuple)) or len(values) != 7:
                 return {"state": "error", "error": f"{name} must have exactly 7 values",
                         "code": f"invalid_arm_{name}"}

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -908,8 +908,7 @@ class HeadPlugin:
         self._ros2 = ros2
         self._pub_node = Node("tianyi2_head_pub", context=ros2.ctx_tianyi)
         ros2.executor_tianyi.add_node(self._pub_node)
-        self._publisher = None
-        self._feedback = _JointCommandFeedback("head", "/head/status")
+        self._publisher = None  # Lazy init
 
     def get_tool(self) -> dict:
         return {
@@ -920,26 +919,18 @@ class HeadPlugin:
                 "type": "object",
                 "properties": {
                     "action": {"type": "string", "enum": ["move_pos", "look_at"],
-                               "default": "move_pos",
                                "description": "控制动作"},
-                    "yaw": {"type": "number", "minimum": -90, "maximum": 90,
-                            "default": 0, "description": "偏航角(度), 左正右负, 范围[-90, 90]"},
-                    "pitch": {"type": "number", "minimum": -25, "maximum": 25,
-                              "default": 0, "description": "俯仰角(度), 下正上负, 范围[-25, 25]"},
-                    "roll": {"type": "number", "minimum": -26, "maximum": 26,
-                             "default": 0, "description": "翻滚角(度), 范围[-26, 26]"},
-                    "speed": {"type": "number", "minimum": 5, "maximum": 60,
-                              "default": 30,
-                              "description": "头部运动速度(度/秒), 范围[5, 60], 默认30"},
+                    "yaw": {"type": "number", "description": "偏航角(度), 左正右负, 范围[-90, 90]"},
+                    "pitch": {"type": "number", "description": "俯仰角(度), 下正上负, 范围[-25, 25]"},
+                    "roll": {"type": "number", "description": "翻滚角(度), 范围[-26, 26]"},
                     "target": {"type": "string", "enum": ["forward", "left", "right", "up", "down"],
-                               "default": "forward",
                                "description": "预设方向"},
                 },
                 "required": ["action"],
                 "x-action-params": {
-                    "move_pos": {"params": ["yaw", "pitch", "roll", "speed"],
+                    "move_pos": {"params": ["yaw", "pitch", "roll"],
                                  "description": "移动头部到指定角度(度)"},
-                    "look_at": {"params": ["target", "speed"],
+                    "look_at": {"params": ["target"],
                                 "description": "看向预设方向"},
                 },
             },
@@ -950,8 +941,7 @@ class HeadPlugin:
             from bodyctrl_msgs.msg import CmdSetMotorPosition
             self._publisher = self._pub_node.create_publisher(
                 CmdSetMotorPosition, "/head/cmd_pos", _RELIABLE_QOS)
-            self._feedback.create_subscriptions(self._pub_node)
-            print("[HeadPlugin] publisher and feedback subscriptions created")
+            print("[HeadPlugin] publisher created")
         except ImportError as e:
             print(f"[HeadPlugin] WARNING: msg import failed ({e})")
 
@@ -960,9 +950,10 @@ class HeadPlugin:
 
     def dispatch(self, action: str, args: dict) -> dict:
         if action == "move_pos":
-            return self._move_to(
-                args.get("yaw", 0), args.get("pitch", 0),
-                args.get("roll", 0), args.get("speed", 30))
+            yaw = args.get("yaw", 0)
+            pitch = args.get("pitch", 0)
+            roll = args.get("roll", 0)
+            return self._send_head_pos(roll, pitch, yaw)
         elif action == "look_at":
             target = args.get("target", "forward")
             presets = {
@@ -972,68 +963,15 @@ class HeadPlugin:
                 "up": (0, -20, 0),
                 "down": (0, 20, 0),
             }
-            if target not in presets:
-                return {"state": "error", "error": "unknown head target",
-                        "code": "invalid_head_target", "target": target}
-            yaw, pitch, roll = presets[target]
-            return self._move_to(
-                yaw, pitch, roll, args.get("speed", 30))
+            yaw, pitch, roll = presets.get(target, (0, 0, 0))
+            return self._send_head_pos(roll, pitch, yaw)
         elif action in ("start", "info"):
-            return {
-                "state": "ready" if self._publisher else "idle",
-                "feedback_supported": True,
-                "feedback_topic": "/head/status",
-            }
+            return {"state": "ready"}
         elif action == "stop":
             return {"state": "idle"}
         return {"error": f"unknown action: {action}"}
 
-    def _move_to(self, yaw, pitch, roll, speed) -> dict:
-        try:
-            yaw = float(yaw)
-            pitch = float(pitch)
-            roll = float(roll)
-            speed = float(speed)
-        except (TypeError, ValueError):
-            return {"state": "error", "error": "head angles and speed must be numeric",
-                    "code": "invalid_head_parameters"}
-        if not all(math.isfinite(value) for value in (yaw, pitch, roll, speed)):
-            return {"state": "error", "error": "head angles and speed must be finite",
-                    "code": "invalid_head_parameters"}
-        limits = {
-            "yaw": (yaw, -90, 90),
-            "pitch": (pitch, -25, 25),
-            "roll": (roll, -26, 26),
-            "speed": (speed, 5, 60),
-        }
-        violations = [
-            {"parameter": name, "value": value, "minimum": lower, "maximum": upper}
-            for name, (value, lower, upper) in limits.items()
-            if value < lower or value > upper
-        ]
-        if violations:
-            return {"state": "error", "error": "Head command exceeds allowed range",
-                    "code": "head_command_out_of_range", "violations": violations}
-        motor_ids = [1, 2, 3]
-        check = self._feedback.preflight(self._publisher, motor_ids)
-        if check is not None:
-            return check
-        baseline_seq, baseline = self._feedback.snapshot(motor_ids)
-        result = self._send_head_pos(roll, pitch, yaw, speed)
-        if "error" in result:
-            return result
-        targets = {1: _deg2rad(roll), 2: _deg2rad(pitch), 3: _deg2rad(yaw)}
-        feedback = self._feedback.wait_for_motion(
-            targets, baseline_seq, baseline)
-        if feedback.get("state") == "error":
-            return feedback
-        result["feedback_verified"] = True
-        result["feedback"] = feedback
-        return result
-
-    def _send_head_pos(
-            self, roll_deg: float, pitch_deg: float,
-            yaw_deg: float, speed_deg: float) -> dict:
+    def _send_head_pos(self, roll_deg: float, pitch_deg: float, yaw_deg: float) -> dict:
         if not self._publisher:
             return {"error": "publisher not initialized"}
         try:
@@ -1044,7 +982,7 @@ class HeadPlugin:
                 cmd = SetMotorPosition()
                 cmd.name = motor_id
                 cmd.pos = _deg2rad(deg)
-                cmd.spd = _deg2rad(speed_deg)
+                cmd.spd = 1.0  # rad/s
                 cmd.cur = 3.0  # A (max current)
                 cmds.append(cmd)
             msg.cmds = cmds

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -1411,6 +1411,13 @@ class HeadGesturePlugin:
 class ArmPlugin:
     """双臂14DOF控制 (位置模式 / 力位混合)"""
 
+    # Conservative raw-control starting gains. The vendor-side controller
+    # applies these gains; this driver does not rate-limit the position step.
+    _DEFAULT_KP = 10.0
+    _DEFAULT_KD = 8.0
+    _KP_RANGE = (5.0, 100.0)
+    _KD_RANGE = (5.0, 30.0)
+
     _JOINT_NAMES = [
         "shoulder_pitch", "shoulder_roll", "shoulder_yaw",
         "elbow_pitch", "wrist_yaw", "wrist_pitch", "wrist_roll",
@@ -1459,14 +1466,14 @@ class ArmPlugin:
                     "speed": {"type": "number", "minimum": 0.2, "maximum": 1.5,
                               "default": 0.5,
                               "description": "运动速度(rad/s), 范围[0.2, 1.5], 默认0.5"},
-                    "kp": {"type": "array", "items": {"type": "number", "minimum": 0, "maximum": 2000},
+                    "kp": {"type": "array", "items": {"type": "number", "minimum": 5, "maximum": 100},
                            "minItems": 7, "maxItems": 7,
-                           "default": [200, 200, 200, 200, 200, 200, 200],
-                           "description": "位置增益(7个), 范围[0,2000], 默认值200"},
-                    "kd": {"type": "array", "items": {"type": "number", "minimum": 0, "maximum": 300},
+                           "default": [10, 10, 10, 10, 10, 10, 10],
+                           "description": "位置增益(7个), 范围[5,100], 默认10；move_ctrl无速度限制，仅建议小角度低增益调试"},
+                    "kd": {"type": "array", "items": {"type": "number", "minimum": 5, "maximum": 30},
                            "minItems": 7, "maxItems": 7,
-                           "default": [20, 20, 20, 20, 20, 20, 20],
-                           "description": "速度增益(7个), 范围[0,300], 默认值20"},
+                           "default": [8, 8, 8, 8, 8, 8, 8],
+                           "description": "速度阻尼增益(7个), 范围[5,30], 默认8"},
                 },
                 "required": ["action"],
                 "x-action-params": {
@@ -1519,8 +1526,8 @@ class ArmPlugin:
             return result
         elif action == "move_ctrl":
             poses = self._requested_poses(args)
-            kp = args.get("kp", [200] * 7)
-            kd = args.get("kd", [20] * 7)
+            kp = args.get("kp", [self._DEFAULT_KP] * 7)
+            kd = args.get("kd", [self._DEFAULT_KD] * 7)
             validated = self._validate_command(
                 poses, kp=kp, kd=kd)
             if isinstance(validated, dict):
@@ -1666,7 +1673,8 @@ class ArmPlugin:
                         "code": "arm_speed_out_of_range", "speed": speed}
             return converted_poses, speed
         for name, values, lower, upper in (
-                ("kp", kp, 0, 2000), ("kd", kd, 0, 300)):
+                ("kp", kp, *cls._KP_RANGE),
+                ("kd", kd, *cls._KD_RANGE)):
             values, error = cls._decode_array_argument(values, name)
             if error is not None:
                 return error
@@ -1733,8 +1741,8 @@ class ArmPlugin:
                     cmd.pos = _deg2rad(deg)
                     cmd.spd = 0.0
                     cmd.tor = 0.0
-                    cmd.kp = kp[i] if i < len(kp) else 200.0
-                    cmd.kd = kd[i] if i < len(kd) else 20.0
+                    cmd.kp = kp[i] if i < len(kp) else self._DEFAULT_KP
+                    cmd.kd = kd[i] if i < len(kd) else self._DEFAULT_KD
                     cmds.append(cmd)
 
             msg.cmds = cmds


### PR DESCRIPTION
## 背景

Tianyi 2.0 原始 arm 关节控制卡此前存在仪表盘数组解析、右臂输入语义和控制反馈不清晰的问题。本 PR 在不修改 head 卡片既有行为的前提下，修复并完善双臂底层关节控制。

## 卡片功能

- 支持 move_pos 位置控制和 move_ctrl 位置加 PD 增益控制。
- 固定提供 left_positions 与 right_positions 两个七关节输入框，每次在同一条 ROS2 消息中发送左右臂共 14 个关节目标，支持两臂同时执行不同姿态。
- 关节顺序为 shoulder_pitch、shoulder_roll、shoulder_yaw、elbow_pitch、wrist_yaw、wrist_pitch、wrist_roll。
- 右臂角度按实际关节方向直接输入，不再自动镜像；卡片提示手动镜像时需对 shoulder_roll、shoulder_yaw、wrist_yaw、wrist_roll 取反。
- 兼容原生 JSON 数组及仪表盘传入的 JSON 数组字符串。
- move_pos 支持 0.2–1.5 rad/s 的速度参数。
- move_ctrl 默认 kp=50、kd=20；允许范围分别为 kp 10–200、kd 5–50。PD 增益由机器人底层控制器应用，驱动不在 Python 侧计算 PD 输出，也不对 move_ctrl 的位置阶跃进行速度限制。

## 安全与反馈

- 分别按左右臂 URDF 限位校验目标角度。
- 发布前检查 /arm/status 新鲜度、目标电机是否存在、电机故障、急停和上电状态。
- 发布后等待更新的 /arm/status，确认关节已开始运动或已经接近目标；错误返回稳定的诊断 code。
- feedback_verified 表示已观察到控制器响应，不代表所有关节已经完全收敛到目标。
- 原始 arm 与 arm_gesture 共用手臂控制话题，不应并发调用；move_ctrl 应从小角度目标开始实机调试。

## 修改文件

- x-humanoid/tianyi2.0/device.py
- x-humanoid/tianyi2.0/README.md

## 验证

- python3 -m py_compile x-humanoid/tianyi2.0/device.py x-humanoid/tianyi2.0/main.py
- git diff --check
- ROS2 无关轻量测试验证左右臂独立角度、14 条电机命令、数组解析、URDF 限位以及 kp/kd 默认值和范围。
- 实机已验证 move_pos 指令能够被控制器接受并收到 /arm/status 反馈。
- 实机已验证 move_ctrl 在多组 PD 参数下能够驱动关节；测试同时确认降低 kp 会减缓初始响应但增大负载相关的稳态位置误差，因此最终采用 kp=50、kd=20 作为折中默认值。