### PR TITLE
fix(g1): 挂载完整数据目录

### DIFF
--- a/unitree/g1/deploy/service.yml
+++ b/unitree/g1/deploy/service.yml
@@ -7,10 +7,7 @@ unitree-g1:
   privileged: true
   volumes:
     - /dev:/dev
-    - /opt/phanthy-motus/data/maps:/opt/phanthy-motus/data/maps
-    - /opt/phanthy-motus/data/spatial.db:/opt/phanthy-motus/data/spatial.db
-    - /opt/phanthy-motus/data/scan_context.db:/opt/phanthy-motus/data/scan_context.db
-    - /opt/phanthy-motus/data/controlled_spatial.db:/opt/phanthy-motus/data/controlled_spatial.db
+    - /opt/phanthy-motus/data:/opt/phanthy-motus/data
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp


### PR DESCRIPTION
## 修改内容
- 保留 `/dev:/dev` 设备挂载。
- 将 G1 service 的地图和数据库单独挂载收敛为 `/opt/phanthy-motus/data:/opt/phanthy-motus/data`。
- 统一持久化 controlled spatial 地图缓存、数据库及后续新增数据。

## 验证
- 使用 YAML 解析器验证 `unitree/g1/deploy/service.yml` 的 volumes 配置。