### PR TITLE
feat(tianyi2): add system inspection and scene routine skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Each driver is a standalone [MCP](https://modelcontextprotocol.io) HTTP server t
 | Driver | Hardware | Port | Description |
 |--------|----------|------|-------------|
 | `unitree/g1` | Unitree G1 Humanoid | 15701 | Locomotion, arm control, mic, speaker, LED, state monitoring |
+| `engineai/t800` | EngineAI T800 Dev Board | 15708 | Motion state machine, body velocity control, upper-limb motion planning, joints/IMU/power sensors, LED, mic/speaker |
 | `phanthy/remote_control` | Remote Control Bridge | 15710 | Remote control relay |
 
 ## Quick Start

--- a/README_dev.md
+++ b/README_dev.md
@@ -369,6 +369,7 @@ Driver ports are allocated in the **15700–15799** range:
 | Driver | Port |
 |--------|------|
 | Unitree G1 | 15701 |
+| EngineAI T800 | 15708 |
 | Phanthy Remote Control | 15710 |
 
 New drivers should choose an unoccupied port. The WebSocket port is typically the MCP port + 1.

--- a/engineai/t800/.gitignore
+++ b/engineai/t800/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+.DS_Store
+*.log

--- a/engineai/t800/Dockerfile
+++ b/engineai/t800/Dockerfile
@@ -1,0 +1,80 @@
+# 众擎 T800 开发版 driver 镜像（ARM64，部署于 T800 应用计算单元 Jetson Orin NX）。
+#
+# 构建上下文约定（与 unitree/g1 一致，driver 目录为上下文；build.sh 自动处理）：
+#   - 本目录（engineai/t800/）下的代码
+#   - interface_protocol/（官方消息源码随 driver 入库，构建容器内编译 interface_protocol 消息包；
+#     若编译失败 colcon build 会打印 WARNING，driver 以 stub 模式运行——订阅将降级）
+#
+# 双 domain 环境：
+#   - 容器默认 env 为 ctx_t800 用（domain 69 + rmw_cyclonedds_cpp + ROS_LOCALHOST_ONLY=0）
+#   - ctx_core 由 driver 进程内临时切换回 domain 42 + rmw_fastrtps_cpp
+
+ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base:latest
+ARG PYPI_MIRROR=https://pypi.org/simple/
+FROM ${ROS_BASE_IMAGE}
+ARG PYPI_MIRROR
+
+WORKDIR /work
+
+RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
+    apt-get install -y --no-install-recommends --allow-unauthenticated \
+        python3-pip \
+        python3-colcon-common-extensions \
+        cmake \
+        build-essential \
+        curl \
+        git \
+        libportaudio2 \
+        libasound2-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
+    pyyaml numpy sounddevice
+
+# ── rmw_cyclonedds_cpp（ctx_t800 需要）──────────────────────────────────────
+# 优先从 apt 源安装 ros-humble-rmw-cyclonedds-cpp；
+# 若镜像 apt 源没有该包，则从源码构建 cyclonedds + rmw_cyclonedds_cpp 到 /ros2_ws。
+RUN (apt-get install -y --no-install-recommends ros-humble-rmw-cyclonedds-cpp 2>/dev/null || true) && \
+    bash -c 'if ! dpkg -s ros-humble-rmw-cyclonedds-cpp >/dev/null 2>&1; then \
+        echo "[cyclonedds] apt 无 ros-humble-rmw-cyclonedds-cpp，从源码构建"; \
+        mkdir -p /tmp/cyclone_src && cd /tmp/cyclone_src && \
+        git clone --depth 1 -b 0.10.5 https://github.com/eclipse-cyclonedds/cyclonedds.git && \
+        cd cyclonedds && mkdir -p build && cd build && \
+        cmake .. -DCMAKE_INSTALL_PREFIX=/opt/cyclonedds -DBUILD_TESTING=OFF && \
+        cmake --build . --target install --parallel && \
+        cd /tmp/cyclone_src && \
+        git clone --depth 1 -b humble https://github.com/ros2/rmw_cyclonedds_cpp.git && \
+        mkdir -p /ros2_ws/src && mv rmw_cyclonedds_cpp /ros2_ws/src/ && \
+        cd /ros2_ws && . /opt/ros/humble/setup.sh && \
+        export CYCLONEDDS_HOME=/opt/cyclonedds && \
+        colcon build --packages-select rmw_cyclonedds_cpp || true; \
+    fi'
+
+# ── 官方消息包（interface_protocol）──────────────────────────────────────────
+# 源码随 driver 入库（interface_protocol/，取自官方 engineai_ros2_workspace 的
+# src/interface_protocol）；interface_example 仅为示例脚本且 C++ 侧依赖
+# engineai_robotics_third_party，不参与编译，driver 只依赖 interface_protocol 的 msg 定义。
+COPY interface_protocol/ /ros2_ws/src/interface_protocol
+RUN cd /ros2_ws && \
+    . /opt/ros/humble/setup.sh && \
+    colcon build --packages-select interface_protocol || \
+    echo "WARNING: interface_protocol build failed, will run in stub mode"
+
+# ── 双域环境（容器默认给 ctx_t800 用；ctx_core 在进程内临时切回 42+fastrtps）──
+ENV ROS_DOMAIN_ID=69
+ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+ENV ROS_LOCALHOST_ONLY=0
+ENV PYTHONUNBUFFERED=1
+
+# 确保容器内可直接 import interface_protocol 消息包（base 镜像 entrypoint 不会 source 工作空间）
+ENV PYTHONPATH=/ros2_ws/install/interface_protocol/local/lib/python3.10/dist-packages:${PYTHONPATH}
+ENV AMENT_PREFIX_PATH=/ros2_ws/install/interface_protocol:${AMENT_PREFIX_PATH}
+ENV LD_LIBRARY_PATH=/ros2_ws/install/interface_protocol/lib:${LD_LIBRARY_PATH}
+
+COPY main.py device.py ros2.py config.yaml driver.yaml /work/
+COPY plugins/  /work/plugins/
+COPY deploy/   /deploy/
+
+EXPOSE 15708
+
+CMD ["/bin/bash", "-c", "source /opt/ros/humble/setup.bash && source /ros_ws/install/setup.bash && (source /ros2_ws/install/setup.bash 2>/dev/null || true) && python3 /work/main.py"]

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -1,0 +1,128 @@
+# 众擎 EngineAI T800 开发版 Driver
+
+将 T800 开发版底层暴露的 ROS2 接口封装为 phanthymotus-driver 规范的能力卡片
+（MCP HTTP server），供 agent-core 画布 / LLM 调用。参照 `unitree/g1` 与
+`x-humanoid/tianyi2.0` 的既有模式。
+
+- 目录：`phanthymotus-driver/engineai/t800/`
+- MCP 端口：**15708**（15700–15799 区间）
+- 硬件：T800 开发版（25 自由度，关节索引 0~24，语义名 `J00_HIP_PITCH_L` … `J24_HEAD_YAW`）
+
+## 能力清单（12 张卡片）
+
+| 卡片 (tool) | 类型 | 机器人话题 (domain 69) | 输出 (domain 42) | 说明 |
+|------|------|------------------------|------|------|
+| `motion_state` | sensor | `/motion/motion_state` | `/{ns}/motion/state` data/json | 当前运动状态 + 可用转换白名单 |
+| `motion_switcher` | actuator | `/motion/set_motion_state` (RELIABLE) | — | 切换目标状态：白名单检查 + 3s 超时 + 状态确认 |
+| `loco` | actuator | `/motion/body_vel_cmd` | — | 100Hz 持续发布；限速 x/y ±1 m/s、yaw ±1 rad/s；2s 无命令自停 |
+| `arm` | actuator | `/motion/joint_motion_plan/request` + `/state` | `/{ns}/arm/state` data/json | 上肢运动规划（13 关节 [12..24]），前置 `lower_body_balance` |
+| `joints` | sensor | `/hardware/joint_state` | `/{ns}/state/joints` data/json | 25 关节按部位聚合，含语义名 |
+| `imu` | sensor | `/hardware/imu_info` | `/{ns}/state/imu` data/json | 四元数/RPY/加速度/角速度 |
+| `power` | sensor | `/hardware/power_info` | `/{ns}/state/power` data/json | 电量/电压/电流 |
+| `gamepad` | sensor | `/hardware/gamepad_keys` | `/{ns}/state/gamepad` data/json | 手柄数字键 + 模拟摇杆 |
+| `led` | actuator | `/hardware/led_control` | — | 11 种模式枚举 |
+| `mic` | sensor | —（ALSA 采集） | `/{ns}/mic/audio` audio/pcm-16k | 16kHz 单声道，chunk 1024~4096B，满足 ASR 协议 |
+| `speaker` | actuator | —（ALSA 播放） | — | 播放 PCM/WAV/本地文件 |
+| `joint_bridge` | actuator | `/hardware/joint_command` | — | 500Hz 全身 PD 直通（**config 默认关闭**），前置 `joint_bridge` 模式 |
+
+运动状态机是所有控制卡的前置：`loco` / `arm` / `joint_bridge` 在 dispatch 时
+检查当前状态，不在正确模式时返回
+`{"state":"error","error":"WRONG_MOTION_STATE","message":"请先切换到 xxx 模式"}`。
+
+T800 支持的运动状态：`idle` / `passive` / `pd_stand` / `rl_basic` /
+`lower_body_balance` / `joint_bridge` / `pd_sitground` / `walk_server` /
+`rl_mimic_supine_to_stance` / `rl_mimic_prone_to_stance` /
+`rl_mimic_stance_to_supine` / `rl_mimic_sitdown_to_stance` /
+`rl_mimic_stance_to_sitdown`。
+
+## 架构（双 rclpy context）
+
+```
+┌────────────────────────── 机器人运控单元 (domain 69 / CycloneDDS) ──────────────────────────┐
+│  /motion/motion_state   /motion/set_motion_state   /motion/body_vel_cmd                    │
+│  /motion/joint_motion_plan/{request,state}         /hardware/joint_state                   │
+│  /hardware/joint_command                           /hardware/{imu_info,power_info,led_control,gamepad_keys} │
+└──────────────────────────────────────────┬─────────────────────────────────────────────────┘
+                                           │ ctx_t800（rclpy context，executor_t800）
+┌──────────────────────────────────────────┴─────────────────────────────────────────────────┐
+│  engineai/t800 driver（main.py + device.py + plugins/*）                                    │
+│  ├─ 传感器转发：订阅 domain 69 → 缓存 → 定时 JSON 发布到 domain 42 /{ns}/xxx                │
+│  ├─ 控制类：   发布 domain 69（运动状态前置检查）                                           │
+│  └─ 音频：     mic 采集/重采样/缓冲 → AudioChunk 发布到 domain 42 /{ns}/mic/audio           │
+└──────────────────────────────────────────┬─────────────────────────────────────────────────┘
+                                           │ ctx_core（rclpy context，executor_core）
+┌──────────────────────────────────────────┴─────────────────────────────────────────────────┐
+│  agent-core (domain 42 / FastDDS)  ·  dashboard 画布渲染  ·  perception ASR/TTS            │
+└─────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+进程内按 context 切换 RMW 实现：`ctx_t800` 用 `rmw_cyclonedds_cpp` +
+`ROS_DOMAIN_ID=69` + `ROS_LOCALHOST_ONLY=0`；`ctx_core` 用 `rmw_fastrtps_cpp` +
+`ROS_DOMAIN_ID=42`（详见 `ros2.py`）。
+
+## 目录结构
+
+```
+engineai/t800/
+├── main.py            # MCP HTTP server 入口（JSON-RPC 2.0，POST /mcp）
+├── device.py          # T800DeviceBundle 插件聚合 + 工具名冲突检查
+├── ros2.py            # Ros2Contexts 双 context 管理 + QoS 常量 + T800_TOPICS
+├── plugins/           # motion.py / sensors.py / peripherals.py（12 张卡片实现）
+├── driver.yaml        # id: t800-driver, port: 15708
+├── config.yaml        # 插件开关（joint_bridge 默认关闭）
+├── Dockerfile         # ros-base + rmw-cyclonedds-cpp + 官方消息包
+├── interface_protocol/  # 官方消息源码（取自 engineai_ros2_workspace，随 driver 入库）
+├── requirements.txt
+├── deploy/service.yml # host 网络 + privileged + /dev:/dev
+└── docs/              # 真机部署实测文档
+```
+
+## 本地运行
+
+```bash
+cd phanthymotus-driver/engineai/t800
+pip install -r requirements.txt
+python3 main.py          # 可选：CONFIG_PATH=/path/to/config.yaml
+```
+
+- 无 ROS2 环境的机器：`ros2.py` / `device.py` / `main.py` 均可在模块级纯 import
+  （rclpy 全部延迟导入），可做静态验证（`python3 -m py_compile *.py`）。
+- 真机运行时需机器人侧 ROS2 已启动（domain 69），
+  `ros2 topic list` 可见 `/hardware/joint_state` 等话题。
+
+## 构建与部署
+
+```bash
+# 方式一：build.sh（从 driver 仓库根目录，上下文为 driver 目录）
+bash build.sh engineai/t800
+
+# 方式二：手动构建（构建上下文 = driver 仓库根目录，无需外部 third_party/；
+#   interface_protocol 消息包源码已随 driver 入库在 engineai/t800/interface_protocol/，
+#   编译失败时才降级 stub 模式运行——消息包不构建、订阅不可用）
+docker build -f engineai/t800/Dockerfile -t t800-driver .
+```
+
+部署：agent-core 部署时提取镜像内 `deploy/service.yml`（host 网络 + privileged +
+`/dev:/dev` 声卡访问），合并进宿主机 `/opt/phanthy-motus/` 的 docker-compose.yml。
+服务名 `engineai-t800`，容器名 `embodied-engineai-t800`。
+
+## 与 agent-core 交互
+
+- **注册**：启动后 POST `http://<agent-core>:15678/api/mcp`
+  （可用 `AGENT_CORE_URL` 覆盖），payload `{id, name, url, transport, category}`；
+  agent-core 随后执行 `initialize` → `tools/list` 注册工具；之后每 30s 心跳。
+- **工具调用**：`tools/call`（JSON-RPC 2.0，POST `/mcp`，带 CORS）。
+  插件 dispatch 返回纯 dict；`{"state":"error",...}` 会被标记 `isError`。
+- **画布渲染**：`topic_out` 的 format 与渲染器映射（README_dev）——
+  本 driver 传感器卡全部用 `data/json`（KV 面板），`mic` 用 `audio/pcm-16k`（波形）。
+- **perception 消费**：agent-core `topic_subscriber` 订阅 String 话题注入 event_bus；
+  ASR 通过 mic 卡的 `audio/pcm-16k` 流（`audio_msgs/AudioChunk`，
+  format=`audio/pcm-16k`，16kHz 单声道 PCM_S16_LE，chunk 1024~4096 字节）。
+
+## 安全注意
+
+- `loco`：官方限速 x/y ±1 m/s、yaw ±1 rad/s；100Hz 发布；接收端 2 秒未收到自动停；
+  停止 = 显式发零速度。
+- `joint_bridge`：500Hz 高频 + 力矩公式 `tau = kp*(q_cmd-q) + kd*(qd_cmd-qd) + ff`，
+  数组长度必须 = 25；**config 默认关闭**，需要时先切换到 `joint_bridge` 运动模式。
+- 所有控制类卡片均做运动状态前置检查，避免在错误状态下下发指令导致机器人摔倒。

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -1,0 +1,34 @@
+mcp_port: 15708
+ros_namespace: ""   # 留空则自动使用 hostname
+name: "EngineAI T800 Bundle"
+id: t800-driver
+
+plugins:
+  # ── 运动控制 ──
+  motion_state:
+    enabled: true
+  motion_switcher:
+    enabled: true
+  loco:
+    enabled: true
+  arm:
+    enabled: true
+  joint_bridge:
+    enabled: false    # 危险：500Hz 全身 PD 直通，默认关闭；需先切换到 joint_bridge 模式
+  # ── 传感器 ──
+  joints:
+    enabled: true
+  imu:
+    enabled: true
+  power:
+    enabled: true
+  gamepad:
+    enabled: true
+  # ── 外设 ──
+  led:
+    enabled: true
+  mic:
+    enabled: true
+    device_index: null   # 采集设备索引，null = 自动选择默认声卡
+  speaker:
+    enabled: true

--- a/engineai/t800/deploy/service.yml
+++ b/engineai/t800/deploy/service.yml
@@ -1,0 +1,24 @@
+# T800 driver 部署片段（agent-core 部署时提取并合并进宿主机 docker-compose.yml）。
+# host 网络 + privileged + /dev:/dev（声卡/硬件访问）。
+# 容器级 env 声明 T800 侧环境（domain 69 + CycloneDDS）；ctx_core 由进程内切换。
+engineai-t800:
+  image: __IMAGE__
+  container_name: embodied-engineai-t800
+  network_mode: host
+  ipc: host
+  pid: host
+  privileged: true
+  volumes:
+    - /dev:/dev
+    - /opt/phanthy-motus/data:/opt/phanthy-motus/data
+  environment:
+    - ROS_DOMAIN_ID=69
+    - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+    - ROS_LOCALHOST_ONLY=0
+    - PYTHONUNBUFFERED=1
+  logging:
+    driver: local
+    options:
+      max-size: "10m"
+      max-file: "3"
+  restart: unless-stopped

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+engineai/t800/device.py — 众擎 T800 开发版设备插件聚合（bundle）。
+
+数据流：
+  - 传感器类插件（motion_state / joints / imu / power / gamepad）：
+      订阅 domain 69 机器人话题 → 缓存 → 定时 JSON 发布到 domain 42 的
+      /{ns}/xxx（std_msgs/String，format=data/json）
+  - 控制类插件（motion_switcher / loco / arm / joint_bridge）：
+      发布 domain 69 控制话题；dispatch 前检查运动状态机前置
+      （不在所需模式时返回 {"state":"error","error":"WRONG_MOTION_STATE",...}）
+  - 外设类插件（led / mic / speaker）：
+      led 发布 domain 69；mic/speaker 走 audio_msgs/AudioChunk 音频协议
+      （format=audio/pcm-16k，16kHz 单声道，chunk >= 1024 字节）
+
+插件实现位于 plugins/ 下（motion.py / sensors.py / peripherals.py），
+本文件只做 import 与聚合，模块级不 import 任何第三方/ROS2 库，
+保证可在无 ROS2 环境下被纯 import 测试。
+"""
+
+from __future__ import annotations
+
+import importlib
+
+# 插件键（config.yaml plugins 键） → (模块, 类名)
+# 固定类名由并行插件 agent 实现，构造签名统一：
+#   __init__(self, plugin_config: dict, namespace: str, ros2: Ros2Contexts)
+_PLUGIN_TABLE = {
+    "motion_state":    ("plugins.motion", "MotionStatePlugin"),
+    "motion_switcher": ("plugins.motion", "MotionSwitcherPlugin"),
+    "loco":            ("plugins.motion", "LocoPlugin"),
+    "arm":             ("plugins.motion", "ArmMotionPlugin"),
+    "joint_bridge":    ("plugins.motion", "JointBridgePlugin"),
+    "joints":          ("plugins.sensors", "JointsStatePlugin"),
+    "imu":             ("plugins.sensors", "ImuPlugin"),
+    "power":           ("plugins.sensors", "PowerPlugin"),
+    "gamepad":         ("plugins.sensors", "GamepadPlugin"),
+    "led":             ("plugins.peripherals", "LedPlugin"),
+    "mic":             ("plugins.peripherals", "MicPlugin"),
+    "speaker":         ("plugins.peripherals", "SpeakerPlugin"),
+}
+
+
+class T800DeviceBundle:
+    """按 config.yaml 的 plugins 键逐个加载启用的插件并聚合工具。"""
+
+    def __init__(self, cfg: dict, namespace: str, ros2):
+        self._cfg = cfg
+        self._namespace = namespace
+        self._plugins: list = []
+        self._module_cache: dict = {}
+
+        plugins_cfg = cfg.get("plugins", {})
+        for key, (module_name, class_name) in _PLUGIN_TABLE.items():
+            plugin_cfg = plugins_cfg.get(key)
+            if not plugin_cfg or not plugin_cfg.get("enabled", False):
+                continue
+            try:
+                module = self._module_cache.get(module_name)
+                if module is None:
+                    module = importlib.import_module(module_name)
+                    self._module_cache[module_name] = module
+                cls = getattr(module, class_name)
+                plugin = cls(plugin_cfg, namespace, ros2)
+                self._plugins.append(plugin)
+                print(f"[bundle] {class_name} loaded", flush=True)
+            except Exception as e:
+                # 插件文件可能由并行 agent 尚未写完，失败不影响其余插件
+                print(f"[bundle] {key} ({class_name}) load FAILED: {e}", flush=True)
+                import traceback
+                traceback.print_exc()
+
+        self._warn_duplicate_tool_names()
+
+    # ── 工具名冲突检查 ────────────────────────────────────────────────────
+
+    def _warn_duplicate_tool_names(self) -> None:
+        """启动时打印重复工具名警告（画布上工具名必须唯一）。"""
+        seen: dict = {}
+        for p in self._plugins:
+            tools = p.get_tools() if hasattr(p, "get_tools") else [p.get_tool()]
+            owner = type(p).__name__
+            for tool in tools or []:
+                name = (tool or {}).get("name", "")
+                if not name:
+                    continue
+                if name in seen:
+                    print(
+                        f"[bundle] WARNING: 工具名 '{name}' 重复，"
+                        f"来自 {seen[name]} 与 {owner}",
+                        flush=True,
+                    )
+                else:
+                    seen[name] = owner
+
+    # ── 生命周期 ───────────────────────────────────────────────────────────
+
+    def start_all(self) -> None:
+        for i, p in enumerate(self._plugins):
+            try:
+                p.start()
+            except Exception as e:
+                print(f"[bundle] Plugin {i} ({type(p).__name__}) start() FAILED: {e}", flush=True)
+                import traceback
+                traceback.print_exc()
+        print(f"[bundle] All {len(self._plugins)} plugins started", flush=True)
+
+    def stop_all(self) -> None:
+        for p in self._plugins:
+            try:
+                p.stop()
+            except Exception:
+                pass
+        print("[bundle] All plugins stopped", flush=True)
+
+    # ── 工具聚合与分发 ─────────────────────────────────────────────────────
+
+    def get_all_tools(self) -> list:
+        tools = []
+        for p in self._plugins:
+            if hasattr(p, "get_tools"):
+                tools.extend(p.get_tools())
+            else:
+                tools.append(p.get_tool())
+        return tools
+
+    def dispatch(self, tool_name: str, args: dict) -> dict | None:
+        """分发工具调用（逻辑同 g1）：
+        - resource 类型直接转发（不 pop action）
+        - 其余类型 args.pop("action", tool_name) 并注入 _tool_name
+        返回纯 dict（MCP content 包装由 HTTP handler 完成）。
+        """
+        for p in self._plugins:
+            plugin_tools = p.get_tools() if hasattr(p, "get_tools") else [p.get_tool()]
+            for tool_def in plugin_tools:
+                if tool_def["name"] == tool_name:
+                    if tool_def["type"] == "resource":
+                        return p.dispatch(tool_name, args)
+                    action = args.pop("action", tool_name)
+                    args["_tool_name"] = tool_name  # 多工具插件据此识别被调用的工具
+                    result = p.dispatch(action, args)
+                    return result
+        return None

--- a/engineai/t800/docs/T800真机部署实测.md
+++ b/engineai/t800/docs/T800真机部署实测.md
@@ -1,0 +1,335 @@
+# T800 真机部署实测文档（预写）
+
+> **预写：尚未真机验证，实测时按实际情况修订。**
+> 本文件依据 `engineai/t800/` 源码（main.py / device.py / ros2.py / plugins/*）与
+> 设计文档 `docs/superpowers/specs/2026-08-05-t800-driver-design.md` 预写，
+> 作为真机部署时的操作清单、逐卡实测步骤与验收路径。所有 IP、用户名、话题频率、
+> 预期行为均以实测结果为准，如有出入请直接修订本文件。
+
+---
+
+## 1. 部署目标环境
+
+| 项 | 值 |
+|----|----|
+| 机型 | 众擎（EngineAI）T800 开发版（25 自由度，关节索引 0~24，语义名 `J00_HIP_PITCH_L` … `J24_HEAD_YAW`） |
+| 应用计算单元 | Jetson Orin NX，IP **192.168.0.162**，SSH：`ssh ubuntu@192.168.0.162` |
+| 运控单元 | IP **192.168.0.163**，SSH：`ssh <user>@192.168.0.163`（用户名实测确认） |
+| 机器人 WIFI | **e12345678** |
+| 网络连接 | 应用单元与运控单元之间走**网线直连**（部署前先用网线连通，再验证 WIFI） |
+| 机器人侧 ROS2 | ROS2 Humble，**ROS_DOMAIN_ID=69**，**rmw_cyclonedds_cpp**（CycloneDDS），`ROS_LOCALHOST_ONLY=0` |
+| core 侧 ROS2 | **ROS_DOMAIN_ID=42**，rmw_fastrtps_cpp（FastDDS），与 agent-core / dashboard / perception 互通 |
+| Driver | `engineai/t800`，MCP 端口 **15708**（15700–15799 区间），服务名 `engineai-t800`，容器名 `embodied-engineai-t800` |
+| 部署形态 | ARM64 Docker + host 网络 + privileged + `/dev:/dev`（与 unitree/g1 一致） |
+| agent-core 注册 | 启动后 POST `http://<agent-core>:15678/api/mcp`（`AGENT_CORE_URL` 覆盖，默认 `https://localhost:15678`），之后每 30s 心跳 |
+
+### 话题拓扑速览（验证时对照）
+
+- 机器人侧（domain 69 / CycloneDDS）：`/motion/motion_state`、`/motion/set_motion_state`、
+  `/motion/body_vel_cmd`、`/motion/joint_motion_plan/{request,state}`、
+  `/hardware/{joint_state,joint_command,imu_info,power_info,led_control,gamepad_keys}`
+- driver 转发输出（domain 42 / FastDDS）：`/{ns}/motion/state`（2Hz）、`/{ns}/arm/state`（5Hz）、
+  `/{ns}/state/joints`（2Hz）、`/{ns}/state/imu`（10Hz）、`/{ns}/state/power`（1Hz）、
+  `/{ns}/state/gamepad`（10Hz）、`/{ns}/mic/audio`（audio/pcm-16k）
+- `{ns}` = `config.yaml` 的 `ros_namespace`，留空时取应用单元主机名
+  （如 `ubuntu`，实测时以容器日志 `[bundle] namespace=...` 为准）
+
+---
+
+## 2. 前置准备检查清单
+
+> 全部打勾后再开始部署。
+
+- [ ] 机器人已完成开机自检，处于安全可控状态（建议先在运控侧遥控/手柄确认状态机可切换）
+- [ ] 应用单元（162）与运控单元（163）之间**网线已连接**，互相 `ping` 通
+- [ ] 应用单元连上机器人 WIFI（`e12345678`），WIFI 网络也能 `ping` 通 192.168.0.163
+- [ ] SSH 可登录：`ssh ubuntu@192.168.0.162`（应用单元）、`ssh <user>@192.168.0.163`（运控单元）
+- [ ] 应用单元 ROS2 环境可用，`ros2 topic list` 能看见机器人话题（详见 2.1）
+- [ ] 应用单元可访问 agent-core（domain 42 / FastDDS 互通）
+- [ ] 声卡设备存在且容器可访问：`aplay -l`（speaker）、`arecord -l`（mic）
+- [ ] 测试场地空旷（≥3 米清场）、机器人不朝向人员/易碎物
+- [ ] Docker 镜像已构建并推送（`build.sh engineai/t800`）
+
+### 2.1 机器人侧话题连通性验证（部署前必须先过）
+
+在应用单元（192.168.0.162）上执行：
+
+```bash
+# 确保 RMW 与 domain 与机器人一致（CycloneDDS / domain 69）
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+export ROS_DOMAIN_ID=69
+export ROS_LOCALHOST_ONLY=0
+
+ros2 topic list
+# 预期可见（至少包含）：
+#   /hardware/joint_state  /hardware/imu_info  /hardware/power_info
+#   /hardware/gamepad_keys /motion/motion_state
+#   /motion/set_motion_state /motion/body_vel_cmd
+#   /motion/joint_motion_plan/request /motion/joint_motion_plan/state
+
+# 关节状态有数据（电机上电后 position/velocity/torque 非全零）
+ros2 topic echo /hardware/joint_state --once --qos-reliability best_effort
+```
+
+> 注意：`/hardware/joint_state`、`/hardware/joint_command` 官方为 BEST_EFFORT，
+> `ros2 topic echo` 需加 `--qos-reliability best_effort`，否则 QoS 不匹配收不到数据。
+> 若宿主机没有 `interface_protocol` 消息定义，可在容器内执行这些命令
+> （镜像已编译消息包，见 3.3）。
+
+---
+
+## 3. 构建与部署
+
+### 3.1 构建镜像（方式一：build.sh）
+
+```bash
+cd phanthymotus-driver   # driver 仓库根目录
+bash build.sh engineai/t800
+# 依赖：driver.yaml + Dockerfile；构建上下文为 driver 仓库根目录，
+# interface_protocol 消息包源码已随 driver 入库（engineai/t800/interface_protocol/），
+# 构建容器内 colcon 编译；若编译失败 driver 以 stub 模式运行（订阅不可用），必须修复后重测
+```
+
+方式二：手动构建
+
+```bash
+docker build -f engineai/t800/Dockerfile -t t800-driver .
+```
+
+镜像要求 ARM64（部署于 Jetson Orin NX），构建产物包含：
+`ros-base + ros-humble-rmw-cyclonedds-cpp + interface_protocol 消息包 + 双域环境变量
+（默认 env = domain 69 / CycloneDDS / ROS_LOCALHOST_ONLY=0，ctx_core 由进程内临时切回 42+FastDDS）`。
+
+### 3.2 Agent Core Web Dashboard 部署
+
+1. 在 agent-core 部署页选择镜像（`.../engineai/t800:<tag>`）；
+2. agent-core 提取镜像内 `deploy/service.yml`，合并进宿主机 `/opt/phanthy-motus/` 的
+   `docker-compose.yml`（服务名 `engineai-t800`，容器名 `embodied-engineai-t800`）；
+3. service.yml 关键项（部署后确认已生效）：
+   - `network_mode: host` + `ipc: host` + `pid: host` + `privileged: true`
+   - 卷挂载：`/dev:/dev`（声卡/硬件访问）、`/opt/phanthy-motus/data:/opt/phanthy-motus/data`
+   - 环境变量：`ROS_DOMAIN_ID=69`、`RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`、
+     `ROS_LOCALHOST_ONLY=0`、`PYTHONUNBUFFERED=1`
+   - `restart: unless-stopped`；日志 `local` driver，单文件 10m、最多 3 个
+4. 如 agent-core 不在 162 本机，追加 `AGENT_CORE_URL`（http/https 按实际部署形态）。
+
+### 3.3 手工 docker run（agent-core 不可用时的等价命令）
+
+```bash
+docker run -d --name embodied-engineai-t800 \
+  --network host --privileged --ipc host --pid host \
+  -v /dev:/dev \
+  -v /opt/phanthy-motus/data:/opt/phanthy-motus/data \
+  -e ROS_DOMAIN_ID=69 \
+  -e RMW_IMPLEMENTATION=rmw_cyclonedds_cpp \
+  -e ROS_LOCALHOST_ONLY=0 \
+  -e PYTHONUNBUFFERED=1 \
+  -e AGENT_CORE_URL=https://<agent-core-host>:15678 \
+  <registry>/phanthy-motus/drivers/engineai/t800:<tag>
+```
+
+容器 CMD 会 source `/opt/ros/humble/setup.bash` 与 `/ros2_ws/install/setup.bash`
+（含 interface_protocol 消息包），随后运行 `python3 /work/main.py`。
+**容器内可直接执行 `ros2 topic echo` 做 domain 69 侧验证（消息定义齐全）。**
+
+### 3.4 启动确认
+
+```bash
+docker logs -f embodied-engineai-t800
+# 预期依次出现：
+#   [bundle] namespace=<hostname> mcp_port=15708
+#   [bundle] dual-domain ROS2 initialized (t800: domain 69/cyclonedds, core: domain 42/fastrtps)
+#   [bundle] MotionStatePlugin loaded ... （12 张卡逐个 loaded）
+#   [bundle] All N plugins started
+#   [bundle] MCP server → http://localhost:15708
+# 之后 [register] 无报错（已向 agent-core 注册成功）
+
+# 健康检查
+curl -s -X POST http://localhost:15708/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+# 预期 result.tools 含 12 张卡：motion_state/motion_switcher/loco/arm/joints/imu/power/gamepad/led/mic/speaker/joint_bridge
+```
+
+---
+
+## 4. 逐卡实测步骤与预期结果
+
+> 测试前置：所有控制类卡片都有**运动状态机前置检查**，必须先切到正确模式，否则返回
+> `{"state":"error","error":"WRONG_MOTION_STATE","message":"..."}` 且机器人不动作。
+> 建议按 4.2 的流程顺序测（先起状态机再测控制卡），传感器卡（4.1）可随时测。
+
+### 4.1 传感器卡（5 张，domain 42 侧验证 `ros2 topic echo /{ns}/...`）
+
+| 卡片 | 操作动作（画布） | 预期画布显示 | 验证命令（domain 42） |
+|------|------------------|--------------|----------------------|
+| `motion_state` | 添加卡片 / 调用 `get` | KV 面板显示 `current_motion_task` 与 `available_transition_motions` 白名单，2Hz 刷新 | `export RMW_IMPLEMENTATION=rmw_fastrtps_cpp ROS_DOMAIN_ID=42 && ros2 topic echo /{ns}/motion/state` |
+| `joints` | 添加卡片 / 调用 `read` | KV 面板按 6 部位（左腿/右腿/腰/左臂/右臂/头）显示 25 关节 `q/dq/tau`（含语义名 J00~J24），2Hz | `ros2 topic echo /{ns}/state/joints`（对比 domain 69：`ros2 topic echo /hardware/joint_state --qos-reliability best_effort`） |
+| `imu` | 添加卡片 / 调用 `read` | 显示 `quaternion/rpy/linear_acceleration/angular_velocity`，10Hz；晃动机器人头部数值应变化 | `ros2 topic echo /{ns}/state/imu`（对比：`ros2 topic echo /hardware/imu_info`） |
+| `power` | 添加卡片 / 调用 `read` | 显示 `enable/percentage/voltage/current/current_limit/error_code`，1Hz | `ros2 topic echo /{ns}/state/power`（对比：`ros2 topic echo /hardware/power_info`） |
+| `gamepad` | 添加卡片 / 按手柄按键 | 按 A/B/X/Y 时 `digital_states` 对应位变 1，摇杆对应 `analog_states` 在 -1~1 变化，10Hz | `ros2 topic echo /{ns}/state/gamepad`（对比：`ros2 topic echo /hardware/gamepad_keys`） |
+
+**预期结果**：5 张卡画布均有数据且数值与 domain 69 原始话题一致；
+`read` 调用返回 `{"parts":...}` 等结构化数据而非错误。
+
+### 4.2 控制卡（运动状态机切换流程 + 动作验证）
+
+> 流程：`idle/passive → pd_stand（PD 站立）→ lower_body_balance（下肢平衡）→ 挥手/握手`，
+> loco 需 `rl_basic`（自然行走）模式。全部动作在机器人站立稳定后进行。
+
+#### 步骤 1：切换到 pd_stand（机器人站立）
+
+| 卡片 | 操作动作 | 预期结果 | 验证命令 |
+|------|----------|----------|----------|
+| `motion_switcher` | `action=switch, mode=pd_stand` | 返回 `{"state":"ok","current_motion":"pd_stand","elapsed_ms":<值>}`；机器人原地站立 | `ros2 topic echo /motion/motion_state --qos-reliability best_effort`（domain 69，`current_motion_task=pd_stand`） |
+| `motion_switcher` | `action=get_state` / `list_available` | 返回当前状态与白名单，pd_stand 应出现在列表中 | 同上 |
+
+失败排查：返回 `NOT_AVAILABLE`（当前状态不允许直达，需先切 `passive`/其他中间态）、
+`TIMEOUT`（3 秒未确认，看运控日志）、`NO_MOTION_STATE`（机器人未上电/运控未启动，见第 5 节）。
+
+#### 步骤 2：切换到 lower_body_balance（上肢运动前置）
+
+| 卡片 | 操作动作 | 预期结果 | 验证命令 |
+|------|----------|----------|----------|
+| `motion_switcher` | `action=switch, mode=lower_body_balance` | 返回 ok，`current_motion_task=lower_body_balance` | 同步骤 1 的 echo 命令 |
+
+#### 步骤 3：上肢手势（挥手 / 握手）
+
+| 卡片 | 操作动作 | 预期结果 | 验证命令 |
+|------|----------|----------|----------|
+| `arm` | `action=wave_hand` | 返回 ok + 任务队列（init→raise_hands→wave_hands_1..5→reset）；机器人举起双手挥手约 2 秒 | domain 69：`ros2 topic echo /motion/joint_motion_plan/request --qos-reliability reliable`（request_id 递增、13 个关节索引 [12..24]）；`ros2 topic echo /motion/joint_motion_plan/state --qos-reliability best_effort`（status 1=IDLE→2=EXECUTING→1） |
+| `arm` | `action=shake_hand` | 返回 ok；机器人伸右手→收右手 | 同上 |
+| `arm` | `action=extend_right_hand` | 返回 ok；机器人伸出右手保持 | 同上 |
+| `arm` | `action=get_state` | 返回 `status=EXECUTING/IDLE`、`progress 0~1`、`queue_remaining` | domain 42：`ros2 topic echo /{ns}/arm/state`（5Hz，含 request_id/status/progress） |
+| `arm` | `action=cancel` | 返回 ok，队列清空，机器人停止当前动作 | — |
+| `arm` | `action=reset` | 返回 ok；上肢回到默认姿态 | 同上 request/state echo |
+
+**负向验证（前置检查）**：不切 `lower_body_balance` 直接调 `arm`，预期返回
+`{"state":"error","error":"WRONG_MOTION_STATE","message":"当前运动状态为 ...，上肢运动规划需要 lower_body_balance..."}`，
+画布标记调用失败（isError），机器人不动作。
+
+#### 步骤 4：loco 前进 / 停止（需 rl_basic）
+
+| 卡片 | 操作动作 | 预期结果 | 验证命令 |
+|------|----------|----------|----------|
+| `motion_switcher` | `action=switch, mode=rl_basic` | 返回 ok；机器人切换到自然行走状态（站立） | `ros2 topic echo /motion/motion_state --qos-reliability best_effort` |
+| `loco` | `action=move, vx=0.1, duration=3` | 返回 ok；机器人以约 0.1 m/s 前进约 3 秒后自动停（duration 自停）；速度渐变无突变 | domain 69：`ros2 topic echo /motion/body_vel_cmd`（约 100Hz，`linear_velocity=[0.1, 0.0]`，`yaw_velocity=0.0`；停止后回到 0） |
+| `loco` | `action=move, vx=0.05` 后**不再下发** | 约 2 秒后机器人自动停止（看门狗自停） | 同上，观察命令停发后 2s 内归零 |
+| `loco` | `action=move, vyaw=0.3, duration=2` | 机器人原地转向约 0.3 rad/s 后自停 | 同上（`yaw_velocity=0.3`） |
+| `loco` | `action=stop` | 返回 ok；显式发布零速度，机器人立即停 | 同上（0 值命令） |
+| `loco` | `action=move, vx=1.5` | 返回 `INVALID_ARGUMENT`（超出 ±1 m/s 限速） | — |
+
+**负向验证**：在非 `rl_basic/walk_server` 状态下调 `loco move`，预期
+`WRONG_MOTION_STATE` 且不动作。
+
+### 4.3 外设卡（LED / 麦克风 / 扬声器）
+
+| 卡片 | 操作动作 | 预期结果 | 验证命令 |
+|------|----------|----------|----------|
+| `led` | `action=set, mode=绿闪` | 返回 ok；机身 LED 绿闪 | domain 69：`ros2 topic echo /hardware/led_control`（`color=2`，即 BLINK_GREEN） |
+| `led` | `action=set, mode=白流水` | 机身 LED 流水效果 | 同上（`color=8`） |
+| `led` | `action=reset` | 返回 ok；LED 还原内置灯光 | 同上（`color=0`） |
+| `mic` | `action=start` | 返回 `{"state":"running",...}`；对着机器人说话，画布出现**波形**动画 | domain 42：`ros2 topic echo /{ns}/mic/audio`（audio_msgs/AudioChunk，`format="audio/pcm-16k"`，每块 `data` 1024 字节） |
+| `mic` | ASR 测试 | perception 层能识别出人声（画布显示识别文本） | 检查 agent-core / perception 日志，ASR 消费 `/{ns}/mic/audio` 成功 |
+| `mic` | `action=info` | 返回 running 状态与 `samples_published` 计数持续增长 | — |
+| `speaker` | `action=play_file, path=<wav>` | 返回 playing；扬声器出声 | 无 ROS 话题，听声音 + `action=list_devices` 确认输出设备 |
+| `speaker` | `action=play_wav, data=<base64 PCM>, sample_rate=16000` | 返回 playing；扬声器出声 | 同上 |
+| `speaker` | `action=stop` | 返回 idle，声音停止 | — |
+
+**预期结果**：LED 肉眼可见；mic 画布波形随说话幅度变化、ASR 能识别（注意音源距离与噪音）；
+speaker 播放正常、无爆音。
+
+### 4.4 危险操作：joint_bridge（关节透传，默认关闭）
+
+> **警示（必须遵守）**：
+> 1. `config.yaml` 中 `joint_bridge.enabled` 默认 **false**，需手工改为 `true` 并**重启容器**才可调用；
+>    未启用时调用返回 `{"state":"error","error":"DISABLED","message":"joint_bridge 卡片默认关闭..."}`；
+> 2. 必须先 `motion_switcher` 切到 **joint_bridge（关节透传）模式**，否则返回 `WRONG_MOTION_STATE`；
+> 3. 操作时机器人必须挂**安全吊架**（防倒），测试场地 **3 米清场**，操作者随时可切断容器；
+> 4. 500Hz 高频全身 PD 直通（力矩公式 `tau = kp*(q_cmd-q) + kd*(qd_cmd-qd) + ff`），
+>    **positions 数组长度必须为 25**（J00~J24），默认 num_steps=1500 ≈ 3 秒插值；
+> 5. 首次测试建议目标位置与当前姿态**相差极小**（如单关节偏移 <0.02 rad），确认行为后再加幅度。
+
+| 卡片 | 操作动作 | 预期结果 | 验证命令 |
+|------|----------|----------|----------|
+| `joint_bridge` | `action=info` | 返回 `enabled: true`（改配置重启后） | — |
+| `joint_bridge` | `action=set_pose, positions=<25 个 rad>` | 返回 ok；机器人 25 关节按线性插值平滑运动到目标后停止发布 | domain 69：`ros2 topic echo /hardware/joint_command --qos-reliability best_effort`（约 500Hz，`position` 长度 25，`stiffness/damping` 为默认 kp/kd） |
+| `joint_bridge` | `action=set_pose, positions=<长度≠25>` | 返回 `INVALID_LENGTH`，不动作 | — |
+| `joint_bridge` | `action=stop` | 停止插值，保持当前命令不再发布 | 观察 echo 停止出数 |
+
+**负向验证**：未切 `joint_bridge` 模式时 `set_pose` 返回 `WRONG_MOTION_STATE`。
+
+### 4.5 十二卡汇总表（操作 → 预期画布 → 验证命令速查）
+
+| # | 卡片 | 类型 | 操作动作 | 预期画布显示 | 验证命令（`ros2 topic echo`） |
+|---|------|------|----------|--------------|-------------------------------|
+| 1 | `motion_state` | sensor | 添加卡片 / `get` | 状态机 KV（当前状态+白名单）2Hz | `/{ns}/motion/state`（42）；`/motion/motion_state --qos-reliability best_effort`（69） |
+| 2 | `motion_switcher` | actuator | `switch mode=pd_stand` | 无 topic_out；返回 ok | `/motion/set_motion_state --qos-reliability reliable`（69）；`/motion/motion_state` 确认变化 |
+| 3 | `loco` | actuator | `move vx=0.1 duration=3` | 无 topic_out；返回 ok | `/motion/body_vel_cmd`（69，100Hz） |
+| 4 | `arm` | actuator | `wave_hand` / `shake_hand` | 无卡片面板，`/{ns}/arm/state` 数据流 | `/motion/joint_motion_plan/{request,state}`（69）；`/{ns}/arm/state`（42，5Hz） |
+| 5 | `joints` | sensor | 添加卡片 / `read` | 6 部位 25 关节 KV 2Hz | `/{ns}/state/joints`（42）；`/hardware/joint_state --qos-reliability best_effort`（69） |
+| 6 | `imu` | sensor | 添加卡片 / `read` | 四元数/RPY/加速度/角速度 KV 10Hz | `/{ns}/state/imu`（42）；`/hardware/imu_info`（69） |
+| 7 | `power` | sensor | 添加卡片 / `read` | 电量/电压/电流 KV 1Hz | `/{ns}/state/power`（42）；`/hardware/power_info`（69） |
+| 8 | `gamepad` | sensor | 添加卡片 / 按手柄 | 按键/摇杆 KV 10Hz | `/{ns}/state/gamepad`（42）；`/hardware/gamepad_keys`（69） |
+| 9 | `led` | actuator | `set mode=绿闪` | 无 topic_out；返回 ok | `/hardware/led_control`（69，color=0x2） |
+| 10 | `mic` | sensor | `start` 后说话 | 画布音频波形 | `/{ns}/mic/audio`（42，audio/pcm-16k，1024B/块）+ ASR 识别文本 |
+| 11 | `speaker` | actuator | `play_file` / `play_wav` | 无 topic_out；返回 playing | 无话题，听声 + `list_devices` |
+| 12 | `joint_bridge` | actuator | `set_pose`（**危险**） | 无 topic_out；返回 ok | `/hardware/joint_command --qos-reliability best_effort`（69，500Hz，长度 25） |
+
+---
+
+## 5. 常见问题排查表
+
+| 现象 | 可能原因 | 排查/解决 |
+|------|----------|-----------|
+| `ros2 topic echo` 收不到数据 | **QoS 不匹配**：官方话题为 BEST_EFFORT（`/hardware/joint_state`、`/motion/motion_state` 等），echo 默认 RELIABLE | echo 加 `--qos-reliability best_effort`；driver 侧订阅 QoS 见 `ros2.py`（QOS_T800_BEST_EFFORT / QOS_T800_JOINT / QOS_T800_RELIABLE），不要改 |
+| driver 容器内 sensor 卡无数据（`NO_FEEDBACK`） | 机器人未上电/运控未启动；domain 69 网络不通；RMW 不是 CycloneDDS | 先按 2.1 在宿主机验证话题可见；`docker exec` 内用 `ros2 topic list`（domain 69）核对；确认容器 env `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`、`ROS_DOMAIN_ID=69`、`ROS_LOCALHOST_ONLY=0` |
+| 画布上某卡片一直无数据 | `{ns}` 不对（namespace=hostname）；卡片 topic_out 与渲染器 format 不匹配 | 看容器日志 `[bundle] namespace=...` 取实际 `{ns}`；sensor 卡 format 必须 `data/json`，mic 必须 `audio/pcm-16k` |
+| 状态机前置失败：`WRONG_MOTION_STATE` | 当前运动状态不在目标卡所需模式 | 先用 `motion_switcher list_available` 看白名单，按流程切：loco→`rl_basic`/`walk_server`；arm→`lower_body_balance`；joint_bridge→`joint_bridge` |
+| `NOT_AVAILABLE` / `TIMEOUT` 切换失败 | 目标状态不在 `available_transition_motions`（需先经中间态）；运控切换超时 | 查询白名单走合法转换链；查看运控单元日志（163 上 `ros2 topic echo /motion/motion_state`）；确认机器人已站立稳定 |
+| `NO_MOTION_STATE`（收不到 motion_state） | 机器人未上电 / 运控 ROS2 未启动 / domain 69 不通 | 按 2.1 排查；检查 162↔163 网线连接与 `ping` |
+| mic 启动失败 `AUDIO_CAPTURE_FAILED` | 容器未访问到声卡（缺 `/dev:/dev` / 非 privileged）；无录音设备；device_index 错误 | `docker inspect` 确认卷挂载与 privileged；宿主机 `arecord -l` 找设备，`config.yaml` 设 `mic.device_index` 后重启 |
+| 画布波形无 / ASR 识别不出 | chunk 不足 1024 字节被 VAD 丢弃；采样率/声道不符 | 确认 `/{ns}/mic/audio` 每块 `data` 长度 1024；协议固定 16kHz 单声道 PCM_S16_LE（`audio/pcm-16k`） |
+| speaker 无声 | 声卡未直通；播放设备不对 | `speaker list_devices` 查输出设备；宿主 `aplay -l`；确认容器 privileged + `/dev:/dev` |
+| DDS 不通（sensor 无数据但容器正常） | 162 与 163 RMW 实现不一致（如运控侧 FastDDS vs 应用侧 CycloneDDS）；多播被禁/跨网段；`ROS_LOCALHOST_ONLY=1` | 两侧确认同一 `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`；`ros2 doctor` 检查；CycloneDDS 需多播可达（网线直连同一交换机）；host 网络下无端口映射问题 |
+| 容器起不来 / `[bundle] xxx load FAILED` | 插件依赖缺失；interface_protocol 消息包编译失败（stub 模式） | `docker logs` 看 traceback；确认镜像构建时 `colcon build` 无 WARNING；修复后重建镜像 |
+| agent-core 画布无该驱动卡片 | 注册失败 / 心跳断 | 容器日志 `[register] failed` 时检查 `AGENT_CORE_URL` 可达性（162 能否访问 agent-core 的 15678）；重启容器重注册 |
+
+---
+
+## 6. 验收标准清单
+
+| # | 验收项 | 通过标准 | 实测结果 |
+|---|--------|----------|----------|
+| 1 | 机器人侧话题连通 | domain 69 `ros2 topic list` 可见 `/hardware/joint_state` 等全部 11 话题，echo 有数据 | ☐ |
+| 2 | 镜像构建部署 | 容器 `embodied-engineai-t800` 运行中，host 网络 + privileged + `/dev:/dev` 生效 | ☐ |
+| 3 | agent-core 注册 | dashboard 出现 12 张 T800 卡片；`tools/list` 返回 12 个 tool | ☐ |
+| 4 | `motion_state` 卡 | 画布显示当前状态与白名单，2Hz 刷新 | ☐ |
+| 5 | `joints` 卡 | 25 关节 6 部位数据与 `/hardware/joint_state` 一致 | ☐ |
+| 6 | `imu` / `power` / `gamepad` 卡 | 数据正常、频率与设计一致（10Hz/1Hz/10Hz），手柄可触发按键变化 | ☐ |
+| 7 | 状态机流程 | `pd_stand → lower_body_balance` 切换成功；错误转换被白名单拦截（NOT_AVAILABLE） | ☐ |
+| 8 | `arm` 卡 | 挥手/握手动作完成，`/{ns}/arm/state` 进度正确；错误状态下调 arm 返回 WRONG_MOTION_STATE 且不动作 | ☐ |
+| 9 | `loco` 卡 | 前进/转向/停止正常；duration 自停与 2s 看门狗自停生效；超限速被拒 | ☐ |
+| 10 | `led` 卡 | 11 种灯效肉眼可见，reset 还原 | ☐ |
+| 11 | `mic` 卡 | 画布波形随声音变化；ASR 识别出人声文本 | ☐ |
+| 12 | `speaker` 卡 | 本地 WAV / base64 PCM 播放出声，stop 生效 | ☐ |
+| 13 | `joint_bridge` 卡（危险） | 配置开启后 `enabled=true`；安全吊架 + 3 米清场下 25 关节插值到位；未开启时返回 DISABLED | ☐ |
+| 14 | 负向安全 | 所有控制卡在错误运动状态下均返回 `WRONG_MOTION_STATE` 且机器人无动作 | ☐ |
+| 15 | 回滚 | 停止容器后机器人回到运控默认行为，无残留控制 | ☐ |
+
+---
+
+## 7. 回滚
+
+- 停容器即停止一切控制输出（joint_bridge 停止发布后机器人回到自身运控默认行为）：
+  `docker stop embodied-engineai-t800`
+- 保留上一镜像 tag 的部署方式即可回滚镜像版本；
+- 修改过 `config.yaml`（如开启 joint_bridge）需在回滚时恢复默认值。
+
+## 8. 实测记录
+
+> 实测时在此记录：日期、测试人、机器人固件/运控版本、每张卡实际结果与偏差、修订说明。
+
+| 日期 | 测试人 | 运控版本 | 结果摘要 | 修订说明 |
+|------|--------|----------|----------|----------|
+|  |  |  |  |  |

--- a/engineai/t800/driver.yaml
+++ b/engineai/t800/driver.yaml
@@ -1,0 +1,9 @@
+id: t800-driver
+name: EngineAI T800 Bundle
+category: driver
+hardware_provider: engineai
+hardware_model: "t800"
+image_name: t800
+port: 15708
+mcp_url: "http://localhost:15708/mcp"
+description: "众擎 T800 开发版 — 运动状态机 + 机体速度控制 + 上肢运动规划 + 关节状态/IMU/电源/手柄传感器 + LED + 麦克风/扬声器 + 关节透传(默认关闭)"

--- a/engineai/t800/interface_protocol/.gitignore
+++ b/engineai/t800/interface_protocol/.gitignore
@@ -1,0 +1,9 @@
+.vscode/
+.idea/
+.cache/
+install/
+build/
+log/
+rosbag2_*/
+__pycache__/
+*.pyc

--- a/engineai/t800/interface_protocol/CMakeLists.txt
+++ b/engineai/t800/interface_protocol/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.8)
+project(interface_protocol)
+
+option(GEN_MESSAGE "Generate ROS message files" ON)
+
+find_package(ament_cmake REQUIRED)
+
+if(GEN_MESSAGE)
+    find_package(rosidl_default_generators REQUIRED)
+    find_package(std_msgs REQUIRED)
+    find_package(std_srvs REQUIRED)
+    find_package(geometry_msgs REQUIRED)
+    # 使用 GLOB 查找文件
+    file(GLOB MSG_FILES "msg/*.msg")
+    file(GLOB SRV_FILES "srv/*.srv")
+
+    # 转换为相对路径
+    foreach(MSG_FILE ${MSG_FILES})
+    file(RELATIVE_PATH REL_MSG_FILE "${CMAKE_CURRENT_SOURCE_DIR}" "${MSG_FILE}")
+    list(APPEND REL_MSG_FILES "${REL_MSG_FILE}")
+    endforeach()
+
+    foreach(SRV_FILE ${SRV_FILES})
+    file(RELATIVE_PATH REL_SRV_FILE "${CMAKE_CURRENT_SOURCE_DIR}" "${SRV_FILE}")
+    list(APPEND REL_SRV_FILES "${REL_SRV_FILE}")
+    endforeach()
+
+    # 打印找到的文件，便于调试
+    message(STATUS "Found message files: ${REL_MSG_FILES}")
+    message(STATUS "Found service files: ${REL_SRV_FILES}")
+
+    rosidl_generate_interfaces(${PROJECT_NAME}
+    ${REL_MSG_FILES}
+    ${REL_SRV_FILES}
+        DEPENDENCIES
+        std_msgs
+        std_srvs
+        geometry_msgs
+    )
+endif()
+
+ament_package() 

--- a/engineai/t800/interface_protocol/LICENSE
+++ b/engineai/t800/interface_protocol/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2025- Shenzhen Zhongqing Robot Technology Co., Ltd. ("EngineAI")
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/engineai/t800/interface_protocol/README.md
+++ b/engineai/t800/interface_protocol/README.md
@@ -1,0 +1,22 @@
+# Interface Protocol
+
+Description of the interface protocol.
+
+## Interface Protocol
+
+
+| Topic Name                        | Type      | Message                    | Description                                                                                                                 | Example                                        |
+| --------------------------------- | --------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| /motion/joint_override_command    | Publish   | JointOverrideCommand.msg   | Override control commands for specific joints; supports smooth trajectory generation with quintic polynomial interpolation. | upper_joint_override_example.py                |
+| /motion/set_motion_state          | Publish   | MotionStateRequest.msg     | Request to switch the robot motion state (e.g. switch to terrain walking gait).                                             | switch_to_terrain_walking_gait_example.py      |
+| /motion/motion_state              | Subscribe | MotionState.msg            | Receive current robot motion state, including current state and available transitions.                                      | switch_to_terrain_walking_gait_example.py      |
+| /hardware/led_control             | Publish   | LedControl.msg             | Control robot LED light patterns; supports multiple colors and effects.                                                     | led_control_example.py                         |
+| /motion/joint_motion_plan/request | Publish   | JointMotionPlanRequest.msg | Request a joint motion planning task; supports trajectory planning and reset to default pose.                               | joint_mutiple_motion_plan_example.py           |
+| /motion/joint_motion_plan/state   | Subscribe | JointMotionPlanState.msg   | Receive joint motion planner state and execution progress.                                                                  | joint_mutiple_motion_plan_example.py           |
+| /hardware/joint_state             | Subscribe | JointState.msg             | Receive current state of all joints (position, velocity, torque).                                                           | joint_bridge_example.py                        |
+| /hardware/joint_command           | Publish   | JointCommand.msg           | Send joint control commands to control motion of all joints (e.g. via joint bridge).                                        | joint_bridge_example.py, joint_test_example.cc |
+| /motion/body_vel_cmd              | Publish   | BodyVelCmd.msg             | Body velocity command (linear velocity and yaw angular velocity).                                                           | body_velocity_control_example.py               |
+| /hardware/gamepad_keys            | Subscribe | GamepadKeys.msg            | Gamepad input data.                                                                                                         | rl_basic_example.cc                            |
+| /hardware/imu_info                | Subscribe | ImuInfo.msg                | IMU sensor data.                                                                                                            | rl_basic_example.cc                            |
+
+

--- a/engineai/t800/interface_protocol/msg/Alert.msg
+++ b/engineai/t800/interface_protocol/msg/Alert.msg
@@ -1,0 +1,7 @@
+# interface_protocol/msg/Alert.msg
+
+uint8 STARTUP   = 0
+uint8 CONFIRM   = 1
+uint8 ERROR     = 2
+
+uint8 type

--- a/engineai/t800/interface_protocol/msg/BodyVelCmd.msg
+++ b/engineai/t800/interface_protocol/msg/BodyVelCmd.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+float64[] linear_velocity
+float64 yaw_velocity

--- a/engineai/t800/interface_protocol/msg/GamepadKeys.msg
+++ b/engineai/t800/interface_protocol/msg/GamepadKeys.msg
@@ -1,0 +1,31 @@
+# Timestamp field using ROS2 header
+uint8 LB = 0
+uint8 RB = 1
+uint8 A = 2
+uint8 B = 3
+uint8 X = 4
+uint8 Y = 5
+uint8 BACK = 6
+uint8 START = 7
+uint8 CROSS_X_UP = 8
+uint8 CROSS_X_DOWN = 9
+uint8 CROSS_Y_LEFT = 10
+uint8 CROSS_Y_RIGHT = 11
+
+uint8 LT = 0
+uint8 RT = 1
+uint8 LEFT_STICK_X = 2
+uint8 LEFT_STICK_Y = 3
+uint8 RIGHT_STICK_X = 4
+uint8 RIGHT_STICK_Y = 5
+
+std_msgs/Header header
+
+# Marks whether the hardware gamepad is connected
+bool hardware_connected
+
+# Digital buttons (0 = released, 1 = pressed)
+int32[12] digital_states  # Fixed size array of 12 elements
+
+# Analog inputs (range: -1.0 to 1.0)
+float64[6] analog_states  # Fixed size array of 6 elements

--- a/engineai/t800/interface_protocol/msg/Heartbeat.msg
+++ b/engineai/t800/interface_protocol/msg/Heartbeat.msg
@@ -1,0 +1,13 @@
+std_msgs/Header header
+
+string node_name
+
+int64 startup_timestamp
+
+# idle, running, error, sleep
+string node_status
+
+int64 error_code
+
+string error_message
+

--- a/engineai/t800/interface_protocol/msg/ImuInfo.msg
+++ b/engineai/t800/interface_protocol/msg/ImuInfo.msg
@@ -1,0 +1,5 @@
+std_msgs/Header header
+geometry_msgs/Quaternion quaternion
+geometry_msgs/Vector3 rpy
+geometry_msgs/Vector3 linear_acceleration
+geometry_msgs/Vector3 angular_velocity

--- a/engineai/t800/interface_protocol/msg/JointCommand.msg
+++ b/engineai/t800/interface_protocol/msg/JointCommand.msg
@@ -1,0 +1,8 @@
+std_msgs/Header header
+float64[] position
+float64[] velocity
+float64[] feed_forward_torque
+float64[] torque
+float64[] stiffness
+float64[] damping
+uint8 parallel_parser_type

--- a/engineai/t800/interface_protocol/msg/JointMotionPlanRequest.msg
+++ b/engineai/t800/interface_protocol/msg/JointMotionPlanRequest.msg
@@ -1,0 +1,17 @@
+## Motion plan request message (via topic)
+## request_type constants
+uint8 REQUEST_PLAN_EXECUTE=0    # Plan and execute
+uint8 REQUEST_CANCEL=1          # Cancel specified request_id
+uint8 REQUEST_RESET=2           # Reset to default pose
+
+int32 request_id
+uint8  request_type
+
+## Motion target (consistent with JointMotion.action)
+bool      use_gravity_compensation
+int32[]   joint_indices           # Empty array means reset to default
+float64[] target_positions        # Target joint positions (rad)
+float64[] target_velocities       # Target joint velocities (empty for auto-planning)
+float64   execution_time          # Expected execution time (s)
+float64[] stiffness               # Optional, empty array for default
+float64[] damping                 # Optional, empty array for default

--- a/engineai/t800/interface_protocol/msg/JointMotionPlanState.msg
+++ b/engineai/t800/interface_protocol/msg/JointMotionPlanState.msg
@@ -1,0 +1,12 @@
+# Planner status
+uint8 STATUS_DISABLED = 0
+uint8 IDLE = 1
+uint8 EXECUTING =2
+uint8 EXITING = 3
+
+int32 request_id
+uint8  status
+
+## Progress and time
+float64 progress          # 0.0~1.0, overall planning/execution progress
+

--- a/engineai/t800/interface_protocol/msg/JointOverrideCommand.msg
+++ b/engineai/t800/interface_protocol/msg/JointOverrideCommand.msg
@@ -1,0 +1,9 @@
+std_msgs/Header header
+float64 weight
+int32[] joint_indices
+float64[] position
+float64[] velocity
+float64[] feed_forward_torque
+float64[] torque
+float64[] stiffness
+float64[] damping

--- a/engineai/t800/interface_protocol/msg/JointState.msg
+++ b/engineai/t800/interface_protocol/msg/JointState.msg
@@ -1,0 +1,4 @@
+std_msgs/Header header
+float64[] position
+float64[] velocity
+float64[] torque

--- a/engineai/t800/interface_protocol/msg/LedControl.msg
+++ b/engineai/t800/interface_protocol/msg/LedControl.msg
@@ -1,0 +1,13 @@
+uint8 BLINK_RED = 0x1
+uint8 BLINK_GREEN = 0x2
+uint8 BLINK_BLUE = 0x3
+uint8 BLINK_WHITE = 0x4
+uint8 CONSTANT_ON_WHITE = 0x5
+uint8 CONSTANT_ON_GREEN = 0x6
+uint8 BREATHE_WHITE = 0x7
+uint8 WATER_WHITE = 0x8
+uint8 BREATHE_RED = 0x9
+uint8 BLINK_ORANGE = 0xa
+uint8 CONSTANT_ON_ORANGE = 0xb
+
+uint8 color

--- a/engineai/t800/interface_protocol/msg/MotionState.msg
+++ b/engineai/t800/interface_protocol/msg/MotionState.msg
@@ -1,0 +1,2 @@
+string current_motion_task
+string[] available_transition_motions

--- a/engineai/t800/interface_protocol/msg/MotionStateRequest.msg
+++ b/engineai/t800/interface_protocol/msg/MotionStateRequest.msg
@@ -1,0 +1,1 @@
+string target_motion_name

--- a/engineai/t800/interface_protocol/msg/MotorCommand.msg
+++ b/engineai/t800/interface_protocol/msg/MotorCommand.msg
@@ -1,0 +1,7 @@
+std_msgs/Header header
+float64[] position
+float64[] velocity
+float64[] feed_forward_torque
+float64[] torque
+float64[] stiffness
+float64[] damping

--- a/engineai/t800/interface_protocol/msg/MotorDebug.msg
+++ b/engineai/t800/interface_protocol/msg/MotorDebug.msg
@@ -1,0 +1,7 @@
+float32[] mos_temperature
+float32[] motor_temperature
+float32[] voltage
+float32[] current
+int32[] error_code
+uint8[] offline
+uint8[] enable

--- a/engineai/t800/interface_protocol/msg/MotorState.msg
+++ b/engineai/t800/interface_protocol/msg/MotorState.msg
@@ -1,0 +1,4 @@
+std_msgs/Header header
+float64[] position
+float64[] velocity
+float64[] torque

--- a/engineai/t800/interface_protocol/msg/ParallelParserType.msg
+++ b/engineai/t800/interface_protocol/msg/ParallelParserType.msg
@@ -1,0 +1,2 @@
+uint8 CLASSIC_PARSER = 0
+uint8 RL_PARSER = 1

--- a/engineai/t800/interface_protocol/msg/PowerInfo.msg
+++ b/engineai/t800/interface_protocol/msg/PowerInfo.msg
@@ -1,0 +1,6 @@
+bool enable
+float32 percentage
+float32 voltage
+float32 current
+float32 current_limit
+int32 error_code

--- a/engineai/t800/interface_protocol/msg/Tts.msg
+++ b/engineai/t800/interface_protocol/msg/Tts.msg
@@ -1,0 +1,11 @@
+# Must, Speech content
+string text
+
+# Optional, Default: en
+string language
+
+# Optional, Default: default
+string speaker
+
+# Optional, Default: 150
+int64 rate

--- a/engineai/t800/interface_protocol/new_msg_dsc.md
+++ b/engineai/t800/interface_protocol/new_msg_dsc.md
@@ -1,0 +1,13 @@
+Topic名称	消息文件	通信方式	概述	参考示例文件
+/motion/joint_override_command	interface_protocol/msg/JointOverrideCommand	发布	覆盖特定关节的控制指令，支持五次多项式插值的平滑轨迹生成	upper_joint_override_example.py
+/motion/set_motion_state	interface_protocol/msg/MotionStateRequest	发布	请求切换机器人的运动状态（如切换到地形行走步态）	switch_to_terrain_walking_gait_example.py
+/motion/motion_state	interface_protocol/msg/MotionState	订阅	接收当前机器人的运动状态信息，包括当前状态和可用转换	switch_to_terrain_walking_gait_example.py
+/hardware/led_control	LedControl.msg	发布	控制机器人的LED灯光模式，支持多种颜色和灯效	led_control_example.py
+/motion/joint_motion_plan/request	interface_protocol/msg/JointMotionPlanRequest	发布	请求关节运动规划任务，支持轨迹规划和重置到默认姿态	joint_mutiple_motion_plan_example.py
+/motion/joint_motion_plan/state	interface_protocol/msg/JointMotionPlanState	订阅	接收关节运动规划器的状态信息和执行进度	joint_mutiple_motion_plan_example.py
+/hardware/joint_state	interface_protocol/msg/JointState	订阅	接收所有关节的当前状态信息（位置、速度、力矩）	joint_bridge_example.py
+/hardware/joint_command	interface_protocol/msg/JointCommand	发布	发送关节控制命令，控制所有关节的运动	joint_bridge_example.py
+/motion/body_vel_cmd	interface_protocol/msg/BodyVelCmd	发布	控制机器人机体的速度命令（线速度和偏航角速度）	body_velocity_control_example.py
+/hardware/joint_command	interface_protocol/msg/JointCommand	发布	通过关节桥接器控制机器人全身关节	joint_test_example.cc
+/hardware/gamepad_keys	interface_protocol/msg/GamepadKeys	订阅	手柄数据	rl_basic_example.cc
+/hardware/imu_info	interface_protocol/msg/ImuInfo		IMU数据	rl_basic_example.cc

--- a/engineai/t800/interface_protocol/package.xml
+++ b/engineai/t800/interface_protocol/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>interface_protocol</name>
+  <version>0.0.1</version>
+  <description>Protocol package containing message and service definitions</description>
+  <maintainer email="info@engineai.com.cn">maintainer</maintainer>
+  <license>BSD 3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package> 

--- a/engineai/t800/interface_protocol/scripts/pm_data_layout.xml
+++ b/engineai/t800/interface_protocol/scripts/pm_data_layout.xml
@@ -1,0 +1,525 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<root>
+ <tabbed_widget parent="main_window" name="Main Window">
+  <Tab tab_name="imu" containers="1">
+   <Container>
+    <DockSplitter sizes="1" count="1" orientation="-">
+     <DockSplitter sizes="0.333487;0.333025;0.333487" count="3" orientation="|">
+      <DockSplitter sizes="0.5;0.5" count="2" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532269" top="0.022935" right="51.530526" bottom="-0.022743"/>
+         <limitY/>
+         <curve color="#1f77b4" name="/hardware/imu_info/rpy/x"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532269" top="0.674534" right="51.530526" bottom="-0.721598"/>
+         <limitY/>
+         <curve color="#ff7f0e" name="/hardware/imu_info/angular_velocity/x"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter sizes="0.5;0.5" count="2" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532269" top="0.026076" right="51.530526" bottom="-0.005975"/>
+         <limitY/>
+         <curve color="#d62728" name="/hardware/imu_info/rpy/y"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532269" top="0.207022" right="51.530526" bottom="-0.294063"/>
+         <limitY/>
+         <curve color="#f14cc1" name="/hardware/imu_info/angular_velocity/y"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter sizes="0.5;0.5" count="2" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532269" top="-0.112675" right="51.530526" bottom="-0.123844"/>
+         <limitY/>
+         <curve color="#1ac938" name="/hardware/imu_info/rpy/z"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532269" top="0.182792" right="51.530526" bottom="-0.398654"/>
+         <limitY/>
+         <curve color="#9467bd" name="/hardware/imu_info/angular_velocity/z"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+     </DockSplitter>
+    </DockSplitter>
+   </Container>
+  </Tab>
+  <Tab tab_name="leg joint pos" containers="1">
+   <Container>
+    <DockSplitter sizes="1" count="1" orientation="-">
+     <DockSplitter sizes="0.333487;0.333025;0.333487" count="3" orientation="|">
+      <DockSplitter sizes="0.25;0.25;0.25;0.25" count="4" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.132317" right="51.530546" bottom="-0.638259"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[0]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[0]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="1.246336" right="51.530546" bottom="-0.452308"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[3]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[3]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.011538" right="51.530546" bottom="-0.579512"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[6]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[6]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="1.061470" right="51.530546" bottom="-0.154423"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[9]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[9]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter sizes="0.25;0.25;0.25;0.25" count="4" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="1.266498" right="51.530546" bottom="-0.461232"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[1]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[1]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="1.446081" right="51.530546" bottom="-0.628373"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[4]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[4]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.683812" right="51.530546" bottom="-1.016646"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[7]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[7]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="1.359056" right="51.530546" bottom="-0.563011"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[10]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[10]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter sizes="0.25;0.25;0.25;0.25" count="4" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.381706" right="51.530546" bottom="-0.430956"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[2]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[2]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.552013" right="51.530546" bottom="-0.181586"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[5]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[5]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.246894" right="51.530546" bottom="-0.438654"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[8]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[8]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.303907" right="51.530546" bottom="-0.664530"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[11]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[11]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+     </DockSplitter>
+    </DockSplitter>
+   </Container>
+  </Tab>
+  <Tab tab_name="arm joint pos" containers="1">
+   <Container>
+    <DockSplitter sizes="1" count="1" orientation="-">
+     <DockSplitter sizes="0.200185;0.199723;0.200185;0.199723;0.200185" count="5" orientation="|">
+      <DockSplitter sizes="0.5;0.5" count="2" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.007653" right="51.530546" bottom="-0.003838"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[13]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[13]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.002522" right="51.530546" bottom="-0.000062"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[18]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[18]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter sizes="0.5;0.5" count="2" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.001275" right="51.530546" bottom="-0.007581"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[14]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[14]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.007589" right="51.530546" bottom="-0.002610"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[19]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[19]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter sizes="0.5;0.5" count="2" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.000031" right="51.530546" bottom="-0.000126"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[15]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[15]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.000115" right="51.530546" bottom="-0.000049"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[20]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[20]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter sizes="0.5;0.5" count="2" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.001204" right="51.530546" bottom="-0.000029"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[16]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[16]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.000911" right="51.530546" bottom="-0.000022"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[21]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[21]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter sizes="0.5;0.5" count="2" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.000001" right="51.530546" bottom="-0.000031"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[17]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[17]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.000027" right="51.530546" bottom="-0.000001"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/position[22]"/>
+         <curve color="#d62728" name="/hardware/joint_command/position[22]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+     </DockSplitter>
+    </DockSplitter>
+   </Container>
+  </Tab>
+  <Tab tab_name="waist and head" containers="1">
+   <Container>
+    <DockSplitter sizes="1" count="1" orientation="-">
+     <DockSplitter sizes="0.5;0.5" count="2" orientation="|">
+      <DockArea name="...">
+       <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+        <range left="46.532275" top="0.007412" right="51.530546" bottom="-0.005961"/>
+        <limitY/>
+        <curve color="#17becf" name="/hardware/joint_state/position[12]"/>
+        <curve color="#d62728" name="/hardware/joint_command/position[12]"/>
+       </plot>
+      </DockArea>
+      <DockArea name="...">
+       <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+        <range left="46.532275" top="0.000041" right="51.530546" bottom="-0.000040"/>
+        <limitY/>
+        <curve color="#17becf" name="/hardware/joint_state/position[23]"/>
+        <curve color="#d62728" name="/hardware/joint_command/position[23]"/>
+       </plot>
+      </DockArea>
+     </DockSplitter>
+    </DockSplitter>
+   </Container>
+  </Tab>
+  <Tab tab_name="leg joint torque" containers="1">
+   <Container>
+    <DockSplitter sizes="1" count="1" orientation="-">
+     <DockSplitter sizes="0.333487;0.333025;0.333487" count="3" orientation="|">
+      <DockSplitter sizes="0.25;0.25;0.25;0.25" count="4" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="22.783771" right="51.530546" bottom="-28.270860"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/torque[0]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="47.699573" right="51.530546" bottom="-43.708123"/>
+         <limitY/>
+         <curve color="#d62728" name="/hardware/joint_state/torque[3]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="24.139127" right="51.530546" bottom="-25.601629"/>
+         <limitY/>
+         <curve color="#f14cc1" name="/hardware/joint_state/torque[6]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="31.455225" right="51.530546" bottom="-47.377484"/>
+         <limitY/>
+         <curve color="#bcbd22" name="/hardware/joint_state/torque[9]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter sizes="0.25;0.25;0.25;0.25" count="4" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="63.800826" right="51.530546" bottom="-24.015794"/>
+         <limitY/>
+         <curve color="#bcbd22" name="/hardware/joint_state/torque[1]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="34.425731" right="51.530546" bottom="-3.209418"/>
+         <limitY/>
+         <curve color="#1ac938" name="/hardware/joint_state/torque[4]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="34.380906" right="51.530546" bottom="-51.559169"/>
+         <limitY/>
+         <curve color="#9467bd" name="/hardware/joint_state/torque[7]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="32.086888" right="51.530546" bottom="-3.890172"/>
+         <limitY/>
+         <curve color="#1f77b4" name="/hardware/joint_state/torque[10]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter sizes="0.25;0.25;0.25;0.25" count="4" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="15.066882" right="51.530546" bottom="-20.995955"/>
+         <limitY/>
+         <curve color="#1f77b4" name="/hardware/joint_state/torque[2]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="10.716545" right="51.530546" bottom="-4.118482"/>
+         <limitY/>
+         <curve color="#ff7f0e" name="/hardware/joint_state/torque[5]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="14.994088" right="51.530546" bottom="-20.987145"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/torque[8]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="5.903207" right="51.530546" bottom="-12.970143"/>
+         <limitY/>
+         <curve color="#d62728" name="/hardware/joint_state/torque[11]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+     </DockSplitter>
+    </DockSplitter>
+   </Container>
+  </Tab>
+  <Tab tab_name="arm joint torque" containers="1">
+   <Container>
+    <DockSplitter sizes="1" count="1" orientation="-">
+     <DockSplitter sizes="0.200185;0.199723;0.200185;0.199723;0.200185" count="5" orientation="|">
+      <DockSplitter sizes="0.5;0.5" count="2" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.962737" right="51.530546" bottom="-1.928057"/>
+         <limitY/>
+         <curve color="#1ac938" name="/hardware/joint_state/torque[13]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.003940" right="51.530546" bottom="-0.632645"/>
+         <limitY/>
+         <curve color="#17becf" name="/hardware/joint_state/torque[18]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter sizes="0.5;0.5" count="2" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="1.896273" right="51.530546" bottom="-0.319109"/>
+         <limitY/>
+         <curve color="#ff7f0e" name="/hardware/joint_state/torque[14]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.654003" right="51.530546" bottom="-1.897423"/>
+         <limitY/>
+         <curve color="#bcbd22" name="/hardware/joint_state/torque[19]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter sizes="0.5;0.5" count="2" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="1.896273" right="51.530546" bottom="-0.319109"/>
+         <limitY/>
+         <curve color="#ff7f0e" name="/hardware/joint_state/torque[14]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.012419" right="51.530546" bottom="-0.028753"/>
+         <limitY/>
+         <curve color="#1f77b4" name="/hardware/joint_state/torque[20]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter sizes="0.5;0.5" count="2" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="-0.086444" right="51.530546" bottom="-0.299634"/>
+         <limitY/>
+         <curve color="#f14cc1" name="/hardware/joint_state/torque[16]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="-0.114062" right="51.530546" bottom="-0.225635"/>
+         <limitY/>
+         <curve color="#d62728" name="/hardware/joint_state/torque[21]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+      <DockSplitter sizes="0.5;0.5" count="2" orientation="-">
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="0.007640" right="51.530546" bottom="0.003524"/>
+         <limitY/>
+         <curve color="#9467bd" name="/hardware/joint_state/torque[17]"/>
+        </plot>
+       </DockArea>
+       <DockArea name="...">
+        <plot flip_y="false" mode="TimeSeries" style="Lines" flip_x="false">
+         <range left="46.532275" top="-0.003772" right="51.530546" bottom="-0.006690"/>
+         <limitY/>
+         <curve color="#1ac938" name="/hardware/joint_state/torque[22]"/>
+        </plot>
+       </DockArea>
+      </DockSplitter>
+     </DockSplitter>
+    </DockSplitter>
+   </Container>
+  </Tab>
+  <currentTabIndex index="1"/>
+ </tabbed_widget>
+ <use_relative_time_offset enabled="1"/>
+ <!-- - - - - - - - - - - - - - - -->
+ <!-- - - - - - - - - - - - - - - -->
+ <Plugins>
+  <plugin ID="DataLoad CSV">
+   <parameters delimiter="0" time_axis=""/>
+  </plugin>
+  <plugin ID="DataLoad MCAP"/>
+  <plugin ID="DataLoad ROS2 bags">
+   <use_header_stamp value="false"/>
+   <discard_large_arrays value="true"/>
+   <max_array_size value="100"/>
+   <boolean_strings_to_number value="true"/>
+   <remove_suffix_from_strings value="true"/>
+   <selected_topics value=""/>
+  </plugin>
+  <plugin ID="DataLoad ULog"/>
+  <plugin ID="ROS2 Topic Subscriber">
+   <use_header_stamp value="false"/>
+   <discard_large_arrays value="true"/>
+   <max_array_size value="100"/>
+   <boolean_strings_to_number value="true"/>
+   <remove_suffix_from_strings value="true"/>
+   <selected_topics value="/hardware/imu_info;/hardware/joint_command;/hardware/joint_state"/>
+  </plugin>
+  <plugin ID="UDP Server"/>
+  <plugin ID="WebSocket Server"/>
+  <plugin ID="ZMQ Subscriber"/>
+  <plugin ID="Fast Fourier Transform"/>
+  <plugin ID="Quaternion to RPY"/>
+  <plugin ID="Reactive Script Editor">
+   <library code="--[[ Helper function to create a series from arrays&#xa;&#xa; new_series: a series previously created with ScatterXY.new(name)&#xa; prefix:     prefix of the timeseries, before the index of the array&#xa; suffix_X:   suffix to complete the name of the series containing the X value. If [nil], use the index of the array.&#xa; suffix_Y:   suffix to complete the name of the series containing the Y value&#xa; timestamp:   usually the tracker_time variable&#xa;              &#xa; Example:&#xa; &#xa; Assuming we have multiple series in the form:&#xa; &#xa;   /trajectory/node.{X}/position/x&#xa;   /trajectory/node.{X}/position/y&#xa;   &#xa; where {N} is the index of the array (integer). We can create a reactive series from the array with:&#xa; &#xa;   new_series = ScatterXY.new(&quot;my_trajectory&quot;) &#xa;   CreateSeriesFromArray( new_series, &quot;/trajectory/node&quot;, &quot;position/x&quot;, &quot;position/y&quot;, tracker_time );&#xa;--]]&#xa;&#xa;function CreateSeriesFromArray( new_series, prefix, suffix_X, suffix_Y, timestamp )&#xa;  &#xa;  --- clear previous values&#xa;  new_series:clear()&#xa;  &#xa;  --- Append points to new_series&#xa;  index = 0&#xa;  while(true) do&#xa;&#xa;    x = index;&#xa;    -- if not nil, get the X coordinate from a series&#xa;    if suffix_X ~= nil then &#xa;      series_x = TimeseriesView.find( string.format( &quot;%s.%d/%s&quot;, prefix, index, suffix_X) )&#xa;      if series_x == nil then break end&#xa;      x = series_x:atTime(timestamp)&#x9; &#xa;    end&#xa;    &#xa;    series_y = TimeseriesView.find( string.format( &quot;%s.%d/%s&quot;, prefix, index, suffix_Y) )&#xa;    if series_y == nil then break end &#xa;    y = series_y:atTime(timestamp)&#xa;    &#xa;    new_series:push_back(x,y)&#xa;    index = index+1&#xa;  end&#xa;end&#xa;&#xa;--[[ Similar to the built-in function GetSeriesNames(), but select only the names with a give prefix. --]]&#xa;&#xa;function GetSeriesNamesByPrefix(prefix)&#xa;  -- GetSeriesNames(9 is a built-in function&#xa;  all_names = GetSeriesNames()&#xa;  filtered_names = {}&#xa;  for i, name in ipairs(all_names)  do&#xa;    -- check the prefix&#xa;    if name:find(prefix, 1, #prefix) then&#xa;      table.insert(filtered_names, name);&#xa;    end&#xa;  end&#xa;  return filtered_names&#xa;end&#xa;&#xa;--[[ Modify an existing series, applying offsets to all their X and Y values&#xa;&#xa; series: an existing timeseries, obtained with TimeseriesView.find(name)&#xa; delta_x: offset to apply to each x value&#xa; delta_y: offset to apply to each y value &#xa;  &#xa;--]]&#xa;&#xa;function ApplyOffsetInPlace(series, delta_x, delta_y)&#xa;  -- use C++ indeces, not Lua indeces&#xa;  for index=0, series:size()-1 do&#xa;    x,y = series:at(index)&#xa;    series:set(index, x + delta_x, y + delta_y)&#xa;  end&#xa;end&#xa;"/>
+   <scripts/>
+  </plugin>
+  <plugin ID="CSV Exporter"/>
+  <plugin ID="ROS2 Topic Re-Publisher"/>
+ </Plugins>
+ <!-- - - - - - - - - - - - - - - -->
+ <previouslyLoaded_Datafiles/>
+ <previouslyLoaded_Streamer name="ROS2 Topic Subscriber"/>
+ <!-- - - - - - - - - - - - - - - -->
+ <customMathEquations/>
+ <snippets/>
+ <!-- - - - - - - - - - - - - - - -->
+</root>
+

--- a/engineai/t800/interface_protocol/srv/EnableMotor.srv
+++ b/engineai/t800/interface_protocol/srv/EnableMotor.srv
@@ -1,0 +1,4 @@
+bool enable
+---
+bool success
+string message

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+engineai/t800/main.py — 众擎 T800 开发版 driver bundle 统一入口（MCP HTTP server）。
+
+读取 config.yaml，按插件配置加载插件，聚合成一个 MCP HTTP server 对外暴露。
+驱动启动时自动 start 所有插件，关闭时自动 stop。
+
+双 domain 架构：
+  - ctx_t800 (domain 69 / rmw_cyclonedds_cpp)：直连 T800 机器人话题
+  - ctx_core (domain 42 / rmw_fastrtps_cpp)  ：与 agent-core / dashboard / perception 通信
+
+启动流程：加载 config → 建 Ros2Contexts → 建 T800DeviceBundle →
+bundle.start_all() → ros2.start() → HTTP server（config 的 mcp_port）→
+向 agent-core 注册并每 30s 心跳。
+
+用法：
+    python3 main.py
+
+环境变量：
+    CONFIG_PATH     — config.yaml 路径（默认同目录下）
+    AGENT_CORE_URL  — agent-core 注册地址（默认 https://localhost:15678）
+
+模块级只 import 标准库；yaml / rclpy 等在函数内延迟导入，
+保证模块可在无 ROS2 环境下被纯 import 测试。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import signal
+import socket
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+
+def _load_config() -> dict:
+    import yaml
+    config_path = os.environ.get("CONFIG_PATH", str(Path(__file__).parent / "config.yaml"))
+    with open(config_path) as f:
+        return yaml.safe_load(f)
+
+
+def _resolve_namespace(cfg: dict) -> str:
+    ns = cfg.get("ros_namespace", "").strip()
+    if ns:
+        return re.sub(r"[^a-zA-Z0-9_]", "_", ns)
+    return re.sub(r"[^a-zA-Z0-9_]", "_", socket.gethostname())
+
+
+# ── MCP HTTP server ───────────────────────────────────────────────────────────
+
+_bundle = None  # T800DeviceBundle，handler 通过闭包访问
+
+
+def make_handler():
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):
+            # 抑制常规请求日志（心跳/info），只记录错误与工具调用
+            msg = fmt % args
+            if '"POST /mcp' in msg and '200' in msg:
+                return
+            print(f"[mcp] {self.address_string()} {msg}")
+
+        def _send(self, status: int, body: str):
+            encoded = body.encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type, Accept")
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def do_GET(self):
+            self.send_response(404)
+            self.end_headers()
+
+        def do_OPTIONS(self):
+            self.send_response(204)
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type, Accept")
+            self.end_headers()
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0))
+            raw = self.rfile.read(length)
+            try:
+                rpc = json.loads(raw)
+            except Exception:
+                self._send(400, json.dumps({"jsonrpc": "2.0", "id": None,
+                                             "error": {"code": -32700, "message": "Parse error"}}))
+                return
+
+            rid = rpc.get("id")
+            method = rpc.get("method", "")
+            params = rpc.get("params") or {}
+
+            if rid is None:
+                self.send_response(202)
+                self.end_headers()
+                return
+
+            def ok(result):
+                self._send(200, json.dumps({"jsonrpc": "2.0", "id": rid, "result": result}))
+
+            def err(code, msg):
+                self._send(200, json.dumps({"jsonrpc": "2.0", "id": rid,
+                                             "error": {"code": code, "message": msg}}))
+
+            try:
+                if method == "initialize":
+                    ok({
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {
+                            "name": _bundle._cfg.get("name", "EngineAI T800 Bundle"),
+                            "version": "1.0.0",
+                        },
+                    })
+                elif method == "tools/list":
+                    ok({"tools": _bundle.get_all_tools()})
+                elif method == "tools/call":
+                    name = params.get("name", "")
+                    args = params.get("arguments") or {}
+                    result = _bundle.dispatch(name, args)
+                    if result is None:
+                        err(-32601, f"Unknown tool: {name}")
+                    else:
+                        tool_result = {
+                            "content": [{
+                                "type": "text",
+                                "text": json.dumps(result, ensure_ascii=False),
+                            }],
+                        }
+                        # 运动状态前置检查等返回 {"state":"error",...} 时标记 isError，
+                        # 让 agent-core / LLM 明确感知调用失败
+                        if (isinstance(result, dict)
+                                and (result.get("state") == "error" or "error" in result)):
+                            tool_result["isError"] = True
+                        ok(tool_result)
+                else:
+                    err(-32601, f"Method not found: {method}")
+            except Exception as e:
+                import traceback
+                traceback.print_exc()
+                err(-32603, str(e))
+
+    return Handler
+
+
+# ── agent-core 注册与心跳 ─────────────────────────────────────────────────────
+
+
+def _start_registration(mcp_port: int, name: str, category: str):
+    """向 agent-core 注册本 driver（后台线程），之后每 30s 心跳。"""
+    import ssl as _ssl
+    import urllib.request as _urllib
+    agent_core_url = os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+    payload = json.dumps({
+        "id": _bundle._cfg.get("id", "t800-driver"),
+        "name": name,
+        "url": f"http://localhost:{mcp_port}/mcp",
+        "transport": "http",
+        "category": category,
+    }).encode()
+    # agent-core 使用自签名证书，本地回环跳过校验
+    _ctx = _ssl.create_default_context()
+    _ctx.check_hostname = False
+    _ctx.verify_mode = _ssl.CERT_NONE
+
+    def _run():
+        import time as _t
+        while True:
+            try:
+                req = _urllib.Request(
+                    f"{agent_core_url}/api/mcp", data=payload,
+                    headers={"Content-Type": "application/json"}, method="POST",
+                )
+                with _urllib.urlopen(req, timeout=3, context=_ctx):
+                    pass  # 心跳成功，抑制日志
+                _t.sleep(30)
+            except Exception as e:
+                print(f"[register] failed: {e}, retrying in 5s")
+                _t.sleep(5)
+
+    threading.Thread(target=_run, daemon=True, name="register").start()
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+
+def main():
+    global _bundle
+
+    cfg = _load_config()
+    namespace = _resolve_namespace(cfg)
+    mcp_port = int(cfg.get("mcp_port", 15708))
+
+    print(f"[bundle] namespace={namespace} mcp_port={mcp_port}")
+
+    # 双域 ROS2：ctx_t800 (domain 69 / CycloneDDS) + ctx_core (domain 42 / FastDDS)
+    from ros2 import Ros2Contexts
+    ros2 = Ros2Contexts(namespace)
+    ros2.start()
+    print("[bundle] dual-domain ROS2 initialized "
+          "(t800: domain 69/cyclonedds, core: domain 42/fastrtps)")
+
+    from device import T800DeviceBundle
+    _bundle = T800DeviceBundle(cfg, namespace, ros2)
+    _bundle.start_all()
+
+    _start_registration(mcp_port, cfg.get("name", "EngineAI T800 Bundle"), "driver")
+
+    server = ThreadingHTTPServer(("", mcp_port), make_handler())
+    print(f"[bundle] MCP server → http://localhost:{mcp_port}")
+
+    def _shutdown(signum, frame):
+        print(f"[bundle] signal {signum}, shutting down")
+        _bundle.stop_all()
+        ros2.shutdown()
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    try:
+        server.serve_forever()
+    finally:
+        _bundle.stop_all()
+        ros2.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/engineai/t800/plugins/__init__.py
+++ b/engineai/t800/plugins/__init__.py
@@ -1,0 +1,6 @@
+"""众擎 T800 开发版 driver 插件包。
+
+- motion.py      运动状态机 / 机体速度控制 / 上肢运动规划 / 关节透传
+- sensors.py     关节状态 / IMU / 电源 / 手柄
+- peripherals.py LED / 麦克风 / 扬声器
+"""

--- a/engineai/t800/plugins/motion.py
+++ b/engineai/t800/plugins/motion.py
@@ -1,0 +1,1411 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+engineai/t800/plugins/motion.py — 众擎（EngineAI）T800 运动相关能力插件（5 张卡片）。
+
+数据流（双 context 转发，参照 tianyi2.0 双域模式）:
+  domain 69 (ctx_t800, CycloneDDS)                domain 42 (ctx_core, FastDDS)
+  /motion/motion_state  ──────────────────────► /{ns}/motion/state   (2Hz, data/json)
+  /motion/set_motion_state     ◄── motion_switcher 发布 (RELIABLE depth1)
+  /motion/body_vel_cmd         ◄── loco 100Hz 持续发布 (depth10)
+  /motion/joint_motion_plan/request ◄── arm 发布 (RELIABLE depth1)
+  /motion/joint_motion_plan/state   ────────► /{ns}/arm/state       (5Hz, data/json)
+  /hardware/joint_state        ──► 缓存（joint_bridge 插值起点）
+  /hardware/joint_command      ◄── joint_bridge 500Hz 发布 (BEST_EFFORT depth3)
+
+插件列表:
+  MotionStatePlugin    (sensor)   — 运动状态机订阅缓存 + 2Hz 转发 core 域 + get 查询
+  MotionSwitcherPlugin (actuator) — 状态切换（白名单校验 + 3 秒超时确认）
+  LocoPlugin           (actuator) — 机体速度控制（100Hz / 20% 渐变 / duration 自停 / 2s 防御自停）
+  ArmMotionPlugin      (actuator) — 上肢运动规划（官方预设手势队列，request_id 递增）
+  JointBridgePlugin    (actuator) — 关节透传 500Hz 全身 PD 控制（config 默认关闭，危险）
+
+设计约束（README_dev / 设计文档 / 官方代码核实）:
+  - 模块级只 import 标准库；rclpy / interface_protocol / std_msgs 全部延迟导入，
+    无 ROS2 环境时进入 stub 模式（可纯 import 测试，参照 tianyi2.0 MotorStatePlugin.start()）
+  - dispatch 返回纯 dict（绝不返回 MCP content 数组），必须处理 start/stop/info 系统动作
+  - 控制类插件缓存最新 motion_state 做前置检查，不在所需模式时返回
+    {"state":"error","error":"WRONG_MOTION_STATE","message":...}（中文 message）
+  - 本批传感器卡 topic_out format 一律 "data/json"
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import time
+
+# ── 常量 ──────────────────────────────────────────────────────────────────────
+
+# T800 开发版 25 自由度，语义名 J00_HIP_PITCH_L ... J24_HEAD_YAW
+JOINT_COUNT = 25
+
+# 上肢运动规划关节索引：腰(12) + 左臂(13-17) + 右臂(18-22) + 头(23-24)，共 13 关节
+UPPER_BODY_JOINT_INDICES = [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
+
+# 官方运动状态机全量状态（description 中列出，供 LLM/用户参考）
+MOTION_STATE_NAMES = [
+    "idle",                 # 空闲
+    "passive",              # 阻力模式
+    "pd_stand",             # PD 站立
+    "rl_basic",             # 自然行走（RL）
+    "lower_body_balance",   # 下肢平衡（上肢运动规划前置）
+    "joint_bridge",         # 关节透传（关节命令前置）
+    "pd_sitground",         # 坐着起身（PD）
+    "walk_server",          # 行走服务端
+    "rl_mimic_supine_to_stance",      # 模仿-仰卧起身
+    "rl_mimic_prone_to_stance",       # 模仿-俯卧起身
+    "rl_mimic_stance_to_supine",      # 模仿-站立躺下（仰）
+    "rl_mimic_stance_to_sitdown",     # 模仿-站立坐下
+    "rl_mimic_sitdown_to_stance",     # 模仿-坐着起身
+]
+
+# 中文别名 → 官方状态名
+_MODE_ALIASES = {
+    "空闲": "idle",
+    "阻力模式": "passive",
+    "PD站立": "pd_stand",
+    "自然行走": "rl_basic",
+    "下肢平衡": "lower_body_balance",
+    "关节透传": "joint_bridge",
+    "坐着起身": "pd_sitground",
+    "行走服务端": "walk_server",
+}
+
+# 官方 t800/motion_plan_shake_hand.yaml 的 stiffness/damping
+#（腰 [400] / 左臂 [40,40,20,40,20] / 右臂 [40,40,20,40,20] / 头 [100,100] 展平为 13 元）
+_UPPER_STIFFNESS_HAND = [400.0, 40.0, 40.0, 20.0, 40.0, 20.0, 40.0, 40.0, 20.0, 40.0, 20.0, 100.0, 100.0]
+_UPPER_DAMPING_HAND = [3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 3.0, 3.0]
+
+# 官方 t800/motion_plan_wave_hands.yaml 的 stiffness（每个任务不同）
+_UPPER_STIFFNESS_WAVE_INIT = [200.0, 30.0, 30.0, 15.0, 30.0, 15.0, 40.0, 40.0, 20.0, 40.0, 20.0, 100.0, 100.0]
+_UPPER_STIFFNESS_WAVE_STEP = [500.0, 30.0, 30.0, 15.0, 30.0, 15.0, 40.0, 40.0, 20.0, 40.0, 20.0, 100.0, 100.0]
+_UPPER_STIFFNESS_WAVE_END = [200.0, 10.0, 10.0, 5.0, 10.0, 5.0, 10.0, 10.0, 5.0, 10.0, 5.0, 100.0, 100.0]
+
+# 官方上肢预设动作（target_positions 与 duration 逐字取自 yaml 文件）
+_ARM_EXTEND_POSITIONS = [0.0, 0.024, 0.081, -0.001, -0.069, 0.000, -0.47, 0.255, 0.161, -0.731, 0.028, 0.000, 0.000]
+_ARM_WITHDRAW_POSITIONS = [0.0, 0.024, 0.081, -0.001, -0.069, 0.000, 0.028, -0.084, 0.001, -0.066, 0.000, 0.000, 0.000]
+_WAVE_INIT_POSITIONS = [0.0, 0.028, 0.084, -0.001, -0.066, 0.000, 0.024, -0.081, 0.001, -0.069, 0.000, 0.0, 0.0]
+_WAVE_RAISE_POSITIONS = [0.0, -1.29568, 1.17971, 0.0757227, -1.06603, -0.0989933,
+                         -0.0211716, -0.322156, 0.0440607, -0.0871668, 0.0196457, 0.0, 0.0]
+_WAVE_HANDS_POSITIONS = [0.0, -1.07786, 1.13928, 0.177577, -1.83356, -0.0875483,
+                         -0.0211716, -0.322156, 0.0440607, -0.0871668, 0.0196457, 0.0, 0.0]
+
+# 官方 t800/pd_joint_test.yaml 的 kp/kd（腿 6+6 / 腰 1 / 臂 5+5 / 头 2，展平为 25 元）
+_JB_DEFAULT_STIFFNESS = [
+    200.0, 200.0, 380.0, 450.0, 400.0, 200.0,   # 左腿 0-5
+    200.0, 200.0, 380.0, 450.0, 400.0, 200.0,   # 右腿 6-11
+    200.0,                                       # 腰 12
+    250.0, 250.0, 250.0, 250.0, 250.0,           # 左臂 13-17
+    250.0, 250.0, 250.0, 250.0, 250.0,           # 右臂 18-22
+    100.0, 100.0,                                # 头 23-24
+]
+_JB_DEFAULT_DAMPING = [
+    5.0, 5.0, 5.0, 5.0, 2.0, 2.0,
+    5.0, 5.0, 5.0, 5.0, 2.0, 2.0,
+    1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0,
+]
+
+# 规划器状态码 → 名称
+_PLAN_STATUS_NAMES = {0: "DISABLED", 1: "IDLE", 2: "EXECUTING", 3: "EXITING"}
+
+# 前置检查：loco 需要的行走类模式（body_vel_cmd 适用）
+_LOCO_REQUIRED_MODES = ("rl_basic", "walk_server")
+
+
+def _err(error: str, message: str) -> dict:
+    """构造统一错误返回（state=error + 错误码 + 中文 message）。"""
+    return {"state": "error", "error": error, "message": message}
+
+
+def _load_ros2_contract():
+    """延迟导入 ros2.py 契约常量；无 ROS2 环境时返回 None（stub 模式）。"""
+    try:
+        # 注意: 必须用绝对导入（与 sensors.py/peripherals.py 一致）——本模块可能经
+        # importlib.import_module("plugins.motion") 以顶层包名加载（__package__="plugins"），
+        # 相对导入会抛 "attempted relative import with no known parent package"，
+        # 被 except 吞掉后整栈落入 stub 模式（生产环境运动控制失效）
+        from ros2 import (QOS_T800_RELIABLE, QOS_T800_BEST_EFFORT,
+                          QOS_T800_JOINT, QOS_CORE, T800_TOPICS)
+        return (QOS_T800_RELIABLE, QOS_T800_BEST_EFFORT,
+                QOS_T800_JOINT, QOS_CORE, T800_TOPICS)
+    except Exception:
+        return None
+
+
+def _load_msgs(*pairs):
+    """延迟导入消息类。pairs = [(模块路径, 类名), ...]；失败返回 None。"""
+    try:
+        result = []
+        for mod_path, cls_name in pairs:
+            import importlib
+            mod = importlib.import_module(mod_path)
+            result.append(getattr(mod, cls_name))
+        return tuple(result)
+    except Exception:
+        return None
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# MotionStatePlugin (sensor, tool "motion_state")
+# 订阅 /motion/motion_state (BEST_EFFORT) → 缓存 → 2Hz 转发 String JSON 到
+# core 域 /{ns}/motion/state，格式 data/json。支持 dispatch action "get" 直查。
+# ══════════════════════════════════════════════════════════════════════════════
+
+class MotionStatePlugin:
+    """T800 运动状态机传感器卡片。
+
+    数据流: /motion/motion_state (domain 69) → 缓存 → /{ns}/motion/state (domain 42, 2Hz)。
+    其他控制类插件各自订阅 /motion/motion_state 做前置检查（避免插件间耦合）。
+    """
+
+    PREFIX = "motion_state"
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        self._ns = namespace
+        self._ros2 = ros2
+        self._topic = f"/{namespace}/motion/state"
+        self._running = False
+        self._lock = threading.Lock()
+        self._latest = None            # {"current_motion_task", "available_transition_motions"}
+        self._thread = None            # 2Hz 转发线程
+
+        # ── 延迟初始化 ROS2（无环境时为 stub 模式） ──
+        self._sub_node = None
+        self._pub_node = None
+        self._pub = None
+        self._state_sub = None
+        self._MotionState = None
+        self._String = None
+        try:
+            contract = _load_ros2_contract()
+            if contract is None:
+                raise ImportError("ros2 契约不可用")
+            _, best_effort_qos, _, core_qos, topics = contract
+            msgs = _load_msgs(
+                ("interface_protocol.msg", "MotionState"),
+                ("std_msgs.msg", "String"),
+            )
+            if msgs is None:
+                raise ImportError("消息类型导入失败")
+            self._MotionState, self._String = msgs
+            self._sub_node = ros2.make_node_t800("t800_motion_state_sub")
+            self._pub_node = ros2.make_node_core("t800_motion_state_pub")
+            self._pub = self._pub_node.create_publisher(
+                self._String, self._topic, core_qos,
+            )
+            self._state_topic = topics["motion_state"]
+            self._state_qos = best_effort_qos
+        except Exception as e:  # noqa: BLE001
+            print(f"[MotionStatePlugin] WARNING: ROS2 初始化失败（{e}），进入 stub 模式")
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "motion_state",
+            "type": "sensor",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": (
+                "T800 运动状态机 — 当前运动任务 current_motion_task 与可用转换白名单 "
+                "available_transition_motions（2Hz 转发）。"
+                "该卡片是其他控制卡（motion_switcher/loco/arm/joint_bridge）的前置状态来源。"
+            ),
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        """启动订阅与 2Hz 转发线程。"""
+        self._running = True
+        if self._sub_node is not None and self._MotionState is not None and self._state_sub is None:
+            try:
+                self._state_sub = self._sub_node.create_subscription(
+                    self._MotionState, self._state_topic, self._on_state, self._state_qos,
+                )
+                print("[MotionStatePlugin] 已订阅 /motion/motion_state")
+            except Exception as e:  # noqa: BLE001
+                print(f"[MotionStatePlugin] WARNING: 订阅失败（{e}），stub 模式")
+        if self._thread is None or not self._thread.is_alive():
+            self._thread = threading.Thread(target=self._publish_loop, daemon=True)
+            self._thread.start()
+
+    def stop(self) -> None:
+        self._running = False
+
+    def _on_state(self, msg) -> None:
+        try:
+            data = {
+                "current_motion_task": str(msg.current_motion_task or ""),
+                "available_transition_motions": list(msg.available_transition_motions or []),
+            }
+            with self._lock:
+                self._latest = data
+        except Exception as e:  # noqa: BLE001
+            print(f"[MotionStatePlugin] 回调异常: {e}")
+
+    def _produce(self) -> dict | None:
+        """当前状态 + 时间戳；无数据返回 None。"""
+        with self._lock:
+            data = self._latest
+        if not data:
+            return None
+        payload = dict(data)
+        payload["timestamp_ms"] = int(time.time() * 1000)
+        return payload
+
+    def _publish_loop(self) -> None:
+        """2Hz 转发到 core 域 /{ns}/motion/state。"""
+        while self._running:
+            time.sleep(0.5)
+            payload = self._produce()
+            if payload is None:
+                continue
+            if self._pub is not None and self._String is not None:
+                try:
+                    out = self._String()
+                    out.data = json.dumps(payload)
+                    self._pub.publish(out)
+                except Exception as e:  # noqa: BLE001
+                    print(f"[MotionStatePlugin] 发布异常: {e}")
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            self.start()
+            return {"state": "running"}
+        if action == "stop":
+            self.stop()
+            return {"state": "idle"}
+        if action == "info":
+            return {
+                "state": "running" if self._running else "idle",
+                "topic_out": [{"topic": self._topic, "format": "data/json"}],
+                "last": self._produce(),
+            }
+        if action in ("get", "read"):
+            payload = self._produce()
+            if payload is None:
+                return {"state": "error", "error": "NO_FEEDBACK",
+                        "message": "尚未收到 /motion/motion_state 数据，请确认机器人运控单元已启动"}
+            return payload
+        return None
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# MotionSwitcherPlugin (actuator, tool "motion_switcher")
+# 订阅 /motion/motion_state 缓存白名单；switch 时校验 mode ∈ available_transition_motions，
+# 发布 /motion/set_motion_state (RELIABLE)，轮询确认最多 3 秒。
+# ══════════════════════════════════════════════════════════════════════════════
+
+class MotionSwitcherPlugin:
+    """T800 运动状态切换卡片。
+
+    数据流: 订阅 /motion/motion_state 维护白名单 → 发布 MotionStateRequest 到
+    /motion/set_motion_state → 轮询当前状态确认切换成功（3 秒超时）。
+    mode 支持中文别名（如 "自然行走" → rl_basic），description 中列出官方全量状态名。
+    """
+
+    PREFIX = "motion_switcher"
+
+    SWITCH_TIMEOUT = 3.0   # 官方切换超时
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        self._ns = namespace
+        self._ros2 = ros2
+        self._lock = threading.Lock()
+        self._latest = None
+
+        self._node = None
+        self._state_sub = None
+        self._req_pub = None
+        self._MotionState = None
+        self._MotionStateRequest = None
+        try:
+            contract = _load_ros2_contract()
+            if contract is None:
+                raise ImportError("ros2 契约不可用")
+            reliable_qos, best_effort_qos, _, _, topics = contract
+            msgs = _load_msgs(
+                ("interface_protocol.msg", "MotionState"),
+                ("interface_protocol.msg", "MotionStateRequest"),
+            )
+            if msgs is None:
+                raise ImportError("消息类型导入失败")
+            self._MotionState, self._MotionStateRequest = msgs
+            self._node = ros2.make_node_t800("t800_motion_switcher")
+            self._req_pub = self._node.create_publisher(
+                self._MotionStateRequest, topics["set_motion_state"], reliable_qos,
+            )
+            self._state_topic = topics["motion_state"]
+            self._state_qos = best_effort_qos
+        except Exception as e:  # noqa: BLE001
+            print(f"[MotionSwitcherPlugin] WARNING: ROS2 初始化失败（{e}），stub 模式")
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "motion_switcher",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": (
+                "T800 运动状态切换 — 目标状态必须位于当前 available_transition_motions 白名单内，"
+                "切换确认最长 3 秒。官方状态机: idle=空闲, passive=阻力模式, pd_stand=PD站立, "
+                "rl_basic=自然行走, lower_body_balance=下肢平衡（上肢运动前置）, "
+                "joint_bridge=关节透传, pd_sitground=坐着起身, walk_server=行走服务端, "
+                "rl_mimic_supine_to_stance=仰卧起身(模仿), rl_mimic_prone_to_stance=俯卧起身(模仿), "
+                "rl_mimic_stance_to_supine=站立躺下(模仿), rl_mimic_stance_to_sitdown=站立坐下(模仿), "
+                "rl_mimic_sitdown_to_stance=坐着起身(模仿)。"
+                "mode 支持中文别名: 空闲/阻力模式/PD站立/自然行走/下肢平衡/关节透传/坐着起身/行走服务端。"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["switch", "get_state", "list_available"],
+                        "description": "要执行的动作",
+                    },
+                    "mode": {
+                        "type": "string",
+                        "description": "目标运动状态名或中文别名（如 rl_basic / 自然行走）",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "switch": {"params": ["mode"],
+                               "description": "切换至目标运动状态（白名单校验，等待确认最长 3 秒）"},
+                    "get_state": {"params": [],
+                                  "description": "查询当前运动状态与可用转换列表"},
+                    "list_available": {"params": [],
+                                       "description": "列出当前可切换的运动状态"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        if self._node is not None and self._MotionState is not None and self._state_sub is None:
+            try:
+                self._state_sub = self._node.create_subscription(
+                    self._MotionState, self._state_topic, self._on_state, self._state_qos,
+                )
+                print("[MotionSwitcherPlugin] 已订阅 /motion/motion_state")
+            except Exception as e:  # noqa: BLE001
+                print(f"[MotionSwitcherPlugin] WARNING: 订阅失败（{e}），stub 模式")
+
+    def stop(self) -> None:
+        pass
+
+    def _on_state(self, msg) -> None:
+        try:
+            data = {
+                "current_motion_task": str(msg.current_motion_task or ""),
+                "available_transition_motions": list(msg.available_transition_motions or []),
+            }
+            with self._lock:
+                self._latest = data
+        except Exception as e:  # noqa: BLE001
+            print(f"[MotionSwitcherPlugin] 回调异常: {e}")
+
+    def _snapshot(self) -> dict | None:
+        with self._lock:
+            return dict(self._latest) if self._latest else None
+
+    def _do_switch(self, mode: str) -> dict:
+        """白名单校验 → 发布请求 → 轮询确认（3 秒超时）。"""
+        official = _MODE_ALIASES.get(mode, mode)
+        st = self._snapshot()
+        if st is None:
+            return _err("NO_MOTION_STATE",
+                        "尚未收到 /motion/motion_state 反馈，无法确认可切换状态，请稍后重试")
+        cur = st.get("current_motion_task")
+        avail = st.get("available_transition_motions") or []
+        if official == cur:
+            return {"state": "ok", "current_motion": official, "elapsed_ms": 0,
+                    "already_in_state": True}
+        if official not in avail:
+            return _err("NOT_AVAILABLE",
+                        f"当前状态 {cur} 不允许直接切换到 {official}。"
+                        f"当前可用转换: {'、'.join(avail) if avail else '（无）'}")
+        if self._req_pub is None or self._MotionStateRequest is None:
+            return _err("ROS2_UNAVAILABLE", "ROS2 环境未初始化（stub 模式），无法发布切换请求")
+        req = self._MotionStateRequest()
+        req.target_motion_name = official
+        self._req_pub.publish(req)
+        t0 = time.monotonic()
+        while time.monotonic() - t0 < self.SWITCH_TIMEOUT:
+            time.sleep(0.05)
+            st2 = self._snapshot()
+            if st2 and st2.get("current_motion_task") == official:
+                return {"state": "ok", "current_motion": official,
+                        "elapsed_ms": int((time.monotonic() - t0) * 1000)}
+        return _err("TIMEOUT",
+                    f"3 秒内未确认切换到 {official}（当前仍为 {cur}），请检查运控状态")
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            self.start()
+            return {"state": "ready"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "info":
+            return {"state": "ready", "last": self._snapshot()}
+        if action == "switch":
+            mode = str(args.get("mode", "")).strip()
+            if not mode:
+                return _err("INVALID_ARGUMENT", "缺少 mode 参数（目标状态名或中文别名）")
+            return self._do_switch(mode)
+        if action == "get_state":
+            st = self._snapshot()
+            if st is None:
+                return _err("NO_MOTION_STATE", "尚未收到运动状态反馈")
+            return st
+        if action == "list_available":
+            st = self._snapshot()
+            if st is None:
+                return _err("NO_MOTION_STATE", "尚未收到运动状态反馈")
+            return {"current": st.get("current_motion_task"),
+                    "available": st.get("available_transition_motions") or []}
+        return None
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# LocoPlugin (actuator, tool "loco")
+# 100Hz 持续发布 /motion/body_vel_cmd；速度渐变（每次 tick 向目标步进 20%）；
+# duration>0 到时自动发零速；>2s 未收到新命令防御性自停（官方接收端 2 秒无数据即停）。
+# ══════════════════════════════════════════════════════════════════════════════
+
+class LocoPlugin:
+    """T800 机体速度控制卡片。
+
+    数据流: move(vx, vy, vyaw) → 100Hz 定时器发布 BodyVelCmd 到 /motion/body_vel_cmd，
+    linear_velocity=[x, y]、yaw_velocity；header.frame_id="body"。限制 x/y ±1 m/s、
+    yaw ±1 rad/s。停止 = 显式发零速度（stop）或定时自停（duration / 2 秒看门狗）。
+    前置检查: 需要 rl_basic（自然行走）或 walk_server 模式。
+    """
+
+    PREFIX = "loco"
+
+    CONTROL_PERIOD = 0.01     # 100Hz
+    WATCHDOG_SEC = 2.0        # 接收端 2 秒未收到命令自动停
+    GRADIENT = 0.2            # 每次 tick 向目标速度步进 20%（简单渐变）
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        self._ns = namespace
+        self._ros2 = ros2
+        self._lock = threading.Lock()
+        self._target = None                 # (vx, vy, vyaw) 目标速度；None = 空闲
+        self._cur = (0.0, 0.0, 0.0)         # 当前实际发布速度（渐变用）
+        self._last_cmd_time = 0.0
+        self._deadline = None               # duration 到期时间（monotonic）
+        self._timer = None
+
+        self._node = None
+        self._pub = None
+        self._state_sub = None
+        self._BodyVelCmd = None
+        self._Header = None
+        self._MotionState = None
+        try:
+            contract = _load_ros2_contract()
+            if contract is None:
+                raise ImportError("ros2 契约不可用")
+            _, best_effort_qos, _, _, topics = contract
+            msgs = _load_msgs(
+                ("interface_protocol.msg", "BodyVelCmd"),
+                ("interface_protocol.msg", "MotionState"),
+                ("std_msgs.msg", "Header"),
+            )
+            if msgs is None:
+                raise ImportError("消息类型导入失败")
+            self._BodyVelCmd, self._MotionState, self._Header = msgs
+            self._node = ros2.make_node_t800("t800_loco")
+            # 官方示例 body_vel_cmd 用默认 depth10 QoS
+            self._pub = self._node.create_publisher(
+                self._BodyVelCmd, topics["body_vel_cmd"], 10,
+            )
+            self._state_topic = topics["motion_state"]
+            self._state_qos = best_effort_qos
+        except Exception as e:  # noqa: BLE001
+            print(f"[LocoPlugin] WARNING: ROS2 初始化失败（{e}），stub 模式")
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "loco",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": (
+                "T800 机体速度控制 — 100Hz 持续发布 /motion/body_vel_cmd。"
+                "限制: x/y 方向 ±1 m/s，yaw ±1 rad/s；duration>0 到时自动停止；"
+                "接收端 2 秒未收到命令会自动停下。停止 = 显式发零速度。"
+                "速度按每次 20% 渐变平滑到达目标。前置条件: rl_basic（自然行走）或 walk_server 模式。"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["move", "stop"],
+                        "description": "要执行的动作",
+                    },
+                    "vx":       {"type": "number", "description": "前进速度 m/s [-1, 1]"},
+                    "vy":       {"type": "number", "description": "横向速度 m/s [-1, 1]"},
+                    "vyaw":     {"type": "number", "description": "转向角速度 rad/s [-1, 1]"},
+                    "duration": {"type": "number",
+                                 "description": "运动时长秒；0 或省略 = 持续运动直到 stop"},
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "move": {"params": ["vx", "vy", "vyaw", "duration"],
+                             "description": "按指定速度运动（100Hz 持续发布，duration>0 到时自动停）"},
+                    "stop": {"params": [],
+                             "description": "立即停止运动（显式发布零速度并停定时器）"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        if self._node is not None and self._MotionState is not None and self._state_sub is None:
+            try:
+                self._state_sub = self._node.create_subscription(
+                    self._MotionState, self._state_topic, self._on_state, self._state_qos,
+                )
+                print("[LocoPlugin] 已订阅 /motion/motion_state")
+            except Exception as e:  # noqa: BLE001
+                print(f"[LocoPlugin] WARNING: 订阅失败（{e}），stub 模式")
+
+    def stop(self) -> None:
+        """系统/工具 stop：立即发零速度并停 timer。"""
+        with self._lock:
+            self._zero_and_stop_locked()
+
+    def _on_state(self, msg) -> None:
+        try:
+            data = {"current_motion_task": str(msg.current_motion_task or ""),
+                    "available_transition_motions": list(msg.available_transition_motions or [])}
+            with self._lock:
+                self._motion_state = data
+        except Exception as e:  # noqa: BLE001
+            print(f"[LocoPlugin] 回调异常: {e}")
+
+    def _snapshot_state(self) -> dict | None:
+        with self._lock:
+            return dict(self._motion_state) if getattr(self, "_motion_state", None) else None
+
+    def _ensure_timer(self) -> None:
+        if self._timer is None and self._node is not None:
+            self._timer = self._node.create_timer(self.CONTROL_PERIOD, self._tick)
+
+    def _publish(self, vx: float, vy: float, vyaw: float) -> None:
+        if self._pub is None or self._BodyVelCmd is None or self._Header is None:
+            return
+        try:
+            msg = self._BodyVelCmd()
+            msg.header = self._Header()
+            msg.header.stamp = self._node.get_clock().now().to_msg()
+            msg.header.frame_id = "body"
+            msg.linear_velocity = [vx, vy]
+            msg.yaw_velocity = vyaw
+            self._pub.publish(msg)
+        except Exception as e:  # noqa: BLE001
+            print(f"[LocoPlugin] 发布异常: {e}")
+
+    def _zero_and_stop_locked(self) -> None:
+        """发零速度 + 停 timer + 置空闲（须持锁调用）。"""
+        vx, vy, vyaw = self._cur
+        self._publish(0.0, 0.0, 0.0)
+        if self._timer is not None:
+            try:
+                self._timer.cancel()
+            except Exception:  # noqa: BLE001
+                pass
+            self._timer = None
+        self._target = None
+        self._deadline = None
+        self._cur = (0.0, 0.0, 0.0)
+        print(f"[LocoPlugin] 已停止（原速度 {vx:.2f}, {vy:.2f}, {vyaw:.2f}）")
+
+    def _tick(self) -> None:
+        """100Hz 定时器：渐变发布 + duration 到期自停 + 2 秒看门狗。"""
+        with self._lock:
+            if self._target is None:
+                return
+            now = time.monotonic()
+            # duration 到期 → 自动停（先于看门狗判断，避免看门狗截断 duration>2s 的运动；
+            # 100Hz 持续发布本身保证接收端不缺数据）
+            if self._deadline is not None and now >= self._deadline:
+                print("[LocoPlugin] duration 到期，自动停止")
+                self._zero_and_stop_locked()
+                return
+            # 防御: 仅持续运动（无 duration 到期时间）距上次 move 命令超过 2 秒 →
+            # 零速自停（官方接收端 2s 无数据即停；带 duration 的运动以到期自停为准）
+            if self._deadline is None and now - self._last_cmd_time > self.WATCHDOG_SEC:
+                print("[LocoPlugin] 看门狗: 超过 2 秒无新命令，自动停止")
+                self._zero_and_stop_locked()
+                return
+            tx, ty, tyaw = self._target
+            cx, cy, cyaw = self._cur
+            # 每次 tick 向目标步进 20%（简单渐变，防突变冲击）
+            nx = cx + (tx - cx) * self.GRADIENT
+            ny = cy + (ty - cy) * self.GRADIENT
+            nyaw = cyaw + (tyaw - cyaw) * self.GRADIENT
+            if abs(tx - nx) < 0.001 and abs(ty - ny) < 0.001 and abs(tyaw - nyaw) < 0.001:
+                nx, ny, nyaw = tx, ty, tyaw   # 已收敛到目标
+            self._cur = (nx, ny, nyaw)
+        self._publish(nx, ny, nyaw)
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            self.start()
+            return {"state": "ready"}
+        if action == "stop":
+            self.stop()
+            return {"state": "idle"}
+        if action == "info":
+            with self._lock:
+                target = list(self._target) if self._target else None
+                cur = list(self._cur)
+            return {"state": "moving" if target else "ready",
+                    "current": cur, "target": target}
+        if action == "move":
+            vx = float(args.get("vx", 0.0))
+            vy = float(args.get("vy", 0.0))
+            vyaw = float(args.get("vyaw", 0.0))
+            duration = float(args.get("duration", 0.0))
+            if abs(vx) > 1.0 or abs(vy) > 1.0:
+                return _err("INVALID_ARGUMENT",
+                            f"x/y 方向速度超出限制 ±1 m/s（vx={vx}, vy={vy}）")
+            if abs(vyaw) > 1.0:
+                return _err("INVALID_ARGUMENT", f"yaw 角速度超出限制 ±1 rad/s（vyaw={vyaw}）")
+            # 运动状态前置检查
+            st = self._snapshot_state()
+            if st is None:
+                return _err("NO_MOTION_STATE",
+                            "尚未收到运动状态反馈，无法确认当前模式，请先启动 motion_state 卡片并确认机器人已上电")
+            cur_mode = st.get("current_motion_task")
+            if cur_mode not in _LOCO_REQUIRED_MODES:
+                return _err("WRONG_MOTION_STATE",
+                            f"当前运动状态为 {cur_mode}，机体速度控制需要行走类模式"
+                            f"（rl_basic 自然行走 / walk_server 行走服务端），请先用 motion_switcher 切换")
+            with self._lock:
+                self._target = (vx, vy, vyaw)
+                self._last_cmd_time = time.monotonic()
+                self._deadline = self._last_cmd_time + duration if duration > 0 else None
+                self._ensure_timer()
+            result = {"state": "ok", "vx": vx, "vy": vy, "vyaw": vyaw, "duration": duration}
+            if duration > 0:
+                result["scheduled_stop_at_ms"] = int((self._deadline or 0) * 1000)
+            return result
+        return None
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ArmMotionPlugin (actuator, tool "arm")
+# 上肢运动规划：发布 /motion/joint_motion_plan/request (RELIABLE)，订阅
+# /motion/joint_motion_plan/state (BEST_EFFORT) 缓存 {request_id, status, progress}，
+# 并 5Hz 转发到 core 域 /{ns}/arm/state。手势以任务队列后台顺序执行（不阻塞 dispatch）。
+# 前置检查: current_motion_task == "lower_body_balance"。
+# ══════════════════════════════════════════════════════════════════════════════
+
+# 官方预设手势（target_positions/duration/stiffness/damping 取自 config/t800/*.yaml）
+_ARM_PRESETS = {
+    "extend_right_hand": [
+        # 注意: 官方 YAML 中该动作拼写为 extand_right_hand，此处保留官方名并注明
+        {"name": "extand_right_hand", "positions": list(_ARM_EXTEND_POSITIONS),
+         "duration": 2.0, "stiffness": list(_UPPER_STIFFNESS_HAND),
+         "damping": list(_UPPER_DAMPING_HAND), "gravity": True},
+    ],
+    "shake_hand": [
+        {"name": "extand_right_hand", "positions": list(_ARM_EXTEND_POSITIONS),
+         "duration": 2.0, "stiffness": list(_UPPER_STIFFNESS_HAND),
+         "damping": list(_UPPER_DAMPING_HAND), "gravity": True},
+        {"name": "withdraw_right_hand", "positions": list(_ARM_WITHDRAW_POSITIONS),
+         "duration": 2.0, "stiffness": list(_UPPER_STIFFNESS_HAND),
+         "damping": list(_UPPER_DAMPING_HAND), "gravity": True},
+    ],
+    "wave_hand": [
+        {"name": "init", "positions": list(_WAVE_INIT_POSITIONS),
+         "duration": 1.0, "stiffness": list(_UPPER_STIFFNESS_WAVE_INIT),
+         "damping": list(_UPPER_DAMPING_HAND), "gravity": True},
+        {"name": "raise_hands", "positions": list(_WAVE_RAISE_POSITIONS),
+         "duration": 2.0, "stiffness": list(_UPPER_STIFFNESS_WAVE_INIT),
+         "damping": list(_UPPER_DAMPING_HAND), "gravity": True},
+        {"name": "wave_hands_1", "positions": list(_WAVE_HANDS_POSITIONS),
+         "duration": 0.3, "stiffness": list(_UPPER_STIFFNESS_WAVE_STEP),
+         "damping": list(_UPPER_DAMPING_HAND), "gravity": True},
+        {"name": "wave_hands_2", "positions": list(_WAVE_RAISE_POSITIONS),
+         "duration": 0.3, "stiffness": list(_UPPER_STIFFNESS_WAVE_STEP),
+         "damping": list(_UPPER_DAMPING_HAND), "gravity": True},
+        {"name": "wave_hands_3", "positions": list(_WAVE_HANDS_POSITIONS),
+         "duration": 0.3, "stiffness": list(_UPPER_STIFFNESS_WAVE_STEP),
+         "damping": list(_UPPER_DAMPING_HAND), "gravity": True},
+        {"name": "wave_hands_4", "positions": list(_WAVE_RAISE_POSITIONS),
+         "duration": 0.3, "stiffness": list(_UPPER_STIFFNESS_WAVE_STEP),
+         "damping": list(_UPPER_DAMPING_HAND), "gravity": True},
+        {"name": "wave_hands_5", "positions": list(_WAVE_HANDS_POSITIONS),
+         "duration": 0.3, "stiffness": list(_UPPER_STIFFNESS_WAVE_END),
+         "damping": list(_UPPER_DAMPING_HAND), "gravity": True},
+        # 官方 yaml 末尾的复位任务：挥手结束后回到默认姿态
+        {"name": "reset", "request_type": "RESET"},
+    ],
+}
+
+
+class ArmMotionPlugin:
+    """T800 上肢运动规划卡片。
+
+    数据流: 预设手势任务入队 → 后台线程等待规划器 IDLE 后依次发布
+    JointMotionPlanRequest（request_id 递增）→ 订阅 JointMotionPlanState 缓存
+    状态/进度 → 5Hz 转发 /{ns}/arm/state (data/json)。
+    前置检查: 需 lower_body_balance（下肢平衡）模式。
+    """
+
+    PREFIX = "arm"
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        self._ns = namespace
+        self._ros2 = ros2
+        self._state_topic_out = f"/{namespace}/arm/state"
+        self._lock = threading.Lock()
+        self._state = None            # {"request_id", "status", "progress"}
+        self._motion_state = None
+        self._request_id = 0
+        self._last_sent_request_id = None
+        self._last_sent_at = 0.0
+        self._expected_ms = 0         # 期望完成时长（execution_time + 余量）
+        self._queue = queue.Queue()
+        self._worker: threading.Thread | None = None
+        self._running = False
+        self._last_error = None
+        self._last_core_pub = 0.0
+
+        self._node = None
+        self._core_node = None
+        self._req_pub = None
+        self._core_pub = None
+        self._state_sub = None
+        self._motion_state_sub = None
+        self._JointMotionPlanRequest = None
+        self._JointMotionPlanState = None
+        self._MotionState = None
+        self._String = None
+        try:
+            contract = _load_ros2_contract()
+            if contract is None:
+                raise ImportError("ros2 契约不可用")
+            reliable_qos, best_effort_qos, _, core_qos, topics = contract
+            msgs = _load_msgs(
+                ("interface_protocol.msg", "JointMotionPlanRequest"),
+                ("interface_protocol.msg", "JointMotionPlanState"),
+                ("interface_protocol.msg", "MotionState"),
+                ("std_msgs.msg", "String"),
+            )
+            if msgs is None:
+                raise ImportError("消息类型导入失败")
+            (self._JointMotionPlanRequest, self._JointMotionPlanState,
+             self._MotionState, self._String) = msgs
+            self._node = ros2.make_node_t800("t800_arm")
+            self._req_pub = self._node.create_publisher(
+                self._JointMotionPlanRequest, topics["motion_plan_request"], reliable_qos,
+            )
+            self._core_node = ros2.make_node_core("t800_arm_state_pub")
+            self._core_pub = self._core_node.create_publisher(
+                self._String, self._state_topic_out, core_qos,
+            )
+            self._state_topic = topics["motion_plan_state"]
+            self._state_qos = best_effort_qos
+            self._motion_topic = topics["motion_state"]
+        except Exception as e:  # noqa: BLE001
+            print(f"[ArmMotionPlugin] WARNING: ROS2 初始化失败（{e}），stub 模式")
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "arm",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": (
+                "T800 上肢运动规划 — 预设手势: extend_right_hand=伸右手, shake_hand=握手"
+                "（伸右手→收右手）, wave_hand=挥手（官方 wave_hands 全任务）; "
+                "reset=复位到默认姿态, cancel=取消当前任务, get_state=查询规划状态/进度。"
+                "前置条件: lower_body_balance（下肢平衡）模式。"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["extend_right_hand", "shake_hand", "wave_hand",
+                                 "reset", "cancel", "get_state"],
+                        "description": "要执行的动作",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "extend_right_hand": {"params": [], "description": "伸出右手（官方 extand_right_hand 姿态）"},
+                    "shake_hand":        {"params": [], "description": "握手（依次执行 伸右手 → 收右手）"},
+                    "wave_hand":         {"params": [], "description": "挥手（执行官方 wave_hands 全部任务，含结尾复位）"},
+                    "reset":             {"params": [], "description": "复位上肢到默认姿态"},
+                    "cancel":            {"params": [], "description": "取消当前规划任务并清空队列"},
+                    "get_state":         {"params": [], "description": "查询规划器状态与进度"},
+                },
+            },
+            "topic_out": [{"topic": self._state_topic_out, "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        """启动订阅与后台任务队列线程。"""
+        self._running = True
+        if self._node is not None and self._state_sub is None:
+            try:
+                self._state_sub = self._node.create_subscription(
+                    self._JointMotionPlanState, self._state_topic,
+                    self._on_plan_state, self._state_qos,
+                )
+                self._motion_state_sub = self._node.create_subscription(
+                    self._MotionState, self._motion_topic,
+                    self._on_motion_state, self._state_qos,
+                )
+                print("[ArmMotionPlugin] 已订阅 /motion/joint_motion_plan/state 与 /motion/motion_state")
+            except Exception as e:  # noqa: BLE001
+                print(f"[ArmMotionPlugin] WARNING: 订阅失败（{e}），stub 模式")
+        if self._worker is None or not self._worker.is_alive():
+            self._worker = threading.Thread(target=self._worker_loop, daemon=True)
+            self._worker.start()
+
+    def stop(self) -> None:
+        """停止: 清空队列、退出 worker、发送取消请求（安全兜底）。"""
+        self._running = False
+        if self._worker is not None:
+            try:
+                self._queue.put_nowait(None)   # 哨兵
+            except queue.Full:
+                pass
+            self._worker.join(timeout=2)
+            self._worker = None
+        self._send_cancel_request()
+
+    # ── 订阅回调 ─────────────────────────────────────────────────────────────
+
+    def _on_plan_state(self, msg) -> None:
+        try:
+            rid = int(msg.request_id)
+            with self._lock:
+                self._state = {"request_id": rid, "status": int(msg.status),
+                               "progress": float(msg.progress)}
+                # 以最新 state 的 request_id 为基准递增（官方示例同此逻辑）
+                if rid >= self._request_id:
+                    self._request_id = rid
+            # 5Hz 节流转发到 core 域 /{ns}/arm/state
+            now = time.monotonic()
+            if self._core_pub is not None and self._String is not None and now - self._last_core_pub >= 0.2:
+                self._last_core_pub = now
+                payload = dict(self._state)
+                payload["timestamp_ms"] = int(now * 1000)
+                out = self._String()
+                out.data = json.dumps(payload)
+                self._core_pub.publish(out)
+        except Exception as e:  # noqa: BLE001
+            print(f"[ArmMotionPlugin] 规划状态回调异常: {e}")
+
+    def _on_motion_state(self, msg) -> None:
+        try:
+            with self._lock:
+                self._motion_state = {
+                    "current_motion_task": str(msg.current_motion_task or ""),
+                    "available_transition_motions": list(msg.available_transition_motions or []),
+                }
+        except Exception as e:  # noqa: BLE001
+            print(f"[ArmMotionPlugin] 运动状态回调异常: {e}")
+
+    # ── 前置检查 ─────────────────────────────────────────────────────────────
+
+    def _check_precondition(self) -> dict | None:
+        """返回错误 dict 或 None（通过）。要求 lower_body_balance 模式。"""
+        with self._lock:
+            st = dict(self._motion_state) if self._motion_state else None
+        if st is None:
+            return _err("NO_MOTION_STATE",
+                        "尚未收到运动状态反馈，无法确认当前模式，请先确认机器人已上电")
+        cur = st.get("current_motion_task")
+        if cur != "lower_body_balance":
+            return _err("WRONG_MOTION_STATE",
+                        f"当前运动状态为 {cur}，上肢运动规划需要 lower_body_balance（下肢平衡）模式，"
+                        f"请先用 motion_switcher 切换")
+        return None
+
+    # ── 后台任务队列（顺序发送，不阻塞 dispatch） ────────────────────────────
+
+    def _worker_loop(self) -> None:
+        """从队列取任务，等待规划器 IDLE 后发送；None 为停止哨兵。"""
+        while self._running:
+            try:
+                task = self._queue.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            if task is None:
+                break
+            try:
+                if not self._wait_planner_idle(20.0):
+                    self._last_error = "规划器未在 20 秒内回到 IDLE，任务未发送"
+                    print(f"[ArmMotionPlugin] {self._last_error}: {task.get('name')}")
+                    continue
+                if task.get("request_type") == "RESET":
+                    self._send_reset_request()   # 复位任务走 REQUEST_RESET
+                else:
+                    self._send_plan_task(task)
+                self._last_error = None
+            except Exception as e:  # noqa: BLE001
+                self._last_error = str(e)
+                print(f"[ArmMotionPlugin] 任务执行异常: {e}")
+
+    def _wait_planner_idle(self, timeout: float) -> bool:
+        """轮询缓存状态，等待规划器 IDLE（status==1）。"""
+        deadline = time.monotonic() + timeout
+        while self._running and time.monotonic() < deadline:
+            with self._lock:
+                status = self._state.get("status") if self._state else None
+            if status == 1:   # IDLE
+                return True
+            time.sleep(0.1)
+        return False
+
+    def _send_plan_task(self, task: dict) -> None:
+        """构建并发布 REQUEST_PLAN_EXECUTE 请求。"""
+        if self._req_pub is None or self._JointMotionPlanRequest is None:
+            self._last_error = "ROS2 环境未初始化（stub 模式），无法发送规划请求"
+            print(f"[ArmMotionPlugin] {self._last_error}")
+            return
+        req = self._JointMotionPlanRequest()
+        with self._lock:
+            self._request_id += 1
+            rid = self._request_id
+        req.request_id = rid
+        req.request_type = self._JointMotionPlanRequest.REQUEST_PLAN_EXECUTE
+        req.use_gravity_compensation = bool(task.get("gravity", True))
+        req.joint_indices = list(UPPER_BODY_JOINT_INDICES)
+        req.target_positions = [float(p) for p in task["positions"]]
+        req.target_velocities = []          # 空数组 = 自动规划
+        req.execution_time = float(task["duration"])
+        req.stiffness = [float(s) for s in (task.get("stiffness") or [])]
+        req.damping = [float(d) for d in (task.get("damping") or [])]
+        self._req_pub.publish(req)
+        with self._lock:
+            self._last_sent_request_id = rid
+            self._last_sent_at = time.monotonic()
+            # 期望完成时长 = execution_time + 2 秒余量（供 get_state 估算进度）
+            self._expected_ms = int(float(task["duration"]) * 1000) + 2000
+        print(f"[ArmMotionPlugin] 已发布规划任务 {task.get('name')} request_id={rid}")
+
+    def _send_cancel_request(self) -> None:
+        """发布 REQUEST_CANCEL（携带最新 request_id）。"""
+        if self._req_pub is None or self._JointMotionPlanRequest is None:
+            return
+        try:
+            with self._lock:
+                self._request_id += 1
+                rid = self._request_id
+            req = self._JointMotionPlanRequest()
+            req.request_id = rid
+            req.request_type = self._JointMotionPlanRequest.REQUEST_CANCEL
+            self._req_pub.publish(req)
+            print(f"[ArmMotionPlugin] 已发布取消请求 request_id={rid}")
+        except Exception as e:  # noqa: BLE001
+            print(f"[ArmMotionPlugin] 取消请求失败: {e}")
+
+    def _send_reset_request(self) -> None:
+        """发布 REQUEST_RESET（joint_indices 置空 = 复位默认姿态）。"""
+        if self._req_pub is None or self._JointMotionPlanRequest is None:
+            return
+        try:
+            with self._lock:
+                self._request_id += 1
+                rid = self._request_id
+            req = self._JointMotionPlanRequest()
+            req.request_id = rid
+            req.request_type = self._JointMotionPlanRequest.REQUEST_RESET
+            req.joint_indices = []          # 空数组表示复位默认姿态
+            req.target_positions = []
+            req.target_velocities = []
+            req.execution_time = 0.0
+            req.stiffness = []
+            req.damping = []
+            self._req_pub.publish(req)
+            with self._lock:
+                self._last_sent_request_id = rid
+                self._last_sent_at = time.monotonic()
+                self._expected_ms = 3000    # 复位按 3 秒估算
+            print(f"[ArmMotionPlugin] 已发布复位请求 request_id={rid}")
+        except Exception as e:  # noqa: BLE001
+            print(f"[ArmMotionPlugin] 复位请求失败: {e}")
+
+    def _enqueue(self, preset_name: str) -> dict:
+        """将预设手势全部任务入队（队列为空时立即返回，不阻塞）。"""
+        tasks = _ARM_PRESETS.get(preset_name)
+        if not tasks:
+            return _err("INVALID_ARGUMENT", f"未知手势: {preset_name}")
+        for t in tasks:
+            self._queue.put(dict(t))
+        return {"state": "ok", "gesture": preset_name,
+                "queued_tasks": [t["name"] for t in tasks],
+                "queue_remaining": self._queue.qsize()}
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            self.start()
+            return {"state": "ready"}
+        if action == "stop":
+            self.stop()
+            return {"state": "idle"}
+        if action == "info":
+            return {"state": "ready",
+                    "topic_out": [{"topic": self._state_topic_out, "format": "data/json"}],
+                    "last": dict(self._state) if self._state else None}
+        if action in ("extend_right_hand", "shake_hand", "wave_hand"):
+            err = self._check_precondition()
+            if err:
+                return err
+            return self._enqueue(action)
+        if action == "reset":
+            err = self._check_precondition()
+            if err:
+                return err
+            # 复位也走队列，确保在上一任务完成后执行
+            self._queue.put({"name": "reset", "request_type": "RESET"})
+            return {"state": "ok", "gesture": "reset", "queued": True,
+                    "queue_remaining": self._queue.qsize()}
+        if action == "cancel":
+            # 清空待执行队列
+            while True:
+                try:
+                    self._queue.get_nowait()
+                except queue.Empty:
+                    break
+            self._send_cancel_request()
+            return {"state": "ok", "cancelled_request_id": self._request_id,
+                    "queue_cleared": True}
+        if action == "get_state":
+            with self._lock:
+                s = dict(self._state) if self._state else None
+                last_sent = self._last_sent_request_id
+                sent_at = self._last_sent_at
+                expected_ms = self._expected_ms
+            queue_remaining = self._queue.qsize()
+            if s is None:
+                return {"state": "idle", "status": "UNKNOWN", "request_id": self._request_id,
+                        "queue_remaining": queue_remaining,
+                        "message": "尚未收到规划状态反馈（规划器可能未启动）"}
+            status = _PLAN_STATUS_NAMES.get(s.get("status"), "UNKNOWN")
+            progress = s.get("progress", 0.0)
+            # 若缓存状态不是本次发送的任务（或未回馈），按期望完成时间估算进度
+            if last_sent is not None and s.get("request_id") != last_sent:
+                elapsed_ms = (time.monotonic() - sent_at) * 1000
+                progress = min(1.0, max(0.0, elapsed_ms / max(expected_ms, 1)))
+            return {"state": "ok", "status": status, "progress": round(progress, 3),
+                    "request_id": s.get("request_id"), "queue_remaining": queue_remaining,
+                    "last_error": self._last_error}
+        return None
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# JointBridgePlugin (actuator, tool "joint_bridge")
+# 500Hz 全身 25 关节 PD 位置控制：订阅 /hardware/joint_state 取当前位置为插值起点，
+# 线性插值（步长=(目标-当前)/(步数-1)，官方 joint_bridge_example 公式）逐拍发布
+# JointCommand 到 /hardware/joint_command。config 默认关闭，仅限专业人员。
+# ══════════════════════════════════════════════════════════════════════════════
+
+class JointBridgePlugin:
+    """T800 关节透传卡片（危险操作）。
+
+    数据流: set_pose(positions[25]) → 以最新 /hardware/joint_state 位置为起点，
+    按 num_steps 线性插值，500Hz 定时器逐拍发布 JointCommand
+    （position=插值位, velocity=0, feed_forward_torque=0, torque=0, stiffness, damping,
+    parallel_parser_type=CLASSIC_PARSER(0)）。
+    前置检查: joint_bridge（关节透传）模式。config.yaml 默认关闭。
+    """
+
+    PREFIX = "joint_bridge"
+
+    CONTROL_PERIOD = 1.0 / 500.0    # 500Hz
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        # config 默认关闭；仅 config.yaml enabled: true 时才会被实例化并放行操作
+        self._enabled = bool((plugin_config or {}).get("enabled", False))
+        self._ns = namespace
+        self._ros2 = ros2
+        self._lock = threading.Lock()
+        self._joint_positions = None      # 最新 /hardware/joint_state 位置
+        self._motion_state = None
+        self._interp = None               # 每关节插值轨迹 [[pos0, pos1, ...], ...]
+        self._num_steps = 0
+        self._step_idx = 0
+        self._stiffness = list(_JB_DEFAULT_STIFFNESS)
+        self._damping = list(_JB_DEFAULT_DAMPING)
+        self._timer = None
+        self._subs_created = False
+
+        self._node = None
+        self._cmd_pub = None
+        self._joint_state_sub = None
+        self._motion_state_sub = None
+        self._JointCommand = None
+        self._JointState = None
+        self._MotionState = None
+        self._Header = None
+        try:
+            contract = _load_ros2_contract()
+            if contract is None:
+                raise ImportError("ros2 契约不可用")
+            _, best_effort_qos, joint_qos, _, topics = contract
+            msgs = _load_msgs(
+                ("interface_protocol.msg", "JointCommand"),
+                ("interface_protocol.msg", "JointState"),
+                ("interface_protocol.msg", "MotionState"),
+                ("std_msgs.msg", "Header"),
+            )
+            if msgs is None:
+                raise ImportError("消息类型导入失败")
+            self._JointCommand, self._JointState, self._MotionState, self._Header = msgs
+            self._node = ros2.make_node_t800("t800_joint_bridge")
+            # 官方 joint_bridge_example: depth3 BEST_EFFORT VOLATILE — 500Hz 高保真，
+            # joint_state 订阅与 joint_command 发布用 QOS_T800_JOINT（depth3），
+            # motion_state 订阅保持 QOS_T800_BEST_EFFORT（depth1）即可
+            self._cmd_pub = self._node.create_publisher(
+                self._JointCommand, topics["joint_command"], joint_qos,
+            )
+            self._joint_state_topic = topics["joint_state"]
+            self._motion_topic = topics["motion_state"]
+            self._state_qos = best_effort_qos
+            self._joint_qos = joint_qos
+        except Exception as e:  # noqa: BLE001
+            print(f"[JointBridgePlugin] WARNING: ROS2 初始化失败（{e}），stub 模式")
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "joint_bridge",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": (
+                "T800 关节透传 — 500Hz 全身 25 关节 PD 位置控制（J00~J24 全部关节）。"
+                "危险操作: 仅限专业人员使用，必须处于 joint_bridge（关节透传）模式，"
+                "并配合安全吊架/清场！config.yaml 默认关闭（enabled: false）。"
+                "关节命令数组长度必须为 25。"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["set_pose", "stop"],
+                        "description": "要执行的动作",
+                    },
+                    "positions": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "description": "目标关节位置 rad，长度必须为 25（J00~J24）",
+                    },
+                    "stiffness": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "description": "刚度 kp 长度 25，缺省用官方 pd_joint_test 值",
+                    },
+                    "damping": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "description": "阻尼 kd 长度 25，缺省用官方 pd_joint_test 值",
+                    },
+                    "num_steps": {
+                        "type": "integer",
+                        "description": "插值步数（默认 1500，对应约 3 秒 @500Hz）",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "set_pose": {"params": ["positions", "stiffness", "damping", "num_steps"],
+                                 "description": "按 25 关节目标位置执行线性插值到位（500Hz）"},
+                    "stop": {"params": [], "description": "立即停止插值（保持当前命令停止发布）"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        if self._node is not None and not self._subs_created:
+            try:
+                self._joint_state_sub = self._node.create_subscription(
+                    self._JointState, self._joint_state_topic,
+                    self._on_joint_state, self._joint_qos,
+                )
+                self._motion_state_sub = self._node.create_subscription(
+                    self._MotionState, self._motion_topic,
+                    self._on_motion_state, self._state_qos,
+                )
+                self._subs_created = True
+                print("[JointBridgePlugin] 已订阅 /hardware/joint_state 与 /motion/motion_state")
+            except Exception as e:  # noqa: BLE001
+                print(f"[JointBridgePlugin] WARNING: 订阅失败（{e}），stub 模式")
+
+    def stop(self) -> None:
+        """停止插值：取消 500Hz 定时器，清空轨迹。"""
+        with self._lock:
+            self._interp = None
+            if self._timer is not None:
+                try:
+                    self._timer.cancel()
+                except Exception:  # noqa: BLE001
+                    pass
+                self._timer = None
+
+    def _on_joint_state(self, msg) -> None:
+        try:
+            with self._lock:
+                self._joint_positions = [float(p) for p in (msg.position or [])]
+        except Exception as e:  # noqa: BLE001
+            print(f"[JointBridgePlugin] 关节状态回调异常: {e}")
+
+    def _on_motion_state(self, msg) -> None:
+        try:
+            with self._lock:
+                self._motion_state = {
+                    "current_motion_task": str(msg.current_motion_task or ""),
+                    "available_transition_motions": list(msg.available_transition_motions or []),
+                }
+        except Exception as e:  # noqa: BLE001
+            print(f"[JointBridgePlugin] 运动状态回调异常: {e}")
+
+    def _check_precondition(self) -> dict | None:
+        """要求 joint_bridge 模式。返回错误 dict 或 None。"""
+        with self._lock:
+            st = dict(self._motion_state) if self._motion_state else None
+        if st is None:
+            return _err("NO_MOTION_STATE",
+                        "尚未收到运动状态反馈，无法确认当前模式，请先确认机器人已上电")
+        if st.get("current_motion_task") != "joint_bridge":
+            return _err("WRONG_MOTION_STATE",
+                        f"当前运动状态为 {st.get('current_motion_task')}，关节透传需要 "
+                        f"joint_bridge（关节透传）模式，请先用 motion_switcher 切换。"
+                        f"危险操作，请确保安全吊架/清场")
+        return None
+
+    def _publish_cmd(self, positions: list) -> None:
+        if self._cmd_pub is None or self._JointCommand is None or self._Header is None:
+            return
+        try:
+            cmd = self._JointCommand()
+            cmd.header = self._Header()
+            cmd.header.stamp = self._node.get_clock().now().to_msg()
+            cmd.header.frame_id = ""
+            cmd.position = [float(p) for p in positions]
+            cmd.velocity = [0.0] * JOINT_COUNT
+            cmd.feed_forward_torque = [0.0] * JOINT_COUNT
+            cmd.torque = [0.0] * JOINT_COUNT
+            cmd.stiffness = self._stiffness
+            cmd.damping = self._damping
+            cmd.parallel_parser_type = 0    # CLASSIC_PARSER
+            self._cmd_pub.publish(cmd)
+        except Exception as e:  # noqa: BLE001
+            print(f"[JointBridgePlugin] 发布异常: {e}")
+
+    def _tick(self) -> None:
+        """500Hz 定时器：按插值轨迹逐拍发布 JointCommand。"""
+        with self._lock:
+            if self._interp is None:
+                return
+            idx = self._step_idx
+            last_idx = self._num_steps - 1
+            positions = [self._interp[j][idx if idx < last_idx else last_idx]
+                         for j in range(JOINT_COUNT)]
+            done = idx >= last_idx
+            if not done:
+                self._step_idx = idx + 1
+        self._publish_cmd(positions)
+        if done:
+            with self._lock:
+                self._interp = None
+                if self._timer is not None:
+                    try:
+                        self._timer.cancel()
+                    except Exception:  # noqa: BLE001
+                        pass
+                    self._timer = None
+            print("[JointBridgePlugin] 插值完成，已停止发布")
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            self.start()
+            return {"state": "ready"}
+        if action == "stop":
+            self.stop()
+            return {"state": "idle"}
+        if action == "info":
+            with self._lock:
+                running = self._interp is not None
+                step = self._step_idx
+            return {"state": "running" if running else "ready",
+                    "interp_step": step, "enabled": self._enabled}
+        if action == "set_pose":
+            if not self._enabled:
+                return _err("DISABLED",
+                            "joint_bridge 卡片默认关闭（config.yaml enabled: false），"
+                            "仅限专业人员启用后使用")
+            # 先做参数/数组长度校验（快速失败，避免被状态错误掩盖）
+            if "positions" not in args:
+                return _err("INVALID_ARGUMENT", "缺少 positions 参数（25 个关节目标位置）")
+            positions = [float(x) for x in args["positions"]]
+            if len(positions) != JOINT_COUNT:
+                return _err("INVALID_LENGTH",
+                            f"positions 长度必须为 {JOINT_COUNT}（J00~J24），当前 {len(positions)}")
+            stiffness = args.get("stiffness")
+            damping = args.get("damping")
+            if stiffness is not None:
+                stiffness = [float(x) for x in stiffness]
+                if len(stiffness) != JOINT_COUNT:
+                    return _err("INVALID_LENGTH",
+                                f"stiffness 长度必须为 {JOINT_COUNT}，当前 {len(stiffness)}")
+            else:
+                stiffness = list(_JB_DEFAULT_STIFFNESS)
+            if damping is not None:
+                damping = [float(x) for x in damping]
+                if len(damping) != JOINT_COUNT:
+                    return _err("INVALID_LENGTH",
+                                f"damping 长度必须为 {JOINT_COUNT}，当前 {len(damping)}")
+            else:
+                damping = list(_JB_DEFAULT_DAMPING)
+            try:
+                num_steps = max(2, int(args.get("num_steps", 1500)))
+            except (TypeError, ValueError):
+                return _err("INVALID_ARGUMENT", "num_steps 必须是整数")
+            # 运动状态前置检查（要求 joint_bridge 模式）
+            err = self._check_precondition()
+            if err:
+                return err
+            with self._lock:
+                cur = list(self._joint_positions) if self._joint_positions else None
+            if cur is None or len(cur) != JOINT_COUNT:
+                return _err("NO_STATE",
+                            "尚未收到 /hardware/joint_state（25 关节位置），无法确定插值起点")
+            # 官方公式: 步长 = (目标 - 当前) / (步数 - 1)
+            interp = []
+            for i in range(JOINT_COUNT):
+                delta = (positions[i] - cur[i]) / (num_steps - 1)
+                interp.append([cur[i] + delta * j for j in range(num_steps)])
+            with self._lock:
+                self._interp = interp
+                self._num_steps = num_steps
+                self._step_idx = 0
+                self._stiffness = stiffness
+                self._damping = damping
+                if self._timer is None and self._node is not None:
+                    self._timer = self._node.create_timer(self.CONTROL_PERIOD, self._tick)
+            print(f"[JointBridgePlugin] set_pose 开始: {num_steps} 步 @500Hz")
+            return {"state": "ok", "num_steps": num_steps,
+                    "positions": positions, "safety": "确认安全吊架/清场！"}
+        return None
+
+
+__all__ = [
+    "MotionStatePlugin",
+    "MotionSwitcherPlugin",
+    "LocoPlugin",
+    "ArmMotionPlugin",
+    "JointBridgePlugin",
+]

--- a/engineai/t800/plugins/peripherals.py
+++ b/engineai/t800/plugins/peripherals.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""
+engineai/t800/plugins/peripherals.py — T800 开发版外设卡片（LED / 麦克风 / 扬声器）。
+
+数据流:
+  LedPlugin      (actuator): dispatch → /hardware/led_control (domain 69, LedControl)
+  MicPlugin      (sensor):   ALSA/sounddevice 采集 → /{ns}/mic/audio (domain 42,
+                             audio_msgs/AudioChunk, format "audio/pcm-16k")
+  SpeakerPlugin  (actuator): 本地 sounddevice 播放 WAV 文件 / base64 PCM，无 ROS 话题
+
+音频协议硬约束（perception 层 ASR）: 16kHz 单声道 PCM_S16_LE，
+chunk 必须 ≥1024 字节（512 samples）—— 攒够 512 samples 才发布一个
+AudioChunk，低于该值会被 ASR 的 VAD 静默丢弃。
+
+模块级只 import 标准库；rclpy / audio_msgs / sounddevice / numpy 均在函数内
+延迟导入并 try/except 容错 —— 本机无 ROS2 环境且无声卡时模块可被纯 import 测试。
+"""
+
+from __future__ import annotations
+
+import base64
+import struct
+import threading
+import time
+
+
+def _resample_linear(samples, src_rate, dst_rate):
+    """线性插值重采样（纯 Python，不依赖 numpy）。48k→16k 时为 3 倍抽取。"""
+    n_in = len(samples)
+    if n_in < 2:
+        return samples
+    n_out = max(1, int(n_in * dst_rate / src_rate))
+    step = (n_in - 1) / float(n_out - 1) if n_out > 1 else 0.0
+    out = []
+    for i in range(n_out):
+        pos = i * step
+        i0 = int(pos)
+        frac = pos - i0
+        i1 = i0 + 1 if i0 + 1 < n_in else i0
+        out.append(int(round(samples[i0] * (1.0 - frac) + samples[i1] * frac)))
+    return out
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# LedPlugin (actuator) — 机身 LED 灯效, tool name="led"
+# ══════════════════════════════════════════════════════════════════════════════
+
+class LedPlugin:
+    """T800 机身 LED 灯效控制 (actuator, tool name="led")。
+
+    发布到 (domain 69): /hardware/led_control (interface_protocol/LedControl, 默认 QoS depth 10)
+    模式枚举: 11 种灯效中文名 → LedControl.color 常量 0x1~0xb；reset 发送 0 还原内置灯光。
+    """
+    PREFIX = "led"
+
+    # 中文名灯效 → LedControl.color 常量（官方 LedControl.msg）
+    _LED_MODES = {
+        "红闪": 0x1, "绿闪": 0x2, "蓝闪": 0x3, "白闪": 0x4,
+        "白常亮": 0x5, "绿常亮": 0x6, "白呼吸": 0x7, "白流水": 0x8,
+        "红呼吸": 0x9, "橙闪": 0xa, "橙常亮": 0xb,
+    }
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        self._plugin_config = plugin_config or {}
+        self._ns = namespace
+        self._ros2 = ros2
+        self._pub_node = None
+        self._pub = None
+        self._current_mode = None  # 当前灯效中文名（None = 未设置/已还原）
+        try:
+            self._pub_node = ros2.make_node_t800("t800_led_pub")
+        except Exception as e:  # noqa: BLE001
+            print(f"[LedPlugin] WARNING: 无 ROS2 环境 ({e})，stub 模式")
+            self._pub_node = None
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "led",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": (
+                "T800 机身 LED 灯效控制 — 11 种模式枚举"
+                "（红闪/绿闪/蓝闪/白闪/白常亮/绿常亮/白呼吸/白流水/红呼吸/橙闪/橙常亮），"
+                "reset 还原内置灯光。"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["set", "reset"],
+                        "description": "要执行的操作",
+                    },
+                    "mode": {
+                        "type": "string",
+                        "enum": list(self._LED_MODES),
+                        "description": "灯效模式（中文名）",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "set": {"params": ["mode"], "description": "设置 LED 灯效模式"},
+                    "reset": {"params": [], "description": "还原内置灯光"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        """创建 LED 控制话题发布者（幂等）。"""
+        try:
+            from rclpy.qos import QoSProfile
+            from ros2 import T800_TOPICS
+            if self._pub_node is None:
+                self._pub_node = self._ros2.make_node_t800("t800_led_pub")
+            if self._pub is None:
+                from interface_protocol.msg import LedControl
+                topic = T800_TOPICS.get("led", "/hardware/led_control")
+                self._pub = self._pub_node.create_publisher(
+                    LedControl, topic, QoSProfile(depth=10))  # 官方示例默认 QoS
+        except Exception as e:  # noqa: BLE001
+            print(f"[LedPlugin] WARNING: 发布者创建失败 ({e})，stub 模式")
+
+    def stop(self) -> None:
+        pass
+
+    def _publish(self, color: int) -> None:
+        if self._pub is None:
+            print("[LedPlugin] 发布者不可用（stub 模式），忽略 LED 指令")
+            return
+        try:
+            from interface_protocol.msg import LedControl
+            msg = LedControl()
+            msg.color = int(color)
+            self._pub.publish(msg)
+        except Exception as e:  # noqa: BLE001
+            print(f"[LedPlugin] 发布失败: {e}")
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            self.start()
+            return {"state": "ready"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "info":
+            return {"state": "ready", "mode": self._current_mode,
+                    "modes": list(self._LED_MODES)}
+        if action == "set":
+            mode = args.get("mode", "")
+            color = self._LED_MODES.get(mode)
+            if color is None:
+                return {"state": "error", "error": "INVALID_MODE",
+                        "message": f"未知灯效: {mode}，可选: {'/'.join(self._LED_MODES)}"}
+            self._publish(color)
+            self._current_mode = mode
+            return {"state": "ok", "mode": mode, "color": color}
+        if action == "reset":
+            self._publish(0)
+            self._current_mode = None
+            return {"state": "ok", "mode": "还原"}
+        return {"state": "error", "error": "INVALID_ARGUMENT",
+                "message": f"未知 action: {action}"}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# MicPlugin (sensor) — 内置麦克风采集, tool name="mic", readOnly
+# ══════════════════════════════════════════════════════════════════════════════
+
+class MicPlugin:
+    """T800 内置麦克风采集 → domain42 AudioChunk (audio/pcm-16k)。
+
+    采集: sounddevice.InputStream 请求 16kHz 单声道 int16；
+          设备不支持 16k 时回退 48k + 手动线性重采样到 16k。
+    缓冲: 内部攒够 512 samples (1024 字节) 才发布一个 AudioChunk
+          —— ASR VAD 硬约束，低于 1024 字节的 chunk 会被静默丢弃。
+    发布: (domain 42) /{ns}/mic/audio (audio_msgs/AudioChunk)。
+    无声卡/无 sounddevice 时 start 返回 error，dispatch 以中文 message 提示。
+    """
+    PREFIX = "mic"
+    _CHUNK_SAMPLES = 512   # 每 chunk 采样数 (16kHz)
+    _CHUNK_BYTES = 1024    # 1024 字节
+    _FLUSH_INTERVAL = 0.05  # 缓冲线程轮询周期 (s)
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        self._plugin_config = plugin_config or {}
+        self._ns = namespace
+        self._ros2 = ros2
+        self._topic = f"/{namespace}/mic/audio"
+        self._running = False
+        self._stream = None
+        self._sd = None
+        self._sd_error = ""
+        self._sr = 16000
+        self._resampling = False
+        self._buf_lock = threading.Lock()
+        self._buf = bytearray()          # int16 LE 样本缓冲
+        self._pub_node = None
+        self._pub = None
+        self._AudioChunk = None
+        self._Header = None
+        self._thread = None
+        self._samples_published = 0
+        try:
+            from audio_msgs.msg import AudioChunk
+            from std_msgs.msg import Header
+            from ros2 import QOS_CORE
+            self._AudioChunk = AudioChunk
+            self._Header = Header
+            self._pub_node = ros2.make_node_core("t800_mic_pub")
+            self._pub = self._pub_node.create_publisher(AudioChunk, self._topic, QOS_CORE)
+        except Exception as e:  # noqa: BLE001
+            print(f"[MicPlugin] WARNING: 无 ROS2 环境 ({e})，stub 模式")
+            self._AudioChunk = None
+            self._Header = None
+            self._pub_node = None
+            self._pub = None
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "mic",
+            "type": "sensor",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": (
+                "T800 内置麦克风 — 16kHz 单声道 PCM_S16_LE 采集，"
+                "重采样并缓冲为 1024 字节/块发布到 " + self._topic +
+                " (audio/pcm-16k)，满足 perception ASR 协议"
+            ),
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._topic, "format": "audio/pcm-16k"}],
+        }
+
+    def start(self) -> str:
+        """打开采集流并开始发布。返回 "ok" 表示成功，否则返回中文错误描述。"""
+        if self._stream is not None:
+            return "ok"
+        try:
+            import sounddevice as sd
+            self._sd = sd
+        except Exception as e:  # noqa: BLE001
+            return f"sounddevice 不可用: {e}"
+        # 首选 16kHz；失败回退 48kHz + 手动线性重采样到 16kHz
+        last_err = None
+        for sr, resampling in ((16000, False), (48000, True)):
+            try:
+                self._stream = self._sd.InputStream(
+                    samplerate=sr, channels=1, dtype="int16",
+                    blocksize=sr // 20, callback=self._on_audio)
+                # 先设置采样率/重采样标志再 start()：声卡线程可能在 start 后立刻触发
+                # 首个回调，若标志未就绪会把 48kHz 样本当作 16k 直接缓冲发布
+                self._sr = sr
+                self._resampling = resampling
+                self._stream.start()
+                break
+            except Exception as e:  # noqa: BLE001
+                self._stream = None
+                last_err = e
+        if self._stream is None:
+            return f"打开声卡失败（无可用录音设备）: {last_err}"
+        self._running = True
+        self._thread = threading.Thread(target=self._flush_loop, daemon=True)
+        self._thread.start()
+        print(f"[MicPlugin] 采集启动 sr={self._sr} resample={self._resampling}")
+        return "ok"
+
+    def stop(self) -> None:
+        """停止采集并释放声卡资源。"""
+        self._running = False
+        if self._stream is not None:
+            try:
+                self._stream.stop()
+                self._stream.close()
+            except Exception as e:  # noqa: BLE001
+                print(f"[MicPlugin] 关闭采集流失败: {e}")
+            self._stream = None
+
+    def _on_audio(self, indata, frames, time_info, status):
+        """sounddevice 采集回调（音频线程内执行，只缓冲不发布）。"""
+        try:
+            samples = indata[:, 0].tolist()  # 单声道 int16 样本
+            if self._resampling:
+                samples = _resample_linear(samples, self._sr, 16000)
+            with self._buf_lock:
+                self._buf.extend(struct.pack(f"<{len(samples)}h", *samples))
+        except Exception as e:  # noqa: BLE001
+            print(f"[MicPlugin] 采集回调错误: {e}")
+
+    def _flush_loop(self) -> None:
+        """后台线程：把缓冲的样本按 1024 字节一块切出来发布。"""
+        while self._running:
+            try:
+                if self._pub is None or self._AudioChunk is None:
+                    time.sleep(self._FLUSH_INTERVAL)
+                    continue
+                with self._buf_lock:
+                    buf = self._buf
+                    self._buf = bytearray()
+                while len(buf) >= self._CHUNK_BYTES:
+                    chunk = bytes(buf[:self._CHUNK_BYTES])
+                    buf = buf[self._CHUNK_BYTES:]
+                    self._publish_chunk(chunk)
+                if buf:
+                    # 不足一个 chunk 的残尾写回缓冲，跨轮继续累积（避免采样丢失）
+                    with self._buf_lock:
+                        self._buf = buf + self._buf
+            except Exception as e:  # noqa: BLE001
+                print(f"[MicPlugin] 缓冲线程错误: {e}")
+            time.sleep(self._FLUSH_INTERVAL)
+
+    def _publish_chunk(self, chunk: bytes) -> None:
+        try:
+            msg = self._AudioChunk()
+            msg.header = self._Header()
+            msg.header.stamp = self._pub_node.get_clock().now().to_msg()
+            msg.format = "audio/pcm-16k"
+            msg.data = list(chunk)
+            self._pub.publish(msg)
+            self._samples_published += len(chunk) // 2
+        except Exception as e:  # noqa: BLE001
+            print(f"[MicPlugin] 发布失败: {e}")
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            err = self.start()
+            if err == "ok":
+                return {"state": "running", "message": "麦克风采集已启动"}
+            return {"state": "error", "error": "AUDIO_CAPTURE_FAILED", "message": err}
+        if action == "stop":
+            self.stop()
+            return {"state": "idle"}
+        if action == "info":
+            return {"state": "running" if self._running else "idle",
+                    "topic_out": [{"topic": self._topic, "format": "audio/pcm-16k"}],
+                    "samples_published": self._samples_published}
+        return {"state": "error", "error": "INVALID_ARGUMENT",
+                "message": f"未知 action: {action}"}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SpeakerPlugin (actuator) — 扬声器播放, tool name="speaker"
+# ══════════════════════════════════════════════════════════════════════════════
+
+class SpeakerPlugin:
+    """T800 扬声器播放 (actuator, tool name="speaker")。
+
+    用 sounddevice 在后台线程播放 WAV 文件或 base64 编码的 PCM_S16_LE 数据；
+    无 ROS 话题。本机开发无 T800 声卡时返回 error 容错。
+    """
+    PREFIX = "speaker"
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        self._plugin_config = plugin_config or {}
+        self._ns = namespace
+        self._ros2 = ros2
+        self._lock = threading.Lock()
+        self._state = "idle"          # idle / playing
+        self._current = None          # 当前播放来源（文件路径 或 "pcm-data"）
+        self._sd = None               # sounddevice 模块（延迟导入）
+        self._sd_error = ""
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "speaker",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "T800 扬声器 — 播放 WAV 文件 / base64 PCM 音频数据",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["play_file", "play_wav", "stop", "list_devices"],
+                        "description": "要执行的操作",
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "要播放的 WAV 文件路径",
+                    },
+                    "data": {
+                        "type": "string",
+                        "description": "base64 编码的 PCM_S16_LE 音频数据",
+                    },
+                    "sample_rate": {
+                        "type": "integer",
+                        "description": "PCM 采样率 (Hz)，默认 16000",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "play_file": {"params": ["path"], "description": "播放本地 WAV 文件"},
+                    "play_wav": {"params": ["data", "sample_rate"],
+                                 "description": "播放 base64 编码的 PCM_S16_LE 音频"},
+                    "stop": {"params": [], "description": "停止当前播放"},
+                    "list_devices": {"params": [], "description": "列出可用音频输出设备"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        """停止当前播放。"""
+        if self._sd is not None:
+            try:
+                self._sd.stop()
+            except Exception:  # noqa: BLE001
+                pass
+        with self._lock:
+            self._state = "idle"
+            self._current = None
+
+    def _get_sd(self):
+        """延迟导入 sounddevice；失败返回 None 并记录原因。"""
+        if self._sd is None:
+            try:
+                import sounddevice as sd
+                self._sd = sd
+            except Exception as e:  # noqa: BLE001
+                self._sd_error = f"sounddevice 不可用: {e}"
+                return None
+        return self._sd
+
+    def _start_play(self, sd, data, sr, source) -> None:
+        """后台线程播放（sd.play 非阻塞，wait 在后台线程等待结束）。"""
+        def worker():
+            try:
+                with self._lock:
+                    self._state = "playing"
+                    self._current = source
+                sd.play(data, sr)
+                sd.wait()
+            except Exception as e:  # noqa: BLE001
+                print(f"[SpeakerPlugin] 播放错误: {e}")
+            finally:
+                with self._lock:
+                    self._state = "idle"
+                    self._current = None
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _play_file(self, path: str) -> dict:
+        sd = self._get_sd()
+        if sd is None:
+            return {"state": "error", "error": "AUDIO_UNAVAILABLE",
+                    "message": self._sd_error}
+        try:
+            import wave
+            import numpy as np
+        except ImportError as e:  # noqa: BLE001
+            return {"state": "error", "error": "AUDIO_UNAVAILABLE",
+                    "message": f"缺少播放依赖 (numpy): {e}"}
+        try:
+            with wave.open(path, "rb") as wf:
+                sr = wf.getframerate()
+                channels = wf.getnchannels()
+                sampwidth = wf.getsampwidth()
+                frames = wf.readframes(wf.getnframes())
+            if sampwidth != 2:
+                return {"state": "error", "error": "UNSUPPORTED_FORMAT",
+                        "message": "仅支持 16bit PCM WAV"}
+            data = np.frombuffer(frames, dtype=np.int16)
+            if channels > 1:
+                # 多声道取平均混为单声道
+                data = data.reshape(-1, channels).mean(axis=1).astype(np.int16)
+            if len(data) == 0:
+                return {"state": "error", "error": "LOAD_FAILED",
+                        "message": f"文件无音频数据: {path}"}
+        except Exception as e:  # noqa: BLE001
+            return {"state": "error", "error": "LOAD_FAILED",
+                    "message": f"读取 WAV 失败: {e}"}
+        self._start_play(sd, data, sr, path)
+        return {"state": "playing", "file": path, "sample_rate": sr}
+
+    def _play_wav(self, b64data: str, sample_rate) -> dict:
+        sd = self._get_sd()
+        if sd is None:
+            return {"state": "error", "error": "AUDIO_UNAVAILABLE",
+                    "message": self._sd_error}
+        if not b64data:
+            return {"state": "error", "error": "INVALID_ARGUMENT",
+                    "message": "缺少 data 参数（base64 编码的 PCM 数据）"}
+        try:
+            import numpy as np
+        except ImportError as e:  # noqa: BLE001
+            return {"state": "error", "error": "AUDIO_UNAVAILABLE",
+                    "message": f"缺少播放依赖 (numpy): {e}"}
+        try:
+            pcm = base64.b64decode(b64data)
+            sr = int(sample_rate or 16000)
+            if sr <= 0:
+                raise ValueError("sample_rate 必须为正整数")
+            data = np.frombuffer(pcm, dtype=np.int16)
+            if len(data) == 0:
+                return {"state": "error", "error": "INVALID_ARGUMENT",
+                        "message": "解码后无音频数据"}
+        except Exception as e:  # noqa: BLE001
+            return {"state": "error", "error": "INVALID_ARGUMENT",
+                    "message": f"解码 PCM 失败: {e}"}
+        self._start_play(sd, data, sr, "pcm-data")
+        return {"state": "playing", "sample_rate": sr, "samples": int(len(data))}
+
+    def _list_devices(self) -> dict:
+        sd = self._get_sd()
+        if sd is None:
+            return {"state": "error", "error": "AUDIO_UNAVAILABLE",
+                    "message": self._sd_error}
+        try:
+            devices = sd.query_devices()
+            rows = [
+                {
+                    "index": i,
+                    "name": dev.get("name", "?"),
+                    "max_output_channels": int(dev.get("max_output_channels", 0)),
+                }
+                for i, dev in enumerate(devices)
+            ]
+            return {"devices": rows, "count": len(rows)}
+        except Exception as e:  # noqa: BLE001
+            return {"state": "error", "error": "AUDIO_UNAVAILABLE",
+                    "message": f"查询设备失败: {e}"}
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "stop":
+            self.stop()
+            return {"state": "idle"}
+        if action == "info":
+            with self._lock:
+                state = self._state
+                current = self._current
+            return {"state": state, "current": current}
+        if action == "play_file":
+            path = args.get("path", "")
+            if not path:
+                return {"state": "error", "error": "INVALID_ARGUMENT",
+                        "message": "缺少 path 参数"}
+            return self._play_file(path)
+        if action == "play_wav":
+            return self._play_wav(args.get("data", ""), args.get("sample_rate"))
+        if action == "list_devices":
+            return self._list_devices()
+        return {"state": "error", "error": "INVALID_ARGUMENT",
+                "message": f"未知 action: {action}"}

--- a/engineai/t800/plugins/sensors.py
+++ b/engineai/t800/plugins/sensors.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""
+engineai/t800/plugins/sensors.py — T800 开发版传感器转发卡片。
+
+数据流（双 context 转发模式，参照 x-humanoid/tianyi2.0 MotorStatePlugin）:
+  domain 69（机器人, CycloneDDS）订阅 →
+    缓存最新一帧 → 定时 JSON 序列化 →
+  domain 42（core, FastDDS）发布 std_msgs/String, format "data/json":
+
+    /hardware/joint_state   → JointsStatePlugin → /{ns}/state/joints  (2Hz)
+    /hardware/imu_info      → ImuPlugin         → /{ns}/state/imu     (10Hz)
+    /hardware/power_info    → PowerPlugin       → /{ns}/state/power   (1Hz)
+    /hardware/gamepad_keys  → GamepadPlugin     → /{ns}/state/gamepad (10Hz)
+
+订阅 QoS 用 QOS_T800_BEST_EFFORT（官方 BEST_EFFORT/VOLATILE depth 1），
+发布 QoS 用 QOS_CORE（core 域 depth 10 BEST_EFFORT），常量与话题表来自
+同目录 ros2.py（Ros2Contexts / QOS_* / T800_TOPICS）。
+
+模块级只 import 标准库；rclpy / interface_protocol / ros2 均在 __init__/start()
+内延迟导入并 try/except 容错 —— 本机无 ROS2 环境时模块可被纯 import 测试。
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 常量表（官方索引 / 部位划分）
+# ══════════════════════════════════════════════════════════════════════════════
+
+# T800 开发版 25 自由度官方语义名（索引 0~24）
+_JOINT_NAMES = [
+    "J00_HIP_PITCH_L", "J01_HIP_ROLL_L", "J02_HIP_YAW_L", "J03_KNEE_PITCH_L",
+    "J04_ANKLE_PITCH_L", "J05_ANKLE_ROLL_L", "J06_HIP_PITCH_R", "J07_HIP_ROLL_R",
+    "J08_HIP_YAW_R", "J09_KNEE_PITCH_R", "J10_ANKLE_PITCH_R", "J11_ANKLE_ROLL_R",
+    "J12_TORSO_YAW",
+    "J13_SHOULDER_PITCH_L", "J14_SHOULDER_ROLL_L", "J15_SHOULDER_YAW_L",
+    "J16_ELBOW_PITCH_L", "J17_ELBOW_YAW_L",
+    "J18_SHOULDER_PITCH_R", "J19_SHOULDER_ROLL_R", "J20_SHOULDER_YAW_R",
+    "J21_ELBOW_PITCH_R", "J22_ELBOW_YAW_R",
+    "J23_HEAD_PITCH", "J24_HEAD_YAW",
+]
+
+# 部位划分: 左腿 0-5 / 右腿 6-11 / 腰 12 / 左臂 13-17 / 右臂 18-22 / 头 23-24
+_JOINT_PARTS = [
+    ("leg_left", [0, 1, 2, 3, 4, 5]),
+    ("leg_right", [6, 7, 8, 9, 10, 11]),
+    ("waist", [12]),
+    ("arm_left", [13, 14, 15, 16, 17]),
+    ("arm_right", [18, 19, 20, 21, 22]),
+    ("head", [23, 24]),
+]
+
+_PART_LABELS = {
+    "leg_left": "左腿 (6DOF)",
+    "leg_right": "右腿 (6DOF)",
+    "waist": "腰 (1DOF)",
+    "arm_left": "左臂 (5DOF)",
+    "arm_right": "右臂 (5DOF)",
+    "head": "头 (2DOF)",
+}
+
+# 手柄按键/摇杆语义名（官方 GamepadKeys 常量表）
+_GAMEPAD_DIGITAL_KEYS = [
+    "LB", "RB", "A", "B", "X", "Y", "BACK", "START",
+    "CROSS_X_UP", "CROSS_X_DOWN", "CROSS_Y_LEFT", "CROSS_Y_RIGHT",
+]
+_GAMEPAD_ANALOG_KEYS = [
+    "LT", "RT", "LEFT_STICK_X", "LEFT_STICK_Y", "RIGHT_STICK_X", "RIGHT_STICK_Y",
+]
+
+
+class _JsonSensorBridge:
+    """domain 69 订阅 → domain 42 JSON 转发的传感器公共基类。
+
+    子类只需声明 _tool_name/_tool_description/_topics_key/_default_topic/
+    _out_suffix/_node_tag/_interval 类属性，并实现 _import_msg_type/_on_msg/_produce。
+    无 ROS2 环境时进入 stub 模式（节点/发布者为 None），模块仍可正常导入。
+    """
+
+    _format = "data/json"
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        self._plugin_config = plugin_config or {}
+        self._ns = namespace
+        self._ros2 = ros2
+        self._topic = f"/{namespace}/{self._out_suffix}"
+        self._running = False
+        self._lock = threading.Lock()
+        self._latest = None            # 最新一帧解析后的 dict（None = 无数据）
+        self._sub_node = None
+        self._pub_node = None
+        self._pub = None
+        self._sub = None
+        self._thread = None
+        self._String = None
+        try:
+            from std_msgs.msg import String
+            from ros2 import QOS_CORE
+            self._String = String
+            self._pub_node = ros2.make_node_core(f"t800_{self._node_tag}_pub")
+            self._pub = self._pub_node.create_publisher(String, self._topic, QOS_CORE)
+            self._sub_node = ros2.make_node_t800(f"t800_{self._node_tag}_sub")
+        except Exception as e:  # noqa: BLE001
+            print(f"[{self.__class__.__name__}] WARNING: 无 ROS2 环境 ({e})，stub 模式")
+            self._String = None
+            self._pub_node = None
+            self._pub = None
+            self._sub_node = None
+
+    def get_tool(self) -> dict:
+        return {
+            "name": self._tool_name,
+            "type": "sensor",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": self._tool_description,
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._topic, "format": self._format}],
+        }
+
+    def start(self) -> None:
+        """创建订阅并启动转发线程（幂等，可重复调用）。"""
+        self._running = True
+        if self._sub is None and self._sub_node is not None:
+            try:
+                from ros2 import QOS_T800_BEST_EFFORT, T800_TOPICS
+                msg_cls = self._import_msg_type()
+                topic = T800_TOPICS.get(self._topics_key, self._default_topic)
+                self._sub = self._sub_node.create_subscription(
+                    msg_cls, topic, self._on_msg, QOS_T800_BEST_EFFORT)
+                print(f"[{self.__class__.__name__}] 已订阅 {topic}")
+            except Exception as e:  # noqa: BLE001
+                print(f"[{self.__class__.__name__}] WARNING: 订阅创建失败 ({e})，stub 模式")
+        if self._thread is None or not self._thread.is_alive():
+            self._thread = threading.Thread(target=self._publish_loop, daemon=True)
+            self._thread.start()
+
+    def stop(self) -> None:
+        self._running = False
+
+    def _publish_loop(self) -> None:
+        """定时把最新一帧数据序列化为 String JSON 发布到 core 域。"""
+        while self._running:
+            payload = self._produce()
+            if payload is not None and self._pub is not None and self._String is not None:
+                try:
+                    msg = self._String()
+                    msg.data = json.dumps(payload, ensure_ascii=False)
+                    self._pub.publish(msg)
+                except Exception as e:  # noqa: BLE001
+                    print(f"[{self.__class__.__name__}] 发布失败: {e}")
+            time.sleep(self._interval)
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            self.start()
+            return {"state": "running"}
+        if action == "stop":
+            self.stop()
+            return {"state": "idle"}
+        if action == "info":
+            return {"state": "running" if self._running else "idle",
+                    "topic_out": [{"topic": self._topic, "format": self._format}]}
+        if action in ("read", "get"):
+            payload = self._produce()
+            if payload is None:
+                return {"state": "error", "error": "NO_FEEDBACK",
+                        "message": "尚未收到该传感器数据"}
+            return payload
+        return {"state": "error", "error": "INVALID_ARGUMENT",
+                "message": f"未知 action: {action}"}
+
+    # ── 子类实现 ───────────────────────────────────────────────────────────────
+    def _import_msg_type(self):
+        """延迟导入并返回 ROS2 消息类型。"""
+        raise NotImplementedError
+
+    def _on_msg(self, msg):
+        """订阅回调：解析并缓存最新一帧。"""
+        raise NotImplementedError
+
+    def _produce(self) -> dict | None:
+        """返回要发布的 JSON 字典；无数据返回 None。"""
+        raise NotImplementedError
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# JointsStatePlugin (sensor) — 全身 25 关节状态, tool name="joints", 2Hz
+# ══════════════════════════════════════════════════════════════════════════════
+
+class JointsStatePlugin(_JsonSensorBridge):
+    """T800 全身 25 关节状态 — 按部位聚合转发 (2Hz)。
+
+    数据源 (domain 69): /hardware/joint_state → interface_protocol/JointState
+    发布到 (domain 42): /{ns}/state/joints (std_msgs/String JSON, data/json)
+    部位: leg_left(0-5)/leg_right(6-11)/waist(12)/arm_left(13-17)/arm_right(18-22)/head(23-24)
+    """
+    PREFIX = "joints"
+    _tool_name = "joints"
+    _out_suffix = "state/joints"
+    _topics_key = "joint_state"
+    _default_topic = "/hardware/joint_state"
+    _node_tag = "joints"
+    _interval = 0.5  # 2Hz
+    _tool_description = (
+        "T800 全身 25 关节状态（按部位聚合, 2Hz）。"
+        "部位: leg_left(6DOF)/leg_right(6DOF)/waist(1DOF)/arm_left(5DOF)/arm_right(5DOF)/head(2DOF)。"
+        "每关节: name=官方语义名(J00~J24), q=角度(rad), dq=速度(rad/s), tau=力矩(Nm)。"
+    )
+
+    def _import_msg_type(self):
+        from interface_protocol.msg import JointState
+        return JointState
+
+    def _on_msg(self, msg):
+        try:
+            position = list(getattr(msg, "position", None) or [])
+            velocity = list(getattr(msg, "velocity", None) or [])
+            torque = list(getattr(msg, "torque", None) or [])
+            if not position:
+                return  # 空数组视为无数据
+            with self._lock:
+                self._latest = {
+                    "position": position,
+                    "velocity": velocity,
+                    "torque": torque,
+                }
+        except Exception as e:  # noqa: BLE001
+            print(f"[JointsStatePlugin] 回调解析失败: {e}")
+
+    def _produce(self) -> dict | None:
+        with self._lock:
+            raw = self._latest
+        if raw is None:
+            return None
+        position = raw["position"]
+        velocity = raw["velocity"]
+        torque = raw["torque"]
+        n = len(position)
+        parts = {}
+        for part_key, idxs in _JOINT_PARTS:
+            joints = []
+            for idx in idxs:
+                if idx >= n:
+                    continue
+                joints.append({
+                    "idx": idx,
+                    "name": _JOINT_NAMES[idx],
+                    "q": round(position[idx], 6),
+                    "dq": round(velocity[idx], 6) if idx < len(velocity) else 0.0,
+                    "tau": round(torque[idx], 6) if idx < len(torque) else 0.0,
+                })
+            parts[part_key] = {
+                "count": len(joints),
+                "label": _PART_LABELS[part_key],
+                "joints": joints,
+            }
+        return {"parts": parts, "timestamp_ms": int(time.time() * 1000)}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ImuPlugin (sensor) — 机身 IMU, tool name="imu", 10Hz
+# ══════════════════════════════════════════════════════════════════════════════
+
+class ImuPlugin(_JsonSensorBridge):
+    """T800 机身 IMU — 四元数/RPY/加速度/角速度转发 (10Hz)。
+
+    数据源 (domain 69): /hardware/imu_info → interface_protocol/ImuInfo
+    发布到 (domain 42): /{ns}/state/imu (std_msgs/String JSON, data/json)
+    """
+    PREFIX = "imu"
+    _tool_name = "imu"
+    _out_suffix = "state/imu"
+    _topics_key = "imu"
+    _default_topic = "/hardware/imu_info"
+    _node_tag = "imu"
+    _interval = 0.1  # 10Hz
+    _tool_description = (
+        "T800 机身 IMU 姿态与运动信息 (10Hz)。"
+        "quaternion=[w,x,y,z], rpy={roll,pitch,yaw}(rad), "
+        "linear_acceleration={x,y,z}(m/s²), angular_velocity={x,y,z}(rad/s)。"
+    )
+
+    def _import_msg_type(self):
+        from interface_protocol.msg import ImuInfo
+        return ImuInfo
+
+    def _on_msg(self, msg):
+        try:
+            payload = {
+                "quaternion": [
+                    round(msg.quaternion.w, 6), round(msg.quaternion.x, 6),
+                    round(msg.quaternion.y, 6), round(msg.quaternion.z, 6),
+                ],
+                "rpy": {
+                    "roll": round(msg.rpy.x, 6),
+                    "pitch": round(msg.rpy.y, 6),
+                    "yaw": round(msg.rpy.z, 6),
+                },
+                "linear_acceleration": {
+                    "x": round(msg.linear_acceleration.x, 6),
+                    "y": round(msg.linear_acceleration.y, 6),
+                    "z": round(msg.linear_acceleration.z, 6),
+                },
+                "angular_velocity": {
+                    "x": round(msg.angular_velocity.x, 6),
+                    "y": round(msg.angular_velocity.y, 6),
+                    "z": round(msg.angular_velocity.z, 6),
+                },
+            }
+            with self._lock:
+                self._latest = payload
+        except Exception as e:  # noqa: BLE001
+            print(f"[ImuPlugin] 回调解析失败: {e}")
+
+    def _produce(self) -> dict | None:
+        with self._lock:
+            payload = self._latest
+        if payload is None:
+            return None
+        return {**payload, "timestamp_ms": int(time.time() * 1000)}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# PowerPlugin (sensor) — 电源状态, tool name="power", 1Hz
+# ══════════════════════════════════════════════════════════════════════════════
+
+class PowerPlugin(_JsonSensorBridge):
+    """T800 电源状态 — 电量/电压/电流转发 (1Hz)。
+
+    数据源 (domain 69): /hardware/power_info → interface_protocol/PowerInfo
+    发布到 (domain 42): /{ns}/state/power (std_msgs/String JSON, data/json)
+    """
+    PREFIX = "power"
+    _tool_name = "power"
+    _out_suffix = "state/power"
+    _topics_key = "power"
+    _default_topic = "/hardware/power_info"
+    _node_tag = "power"
+    _interval = 1.0  # 1Hz
+    _tool_description = (
+        "T800 电源状态 (1Hz)。enable=电源使能, percentage=电量(%), "
+        "voltage=电压(V), current=电流(A), current_limit=限流(A), error_code=故障码。"
+    )
+
+    def _import_msg_type(self):
+        from interface_protocol.msg import PowerInfo
+        return PowerInfo
+
+    def _on_msg(self, msg):
+        try:
+            payload = {
+                "enable": bool(getattr(msg, "enable", False)),
+                "percentage": round(float(getattr(msg, "percentage", 0.0)), 4),
+                "voltage": round(float(getattr(msg, "voltage", 0.0)), 4),
+                "current": round(float(getattr(msg, "current", 0.0)), 4),
+                "current_limit": round(float(getattr(msg, "current_limit", 0.0)), 4),
+                "error_code": int(getattr(msg, "error_code", 0)),
+            }
+            with self._lock:
+                self._latest = payload
+        except Exception as e:  # noqa: BLE001
+            print(f"[PowerPlugin] 回调解析失败: {e}")
+
+    def _produce(self) -> dict | None:
+        with self._lock:
+            payload = self._latest
+        if payload is None:
+            return None
+        return {**payload, "timestamp_ms": int(time.time() * 1000)}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# GamepadPlugin (sensor) — 手柄状态, tool name="gamepad", 10Hz
+# ══════════════════════════════════════════════════════════════════════════════
+
+class GamepadPlugin(_JsonSensorBridge):
+    """T800 手柄状态 — 数字按键 + 模拟摇杆转发 (10Hz)。
+
+    数据源 (domain 69): /hardware/gamepad_keys → interface_protocol/GamepadKeys
+    发布到 (domain 42): /{ns}/state/gamepad (std_msgs/String JSON, data/json)
+    """
+    PREFIX = "gamepad"
+    _tool_name = "gamepad"
+    _out_suffix = "state/gamepad"
+    _topics_key = "gamepad"
+    _default_topic = "/hardware/gamepad_keys"
+    _node_tag = "gamepad"
+    _interval = 0.1  # 10Hz
+    _tool_description = (
+        "T800 手柄状态 (10Hz)。digital_states: LB/RB/A/B/X/Y/BACK/START/十字键 (0/1), "
+        "analog_states: LT/RT/左右摇杆 x/y (-1~1)。"
+    )
+
+    def _import_msg_type(self):
+        from interface_protocol.msg import GamepadKeys
+        return GamepadKeys
+
+    def _on_msg(self, msg):
+        try:
+            digital = list(getattr(msg, "digital_states", None) or [])
+            analog = list(getattr(msg, "analog_states", None) or [])
+            payload = {
+                "hardware_connected": bool(getattr(msg, "hardware_connected", False)),
+                "digital_states": {
+                    key: int(digital[i]) if i < len(digital) else 0
+                    for i, key in enumerate(_GAMEPAD_DIGITAL_KEYS)
+                },
+                "analog_states": {
+                    key: round(float(analog[i]), 6) if i < len(analog) else 0.0
+                    for i, key in enumerate(_GAMEPAD_ANALOG_KEYS)
+                },
+            }
+            with self._lock:
+                self._latest = payload
+        except Exception as e:  # noqa: BLE001
+            print(f"[GamepadPlugin] 回调解析失败: {e}")
+
+    def _produce(self) -> dict | None:
+        with self._lock:
+            payload = self._latest
+        if payload is None:
+            return None
+        return {**payload, "timestamp_ms": int(time.time() * 1000)}

--- a/engineai/t800/requirements.txt
+++ b/engineai/t800/requirements.txt
@@ -1,0 +1,3 @@
+pyyaml>=6.0
+sounddevice>=0.4.6
+numpy>=1.24

--- a/engineai/t800/ros2.py
+++ b/engineai/t800/ros2.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+engineai/t800/ros2.py — 众擎 T800 开发版 driver 双 rclpy context 管理（骨架）。
+
+数据流：
+  ctx_t800  (domain 69, rmw_cyclonedds_cpp, ROS_LOCALHOST_ONLY=0)
+            —— 直连 T800 机器人运控单元，订阅/发布机器人话题
+            （/motion/*、/hardware/*）
+  ctx_core  (domain 42, rmw_fastrtps_cpp)
+            —— 与 agent-core / dashboard / perception 通信，
+            传感器转发插件通过 core 节点发布 /{ns}/xxx（std_msgs/String JSON）
+
+进程内 RMW 切换：每个 context 创建前设置环境变量
+（RMW_IMPLEMENTATION / ROS_DOMAIN_ID / ROS_LOCALHOST_ONLY），
+并在 rclpy.init 的 args 中显式传 __rmw 与 __domain_id remap 双重保证，
+创建完成后恢复原环境变量（与 x-humanoid/tianyi2.0 双 context 模式一致）。
+
+模块级只 import 标准库；rclpy 相关导入全部在方法内延迟进行，
+保证本模块在没有 ROS2 环境的机器上可被纯 import 测试。
+
+对外常量：
+  T800_TOPICS            —— 机器人侧话题名表（domain 69）
+  QOS_T800_RELIABLE      —— depth1 RELIABLE VOLATILE
+  QOS_T800_BEST_EFFORT   —— depth1 BEST_EFFORT VOLATILE
+  QOS_T800_JOINT         —— depth3 BEST_EFFORT VOLATILE（joint_state/joint_command 官方用）
+  QOS_CORE               —— depth10 BEST_EFFORT VOLATILE（core 域发布）
+  QOS_DEFAULT            —— depth10 默认 QoS（body_vel_cmd / led_control 官方用）
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+
+# ── 双域常量 ──────────────────────────────────────────────────────────────────
+
+T800_DOMAIN_ID = 69   # 机器人侧（运控单元）
+CORE_DOMAIN_ID = 42   # core 侧（agent-core / dashboard / perception）
+
+# 机器人侧话题（domain 69），消息类型见 interface_protocol/msg/*.msg
+T800_TOPICS = {
+    "motion_state":        "/motion/motion_state",              # MotionState
+    "set_motion_state":    "/motion/set_motion_state",          # MotionStateRequest
+    "joint_state":         "/hardware/joint_state",             # JointState
+    "joint_command":       "/hardware/joint_command",           # JointCommand
+    "body_vel_cmd":        "/motion/body_vel_cmd",              # BodyVelCmd
+    "motion_plan_request": "/motion/joint_motion_plan/request", # JointMotionPlanRequest
+    "motion_plan_state":   "/motion/joint_motion_plan/state",   # JointMotionPlanState
+    "led":                 "/hardware/led_control",             # LedControl
+    "imu":                 "/hardware/imu_info",                # ImuInfo
+    "power":               "/hardware/power_info",              # PowerInfo
+    "gamepad":             "/hardware/gamepad_keys",            # GamepadKeys
+}
+
+# ── 惰性 QoS 常量（首次访问时创建，避免模块级导入 rclpy）─────────────────────
+
+_QOS_PROFILES: dict = {}
+
+
+def _build_qos_profiles() -> dict:
+    """按官方例程（interface_example/scripts）创建 QoSProfile 常量表。"""
+    from rclpy.qos import (
+        DurabilityPolicy,
+        HistoryPolicy,
+        QoSProfile,
+        ReliabilityPolicy,
+    )
+    return {
+        # 官方规定：/motion/set_motion_state、/motion/joint_motion_plan/request 发布用
+        "QOS_T800_RELIABLE": QoSProfile(
+            depth=1,
+            reliability=ReliabilityPolicy.RELIABLE,
+            history=HistoryPolicy.KEEP_LAST,
+            durability=DurabilityPolicy.VOLATILE,
+        ),
+        # 官方规定：/motion/motion_state、/motion/joint_motion_plan/state 订阅用
+        "QOS_T800_BEST_EFFORT": QoSProfile(
+            depth=1,
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            history=HistoryPolicy.KEEP_LAST,
+            durability=DurabilityPolicy.VOLATILE,
+        ),
+        # 官方 joint 例程：/hardware/joint_state、/hardware/joint_command 用 depth 3
+        "QOS_T800_JOINT": QoSProfile(
+            depth=3,
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            history=HistoryPolicy.KEEP_LAST,
+            durability=DurabilityPolicy.VOLATILE,
+        ),
+        # core 域发布（/{ns}/xxx）：depth 10 BEST_EFFORT VOLATILE
+        "QOS_CORE": QoSProfile(
+            depth=10,
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            history=HistoryPolicy.KEEP_LAST,
+            durability=DurabilityPolicy.VOLATILE,
+        ),
+        # 官方默认 QoS（/motion/body_vel_cmd、/hardware/led_control 直接用 depth 10）
+        "QOS_DEFAULT": QoSProfile(depth=10),
+    }
+
+
+def __getattr__(name: str):
+    """PEP 562 惰性暴露 QOS_* 常量：首次访问时才 import rclpy 构造 QoSProfile。"""
+    global _QOS_PROFILES
+    if name in ("QOS_T800_RELIABLE", "QOS_T800_BEST_EFFORT",
+                "QOS_T800_JOINT", "QOS_CORE", "QOS_DEFAULT"):
+        if not _QOS_PROFILES:
+            _QOS_PROFILES = _build_qos_profiles()
+        return _QOS_PROFILES[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# ── 双 context 管理 ───────────────────────────────────────────────────────────
+
+
+class Ros2Contexts:
+    """T800 双 rclpy context 管理。
+
+    - ctx_t800：domain 69 + rmw_cyclonedds_cpp，直连机器人话题
+    - ctx_core：domain 42 + rmw_fastrtps_cpp，与 agent-core 通信
+    每个 context 配一个 SingleThreadedExecutor，start() 起两个 daemon spin 线程。
+    """
+
+    def __init__(self, namespace: str):
+        self.namespace = namespace
+        self.ctx_t800 = None
+        self.ctx_core = None
+        self.executor_t800 = None
+        self.executor_core = None
+        self._spin_threads: list = []
+        self._rclpy = None
+        self._init_contexts()
+
+    # ── 初始化 ─────────────────────────────────────────────────────────────
+
+    def _init_contexts(self) -> None:
+        """按 context 切换 RMW 实现并分别 rclpy.init（环境变量方案，与 tianyi2.0 一致）。"""
+        import rclpy
+        from rclpy.context import Context
+        from rclpy.executors import SingleThreadedExecutor
+        self._rclpy = rclpy
+
+        # 保存原环境变量，context 创建后恢复，避免影响进程内其他组件
+        saved = {
+            k: os.environ.get(k)
+            for k in ("RMW_IMPLEMENTATION", "ROS_DOMAIN_ID", "ROS_LOCALHOST_ONLY")
+        }
+        try:
+            # ctx_t800：domain 69 + CycloneDDS（机器人侧）
+            os.environ["RMW_IMPLEMENTATION"] = "rmw_cyclonedds_cpp"
+            os.environ["ROS_DOMAIN_ID"] = str(T800_DOMAIN_ID)
+            os.environ["ROS_LOCALHOST_ONLY"] = "0"
+            self.ctx_t800 = Context()
+            rclpy.init(
+                args=["--ros-args", "-r", f"__rmw:=rmw_cyclonedds_cpp",
+                      "-r", f"__domain_id:={T800_DOMAIN_ID}"],
+                context=self.ctx_t800,
+            )
+            self.executor_t800 = SingleThreadedExecutor(context=self.ctx_t800)
+
+            # ctx_core：domain 42 + FastDDS（core 侧；本地回环约束不强制）
+            os.environ["RMW_IMPLEMENTATION"] = "rmw_fastrtps_cpp"
+            os.environ["ROS_DOMAIN_ID"] = str(CORE_DOMAIN_ID)
+            os.environ.pop("ROS_LOCALHOST_ONLY", None)
+            self.ctx_core = Context()
+            rclpy.init(
+                args=["--ros-args", "-r", f"__rmw:=rmw_fastrtps_cpp",
+                      "-r", f"__domain_id:={CORE_DOMAIN_ID}"],
+                context=self.ctx_core,
+            )
+            self.executor_core = SingleThreadedExecutor(context=self.ctx_core)
+        finally:
+            for k, v in saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+    # ── 节点创建 ───────────────────────────────────────────────────────────
+
+    def make_node_t800(self, name: str):
+        """在 ctx_t800（domain 69 / CycloneDDS）创建节点并加入 executor_t800。"""
+        node = self._rclpy.node.Node(name, context=self.ctx_t800)
+        self.executor_t800.add_node(node)
+        return node
+
+    def make_node_core(self, name: str):
+        """在 ctx_core（domain 42 / FastDDS）创建节点并加入 executor_core。"""
+        node = self._rclpy.node.Node(name, context=self.ctx_core)
+        self.executor_core.add_node(node)
+        return node
+
+    # ── 生命周期 ───────────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """两个 executor 各起 daemon 线程 spin。"""
+        def _spin(executor, label: str) -> None:
+            try:
+                while self._rclpy.ok(context=executor.context):
+                    executor.spin_once(timeout_sec=0.1)
+            except Exception as e:
+                print(f"[ros2] {label} spin error: {e}", flush=True)
+            print(f"[ros2] {label} spin exited", flush=True)
+
+        t1 = threading.Thread(target=_spin, args=(self.executor_t800, "t800(69)"), daemon=True)
+        t2 = threading.Thread(target=_spin, args=(self.executor_core, "core(42)"), daemon=True)
+        t1.start()
+        t2.start()
+        self._spin_threads = [t1, t2]
+
+    def shutdown(self) -> None:
+        """销毁节点、executor 与 context（幂等，异常吞掉）。"""
+        for ex in (self.executor_t800, self.executor_core):
+            if ex is None:
+                continue
+            # 尽力销毁已注册节点（插件 stop() 已销毁的节点此处会静默跳过）
+            for node in list(getattr(ex, "_nodes", []) or []):
+                try:
+                    node.destroy_node()
+                except Exception:
+                    pass
+            try:
+                ex.shutdown()
+            except Exception:
+                pass
+        if self._rclpy is not None:
+            for ctx in (self.ctx_t800, self.ctx_core):
+                try:
+                    self._rclpy.shutdown(context=ctx)
+                except Exception:
+                    pass
+        print("[ros2] contexts shut down", flush=True)

--- a/unitree/g1/Dockerfile
+++ b/unitree/g1/Dockerfile
@@ -50,6 +50,7 @@ COPY device.py /work/device.py
 COPY rpc_proxy.py /work/rpc_proxy.py
 COPY ext_devices.py /work/ext_devices.py
 COPY safety_harness.py /work/safety_harness.py
+COPY velocity_proposal.py /work/velocity_proposal.py
 COPY scan_context.py /work/scan_context.py
 COPY controlled_spatial.py /work/controlled_spatial.py
 COPY controlled_spatial_map.py /work/controlled_spatial_map.py

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -12,6 +12,29 @@ plugins:
     enabled: true
   loco:
     enabled: true
+    # N5 canvas input. Driver startup is disarmed until loco action=start binds
+    # the one authoritative proposal topic.
+    velocity_proposal_enabled: true
+    velocity_proposal_driver_authorized: true
+    velocity_proposal_max_ttl_ms: 250
+    velocity_proposal_min_x: -0.05
+    velocity_proposal_max_x: 0.15
+    velocity_proposal_max_abs_y: 0.12
+    velocity_proposal_max_abs_yaw: 0.35
+    velocity_proposal_max_planar_speed: 0.18
+    velocity_proposal_odom_timeout: 0.5
+    velocity_proposal_scan_timeout: 0.5
+    velocity_proposal_fsm_check_interval: 0.2
+    velocity_proposal_fsm_timeout: 0.5
+    velocity_proposal_nav_status_timeout: 0.25
+    velocity_proposal_watchdog_hz: 40
+    velocity_proposal_rpc_timeout: 0.1
+    velocity_proposal_stop_rpc_timeout: 0.1
+    velocity_proposal_fsm_rpc_timeout: 0.2
+    velocity_proposal_stop_confirm_timeout: 0.5
+    velocity_proposal_stop_linear_epsilon: 0.03
+    velocity_proposal_stop_yaw_epsilon: 0.05
+    velocity_proposal_allowed_fsm_ids: [500, 801]
   arm:
     enabled: true
   state:

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -38,6 +38,7 @@ from unitree_sdk2py.g1.audio.g1_audio_client import AudioClient
 from pointcloud_utils import gravity_align_inplace
 from velocity_proposal import (
     DEFAULT_VELOCITY_PROPOSAL_TOPIC,
+    resolve_expected_nav_id,
     resolve_input_topic,
     velocity_proposal_port,
 )
@@ -1036,6 +1037,7 @@ class LocoPlugin:
     def _connect_velocity_proposal(self, args: dict) -> dict:
         try:
             topic = resolve_input_topic(args, self._velocity_proposal_topic)
+            expected_nav_id = resolve_expected_nav_id(args)
         except ValueError as exc:
             self._client.StopMove()
             if self._smart_motion:
@@ -1054,15 +1056,17 @@ class LocoPlugin:
                 "error": "SmartMotion safety harness is required for velocity_proposal",
                 "topic_in": [self._velocity_proposal_port()],
             }
-        result = self._smart_motion.bind_velocity_proposal(topic)
+        result = self._smart_motion.bind_velocity_proposal(topic, expected_nav_id)
         if result.get("error") or not (
             result.get("connected") and result.get("armed")
         ):
             self._client.StopMove()
         return {
-            "state": "ready" if result.get("connected") else "error",
-            "topic_in": [self._velocity_proposal_port()],
             **result,
+            "state": "ready" if (
+                result.get("connected") and result.get("armed")
+            ) else "error",
+            "topic_in": [self._velocity_proposal_port()],
         }
 
     def _disconnect_velocity_proposal(self, reason: str) -> dict:

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -18,6 +18,8 @@ drivers/unitree/g1/device.py — Unitree G1 设备插件（重构版）。
   StatePlugin        (sensor)    — DDS LowState → IMU/battery ROS2 topic
 """
 
+from __future__ import annotations
+
 import json
 import queue
 import socket
@@ -34,6 +36,11 @@ from audio_msgs.msg import AudioChunk
 
 from unitree_sdk2py.g1.audio.g1_audio_client import AudioClient
 from pointcloud_utils import gravity_align_inplace
+from velocity_proposal import (
+    DEFAULT_VELOCITY_PROPOSAL_TOPIC,
+    resolve_input_topic,
+    velocity_proposal_port,
+)
 
 # ── 常量 ──────────────────────────────────────────────────────────────────────
 
@@ -894,13 +901,18 @@ class LocoStatePlugin:
 
 class LocoPlugin:
     PREFIX = "loco"
+    # Stop locomotion before tearing down any other plugin during bundle
+    # shutdown.  This is an explicit lifecycle contract consumed by main.py.
+    STOP_PRIORITY = 0
 
     def __init__(self, plugin_config: dict, namespace: str, executor, loco_client, slam_client=None, smart_motion=None):
         self._client = loco_client
         self._slam_client = slam_client
         self._smart_motion = smart_motion
         self._namespace = namespace
+        self._control_lock = threading.RLock()
         self._move_timer: threading.Timer | None = None
+        self._velocity_proposal_topic = DEFAULT_VELOCITY_PROPOSAL_TOPIC
 
     def get_tools(self) -> list:
         tools = [self._loco_tool(), self._switch_mode_tool(), self._switch_mode_expert_tool()]
@@ -955,7 +967,11 @@ class LocoPlugin:
                     "shake_hand":       {"params": [],                                 "description": "Perform a handshake gesture"},
                 },
             },
+            "topic_in": [self._velocity_proposal_port()],
         }
+
+    def _velocity_proposal_port(self) -> dict:
+        return velocity_proposal_port(self._velocity_proposal_topic)
 
     # ── FSM state groups for safety checks ──────────────────────────────────────
     _GROUND_STATES = {0, 1}            # zero_torque, damp — lying on ground
@@ -1006,30 +1022,135 @@ class LocoPlugin:
         }
 
     def start(self) -> None:
+        # Driver startup remains disarmed.  Canvas action=start with the exact
+        # connected topic is the only path that arms proposal execution.
         pass
 
     def stop(self) -> None:
-        if self._move_timer:
-            self._move_timer.cancel()
-            self._move_timer = None
-        self._client.StopMove()
+        with self._control_lock:
+            if self._move_timer:
+                self._move_timer.cancel()
+                self._move_timer = None
+            self._disconnect_velocity_proposal("driver_stop")
+
+    def _connect_velocity_proposal(self, args: dict) -> dict:
+        try:
+            topic = resolve_input_topic(args, self._velocity_proposal_topic)
+        except ValueError as exc:
+            self._client.StopMove()
+            if self._smart_motion:
+                self._smart_motion.unbind_velocity_proposal("proposal_bind_rejected")
+            return {
+                "state": "error",
+                "connected": False,
+                "error": str(exc),
+                "topic_in": [self._velocity_proposal_port()],
+            }
+        if not self._smart_motion:
+            self._client.StopMove()
+            return {
+                "state": "error",
+                "connected": False,
+                "error": "SmartMotion safety harness is required for velocity_proposal",
+                "topic_in": [self._velocity_proposal_port()],
+            }
+        result = self._smart_motion.bind_velocity_proposal(topic)
+        if result.get("error") or not (
+            result.get("connected") and result.get("armed")
+        ):
+            self._client.StopMove()
+        return {
+            "state": "ready" if result.get("connected") else "error",
+            "topic_in": [self._velocity_proposal_port()],
+            **result,
+        }
+
+    def _disconnect_velocity_proposal(self, reason: str) -> dict:
+        # Main-process RPC is an independent first stop path.  It guarantees
+        # StopMove precedes subscriber teardown even if SmartMotion IPC hangs
+        # and the child has to be terminated fail-closed.
+        fallback_stop_ret = self._client.StopMove()
+        if self._smart_motion:
+            try:
+                result = self._smart_motion.unbind_velocity_proposal(reason)
+            except Exception as exc:
+                return {
+                    "state": "error",
+                    "connected": False,
+                    "stop_confirmed": False,
+                    "error": f"SmartMotion unbind failed: {exc}",
+                    "fallback_stop_ret": fallback_stop_ret,
+                    "topic_in": [self._velocity_proposal_port()],
+                }
+            stop_failed = (
+                result.get("error")
+                or result.get("stop_confirmed") is not True
+            )
+            if stop_failed:
+                result.setdefault("state", "error")
+                result.setdefault("error", "StopMove was not confirmed")
+                result["fallback_stop_ret"] = fallback_stop_ret
+            return {"topic_in": [self._velocity_proposal_port()], **result}
+        return {
+            "state": "idle" if fallback_stop_ret == 0 else "error",
+            "connected": False,
+            "stop_confirmed": fallback_stop_ret == 0,
+            "reason": reason,
+            "topic_in": [self._velocity_proposal_port()],
+            **({"error": f"StopMove failed: code={fallback_stop_ret}"} if fallback_stop_ret != 0 else {}),
+        }
 
     def _auto_stop(self):
         """Timer 回调：自动停止运动"""
-        self._move_timer = None
-        self._client.StopMove()
+        with self._control_lock:
+            self._move_timer = None
+            self._client.StopMove()
 
     def dispatch(self, action: str, args: dict) -> dict | None:
+        with self._control_lock:
+            try:
+                return self._dispatch_serialized(action, args)
+            except Exception as exc:
+                self._client.StopMove()
+                return {
+                    "state": "error",
+                    "connected": False,
+                    "error": f"loco safety fallback: {exc}",
+                    "topic_in": [self._velocity_proposal_port()],
+                }
+
+    def _dispatch_serialized(self, action: str, args: dict) -> dict | None:
+        tool_name = args.get("_tool_name", "loco")
         if action == "start":
-            return {"state": "ready"}
+            if tool_name == "loco":
+                return self._connect_velocity_proposal(args)
+            return {"state": "running" if tool_name == "motion_events" else "ready"}
         if action == "stop":
+            if tool_name == "loco":
+                return self._disconnect_velocity_proposal("canvas_stop")
             return {"state": "idle"}
         if action == "info":
-            tool_name = args.get("_tool_name", "motion_events")
             if tool_name == "motion_events" and self._smart_motion:
                 topic = f"/{self._namespace}/safety/motion_events"
                 return {"state": "running", "topic_out": [{"topic": topic, "format": "data/json"}]}
-            return None
+            if tool_name != "loco":
+                return {"state": "ready"}
+            if self._smart_motion:
+                result = self._smart_motion.get_velocity_proposal_status()
+                if result.get("error"):
+                    self._client.StopMove()
+            else:
+                result = {
+                    "enabled": False,
+                    "connected": False,
+                    "armed": False,
+                    "last_reason": "SmartMotion safety harness unavailable",
+                }
+            return {
+                "state": "running" if result.get("connected") else "ready",
+                "topic_in": [self._velocity_proposal_port()],
+                **result,
+            }
         if action == "move":
             vx   = float(args.get("vx",   0))
             vy   = float(args.get("vy",   0))
@@ -1038,7 +1159,10 @@ class LocoPlugin:
 
             # Route through SmartMotion safety harness
             if self._smart_motion:
-                return self._smart_motion.move(vx, vy, vyaw, duration)
+                result = self._smart_motion.move(vx, vy, vyaw, duration)
+                if result.get("error"):
+                    self._client.StopMove()
+                return result
 
             # Fallback: direct control (no safety harness)
             vx   = max(-1.0, min(1.0, vx))
@@ -1062,7 +1186,10 @@ class LocoPlugin:
         elif action == "stop_move":
             # Route through SmartMotion safety harness
             if self._smart_motion:
-                return self._smart_motion.stop()
+                result = self._smart_motion.stop()
+                if result.get("error"):
+                    self._client.StopMove()
+                return result
 
             # Fallback: direct control
             if self._move_timer:
@@ -1077,6 +1204,13 @@ class LocoPlugin:
             return {"ret": ret}
         elif action == "switch_mode":
             mode = args.get("mode", "")
+            if mode != "get_current_mode":
+                stopped = self._disconnect_velocity_proposal("mode_switch")
+                if mode != "emergency_stop" and (
+                    stopped.get("error")
+                    or stopped.get("stop_confirmed") is not True
+                ):
+                    return stopped
             code, current_fsm = self._client.GetFsmId()
 
             if code != 0:
@@ -1170,6 +1304,9 @@ class LocoPlugin:
                                  f"standup2squat, squat2standup, damp, zero_torque, "
                                  f"emergency_stop, get_current_mode"}
         elif action == "switch_mode_expert":
+            stopped = self._disconnect_velocity_proposal("expert_mode_switch")
+            if stopped.get("error") or stopped.get("stop_confirmed") is not True:
+                return stopped
             fid = int(args.get("fsm_id", 0))
             ret = self._client.SetFsmId(fid)
             return {"ret": ret, "fsm_id": fid}

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -182,8 +182,18 @@ class G1DeviceBundle:
         print(f"[bundle] All {len(self._plugins)} plugins started", flush=True)
 
     def stop_all(self) -> None:
-        for p in self._plugins:
-            p.stop()
+        ordered_plugins = sorted(
+            enumerate(self._plugins),
+            key=lambda item: getattr(item[1], "STOP_PRIORITY", 100),
+        )
+        for i, p in ordered_plugins:
+            try:
+                p.stop()
+            except Exception as exc:
+                print(
+                    f"[bundle] Plugin {i} ({type(p).__name__}) stop() FAILED: {exc}",
+                    flush=True,
+                )
         print("[bundle] All plugins stopped")
 
     def get_all_tools(self) -> list:
@@ -393,7 +403,14 @@ def main():
     harness_cfg = cfg.get("safety_harness", {})
     if harness_cfg.get("enabled", True):
         from safety_harness import SmartMotionProxy
-        smart_motion = SmartMotionProxy(namespace, harness_cfg, network_iface)
+        proposal_cfg = cfg.get("plugins", {}).get("loco", {})
+        smart_motion = SmartMotionProxy(
+            namespace,
+            harness_cfg,
+            network_iface,
+            proposal_config=proposal_cfg,
+            fallback_stop=loco_client.StopMove,
+        )
         print("[bundle] SmartMotion safety harness active (subprocess)")
 
     _bundle = G1DeviceBundle(cfg, namespace, executor, audio_client, loco_client, arm_client, slam_client, msc_client, smart_motion=smart_motion, network_iface=network_iface)
@@ -411,12 +428,29 @@ def main():
     server = ThreadingHTTPServer(("", mcp_port), make_handler())
     print(f"[bundle] MCP server → http://localhost:{mcp_port}")
 
+    shutdown_lock = threading.RLock()
+    shutdown_started = False
+
+    def _stop_runtime():
+        nonlocal shutdown_started
+        with shutdown_lock:
+            if shutdown_started:
+                return
+            shutdown_started = True
+            # LocoPlugin must StopMove/unbind while both motion subprocesses
+            # are still available; only then terminate those subprocesses.
+            try:
+                _bundle.stop_all()
+            finally:
+                try:
+                    if smart_motion:
+                        smart_motion.shutdown()
+                finally:
+                    loco_client.stop()
+
     def _shutdown(signum, frame):
         print(f"[bundle] signal {signum}, shutting down")
-        if smart_motion:
-            smart_motion.shutdown()
-        _bundle.stop_all()
-        loco_client.stop()
+        _stop_runtime()
         threading.Thread(target=server.shutdown, daemon=True).start()
 
     signal.signal(signal.SIGTERM, _shutdown)
@@ -425,7 +459,7 @@ def main():
     try:
         server.serve_forever()
     finally:
-        _bundle.stop_all()
+        _stop_runtime()
         executor.shutdown()
         rclpy.shutdown()
 

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -14,6 +14,8 @@ drivers/unitree/g1/safety_harness.py — SmartMotion 独立进程安全层。
 此模块不是 MCP plugin，由驱动生命周期管理，默认自动启动。
 """
 
+from __future__ import annotations
+
 import enum
 import json
 import math
@@ -25,6 +27,12 @@ import threading
 import time
 from dataclasses import dataclass, field
 from typing import Optional
+
+from velocity_proposal import (
+    DEFAULT_VELOCITY_PROPOSAL_TOPIC,
+    ProposalLimits,
+    VelocityProposalGate,
+)
 
 
 # ── Enums & Data Classes (shared between processes) ──────────────────────────
@@ -71,26 +79,79 @@ class SpeedLimits:
 class SmartMotionProxy:
     """Main-process proxy that communicates with the SmartMotion subprocess."""
 
-    def __init__(self, namespace: str, config: dict, network_iface: str):
+    def __init__(self, namespace: str, config: dict, network_iface: str,
+                 proposal_config: Optional[dict] = None,
+                 fallback_stop=None):
         ctx = mp.get_context("spawn")
         self._cmd_queue = ctx.Queue()
         self._result_queue = ctx.Queue()
+        self._call_lock = threading.Lock()
+        self._request_id = 0
         self._proc = ctx.Process(
             target=_run_smart_motion_process,
-            args=(namespace, config, network_iface, self._cmd_queue, self._result_queue),
+            args=(namespace, config, proposal_config or {}, network_iface,
+                  self._cmd_queue, self._result_queue),
             name="smart_motion", daemon=True,
         )
         self._proc.start()
+        self._fallback_stop = fallback_stop
+        self._exit_monitor = threading.Thread(
+            target=self._monitor_process_exit,
+            daemon=True,
+            name="smart_motion_exit_monitor",
+        )
+        self._exit_monitor.start()
         print(f"[SmartMotionProxy] subprocess started → pid={self._proc.pid}")
 
-    def _call(self, method: str, timeout: float = 15.0, **kwargs) -> dict:
-        """Send command to subprocess and wait for result."""
-        self._cmd_queue.put({"method": method, **kwargs})
+    def _monitor_process_exit(self) -> None:
+        """Issue an independent parent-side stop on every child exit.
+
+        The child normally stops itself in its cleanup path.  This second path
+        covers unhandled exceptions, SIGKILL/SIGTERM, and forced termination
+        after an IPC timeout, where Python cleanup cannot be relied upon.
+        """
+        self._proc.join()
+        if self._fallback_stop is None:
+            return
         try:
-            result = self._result_queue.get(timeout=timeout)
-            return result
-        except queue.Empty:
-            return {"error": f"SmartMotion subprocess timeout ({method})"}
+            self._fallback_stop()
+        except Exception as exc:
+            print(
+                f"[SmartMotionProxy] child-exit StopMove failed: {exc}",
+                flush=True,
+            )
+
+    def _call(self, method: str, timeout: float = 15.0, **kwargs) -> dict:
+        """Serialize calls and correlate replies across HTTP/ROS threads."""
+        with self._call_lock:
+            if not self._proc.is_alive():
+                return {"error": "SmartMotion subprocess is not running"}
+            self._request_id += 1
+            request_id = self._request_id
+            self._cmd_queue.put({
+                "method": method,
+                "request_id": request_id,
+                **kwargs,
+            })
+            deadline = time.monotonic() + timeout
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0.0:
+                    self._terminate_unresponsive_process()
+                    return {"error": f"SmartMotion subprocess timeout ({method})"}
+                try:
+                    envelope = self._result_queue.get(timeout=remaining)
+                except queue.Empty:
+                    self._terminate_unresponsive_process()
+                    return {"error": f"SmartMotion subprocess timeout ({method})"}
+                if envelope.get("request_id") == request_id:
+                    return envelope.get("result") or {}
+
+    def _terminate_unresponsive_process(self) -> None:
+        """Fail closed: an IPC-hung motion owner may not keep executing."""
+        if self._proc.is_alive():
+            self._proc.terminate()
+            self._proc.join(timeout=1.0)
 
     def move(self, vx: float, vy: float, vyaw: float, duration: float = -1.0) -> dict:
         return self._call("move", vx=vx, vy=vy, vyaw=vyaw, duration=duration)
@@ -119,6 +180,15 @@ class SmartMotionProxy:
     def get_state(self) -> dict:
         return self._call("get_state")
 
+    def bind_velocity_proposal(self, topic: str) -> dict:
+        return self._call("bind_velocity_proposal", topic=topic)
+
+    def unbind_velocity_proposal(self, reason: str = "canvas_stop") -> dict:
+        return self._call("unbind_velocity_proposal", reason=reason)
+
+    def get_velocity_proposal_status(self) -> dict:
+        return self._call("get_velocity_proposal_status")
+
     # ── SLAM RPC passthrough (single SlamClient owns all SLAM operations) ──
 
     def start_mapping(self) -> dict:
@@ -134,20 +204,24 @@ class SmartMotionProxy:
 
     def shutdown(self) -> None:
         try:
-            self._cmd_queue.put({"method": "shutdown"})
+            self._call("shutdown", timeout=3.0)
             self._proc.join(timeout=3.0)
         except Exception:
             pass
         if self._proc.is_alive():
             self._proc.terminate()
             self._proc.join(timeout=2.0)
+        # Ensure the parent-side child-exit StopMove completes before the
+        # caller tears down the independent RpcProxy used by that callback.
+        self._exit_monitor.join(timeout=2.0)
         print("[SmartMotionProxy] subprocess stopped")
 
 
 # ── SmartMotion subprocess entry ─────────────────────────────────────────────
 
-def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
-                              cmd_queue: mp.Queue, result_queue: mp.Queue):
+def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dict,
+                              network_iface: str, cmd_queue: mp.Queue,
+                              result_queue: mp.Queue):
     """Entry point for the SmartMotion subprocess.
 
     Initializes its own DDS channel, RPC clients, ROS2 node, and LiDAR subscription.
@@ -170,6 +244,12 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         depth=200,
         durability=DurabilityPolicy.VOLATILE,
     )
+    _PROPOSAL_QOS = QoSProfile(
+        reliability=ReliabilityPolicy.RELIABLE,
+        history=HistoryPolicy.KEEP_LAST,
+        depth=10,
+        durability=DurabilityPolicy.VOLATILE,
+    )
 
     # ── Initialize DDS ──
     ChannelFactoryInitialize(0, network_iface)
@@ -179,6 +259,30 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     loco_client = LocoClient()
     loco_client.Init()
     loco_client.SetTimeout(10.0)
+
+    # Proposal execution, stopping, watchdog stopping and FSM polling use
+    # independent RPC clients so a delayed call cannot block physical stop.
+    proposal_rpc_timeout = min(
+        0.2, max(0.02, float(proposal_config.get("velocity_proposal_rpc_timeout", 0.1)))
+    )
+    stop_rpc_timeout = min(
+        0.2, max(0.02, float(proposal_config.get("velocity_proposal_stop_rpc_timeout", 0.1)))
+    )
+    fsm_rpc_timeout = min(
+        0.5, max(0.05, float(proposal_config.get("velocity_proposal_fsm_rpc_timeout", 0.2)))
+    )
+    proposal_loco_client = LocoClient()
+    proposal_loco_client.Init()
+    proposal_loco_client.SetTimeout(proposal_rpc_timeout)
+    stop_loco_client = LocoClient()
+    stop_loco_client.Init()
+    stop_loco_client.SetTimeout(stop_rpc_timeout)
+    watchdog_loco_client = LocoClient()
+    watchdog_loco_client.Init()
+    watchdog_loco_client.SetTimeout(stop_rpc_timeout)
+    fsm_loco_client = LocoClient()
+    fsm_loco_client.Init()
+    fsm_loco_client.SetTimeout(fsm_rpc_timeout)
 
     slam_client = SlamClient()
     slam_client.Init()
@@ -206,6 +310,30 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     executor.add_node(event_node)
     print(f"[SmartMotion:pid={os.getpid()}] ROS2 event node ready → /{namespace}/safety/motion_events")
 
+    class _VelocityProposalNode(Node):
+        """Own the one dynamically connected N5 proposal subscription."""
+
+        def __init__(self):
+            super().__init__("g1_loco_velocity_proposal")
+            self._subscription = None
+            self.topic = ""
+
+        def bind(self, topic: str, callback) -> None:
+            self.unbind()
+            self._subscription = self.create_subscription(
+                String, topic, callback, _PROPOSAL_QOS
+            )
+            self.topic = topic
+
+        def unbind(self) -> None:
+            if self._subscription is not None:
+                self.destroy_subscription(self._subscription)
+                self._subscription = None
+            self.topic = ""
+
+    proposal_node = _VelocityProposalNode()
+    executor.add_node(proposal_node)
+
     # ── Config ──
     decel_threshold = config.get("decel_threshold", 2.0)
     stop_threshold = config.get("stop_threshold", 0.8)
@@ -213,6 +341,52 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     z_min = config.get("z_min", 0.1)
     z_max = config.get("z_max", 1.8)
     limits = SpeedLimits()
+    proposal_enabled = bool(proposal_config.get("velocity_proposal_enabled", True))
+    proposal_driver_authorized = bool(
+        proposal_config.get("velocity_proposal_driver_authorized", False)
+    )
+    expected_proposal_topic = DEFAULT_VELOCITY_PROPOSAL_TOPIC
+    # Deployment configuration may tighten, but never loosen, N5 limits.
+    proposal_limits = ProposalLimits(
+        frame="base_link",
+        max_ttl_ms=min(250, int(proposal_config.get("velocity_proposal_max_ttl_ms", 250))),
+        min_x=max(-0.05, float(proposal_config.get("velocity_proposal_min_x", -0.05))),
+        max_x=min(0.15, float(proposal_config.get("velocity_proposal_max_x", 0.15))),
+        max_abs_y=min(0.12, float(proposal_config.get("velocity_proposal_max_abs_y", 0.12))),
+        max_abs_yaw=min(0.35, float(proposal_config.get("velocity_proposal_max_abs_yaw", 0.35))),
+        max_planar_speed=min(0.18, float(proposal_config.get("velocity_proposal_max_planar_speed", 0.18))),
+    )
+    proposal_gate = VelocityProposalGate(proposal_limits)
+    proposal_odom_timeout = float(proposal_config.get("velocity_proposal_odom_timeout", 0.5))
+    proposal_scan_timeout = float(proposal_config.get("velocity_proposal_scan_timeout", 0.5))
+    proposal_fsm_check_interval = float(
+        proposal_config.get("velocity_proposal_fsm_check_interval", 0.2)
+    )
+    proposal_fsm_timeout = max(
+        proposal_fsm_check_interval,
+        float(proposal_config.get("velocity_proposal_fsm_timeout", 0.5)),
+    )
+    proposal_nav_status_timeout = min(
+        proposal_limits.max_ttl_ms / 1000.0,
+        float(proposal_config.get("velocity_proposal_nav_status_timeout", 0.25)),
+    )
+    proposal_watchdog_hz = max(
+        20.0, float(proposal_config.get("velocity_proposal_watchdog_hz", 40.0))
+    )
+    proposal_stop_confirm_timeout = min(
+        1.0,
+        max(0.1, float(proposal_config.get("velocity_proposal_stop_confirm_timeout", 0.5))),
+    )
+    proposal_stop_linear_epsilon = max(
+        0.0, float(proposal_config.get("velocity_proposal_stop_linear_epsilon", 0.03))
+    )
+    proposal_stop_yaw_epsilon = max(
+        0.0, float(proposal_config.get("velocity_proposal_stop_yaw_epsilon", 0.05))
+    )
+    proposal_allowed_fsm_ids = {
+        int(value)
+        for value in proposal_config.get("velocity_proposal_allowed_fsm_ids", [500, 801])
+    }
 
     # ── State ──
     state = MotionState.IDLE
@@ -220,6 +394,57 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     nav_cmd = None      # dict: {target_name, target_pose, start_time}
     speed_zone = SpeedZone.NORMAL
     move_timer = None   # threading.Timer
+    last_cloud_time = 0.0
+    last_odom_time = 0.0
+    last_fsm_check = 0.0
+    last_fsm_id = None
+    main_control_ready = False
+    last_nav_status_time = 0.0
+    last_odom_motion = (float("inf"), float("inf"), float("inf"))
+    safety_lock = threading.Lock()
+    motion_command_lock = threading.RLock()
+    proposal_execution_lock = threading.Lock()
+    proposal_connected = threading.Event()
+    safety_threads_shutdown = threading.Event()
+    proposal_execution_generation = 0
+    proposal_execution_active = False
+    proposal_execution_deadline = 0.0
+    proposal_watchdog_fault = None
+
+    def motion_synchronized(func):
+        def locked(*args, **kwargs):
+            with motion_command_lock:
+                return func(*args, **kwargs)
+        return locked
+
+    def arm_proposal_execution(deadline):
+        nonlocal proposal_execution_generation, proposal_execution_active
+        nonlocal proposal_execution_deadline, proposal_watchdog_fault
+        with proposal_execution_lock:
+            proposal_execution_generation += 1
+            proposal_execution_active = True
+            proposal_execution_deadline = deadline
+            proposal_watchdog_fault = None
+            return proposal_execution_generation
+
+    def clear_proposal_execution():
+        nonlocal proposal_execution_generation, proposal_execution_active
+        nonlocal proposal_execution_deadline, proposal_watchdog_fault
+        with proposal_execution_lock:
+            proposal_execution_generation += 1
+            proposal_execution_active = False
+            proposal_execution_deadline = 0.0
+            proposal_watchdog_fault = None
+
+    def proposal_fault_for_generation(generation):
+        with proposal_execution_lock:
+            if proposal_watchdog_fault and proposal_watchdog_fault[0] == generation:
+                return proposal_watchdog_fault[1]
+            return ""
+
+    def current_proposal_watchdog_fault():
+        with proposal_execution_lock:
+            return proposal_watchdog_fault
 
     # Obstacle state (written by LiDAR callback, read by main loop)
     obstacle_lock = threading.Lock()
@@ -250,17 +475,36 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         event_node.publish(event)
         print(f"[SmartMotion] event: {event_type} | {json.dumps(data)}", flush=True)
 
+    def issue_stop_move():
+        """Call StopMove and return the Unitree RPC acknowledgement code."""
+        return stop_loco_client.StopMove()
+
+    @motion_synchronized
     def do_stop(reason_str):
         nonlocal state, current_cmd, speed_zone, move_timer, stop_repeat_count
+        was_proposal_motion = bool(
+            current_cmd and current_cmd.get("source") == "velocity_proposal"
+        )
         if move_timer:
             move_timer.cancel()
             move_timer = None
-        loco_client.StopMove()
+        clear_proposal_execution()
+        stop_ret = None
+        stop_error = None
+        try:
+            stop_ret = issue_stop_move()
+        except Exception as exc:
+            stop_error = str(exc)
+        # A physical-stop confirmation must use odometry newer than the
+        # completed StopMove RPC attempt.
+        stop_issued_monotonic = time.monotonic()
         was_moving = state == MotionState.MOVING
         state = MotionState.IDLE
         current_cmd = None
         speed_zone = SpeedZone.NORMAL
         stop_repeat_count = 3  # repeat StopMove to ensure controller stops
+        if was_proposal_motion and reason_str == "obstacle":
+            proposal_gate.disarm("obstacle_stop_latched")
         if was_moving:
             event_data = {"reason": reason_str}
             if reason_str == "obstacle":
@@ -268,8 +512,18 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     event_data["obstacle_distance"] = round(obstacle_dist, 2)
                     event_data["obstacle_angle_deg"] = round(math.degrees(obstacle_angle), 1)
             publish_event("motion_stop", event_data)
-        return {"ret": 0, "state": "idle", "reason": reason_str}
+        result = {
+            "ret": stop_ret,
+            "state": "idle",
+            "reason": reason_str,
+            "stop_confirmed": stop_ret == 0,
+            "stop_issued_monotonic": stop_issued_monotonic,
+        }
+        if stop_error:
+            result["error"] = f"StopMove failed: {stop_error}"
+        return result
 
+    @motion_synchronized
     def do_stop_nav():
         nonlocal state, nav_cmd, speed_zone
         try:
@@ -284,6 +538,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             publish_event("nav_stopped", {"reason": "command"})
         return {"status": "stopped"}
 
+    @motion_synchronized
     def duration_expired():
         nonlocal state, current_cmd, speed_zone, move_timer
         move_timer = None
@@ -292,7 +547,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
 
     # ── LiDAR DDS Subscription ──
     def on_cloud(msg):
-        nonlocal obstacle_dist, obstacle_angle, lateral_obstacle
+        nonlocal obstacle_dist, obstacle_angle, lateral_obstacle, last_cloud_time
 
         # Get heading
         if state == MotionState.MOVING and current_cmd:
@@ -314,6 +569,8 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         n_valid = min(total_points, len(data) // point_step)
         if n_valid == 0:
             return
+        with safety_lock:
+            last_cloud_time = time.monotonic()
 
         # Numpy batch extraction (xyz at offsets 0, 4, 8 — already gravity-aligned)
         buf = np.frombuffer(data, dtype=np.uint8, count=n_valid * point_step).reshape(n_valid, point_step)
@@ -389,8 +646,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     motor_temp_stop = config.get("motor_temp_stop", 85)
 
     # Safety state
-    safety_lock = threading.Lock()
-    last_lowstate_time = time.monotonic()
+    last_lowstate_time = 0.0
     tilt_triggered = False
     foot_airborne_start = 0.0
     foot_force_seen_nonzero = False  # only enable airborne detection after seeing real force
@@ -398,13 +654,20 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     last_temp_check = 0.0
     stop_repeat_count = 0  # counter for repeated StopMove after emergency
 
+    @motion_synchronized
     def emergency_stop(reason_str, extra=None):
         """Emergency stop with optional damp mode for tilt."""
         nonlocal state, current_cmd, speed_zone, move_timer, stop_repeat_count
+        if current_cmd and current_cmd.get("source") == "velocity_proposal":
+            proposal_gate.disarm(f"{reason_str}_latched")
         if move_timer:
             move_timer.cancel()
             move_timer = None
-        loco_client.StopMove()
+        clear_proposal_execution()
+        try:
+            stop_loco_client.StopMove()
+        except Exception:
+            pass
         if reason_str == "tilt":
             try:
                 loco_client.SetFsmId(1)  # damp mode
@@ -432,23 +695,29 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         nonlocal last_lowstate_time, tilt_triggered, max_motor_temp, last_temp_check
 
         now = time.monotonic()
-        with safety_lock:
-            last_lowstate_time = now
-
         # Tilt detection (20Hz, every callback)
         imu = msg.imu_state
         roll = abs(float(imu.rpy[0]))
         pitch = abs(float(imu.rpy[1]))
+        is_tilted = roll > tilt_threshold or pitch > tilt_threshold
+        with safety_lock:
+            last_lowstate_time = now
+            was_tilted = tilt_triggered
+            tilt_triggered = is_tilted
 
-        if (roll > tilt_threshold or pitch > tilt_threshold):
-            if not tilt_triggered and state in (MotionState.MOVING, MotionState.NAVIGATING, MotionState.NAV_PAUSED):
-                tilt_triggered = True
-                emergency_stop("tilt", {
-                    "roll_deg": round(math.degrees(roll), 1),
-                    "pitch_deg": round(math.degrees(pitch), 1),
-                })
-        else:
-            tilt_triggered = False
+        if (
+            is_tilted
+            and not was_tilted
+            and state in (
+                MotionState.MOVING,
+                MotionState.NAVIGATING,
+                MotionState.NAV_PAUSED,
+            )
+        ):
+            emergency_stop("tilt", {
+                "roll_deg": round(math.degrees(roll), 1),
+                "pitch_deg": round(math.degrees(pitch), 1),
+            })
 
         # Joint temperature (1Hz check)
         if now - last_temp_check >= 1.0:
@@ -472,6 +741,17 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     # ── OdomState DDS Subscription (foot force) ──
     def on_odom(msg):
         nonlocal foot_airborne_start, foot_force_seen_nonzero
+        nonlocal last_odom_time, last_odom_motion
+
+        velocity = list(msg.velocity)
+        motion = (
+            float(velocity[0]) if len(velocity) > 0 else float("inf"),
+            float(velocity[1]) if len(velocity) > 1 else float("inf"),
+            float(msg.yaw_speed),
+        )
+        with safety_lock:
+            last_odom_time = time.monotonic()
+            last_odom_motion = motion
 
         if state != MotionState.MOVING:
             foot_airborne_start = 0.0
@@ -566,8 +846,95 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     except Exception as e:
         print(f"[SmartMotion:pid={os.getpid()}] WARNING: rt/slam_info subscribe failed: {e}")
 
+    def refresh_fsm_state():
+        nonlocal last_fsm_check, last_fsm_id, main_control_ready
+        try:
+            code, fsm_id = fsm_loco_client.GetFsmId()
+            ready = code == 0 and int(fsm_id) in proposal_allowed_fsm_ids
+        except Exception:
+            fsm_id = None
+            ready = False
+        with safety_lock:
+            last_fsm_check = time.monotonic()
+            last_fsm_id = fsm_id
+            main_control_ready = ready
+
+    def proposal_runtime_status(force_fsm_check=False):
+        """Return current Driver-owned readiness for proposal execution."""
+        if force_fsm_check:
+            refresh_fsm_state()
+        now = time.monotonic()
+        with safety_lock:
+            lowstate_age = now - last_lowstate_time if last_lowstate_time else float("inf")
+            odom_age = now - last_odom_time if last_odom_time else float("inf")
+            scan_age = now - last_cloud_time if last_cloud_time else float("inf")
+            nav_status_age = (
+                now - last_nav_status_time if last_nav_status_time else float("inf")
+            )
+            fsm_age = now - last_fsm_check if last_fsm_check else float("inf")
+            temperature = max_motor_temp
+            fsm_id = last_fsm_id
+            control_ready = main_control_ready
+            tilted = tilt_triggered
+
+        reason = ""
+        if not proposal_driver_authorized:
+            reason = "driver_execution_not_authorized"
+        elif lowstate_age > comm_timeout:
+            reason = "main_control_state_stale"
+        elif odom_age > proposal_odom_timeout:
+            reason = "odometry_stale"
+        elif scan_age > proposal_scan_timeout:
+            reason = "scan_stale"
+        elif tilted:
+            reason = "tilt_latched"
+        elif temperature > motor_temp_stop:
+            reason = "joint_overheat_latched"
+        elif nav_status_age > proposal_nav_status_timeout:
+            reason = "nav2_status_stale"
+        elif fsm_age > proposal_fsm_timeout:
+            reason = "main_control_status_stale"
+        elif not control_ready:
+            reason = "main_control_not_ready"
+
+        return {
+            "ready": not reason,
+            "reason": reason or None,
+            "fsm_id": fsm_id,
+            # In this G1 API, a fresh allowed locomotion FSM is the native
+            # fail-closed proxy for main-control/e-stop execution permission.
+            "emergency_stop_clear": control_ready and fsm_age <= proposal_fsm_timeout,
+            "lowstate_age_ms": None if not math.isfinite(lowstate_age) else round(lowstate_age * 1000),
+            "odometry_age_ms": None if not math.isfinite(odom_age) else round(odom_age * 1000),
+            "scan_age_ms": None if not math.isfinite(scan_age) else round(scan_age * 1000),
+            "nav2_status_age_ms": None if not math.isfinite(nav_status_age) else round(nav_status_age * 1000),
+            "fsm_age_ms": None if not math.isfinite(fsm_age) else round(fsm_age * 1000),
+        }
+
+    def confirm_robot_stopped(timeout, not_before):
+        """Confirm StopMove using a fresh near-zero measured odometry sample."""
+        deadline = time.monotonic() + timeout
+        while True:
+            now = time.monotonic()
+            with safety_lock:
+                odom_time = last_odom_time
+                vx, vy, yaw = last_odom_motion
+            if (
+                odom_time
+                and odom_time >= not_before
+                and now - odom_time <= proposal_odom_timeout
+                and abs(vx) <= proposal_stop_linear_epsilon
+                and abs(vy) <= proposal_stop_linear_epsilon
+                and abs(yaw) <= proposal_stop_yaw_epsilon
+            ):
+                return True
+            if now >= deadline:
+                return False
+            time.sleep(min(0.02, deadline - now))
+
     # ── Command handlers ──
-    def handle_move(vx, vy, vyaw, duration):
+    @motion_synchronized
+    def handle_move(vx, vy, vyaw, duration, finite_rpc=False, source="mcp"):
         nonlocal state, current_cmd, speed_zone, move_timer
 
         if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
@@ -578,7 +945,12 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
 
         previous = None
         if state == MotionState.MOVING and current_cmd:
-            previous = {"vx": current_cmd["vx"], "vy": current_cmd["vy"], "vyaw": current_cmd["vyaw"]}
+            previous = {
+                "vx": current_cmd["vx"],
+                "vy": current_cmd["vy"],
+                "vyaw": current_cmd["vyaw"],
+                "source": current_cmd.get("source", "mcp"),
+            }
 
         clamped_vx, clamped_vy, clamped_vyaw = clamp(vx, vy, vyaw, SpeedZone.NORMAL)
 
@@ -587,29 +959,68 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             "vx": vx, "vy": vy, "vyaw": vyaw,
             "duration": duration, "start_time": now,
             "end_time": (now + duration) if duration > 0 else None,
+            "source": source,
         }
         state = MotionState.MOVING
         speed_zone = SpeedZone.NORMAL
 
-        ret = loco_client.Move(clamped_vx, clamped_vy, clamped_vyaw, True)
+        proposal_generation = None
+        if finite_rpc:
+            proposal_generation = arm_proposal_execution(
+                time.monotonic() + duration
+            )
+            ret = proposal_loco_client.SetVelocity(
+                clamped_vx, clamped_vy, clamped_vyaw, duration
+            )
+        else:
+            clear_proposal_execution()
+            ret = loco_client.Move(clamped_vx, clamped_vy, clamped_vyaw, True)
 
-        if duration > 0:
+        watchdog_reason = (
+            proposal_fault_for_generation(proposal_generation)
+            if proposal_generation is not None
+            else ""
+        )
+        if watchdog_reason:
+            return {
+                "ret": ret,
+                "duration": duration,
+                "state": state.value,
+                "watchdog_reason": watchdog_reason,
+            }
+
+        if duration > 0 and not finite_rpc:
             move_timer = threading.Timer(duration, duration_expired)
             move_timer.start()
 
-        if previous:
+        if previous and not (
+            source == "velocity_proposal"
+            and previous.get("source") == "velocity_proposal"
+        ):
             publish_event("new_command", {
                 "previous": previous,
-                "new": {"vx": clamped_vx, "vy": clamped_vy, "vyaw": clamped_vyaw},
+                "new": {
+                    "vx": clamped_vx,
+                    "vy": clamped_vy,
+                    "vyaw": clamped_vyaw,
+                    "source": source,
+                },
             })
-        else:
+        elif not previous:
             publish_event("motion_start", {
-                "params": {"vx": clamped_vx, "vy": clamped_vy, "vyaw": clamped_vyaw, "duration": duration},
+                "params": {
+                    "vx": clamped_vx,
+                    "vy": clamped_vy,
+                    "vyaw": clamped_vyaw,
+                    "duration": duration,
+                    "source": source,
+                },
             })
 
         return {"ret": ret, "vx": clamped_vx, "vy": clamped_vy, "vyaw": clamped_vyaw,
                 "duration": duration, "state": state.value}
 
+    @motion_synchronized
     def handle_navigate_to(x, y, yaw, target_name, speed=0.5, mode=1, stall_timeout=60):
         nonlocal state, nav_cmd, speed_zone, nav_arrived_flag, nav_arrived_error
 
@@ -737,6 +1148,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         print(f"[SmartMotion] wait_nav_done: state changed to {state.value}", flush=True)
         return {"status": "stopped", "state": state.value}
 
+    @motion_synchronized
     def handle_pause_nav(reason_str):
         nonlocal state
         if state != MotionState.NAVIGATING:
@@ -750,6 +1162,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         publish_event("nav_paused", event_data)
         return {"status": "paused"} if code == 0 else {"error": f"PauseNav failed, code={code}"}
 
+    @motion_synchronized
     def handle_resume_nav():
         nonlocal state
         if state != MotionState.NAV_PAUSED:
@@ -759,6 +1172,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         publish_event("nav_resumed", {})
         return {"status": "resumed"} if code == 0 else {"error": f"ResumeNav failed, code={code}"}
 
+    @motion_synchronized
     def handle_get_state():
         result = {"state": state.value, "speed_zone": speed_zone.value}
         if current_cmd and state == MotionState.MOVING:
@@ -770,7 +1184,221 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             result["lateral_obstacle"] = lateral_obstacle
         return result
 
+    @motion_synchronized
+    def handle_bind_velocity_proposal(topic):
+        # A proposal stream and Unitree native navigation may never own motion
+        # at the same time.
+        if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
+            do_stop_nav()
+        if proposal_gate.connected_topic or proposal_node.topic:
+            stopped = handle_unbind_velocity_proposal("proposal_rebind")
+            if not stopped.get("stop_confirmed"):
+                return {
+                    "error": "StopMove was not confirmed before proposal rebind",
+                    "connected": False,
+                    "stop_confirmed": False,
+                }
+        else:
+            stopped = do_stop("proposal_bind")
+            physically_stopped = (
+                stopped.get("stop_confirmed")
+                and confirm_robot_stopped(
+                    proposal_stop_confirm_timeout,
+                    stopped["stop_issued_monotonic"],
+                )
+            )
+            if not physically_stopped:
+                return {
+                    "error": "StopMove/odometry stop was not confirmed before proposal bind",
+                    "connected": False,
+                    "stop_confirmed": False,
+                }
+        if not proposal_enabled:
+            return {"error": "velocity_proposal_execution_disabled", "connected": False}
+        if not proposal_driver_authorized:
+            return {"error": "driver_execution_not_authorized", "connected": False}
+        if topic != expected_proposal_topic:
+            return {
+                "error": "unexpected_velocity_proposal_topic",
+                "expected_topic": expected_proposal_topic,
+                "connected": False,
+            }
+        try:
+            proposal_node.bind(topic, on_velocity_proposal)
+            proposal_gate.bind(topic)
+            proposal_connected.set()
+            refresh_fsm_state()
+        except Exception as exc:
+            proposal_gate.unbind("subscription_create_failed")
+            proposal_connected.clear()
+            proposal_node.unbind()
+            try:
+                stop_loco_client.StopMove()
+            except Exception:
+                pass
+            return {"error": f"velocity_proposal_subscribe_failed: {exc}", "connected": False}
+        result = handle_get_velocity_proposal_status()
+        result["state"] = "connected"
+        return result
+
+    @motion_synchronized
+    def handle_unbind_velocity_proposal(reason="canvas_stop"):
+        # N5 ordering: command and observe physical stop before destroying the
+        # only proposal subscription.
+        if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
+            do_stop_nav()
+        stopped = do_stop(reason)
+        for _ in range(2):
+            if stopped.get("stop_confirmed"):
+                break
+            try:
+                stop_ret = issue_stop_move()
+            except Exception as exc:
+                stopped["error"] = f"StopMove failed: {exc}"
+            else:
+                stopped["ret"] = stop_ret
+                stopped["stop_confirmed"] = stop_ret == 0
+            finally:
+                stopped["stop_issued_monotonic"] = time.monotonic()
+        stopped["stop_confirmed"] = bool(
+            stopped.get("stop_confirmed")
+            and confirm_robot_stopped(
+                proposal_stop_confirm_timeout,
+                stopped["stop_issued_monotonic"],
+            )
+        )
+        if not stopped["stop_confirmed"]:
+            proposal_gate.disarm("stop_unconfirmed")
+            proposal_connected.clear()
+            return {
+                "state": "error",
+                "connected": bool(proposal_node.topic),
+                "armed": False,
+                "stop_confirmed": False,
+                "subscriber_retained": bool(proposal_node.topic),
+                "reason": reason,
+                "error": stopped.get("error") or "fresh zero-odometry stop was not confirmed",
+            }
+        proposal_gate.unbind(reason)
+        proposal_connected.clear()
+        proposal_node.unbind()
+        return {
+            "state": "idle",
+            "connected": False,
+            "stop_confirmed": True,
+            "reason": reason,
+            **({"error": stopped["error"]} if stopped.get("error") else {}),
+        }
+
+    @motion_synchronized
+    def handle_get_velocity_proposal_status():
+        result = proposal_gate.snapshot(time.monotonic())
+        result.update({
+            "enabled": proposal_enabled,
+            "canvas_running": proposal_connected.is_set(),
+            "driver_authorized": bool(
+                proposal_driver_authorized
+                and proposal_gate.connected_topic
+                and proposal_gate.armed
+            ),
+            "expected_topic": expected_proposal_topic,
+            "schema": proposal_limits.schema,
+            "safety": proposal_runtime_status(force_fsm_check=False),
+        })
+        return result
+
+    @motion_synchronized
+    def on_velocity_proposal(msg):
+        nonlocal last_nav_status_time
+        now = time.monotonic()
+        pending_fault = current_proposal_watchdog_fault()
+        if pending_fault:
+            _, reason = pending_fault
+            if reason == "proposal_ttl_expired":
+                proposal_gate.watchdog(now)
+                do_stop(reason)
+            else:
+                proposal_gate.disarm(reason)
+                do_stop(reason)
+                return
+        try:
+            payload = json.loads(msg.data)
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            if proposal_gate.armed:
+                proposal_gate.disarm("invalid_json")
+                do_stop("invalid_json")
+            return
+
+        was_armed = proposal_gate.armed
+        decision = proposal_gate.accept(payload, now)
+        if decision.stop:
+            is_proposal_motion = bool(
+                current_cmd and current_cmd.get("source") == "velocity_proposal"
+            )
+            newly_disarmed = was_armed and not proposal_gate.armed
+            if decision.proposal is not None or is_proposal_motion or newly_disarmed:
+                do_stop(decision.reason)
+            return
+        if not decision.execute or decision.proposal is None:
+            return
+
+        with safety_lock:
+            last_nav_status_time = now
+
+        # Refresh the Unitree controller state immediately before every
+        # physical command; do not authorize from a cached FSM sample.
+        runtime = proposal_runtime_status(force_fsm_check=True)
+        if not runtime["ready"]:
+            reason = runtime["reason"] or "driver_safety_not_ready"
+            proposal_gate.disarm(reason)
+            do_stop(reason)
+            return
+
+        proposal = decision.proposal
+        remaining = proposal_gate.deadline_monotonic - time.monotonic()
+        if remaining <= 0.0:
+            proposal_gate.watchdog(time.monotonic())
+            do_stop("proposal_ttl_expired")
+            return
+        result = handle_move(
+            proposal.x,
+            proposal.y,
+            proposal.yaw,
+            remaining,
+            finite_rpc=True,
+            source="velocity_proposal",
+        )
+        watchdog_reason = result.get("watchdog_reason")
+        if watchdog_reason:
+            if watchdog_reason != "proposal_ttl_expired":
+                proposal_gate.disarm(watchdog_reason)
+            else:
+                proposal_gate.watchdog(time.monotonic())
+            do_stop(watchdog_reason)
+            return
+        ret = result.get("ret")
+        if ret not in (None, 0):
+            proposal_gate.disarm("set_velocity_failed")
+            do_stop("set_velocity_failed")
+
+    @motion_synchronized
+    def apply_safety_velocity(cmd, vx, vy, vyaw):
+        """Preserve a proposal's finite firmware lease during deceleration."""
+        if cmd and cmd.get("source") == "velocity_proposal":
+            remaining = proposal_gate.deadline_monotonic - time.monotonic()
+            if remaining <= 0.0:
+                proposal_gate.watchdog(time.monotonic())
+                do_stop("proposal_ttl_expired")
+                return
+            ret = proposal_loco_client.SetVelocity(vx, vy, vyaw, remaining)
+            if ret != 0:
+                proposal_gate.disarm("set_velocity_failed")
+                do_stop("set_velocity_failed")
+            return
+        loco_client.Move(vx, vy, vyaw, True)
+
     # ── Safety checks (inline in main loop) ──
+    @motion_synchronized
     def process_safety_checks():
         nonlocal state, speed_zone
 
@@ -793,7 +1421,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     speed_zone = SpeedZone.DECELERATED
                     if current_cmd:
                         dvx, dvy, dvyaw = clamp(current_cmd["vx"], current_cmd["vy"], current_cmd["vyaw"], SpeedZone.DECELERATED)
-                        loco_client.Move(dvx, dvy, dvyaw, True)
+                        apply_safety_velocity(current_cmd, dvx, dvy, dvyaw)
                         publish_event("joint_overheat", {
                             "max_temp": round(temp, 1),
                             "action": "decelerate",
@@ -819,7 +1447,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     print(f"[SmartMotion:obstacle] DECEL — dist={dist:.2f}m angle={math.degrees(obstacle_angle):.1f}° lateral={lateral}", flush=True)
                     if cmd:
                         dvx, dvy, dvyaw = clamp(cmd["vx"], cmd["vy"], cmd["vyaw"], SpeedZone.DECELERATED)
-                        loco_client.Move(dvx, dvy, dvyaw, True)
+                        apply_safety_velocity(cmd, dvx, dvy, dvyaw)
                         with obstacle_lock:
                             od = obstacle_dist
                             oa = obstacle_angle
@@ -834,7 +1462,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     speed_zone = SpeedZone.NORMAL
                     if cmd:
                         cvx, cvy, cvyaw = clamp(cmd["vx"], cmd["vy"], cmd["vyaw"], SpeedZone.NORMAL)
-                        loco_client.Move(cvx, cvy, cvyaw, True)
+                        apply_safety_velocity(cmd, cvx, cvy, cvyaw)
                         publish_event("motion_resume", {"speed": {"vx": cvx, "vy": cvy, "vyaw": cvyaw}})
 
         elif state == MotionState.NAVIGATING:
@@ -856,39 +1484,147 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                 print(f"[SmartMotion:nav_obstacle] RESUME NAV — "
                       f"dist={dist:.2f}m, obstacle cleared", flush=True)
 
+    def fsm_monitor_loop():
+        """Poll main-control authorization independently of proposal callbacks."""
+        while not safety_threads_shutdown.is_set():
+            if not proposal_connected.wait(timeout=0.05):
+                continue
+            refresh_fsm_state()
+            if safety_threads_shutdown.wait(proposal_fsm_check_interval):
+                break
+
+    def proposal_watchdog_loop():
+        """At >=20 Hz, physically stop an active proposal on TTL or fault."""
+        nonlocal proposal_execution_active, proposal_watchdog_fault
+        period = 1.0 / proposal_watchdog_hz
+        while not safety_threads_shutdown.wait(period):
+            now = time.monotonic()
+            with proposal_execution_lock:
+                if not proposal_execution_active:
+                    continue
+                generation = proposal_execution_generation
+                deadline = proposal_execution_deadline
+            reason = "proposal_ttl_expired" if now >= deadline else ""
+            if not reason:
+                runtime = proposal_runtime_status(force_fsm_check=False)
+                if not runtime["ready"]:
+                    reason = runtime["reason"] or "driver_safety_not_ready"
+            if not reason:
+                continue
+            with proposal_execution_lock:
+                if (
+                    not proposal_execution_active
+                    or generation != proposal_execution_generation
+                ):
+                    continue
+                proposal_execution_active = False
+                proposal_watchdog_fault = (generation, reason)
+            try:
+                watchdog_loco_client.StopMove()
+            except Exception:
+                pass
+
+    def consume_proposal_watchdog_fault():
+        with proposal_execution_lock:
+            fault = proposal_watchdog_fault
+        if not fault:
+            return
+        generation, reason = fault
+        with proposal_execution_lock:
+            if generation != proposal_execution_generation:
+                return
+        with motion_command_lock:
+            if reason == "proposal_ttl_expired":
+                proposal_gate.watchdog(time.monotonic())
+            else:
+                proposal_gate.disarm(reason)
+            do_stop(reason)
+
     # ── Main loop ──
+    fsm_monitor_thread = threading.Thread(
+        target=fsm_monitor_loop,
+        daemon=True,
+        name="g1_loco_fsm_monitor",
+    )
+    proposal_watchdog_thread = threading.Thread(
+        target=proposal_watchdog_loop,
+        daemon=True,
+        name="g1_loco_velocity_watchdog",
+    )
+    fsm_monitor_thread.start()
+    proposal_watchdog_thread.start()
     print(f"[SmartMotion:pid={os.getpid()}] entering main loop")
     running = True
     last_obstacle_check = 0.0
     last_slam_info_log = 0.0
 
     while running:
+        try:
+            consume_proposal_watchdog_fault()
+        except Exception as exc:
+            with motion_command_lock:
+                proposal_gate.disarm("watchdog_fault_handler_error")
+                try:
+                    stop_loco_client.StopMove()
+                except Exception:
+                    pass
+            print(
+                f"[SmartMotion] watchdog fault handling failed closed: {exc}",
+                flush=True,
+            )
         # Process commands (non-blocking)
+        cmd = None
         try:
             cmd = cmd_queue.get(timeout=0.05)
             method = cmd.get("method")
             result = None
 
             if method == "move":
-                result = handle_move(cmd["vx"], cmd["vy"], cmd["vyaw"], cmd["duration"])
+                with motion_command_lock:
+                    proposal_gate.disarm("manual_override")
+                    result = handle_move(
+                        cmd["vx"], cmd["vy"], cmd["vyaw"], cmd["duration"],
+                        source="mcp",
+                    )
             elif method == "stop":
-                result = do_stop(cmd.get("reason", "command"))
+                with motion_command_lock:
+                    proposal_gate.disarm("manual_stop")
+                    if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
+                        do_stop_nav()
+                    result = do_stop(cmd.get("reason", "command"))
             elif method == "navigate_to":
-                result = handle_navigate_to(cmd["x"], cmd["y"], cmd["yaw"],
-                                            cmd.get("target_name", ""),
-                                            speed=cmd.get("speed", 0.5),
-                                            mode=cmd.get("mode", 1),
-                                            stall_timeout=cmd.get("stall_timeout", 60))
+                with motion_command_lock:
+                    proposal_gate.disarm("native_navigation_override")
+                    result = handle_navigate_to(
+                        cmd["x"], cmd["y"], cmd["yaw"],
+                        cmd.get("target_name", ""),
+                        speed=cmd.get("speed", 0.5),
+                        mode=cmd.get("mode", 1),
+                        stall_timeout=cmd.get("stall_timeout", 60),
+                    )
             elif method == "pause_nav":
                 result = handle_pause_nav(cmd.get("reason", "command"))
             elif method == "resume_nav":
                 result = handle_resume_nav()
             elif method == "stop_nav":
-                result = do_stop_nav()
+                with motion_command_lock:
+                    proposal_gate.disarm("native_stop_nav")
+                    if state == MotionState.MOVING:
+                        result = do_stop("native_stop_nav")
+                    else:
+                        result = do_stop_nav()
             elif method == "wait_nav_done":
                 result = handle_wait_nav_done(cmd.get("stall_timeout", 60))
             elif method == "get_state":
                 result = handle_get_state()
+            elif method == "bind_velocity_proposal":
+                result = handle_bind_velocity_proposal(cmd.get("topic", ""))
+            elif method == "unbind_velocity_proposal":
+                result = handle_unbind_velocity_proposal(
+                    cmd.get("reason", "canvas_stop")
+                )
+            elif method == "get_velocity_proposal_status":
+                result = handle_get_velocity_proposal_status()
             elif method == "start_mapping":
                 code, resp = slam_client.StartMapping()
                 result = {"code": code, "response": resp}
@@ -909,30 +1645,56 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                 )
                 result = {"code": code, "response": resp}
             elif method == "shutdown":
-                if state == MotionState.MOVING:
-                    loco_client.StopMove()
-                elif state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
-                    try:
-                        slam_client.PauseNav()
-                    except Exception:
-                        pass
+                handle_unbind_velocity_proposal("process_shutdown")
                 running = False
                 result = {"status": "shutdown"}
+            else:
+                result = {"error": f"unknown SmartMotion method: {method}"}
 
             if result is not None:
-                result_queue.put(result)
+                result_queue.put({
+                    "request_id": cmd.get("request_id"),
+                    "result": result,
+                })
         except queue.Empty:
             pass
+        except Exception as exc:
+            with motion_command_lock:
+                proposal_gate.disarm("smart_motion_command_error")
+                try:
+                    stop_loco_client.StopMove()
+                except Exception:
+                    pass
+            if cmd is not None:
+                result_queue.put({
+                    "request_id": cmd.get("request_id"),
+                    "result": {"error": f"SmartMotion command failed: {exc}"},
+                })
 
         # Safety checks at 10Hz
         now = time.monotonic()
         if now - last_obstacle_check >= 0.1:
             last_obstacle_check = now
-            process_safety_checks()
+            try:
+                process_safety_checks()
+            except Exception as exc:
+                with motion_command_lock:
+                    proposal_gate.disarm("safety_check_error")
+                    try:
+                        stop_loco_client.StopMove()
+                    except Exception:
+                        pass
+                print(
+                    f"[SmartMotion] safety check failed closed: {exc}",
+                    flush=True,
+                )
 
             # Repeat StopMove after emergency_stop to ensure controller receives it
             if stop_repeat_count > 0 and state == MotionState.IDLE:
-                loco_client.StopMove()
+                try:
+                    stop_loco_client.StopMove()
+                except Exception:
+                    pass
                 stop_repeat_count -= 1
 
         # Periodic health log: verify slam_info subscription is working
@@ -942,11 +1704,30 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                   f"pos_info={slam_info_pos_count} state={state.value}", flush=True)
 
         # Spin ROS2 (non-blocking)
-        executor.spin_once(timeout_sec=0)
+        try:
+            executor.spin_once(timeout_sec=0)
+        except Exception as exc:
+            with motion_command_lock:
+                proposal_gate.disarm("proposal_callback_error")
+                do_stop("proposal_callback_error")
+            print(f"[SmartMotion] ROS callback failed: {exc}", flush=True)
 
     # Cleanup
+    safety_threads_shutdown.set()
+    proposal_connected.clear()
+    proposal_watchdog_thread.join(timeout=0.5)
+    fsm_monitor_thread.join(timeout=0.75)
     if move_timer:
         move_timer.cancel()
+    with motion_command_lock:
+        stopped = do_stop("process_exit")
+        if stopped.get("stop_confirmed"):
+            stopped["stop_confirmed"] = confirm_robot_stopped(
+                proposal_stop_confirm_timeout,
+                stopped["stop_issued_monotonic"],
+            )
+        proposal_gate.unbind("process_exit")
+        proposal_node.unbind()
     executor.shutdown()
     rclpy.shutdown()
     print(f"[SmartMotion:pid={os.getpid()}] shutdown complete")

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -32,6 +32,7 @@ from velocity_proposal import (
     DEFAULT_VELOCITY_PROPOSAL_TOPIC,
     ProposalLimits,
     VelocityProposalGate,
+    resolve_expected_nav_id,
 )
 
 
@@ -180,8 +181,12 @@ class SmartMotionProxy:
     def get_state(self) -> dict:
         return self._call("get_state")
 
-    def bind_velocity_proposal(self, topic: str) -> dict:
-        return self._call("bind_velocity_proposal", topic=topic)
+    def bind_velocity_proposal(self, topic: str, expected_nav_id: str) -> dict:
+        return self._call(
+            "bind_velocity_proposal",
+            topic=topic,
+            expected_nav_id=expected_nav_id,
+        )
 
     def unbind_velocity_proposal(self, reason: str = "canvas_stop") -> dict:
         return self._call("unbind_velocity_proposal", reason=reason)
@@ -1185,7 +1190,23 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         return result
 
     @motion_synchronized
-    def handle_bind_velocity_proposal(topic):
+    def handle_bind_velocity_proposal(topic, expected_nav_id):
+        try:
+            expected_nav_id = resolve_expected_nav_id(
+                {"expected_nav_id": expected_nav_id}
+            )
+        except ValueError as exc:
+            proposal_gate.disarm(str(exc))
+            do_stop(str(exc))
+            return {
+                "error": str(exc),
+                "connected": bool(proposal_node.topic),
+                "armed": False,
+            }
+        if proposal_gate.is_bound_to(topic, expected_nav_id):
+            result = handle_get_velocity_proposal_status()
+            result["state"] = "connected"
+            return result
         # A proposal stream and Unitree native navigation may never own motion
         # at the same time.
         if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
@@ -1224,8 +1245,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 "connected": False,
             }
         try:
+            proposal_gate.bind(topic, expected_nav_id)
             proposal_node.bind(topic, on_velocity_proposal)
-            proposal_gate.bind(topic)
             proposal_connected.set()
             refresh_fsm_state()
         except Exception as exc:
@@ -1618,7 +1639,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             elif method == "get_state":
                 result = handle_get_state()
             elif method == "bind_velocity_proposal":
-                result = handle_bind_velocity_proposal(cmd.get("topic", ""))
+                result = handle_bind_velocity_proposal(
+                    cmd.get("topic", ""),
+                    cmd.get("expected_nav_id", ""),
+                )
             elif method == "unbind_velocity_proposal":
                 result = handle_unbind_velocity_proposal(
                     cmd.get("reason", "canvas_stop")

--- a/unitree/g1/tests/test_loco_topic_lifecycle.py
+++ b/unitree/g1/tests/test_loco_topic_lifecycle.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+
+
+def _install_driver_import_stubs():
+    rclpy = types.ModuleType("rclpy")
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_qos = types.ModuleType("rclpy.qos")
+
+    class Node:
+        pass
+
+    class QoSProfile:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class EnumValue:
+        BEST_EFFORT = "best_effort"
+        RELIABLE = "reliable"
+        KEEP_LAST = "keep_last"
+        VOLATILE = "volatile"
+
+    rclpy_node.Node = Node
+    rclpy_qos.QoSProfile = QoSProfile
+    rclpy_qos.ReliabilityPolicy = EnumValue
+    rclpy_qos.HistoryPolicy = EnumValue
+    rclpy_qos.DurabilityPolicy = EnumValue
+
+    std_msgs = types.ModuleType("std_msgs")
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    std_msgs_msg.Header = type("Header", (), {})
+    std_msgs_msg.String = type("String", (), {})
+
+    audio_msgs = types.ModuleType("audio_msgs")
+    audio_msgs_msg = types.ModuleType("audio_msgs.msg")
+    audio_msgs_msg.AudioChunk = type("AudioChunk", (), {})
+
+    unitree_sdk = types.ModuleType("unitree_sdk2py")
+    unitree_g1 = types.ModuleType("unitree_sdk2py.g1")
+    unitree_audio = types.ModuleType("unitree_sdk2py.g1.audio")
+    unitree_audio_client = types.ModuleType("unitree_sdk2py.g1.audio.g1_audio_client")
+    unitree_audio_client.AudioClient = type("AudioClient", (), {})
+
+    pointcloud_utils = types.ModuleType("pointcloud_utils")
+    pointcloud_utils.gravity_align_inplace = lambda *args, **kwargs: None
+    numpy = types.ModuleType("numpy")
+
+    modules = {
+        "rclpy": rclpy,
+        "rclpy.node": rclpy_node,
+        "rclpy.qos": rclpy_qos,
+        "std_msgs": std_msgs,
+        "std_msgs.msg": std_msgs_msg,
+        "audio_msgs": audio_msgs,
+        "audio_msgs.msg": audio_msgs_msg,
+        "unitree_sdk2py": unitree_sdk,
+        "unitree_sdk2py.g1": unitree_g1,
+        "unitree_sdk2py.g1.audio": unitree_audio,
+        "unitree_sdk2py.g1.audio.g1_audio_client": unitree_audio_client,
+        "pointcloud_utils": pointcloud_utils,
+        "numpy": numpy,
+    }
+    for name, module in modules.items():
+        sys.modules.setdefault(name, module)
+
+
+_install_driver_import_stubs()
+
+from device import LocoPlugin  # noqa: E402
+
+
+class FakeClient:
+    def __init__(self):
+        self.stop_count = 0
+        self.fsm_ids = []
+
+    def StopMove(self):
+        self.stop_count += 1
+        return 0
+
+    def SetFsmId(self, fsm_id):
+        self.fsm_ids.append(fsm_id)
+        return 0
+
+
+class FakeSmartMotion:
+    def __init__(self):
+        self.bound_topic = ""
+        self.unbind_reasons = []
+        self.unbind_result = {
+            "state": "idle",
+            "connected": False,
+            "stop_confirmed": True,
+        }
+
+    def bind_velocity_proposal(self, topic):
+        self.bound_topic = topic
+        return {"connected": True, "armed": True, "topic": topic}
+
+    def unbind_velocity_proposal(self, reason):
+        self.unbind_reasons.append(reason)
+        result = dict(self.unbind_result)
+        if not result.get("connected"):
+            self.bound_topic = ""
+        return result
+
+    def get_velocity_proposal_status(self):
+        return {
+            "connected": bool(self.bound_topic),
+            "armed": bool(self.bound_topic),
+            "topic": self.bound_topic or None,
+        }
+
+
+class LocoTopicLifecycleTest(unittest.TestCase):
+    def setUp(self):
+        self.client = FakeClient()
+        self.smart_motion = FakeSmartMotion()
+        self.plugin = LocoPlugin(
+            {}, "ubuntu", executor=None, loco_client=self.client,
+            smart_motion=self.smart_motion,
+        )
+        self.topic = "/ubuntu/navigation/nav2/velocity_proposal"
+
+    def test_tool_exposes_velocity_proposal_input(self):
+        self.assertEqual(self.plugin.STOP_PRIORITY, 0)
+        tool = self.plugin.get_tools()[0]
+        port = tool["topic_in"]
+        self.assertEqual(len(port), 1)
+        self.assertEqual(port[0]["port"], "velocity_proposal")
+        self.assertEqual(port[0]["topic"], self.topic)
+        self.assertEqual(
+            tool["inputSchema"]["properties"]["action"]["enum"],
+            [
+                "move", "stop_move", "set_stand_height", "get_fsm_id",
+                "get_fsm_mode", "get_balance_mode", "get_swing_height",
+                "get_stand_height", "get_phase", "wave_hand", "shake_hand",
+            ],
+        )
+
+    def test_start_info_stop_owns_real_subscription_lifecycle(self):
+        started = self.plugin.dispatch("start", {"input_topic": self.topic})
+        self.assertTrue(started["connected"])
+        self.assertEqual(self.smart_motion.bound_topic, self.topic)
+
+        info = self.plugin.dispatch("info", {"_tool_name": "loco"})
+        self.assertTrue(info["connected"])
+        self.assertTrue(info["armed"])
+
+        stopped = self.plugin.dispatch("stop", {})
+        self.assertFalse(stopped["connected"])
+        self.assertTrue(stopped["stop_confirmed"])
+        self.assertEqual(self.smart_motion.unbind_reasons, ["canvas_stop"])
+
+    def test_start_accepts_exactly_one_input_topics_entry(self):
+        started = self.plugin.dispatch("start", {"input_topics": [self.topic]})
+        self.assertTrue(started["connected"])
+        self.assertEqual(self.smart_motion.bound_topic, self.topic)
+
+    def test_other_tools_do_not_bind_or_unbind_loco_topic(self):
+        self.smart_motion.bound_topic = self.topic
+
+        started = self.plugin.dispatch(
+            "start", {"_tool_name": "motion_events"}
+        )
+        stopped = self.plugin.dispatch(
+            "stop", {"_tool_name": "switch_mode"}
+        )
+
+        self.assertEqual(started, {"state": "running"})
+        self.assertEqual(stopped, {"state": "idle"})
+        self.assertEqual(self.smart_motion.bound_topic, self.topic)
+        self.assertEqual(self.smart_motion.unbind_reasons, [])
+        self.assertEqual(self.client.stop_count, 0)
+
+    def test_wrong_topic_fails_closed_without_binding(self):
+        self.smart_motion.bound_topic = self.topic
+        result = self.plugin.dispatch(
+            "start", {"input_topic": "/ubuntu/navigation/nav2/cmd_vel_shadow"}
+        )
+        self.assertEqual(result["state"], "error")
+        self.assertFalse(result["connected"])
+        self.assertEqual(self.client.stop_count, 1)
+        self.assertEqual(self.smart_motion.bound_topic, "")
+        self.assertEqual(self.smart_motion.unbind_reasons, ["proposal_bind_rejected"])
+
+    def test_missing_safety_harness_cannot_execute_topic(self):
+        plugin = LocoPlugin({}, "ubuntu", None, self.client, smart_motion=None)
+        result = plugin.dispatch("start", {"input_topic": self.topic})
+        self.assertEqual(result["state"], "error")
+        self.assertFalse(result["connected"])
+        self.assertEqual(self.client.stop_count, 1)
+
+    def test_unconfirmed_stop_falls_back_and_blocks_mode_switch(self):
+        self.smart_motion.bound_topic = self.topic
+        self.smart_motion.unbind_result = {
+            "state": "error",
+            "connected": True,
+            "stop_confirmed": False,
+            "error": "fresh zero-odometry stop was not confirmed",
+        }
+
+        result = self.plugin.dispatch("switch_mode_expert", {"fsm_id": 1})
+
+        self.assertEqual(result["state"], "error")
+        self.assertEqual(self.client.stop_count, 1)
+        self.assertEqual(self.client.fsm_ids, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_loco_topic_lifecycle.py
+++ b/unitree/g1/tests/test_loco_topic_lifecycle.py
@@ -89,6 +89,7 @@ class FakeClient:
 class FakeSmartMotion:
     def __init__(self):
         self.bound_topic = ""
+        self.expected_nav_id = ""
         self.unbind_reasons = []
         self.unbind_result = {
             "state": "idle",
@@ -96,15 +97,24 @@ class FakeSmartMotion:
             "stop_confirmed": True,
         }
 
-    def bind_velocity_proposal(self, topic):
+    def bind_velocity_proposal(self, topic, expected_nav_id):
         self.bound_topic = topic
-        return {"connected": True, "armed": True, "topic": topic}
+        self.expected_nav_id = expected_nav_id
+        return {
+            "state": "connected",
+            "connected": True,
+            "armed": True,
+            "topic": topic,
+            "expected_nav_id": expected_nav_id,
+            "active_nav_id": expected_nav_id,
+        }
 
     def unbind_velocity_proposal(self, reason):
         self.unbind_reasons.append(reason)
         result = dict(self.unbind_result)
         if not result.get("connected"):
             self.bound_topic = ""
+            self.expected_nav_id = ""
         return result
 
     def get_velocity_proposal_status(self):
@@ -112,6 +122,8 @@ class FakeSmartMotion:
             "connected": bool(self.bound_topic),
             "armed": bool(self.bound_topic),
             "topic": self.bound_topic or None,
+            "expected_nav_id": self.expected_nav_id or None,
+            "active_nav_id": self.expected_nav_id or None,
         }
 
 
@@ -124,6 +136,7 @@ class LocoTopicLifecycleTest(unittest.TestCase):
             smart_motion=self.smart_motion,
         )
         self.topic = "/ubuntu/navigation/nav2/velocity_proposal"
+        self.nav_id = "nav-001"
 
     def test_tool_exposes_velocity_proposal_input(self):
         self.assertEqual(self.plugin.STOP_PRIORITY, 0)
@@ -142,9 +155,14 @@ class LocoTopicLifecycleTest(unittest.TestCase):
         )
 
     def test_start_info_stop_owns_real_subscription_lifecycle(self):
-        started = self.plugin.dispatch("start", {"input_topic": self.topic})
+        started = self.plugin.dispatch(
+            "start",
+            {"input_topic": self.topic, "expected_nav_id": self.nav_id},
+        )
         self.assertTrue(started["connected"])
+        self.assertEqual(started["state"], "ready")
         self.assertEqual(self.smart_motion.bound_topic, self.topic)
+        self.assertEqual(self.smart_motion.expected_nav_id, self.nav_id)
 
         info = self.plugin.dispatch("info", {"_tool_name": "loco"})
         self.assertTrue(info["connected"])
@@ -156,9 +174,21 @@ class LocoTopicLifecycleTest(unittest.TestCase):
         self.assertEqual(self.smart_motion.unbind_reasons, ["canvas_stop"])
 
     def test_start_accepts_exactly_one_input_topics_entry(self):
-        started = self.plugin.dispatch("start", {"input_topics": [self.topic]})
+        started = self.plugin.dispatch(
+            "start",
+            {"input_topics": [self.topic], "expected_nav_id": self.nav_id},
+        )
         self.assertTrue(started["connected"])
         self.assertEqual(self.smart_motion.bound_topic, self.topic)
+
+    def test_start_without_trusted_nav_id_fails_closed(self):
+        result = self.plugin.dispatch("start", {"input_topic": self.topic})
+
+        self.assertEqual(result["state"], "error")
+        self.assertFalse(result["connected"])
+        self.assertEqual(result["error"], "expected_nav_id_required")
+        self.assertEqual(self.smart_motion.bound_topic, "")
+        self.assertEqual(self.client.stop_count, 1)
 
     def test_other_tools_do_not_bind_or_unbind_loco_topic(self):
         self.smart_motion.bound_topic = self.topic
@@ -179,7 +209,11 @@ class LocoTopicLifecycleTest(unittest.TestCase):
     def test_wrong_topic_fails_closed_without_binding(self):
         self.smart_motion.bound_topic = self.topic
         result = self.plugin.dispatch(
-            "start", {"input_topic": "/ubuntu/navigation/nav2/cmd_vel_shadow"}
+            "start",
+            {
+                "input_topic": "/ubuntu/navigation/nav2/cmd_vel_shadow",
+                "expected_nav_id": self.nav_id,
+            },
         )
         self.assertEqual(result["state"], "error")
         self.assertFalse(result["connected"])
@@ -189,7 +223,10 @@ class LocoTopicLifecycleTest(unittest.TestCase):
 
     def test_missing_safety_harness_cannot_execute_topic(self):
         plugin = LocoPlugin({}, "ubuntu", None, self.client, smart_motion=None)
-        result = plugin.dispatch("start", {"input_topic": self.topic})
+        result = plugin.dispatch(
+            "start",
+            {"input_topic": self.topic, "expected_nav_id": self.nav_id},
+        )
         self.assertEqual(result["state"], "error")
         self.assertFalse(result["connected"])
         self.assertEqual(self.client.stop_count, 1)

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import unittest
+
+from safety_harness import SmartMotionProxy
+
+
+class FakeProcess:
+    def __init__(self):
+        self.join_count = 0
+
+    def join(self):
+        self.join_count += 1
+
+
+class SmartMotionExitMonitorTest(unittest.TestCase):
+    def test_child_exit_always_issues_parent_side_stop(self):
+        process = FakeProcess()
+        stop_calls = []
+        proxy = SmartMotionProxy.__new__(SmartMotionProxy)
+        proxy._proc = process
+        proxy._fallback_stop = lambda: stop_calls.append("StopMove")
+
+        proxy._monitor_process_exit()
+
+        self.assertEqual(process.join_count, 1)
+        self.assertEqual(stop_calls, ["StopMove"])
+
+    def test_stop_failure_does_not_crash_exit_monitor(self):
+        proxy = SmartMotionProxy.__new__(SmartMotionProxy)
+        proxy._proc = FakeProcess()
+
+        def fail_stop():
+            raise RuntimeError("rpc unavailable")
+
+        proxy._fallback_stop = fail_stop
+        proxy._monitor_process_exit()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -8,6 +8,7 @@ from velocity_proposal import (
     ProposalLimits,
     VelocityProposalGate,
     VelocityProposalValidationError,
+    resolve_expected_nav_id,
     resolve_input_topic,
     validate_velocity_proposal,
     velocity_proposal_port,
@@ -78,6 +79,22 @@ class TopicResolutionTest(unittest.TestCase):
             with self.subTest(args=args), self.assertRaises(ValueError):
                 resolve_input_topic(args, EXPECTED_TOPIC)
 
+    def test_resolves_trusted_expected_nav_id_from_control_plane(self):
+        self.assertEqual(
+            resolve_expected_nav_id({"expected_nav_id": " nav-001 "}),
+            "nav-001",
+        )
+
+    def test_rejects_missing_or_invalid_expected_nav_id(self):
+        for args in (
+            {},
+            {"expected_nav_id": ""},
+            {"expected_nav_id": 123},
+            {"expected_nav_id": "x" * 129},
+        ):
+            with self.subTest(args=args), self.assertRaises(ValueError):
+                resolve_expected_nav_id(args)
+
 
 class ProposalValidationTest(unittest.TestCase):
     def setUp(self):
@@ -145,7 +162,15 @@ class ProposalValidationTest(unittest.TestCase):
 class ProposalGateTest(unittest.TestCase):
     def setUp(self):
         self.gate = VelocityProposalGate(ProposalLimits())
-        self.gate.bind(EXPECTED_TOPIC)
+        self.gate.bind(EXPECTED_TOPIC, "nav-001")
+
+    def test_first_packet_must_match_control_plane_nav_lease(self):
+        rejected = self.gate.accept(
+            proposal(nav_id="attacker-selected", sequence=1), now=10.0
+        )
+        self.assertTrue(rejected.stop)
+        self.assertEqual(rejected.reason, "nav_id_mismatch")
+        self.assertFalse(self.gate.armed)
 
     def test_sequence_must_strictly_increase_for_active_nav(self):
         first = self.gate.accept(proposal(sequence=10), now=100.0)
@@ -163,7 +188,7 @@ class ProposalGateTest(unittest.TestCase):
         self.assertTrue(rejected.stop)
         self.assertEqual(rejected.reason, "nav_id_mismatch")
 
-    def test_terminal_zero_releases_nav_lease(self):
+    def test_terminal_zero_retires_and_disarms_nav_lease(self):
         self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
         terminal = self.gate.accept(
             proposal(
@@ -174,8 +199,15 @@ class ProposalGateTest(unittest.TestCase):
             now=10.1,
         )
         self.assertTrue(terminal.stop)
+        self.assertFalse(self.gate.armed)
         next_task = self.gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.2)
-        self.assertTrue(next_task.execute)
+        self.assertFalse(next_task.execute)
+        self.assertTrue(next_task.stop)
+
+        self.gate.bind(EXPECTED_TOPIC, "nav-002")
+        self.assertTrue(
+            self.gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.3).execute
+        )
 
     def test_completed_nav_id_cannot_be_replayed(self):
         self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
@@ -187,9 +219,8 @@ class ProposalGateTest(unittest.TestCase):
             ),
             now=10.1,
         )
-        replay = self.gate.accept(proposal(sequence=3), now=10.2)
-        self.assertTrue(replay.stop)
-        self.assertEqual(replay.reason, "retired_nav_id_replay")
+        with self.assertRaises(ValueError):
+            self.gate.bind(EXPECTED_TOPIC, "nav-001")
 
     def test_watchdog_uses_local_monotonic_deadline(self):
         accepted = self.gate.accept(proposal(ttl_ms=200), now=50.0)
@@ -207,8 +238,33 @@ class ProposalGateTest(unittest.TestCase):
         self.assertFalse(self.gate.armed)
         still_rejected = self.gate.accept(proposal(sequence=2), now=10.1)
         self.assertFalse(still_rejected.execute)
-        self.gate.bind(EXPECTED_TOPIC)
-        self.assertTrue(self.gate.accept(proposal(), now=10.2).execute)
+        with self.assertRaises(ValueError):
+            self.gate.bind(EXPECTED_TOPIC, "nav-001")
+        self.gate.bind(EXPECTED_TOPIC, "nav-002")
+        self.assertTrue(
+            self.gate.accept(proposal(nav_id="nav-002"), now=10.2).execute
+        )
+
+    def test_canvas_unbind_retires_nav_id_against_delayed_replay(self):
+        self.gate.unbind("canvas_stop")
+        with self.assertRaises(ValueError):
+            self.gate.bind(EXPECTED_TOPIC, "nav-001")
+
+    def test_repeated_identical_bind_is_idempotent_without_sequence_reset(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=10), now=10.0).execute)
+        self.gate.bind(EXPECTED_TOPIC, "nav-001")
+        replay = self.gate.accept(proposal(sequence=10), now=10.1)
+        self.assertTrue(replay.stop)
+        self.assertEqual(replay.reason, "sequence_not_increasing")
+
+    def test_retired_nav_ids_are_not_dropped_after_a_fixed_window(self):
+        self.gate.unbind("canvas_stop")
+        for index in range(2, 41):
+            self.gate.bind(EXPECTED_TOPIC, f"nav-{index:03d}")
+            self.gate.unbind("canvas_stop")
+        for index in range(1, 41):
+            with self.subTest(index=index), self.assertRaises(ValueError):
+                self.gate.bind(EXPECTED_TOPIC, f"nav-{index:03d}")
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import math
+import unittest
+
+from velocity_proposal import (
+    DEFAULT_VELOCITY_PROPOSAL_TOPIC,
+    ProposalLimits,
+    VelocityProposalGate,
+    VelocityProposalValidationError,
+    resolve_input_topic,
+    validate_velocity_proposal,
+    velocity_proposal_port,
+)
+
+
+EXPECTED_TOPIC = "/ubuntu/navigation/nav2/velocity_proposal"
+
+
+def proposal(**changes):
+    value = {
+        "schema": "phanthy.navigation.velocity_proposal.v1",
+        "nav_id": "nav-001",
+        "sequence": 1,
+        "issued_at_unix_ms": 1_800_000_000_000,
+        "ttl_ms": 200,
+        "frame": "base_link",
+        "shadow_only": True,
+        "physical_execution": False,
+        "nav_status": "navigating",
+        "velocity": {"x": 0.10, "y": 0.02, "yaw": 0.15},
+    }
+    value.update(changes)
+    return value
+
+
+class TopicResolutionTest(unittest.TestCase):
+    def test_n5_topic_is_not_namespace_dependent(self):
+        self.assertEqual(DEFAULT_VELOCITY_PROPOSAL_TOPIC, EXPECTED_TOPIC)
+
+    def test_port_matches_n5_contract(self):
+        self.assertEqual(
+            velocity_proposal_port(EXPECTED_TOPIC),
+            {
+                "port": "velocity_proposal",
+                "topic": EXPECTED_TOPIC,
+                "format": "data/json",
+                "ros_type": "std_msgs/msg/String",
+                "qos": "RELIABLE + KEEP_LAST(depth=10) + VOLATILE",
+                "schema": "phanthy.navigation.velocity_proposal.v1",
+            },
+        )
+
+    def test_accepts_single_input_topic(self):
+        self.assertEqual(
+            resolve_input_topic({"input_topic": EXPECTED_TOPIC}, EXPECTED_TOPIC),
+            EXPECTED_TOPIC,
+        )
+
+    def test_accepts_single_input_topics_entry(self):
+        self.assertEqual(
+            resolve_input_topic({"input_topics": [EXPECTED_TOPIC]}, EXPECTED_TOPIC),
+            EXPECTED_TOPIC,
+        )
+
+    def test_rejects_empty_multiple_or_unexpected_topics(self):
+        for args in (
+            {},
+            {"input_topics": []},
+            {"input_topics": [EXPECTED_TOPIC, ""]},
+            {"input_topics": [EXPECTED_TOPIC, "/other"]},
+            {
+                "input_topic": EXPECTED_TOPIC,
+                "input_topics": [EXPECTED_TOPIC],
+            },
+            {"input_topic": "/ubuntu/navigation/nav2/cmd_vel_shadow"},
+        ):
+            with self.subTest(args=args), self.assertRaises(ValueError):
+                resolve_input_topic(args, EXPECTED_TOPIC)
+
+
+class ProposalValidationTest(unittest.TestCase):
+    def setUp(self):
+        self.limits = ProposalLimits()
+
+    def test_valid_proposal(self):
+        result = validate_velocity_proposal(proposal(), self.limits)
+        self.assertEqual(result.nav_id, "nav-001")
+        self.assertEqual(result.ttl_ms, 200)
+        self.assertFalse(result.is_zero)
+
+    def test_rejects_wrong_schema_frame_or_flags(self):
+        cases = (
+            {"schema": "other"},
+            {"frame": "map"},
+            {"shadow_only": False},
+            {"physical_execution": True},
+        )
+        for changes in cases:
+            with self.subTest(changes=changes), self.assertRaises(VelocityProposalValidationError):
+                validate_velocity_proposal(proposal(**changes), self.limits)
+
+    def test_rejects_invalid_identity_timing_and_status_fields(self):
+        cases = (
+            {"nav_id": ""},
+            {"sequence": True},
+            {"issued_at_unix_ms": math.inf},
+            {"ttl_ms": True},
+            {"nav_status": "unknown"},
+            {"nav_status": None, "status": "navigating"},
+            {"nav_status": "navigating", "status": "navigating"},
+        )
+        for changes in cases:
+            with self.subTest(changes=changes), self.assertRaises(VelocityProposalValidationError):
+                validate_velocity_proposal(proposal(**changes), self.limits)
+
+    def test_rejects_nonfinite_and_each_speed_limit(self):
+        velocities = (
+            {"x": math.nan, "y": 0.0, "yaw": 0.0},
+            {"x": 0.151, "y": 0.0, "yaw": 0.0},
+            {"x": -0.051, "y": 0.0, "yaw": 0.0},
+            {"x": 0.0, "y": 0.121, "yaw": 0.0},
+            {"x": 0.0, "y": 0.0, "yaw": 0.351},
+            {"x": 0.15, "y": 0.11, "yaw": 0.0},
+        )
+        for velocity in velocities:
+            with self.subTest(velocity=velocity), self.assertRaises(VelocityProposalValidationError):
+                validate_velocity_proposal(proposal(velocity=velocity), self.limits)
+
+    def test_rejects_ttl_above_250_ms(self):
+        with self.assertRaises(VelocityProposalValidationError):
+            validate_velocity_proposal(proposal(ttl_ms=251), self.limits)
+
+    def test_terminal_status_requires_zero_velocity(self):
+        with self.assertRaises(VelocityProposalValidationError):
+            validate_velocity_proposal(proposal(nav_status="arrived"), self.limits)
+        result = validate_velocity_proposal(
+            proposal(nav_status="arrived", velocity={"x": 0.0, "y": 0.0, "yaw": 0.0}),
+            self.limits,
+        )
+        self.assertTrue(result.is_terminal)
+        self.assertTrue(result.is_zero)
+
+
+class ProposalGateTest(unittest.TestCase):
+    def setUp(self):
+        self.gate = VelocityProposalGate(ProposalLimits())
+        self.gate.bind(EXPECTED_TOPIC)
+
+    def test_sequence_must_strictly_increase_for_active_nav(self):
+        first = self.gate.accept(proposal(sequence=10), now=100.0)
+        second = self.gate.accept(proposal(sequence=11), now=100.05)
+        replay = self.gate.accept(proposal(sequence=11), now=100.10)
+        self.assertTrue(first.execute)
+        self.assertTrue(second.execute)
+        self.assertTrue(replay.stop)
+        self.assertFalse(self.gate.armed)
+        self.assertEqual(replay.reason, "sequence_not_increasing")
+
+    def test_nav_id_cannot_change_mid_task(self):
+        self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
+        rejected = self.gate.accept(proposal(nav_id="nav-002", sequence=2), now=10.1)
+        self.assertTrue(rejected.stop)
+        self.assertEqual(rejected.reason, "nav_id_mismatch")
+
+    def test_terminal_zero_releases_nav_lease(self):
+        self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
+        terminal = self.gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+        self.assertTrue(terminal.stop)
+        next_task = self.gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.2)
+        self.assertTrue(next_task.execute)
+
+    def test_completed_nav_id_cannot_be_replayed(self):
+        self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
+        self.gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+        replay = self.gate.accept(proposal(sequence=3), now=10.2)
+        self.assertTrue(replay.stop)
+        self.assertEqual(replay.reason, "retired_nav_id_replay")
+
+    def test_watchdog_uses_local_monotonic_deadline(self):
+        accepted = self.gate.accept(proposal(ttl_ms=200), now=50.0)
+        self.assertAlmostEqual(accepted.duration, 0.2)
+        self.assertFalse(self.gate.watchdog(now=50.199).stop)
+        expired = self.gate.watchdog(now=50.201)
+        self.assertTrue(expired.stop)
+        self.assertEqual(expired.reason, "proposal_ttl_expired")
+        self.assertFalse(self.gate.armed)
+        self.assertFalse(self.gate.accept(proposal(sequence=2), now=50.202).execute)
+
+    def test_invalid_payload_disarms_until_explicit_bind(self):
+        rejected = self.gate.accept(proposal(frame="map"), now=10.0)
+        self.assertTrue(rejected.stop)
+        self.assertFalse(self.gate.armed)
+        still_rejected = self.gate.accept(proposal(sequence=2), now=10.1)
+        self.assertFalse(still_rejected.execute)
+        self.gate.bind(EXPECTED_TOPIC)
+        self.assertTrue(self.gate.accept(proposal(), now=10.2).execute)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -1,0 +1,303 @@
+"""Pure validation and lease state for the N5 Nav2 velocity proposal gate.
+
+This module deliberately has no ROS 2 or Unitree dependency.  The SmartMotion
+subprocess owns physical execution; it may act only on a ProposalDecision
+returned here.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+
+VELOCITY_PROPOSAL_SCHEMA = "phanthy.navigation.velocity_proposal.v1"
+DEFAULT_VELOCITY_PROPOSAL_TOPIC = "/ubuntu/navigation/nav2/velocity_proposal"
+TERMINAL_STATUSES = {
+    "paused",
+    "arrived",
+    "cancelled",
+    "stopped",
+    "error",
+    "aborted",
+    "rejected",
+}
+ACTIVE_STATUSES = {"planning", "navigating", "replanning", "running", "active"}
+ALLOWED_STATUSES = TERMINAL_STATUSES | ACTIVE_STATUSES
+_STATUS_FIELD = "nav_status"
+_UNSUPPORTED_STATUS_ALIASES = {"status", "navigation_status", "navigation_state"}
+
+
+def velocity_proposal_port(topic: str) -> dict:
+    """Return the authoritative N5 canvas port declaration."""
+    return {
+        "port": "velocity_proposal",
+        "topic": topic,
+        "format": "data/json",
+        "ros_type": "std_msgs/msg/String",
+        "qos": "RELIABLE + KEEP_LAST(depth=10) + VOLATILE",
+        "schema": VELOCITY_PROPOSAL_SCHEMA,
+    }
+
+
+class VelocityProposalValidationError(ValueError):
+    """Validation error with a stable fail-closed reason code."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class ProposalLimits:
+    schema: str = VELOCITY_PROPOSAL_SCHEMA
+    frame: str = "base_link"
+    max_ttl_ms: int = 250
+    min_x: float = -0.05
+    max_x: float = 0.15
+    max_abs_y: float = 0.12
+    max_abs_yaw: float = 0.35
+    max_planar_speed: float = 0.18
+
+
+@dataclass(frozen=True)
+class ValidatedVelocityProposal:
+    nav_id: str
+    sequence: int
+    issued_at_unix_ms: float
+    ttl_ms: int
+    frame: str
+    status: str
+    x: float
+    y: float
+    yaw: float
+
+    @property
+    def is_zero(self) -> bool:
+        return self.x == 0.0 and self.y == 0.0 and self.yaw == 0.0
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in TERMINAL_STATUSES
+
+
+@dataclass(frozen=True)
+class ProposalDecision:
+    execute: bool = False
+    stop: bool = False
+    reason: str = ""
+    duration: float = 0.0
+    proposal: Optional[ValidatedVelocityProposal] = None
+
+
+def resolve_input_topic(args: Mapping[str, Any], expected_topic: str) -> str:
+    """Resolve the canvas connection and reject every topic except the N5 port."""
+    has_input_topic = bool(str(args.get("input_topic") or "").strip())
+    has_input_topics = args.get("input_topics") is not None
+    if has_input_topic and has_input_topics:
+        raise ValueError("input_topic_and_input_topics_are_mutually_exclusive")
+    topics = []
+    input_topics = args.get("input_topics")
+    if input_topics is not None:
+        if not isinstance(input_topics, (list, tuple)):
+            raise ValueError("input_topics_must_be_a_list")
+        if len(input_topics) != 1:
+            raise ValueError("exactly_one_velocity_proposal_topic_required")
+        topics.append(str(input_topics[0]).strip())
+    input_topic = str(args.get("input_topic") or "").strip()
+    if input_topic and input_topic not in topics:
+        topics.append(input_topic)
+    if len(topics) != 1:
+        raise ValueError("exactly_one_velocity_proposal_topic_required")
+    if topics[0] != expected_topic:
+        raise ValueError("unexpected_velocity_proposal_topic")
+    return topics[0]
+
+
+def _finite_number(value: Any, code: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise VelocityProposalValidationError(code)
+    result = float(value)
+    if not math.isfinite(result):
+        raise VelocityProposalValidationError(code)
+    return result
+
+
+def _status(payload: Mapping[str, Any]) -> str:
+    if any(field in payload for field in _UNSUPPORTED_STATUS_ALIASES):
+        raise VelocityProposalValidationError("unsupported_navigation_status_field")
+    status = payload.get(_STATUS_FIELD)
+    if not isinstance(status, str) or not status.strip():
+        raise VelocityProposalValidationError("invalid_navigation_status")
+    normalized = status.strip().lower()
+    if normalized not in ALLOWED_STATUSES:
+        raise VelocityProposalValidationError("unsupported_navigation_status")
+    return normalized
+
+
+def validate_velocity_proposal(
+    payload: Mapping[str, Any],
+    limits: ProposalLimits,
+) -> ValidatedVelocityProposal:
+    if not isinstance(payload, Mapping):
+        raise VelocityProposalValidationError("proposal_must_be_object")
+    if payload.get("schema") != limits.schema:
+        raise VelocityProposalValidationError("schema_mismatch")
+    if payload.get("frame") != limits.frame:
+        raise VelocityProposalValidationError("frame_mismatch")
+    if payload.get("shadow_only") is not True:
+        raise VelocityProposalValidationError("shadow_only_flag_required")
+    if payload.get("physical_execution") is not False:
+        raise VelocityProposalValidationError("physical_execution_flag_must_be_false")
+
+    nav_id = payload.get("nav_id")
+    if not isinstance(nav_id, str) or not nav_id.strip() or len(nav_id) > 128:
+        raise VelocityProposalValidationError("invalid_nav_id")
+    sequence = payload.get("sequence")
+    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 0:
+        raise VelocityProposalValidationError("invalid_sequence")
+    ttl_ms = payload.get("ttl_ms")
+    if (
+        isinstance(ttl_ms, bool)
+        or not isinstance(ttl_ms, int)
+        or ttl_ms <= 0
+        or ttl_ms > limits.max_ttl_ms
+    ):
+        raise VelocityProposalValidationError("invalid_ttl_ms")
+    issued_at = _finite_number(payload.get("issued_at_unix_ms"), "invalid_issued_at_unix_ms")
+
+    velocity = payload.get("velocity")
+    if not isinstance(velocity, Mapping):
+        raise VelocityProposalValidationError("velocity_must_be_object")
+    x = _finite_number(velocity.get("x"), "invalid_velocity_x")
+    y = _finite_number(velocity.get("y"), "invalid_velocity_y")
+    yaw = _finite_number(velocity.get("yaw"), "invalid_velocity_yaw")
+    if x < limits.min_x or x > limits.max_x:
+        raise VelocityProposalValidationError("velocity_x_limit")
+    if abs(y) > limits.max_abs_y:
+        raise VelocityProposalValidationError("velocity_y_limit")
+    if abs(yaw) > limits.max_abs_yaw:
+        raise VelocityProposalValidationError("velocity_yaw_limit")
+    if math.hypot(x, y) > limits.max_planar_speed:
+        raise VelocityProposalValidationError("planar_speed_limit")
+
+    result = ValidatedVelocityProposal(
+        nav_id=nav_id.strip(),
+        sequence=sequence,
+        issued_at_unix_ms=issued_at,
+        ttl_ms=ttl_ms,
+        frame=limits.frame,
+        status=_status(payload),
+        x=x,
+        y=y,
+        yaw=yaw,
+    )
+    if result.is_terminal and not result.is_zero:
+        raise VelocityProposalValidationError("terminal_status_requires_zero_velocity")
+    return result
+
+
+class VelocityProposalGate:
+    """Connection, task lease, replay protection, and monotonic TTL state."""
+
+    def __init__(self, limits: ProposalLimits):
+        self.limits = limits
+        self.connected_topic = ""
+        self.armed = False
+        self.active_nav_id = ""
+        self.retired_nav_ids: list[str] = []
+        self.last_sequence = -1
+        self.last_receive_monotonic = 0.0
+        self.deadline_monotonic = 0.0
+        self.last_reason = "not_connected"
+
+    def bind(self, topic: str) -> None:
+        self.connected_topic = topic
+        self.armed = True
+        self.active_nav_id = ""
+        self.retired_nav_ids = []
+        self.last_sequence = -1
+        self.last_receive_monotonic = 0.0
+        self.deadline_monotonic = 0.0
+        self.last_reason = ""
+
+    def unbind(self, reason: str = "canvas_stop") -> None:
+        self.connected_topic = ""
+        self.armed = False
+        self.active_nav_id = ""
+        self.retired_nav_ids = []
+        self.last_sequence = -1
+        self.last_receive_monotonic = 0.0
+        self.deadline_monotonic = 0.0
+        self.last_reason = reason
+
+    def disarm(self, reason: str) -> None:
+        self.armed = False
+        self.deadline_monotonic = 0.0
+        self.last_reason = reason
+
+    def accept(self, payload: Mapping[str, Any], now: float) -> ProposalDecision:
+        if not self.connected_topic:
+            return ProposalDecision(stop=True, reason="proposal_not_connected")
+        if not self.armed:
+            return ProposalDecision(stop=True, reason=self.last_reason or "proposal_not_armed")
+        try:
+            proposal = validate_velocity_proposal(payload, self.limits)
+        except VelocityProposalValidationError as exc:
+            self.disarm(exc.code)
+            return ProposalDecision(stop=True, reason=exc.code)
+
+        if not self.active_nav_id:
+            if proposal.nav_id in self.retired_nav_ids:
+                self.disarm("retired_nav_id_replay")
+                return ProposalDecision(
+                    stop=True,
+                    reason="retired_nav_id_replay",
+                    proposal=proposal,
+                )
+            self.active_nav_id = proposal.nav_id
+            self.last_sequence = -1
+        elif proposal.nav_id != self.active_nav_id:
+            self.disarm("nav_id_mismatch")
+            return ProposalDecision(stop=True, reason="nav_id_mismatch", proposal=proposal)
+        if proposal.sequence <= self.last_sequence:
+            self.disarm("sequence_not_increasing")
+            return ProposalDecision(stop=True, reason="sequence_not_increasing", proposal=proposal)
+
+        self.last_sequence = proposal.sequence
+        self.last_receive_monotonic = now
+        if proposal.is_zero:
+            self.deadline_monotonic = 0.0
+            if proposal.is_terminal:
+                self.retired_nav_ids.append(proposal.nav_id)
+                del self.retired_nav_ids[:-32]
+                self.active_nav_id = ""
+                self.last_sequence = -1
+            self.last_reason = proposal.status
+            return ProposalDecision(stop=True, reason="proposal_zero", proposal=proposal)
+
+        duration = proposal.ttl_ms / 1000.0
+        self.deadline_monotonic = now + duration
+        self.last_reason = ""
+        return ProposalDecision(execute=True, duration=duration, proposal=proposal)
+
+    def watchdog(self, now: float) -> ProposalDecision:
+        if self.deadline_monotonic <= 0.0 or now < self.deadline_monotonic:
+            return ProposalDecision()
+        self.disarm("proposal_ttl_expired")
+        return ProposalDecision(stop=True, reason=self.last_reason)
+
+    def snapshot(self, now: float) -> dict:
+        age_ms = None
+        if self.last_receive_monotonic > 0.0:
+            age_ms = max(0, round((now - self.last_receive_monotonic) * 1000))
+        return {
+            "connected": bool(self.connected_topic),
+            "armed": self.armed,
+            "topic": self.connected_topic or None,
+            "active_nav_id": self.active_nav_id or None,
+            "last_sequence": self.last_sequence if self.last_sequence >= 0 else None,
+            "last_message_age_ms": age_ms,
+            "last_reason": self.last_reason or None,
+        }

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -115,6 +115,21 @@ def resolve_input_topic(args: Mapping[str, Any], expected_topic: str) -> str:
     return topics[0]
 
 
+def resolve_expected_nav_id(args: Mapping[str, Any]) -> str:
+    """Resolve the task lease supplied by the trusted lifecycle control plane."""
+    value = args.get("expected_nav_id")
+    if value is None or value == "":
+        raise ValueError("expected_nav_id_required")
+    if not isinstance(value, str):
+        raise ValueError("invalid_expected_nav_id")
+    nav_id = value.strip()
+    if not nav_id:
+        raise ValueError("expected_nav_id_required")
+    if len(nav_id) > 128:
+        raise ValueError("invalid_expected_nav_id")
+    return nav_id
+
+
 def _finite_number(value: Any, code: str) -> float:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise VelocityProposalValidationError(code)
@@ -205,37 +220,53 @@ class VelocityProposalGate:
         self.limits = limits
         self.connected_topic = ""
         self.armed = False
-        self.active_nav_id = ""
-        self.retired_nav_ids: list[str] = []
+        self.expected_nav_id = ""
+        self.retired_nav_ids: set[str] = set()
         self.last_sequence = -1
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = "not_connected"
 
-    def bind(self, topic: str) -> None:
+    def bind(self, topic: str, expected_nav_id: str) -> None:
+        nav_id = resolve_expected_nav_id({"expected_nav_id": expected_nav_id})
+        if self.is_bound_to(topic, nav_id):
+            return
+        if nav_id in self.retired_nav_ids:
+            raise ValueError("retired_nav_id_replay")
         self.connected_topic = topic
         self.armed = True
-        self.active_nav_id = ""
-        self.retired_nav_ids = []
+        self.expected_nav_id = nav_id
         self.last_sequence = -1
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = ""
 
     def unbind(self, reason: str = "canvas_stop") -> None:
+        self._retire_expected_nav_id()
         self.connected_topic = ""
         self.armed = False
-        self.active_nav_id = ""
-        self.retired_nav_ids = []
+        self.expected_nav_id = ""
         self.last_sequence = -1
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = reason
 
     def disarm(self, reason: str) -> None:
+        self._retire_expected_nav_id()
         self.armed = False
         self.deadline_monotonic = 0.0
         self.last_reason = reason
+
+    def _retire_expected_nav_id(self) -> None:
+        if self.expected_nav_id:
+            self.retired_nav_ids.add(self.expected_nav_id)
+
+    def is_bound_to(self, topic: str, expected_nav_id: str) -> bool:
+        return bool(
+            self.armed
+            and self.connected_topic == topic
+            and self.expected_nav_id == expected_nav_id
+        )
 
     def accept(self, payload: Mapping[str, Any], now: float) -> ProposalDecision:
         if not self.connected_topic:
@@ -248,17 +279,7 @@ class VelocityProposalGate:
             self.disarm(exc.code)
             return ProposalDecision(stop=True, reason=exc.code)
 
-        if not self.active_nav_id:
-            if proposal.nav_id in self.retired_nav_ids:
-                self.disarm("retired_nav_id_replay")
-                return ProposalDecision(
-                    stop=True,
-                    reason="retired_nav_id_replay",
-                    proposal=proposal,
-                )
-            self.active_nav_id = proposal.nav_id
-            self.last_sequence = -1
-        elif proposal.nav_id != self.active_nav_id:
+        if proposal.nav_id != self.expected_nav_id:
             self.disarm("nav_id_mismatch")
             return ProposalDecision(stop=True, reason="nav_id_mismatch", proposal=proposal)
         if proposal.sequence <= self.last_sequence:
@@ -270,11 +291,9 @@ class VelocityProposalGate:
         if proposal.is_zero:
             self.deadline_monotonic = 0.0
             if proposal.is_terminal:
-                self.retired_nav_ids.append(proposal.nav_id)
-                del self.retired_nav_ids[:-32]
-                self.active_nav_id = ""
-                self.last_sequence = -1
-            self.last_reason = proposal.status
+                self.disarm("nav_task_terminal")
+            else:
+                self.last_reason = proposal.status
             return ProposalDecision(stop=True, reason="proposal_zero", proposal=proposal)
 
         duration = proposal.ttl_ms / 1000.0
@@ -296,7 +315,8 @@ class VelocityProposalGate:
             "connected": bool(self.connected_topic),
             "armed": self.armed,
             "topic": self.connected_topic or None,
-            "active_nav_id": self.active_nav_id or None,
+            "expected_nav_id": self.expected_nav_id or None,
+            "active_nav_id": self.expected_nav_id if self.armed else None,
             "last_sequence": self.last_sequence if self.last_sequence >= 0 else None,
             "last_message_age_ms": age_ms,
             "last_reason": self.last_reason or None,

--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -4,6 +4,31 @@ Phanthy Motus driver bundle for the Tianyi 2.0 Pro humanoid robot. The driver
 bridges robot-side ROS2 topics on domain 0 to Agent Core topics on domain 42 and
 exposes the capabilities as MCP tools.
 
+## Pre-task system inspection skill
+
+`system_inspection` is a read-only, scene-facing MCP skill that turns the
+bundle's individual status cards into one motion-readiness decision. The
+`inspect` action composes `robot_faults`, `estop`, `battery`, `power_board`, and
+`motors`; `hand_state` and `force_sensor` are checked as optional capabilities.
+It returns:
+
+- `ready_for_motion`: whether the shared whole-body motion prerequisites pass;
+- `status`: `healthy`, `warning`, or `critical`;
+- `blockers`: stable machine-readable reasons that prevent motion;
+- `checks`: the normalized result from each source card.
+
+The skill fails closed when a required source card is missing, its feedback is
+unavailable, emergency stop/power interlocks are active, battery or power-board
+state is unsafe, chassis faults are active, or any of the 21 whole-body motor
+channels is missing or faulty. Missing dexterous-hand or wrist-force feedback
+produces a warning without claiming those specialized capabilities are ready.
+
+This tool sends no robot command and does not add duplicate ROS2 subscribers.
+It reads the existing plugin instances in the same bundle, so later scene code
+can gate `nav`, `arm`, `hand`, or other motion cards on a single
+`ready_for_motion` result. A passing snapshot does not replace continuous
+emergency-stop, collision, and controller-feedback monitoring during motion.
+
 ## Raw arm joint card
 
 `arm` directly commands seven joints per selected arm in this canonical order:

--- a/x-humanoid/tianyi2.0/README.md
+++ b/x-humanoid/tianyi2.0/README.md
@@ -29,6 +29,58 @@ can gate `nav`, `arm`, `hand`, or other motion cards on a single
 `ready_for_motion` result. A passing snapshot does not replace continuous
 emergency-stop, collision, and controller-feedback monitoring during motion.
 
+## Fixed scene skills
+
+`stage_greeting` and `photo_pose` are scene-facing MCP skills implemented by a
+single shared routine plugin in `device.py`. They reuse the existing cards in
+the same Tianyi bundle, so they add neither duplicate ROS2 nodes nor another
+device connection. Both expose the same lifecycle:
+
+- `run` validates input, acquires exclusive routine resources, performs
+  `system_inspection`, and starts the sequence in a background thread;
+- `status` returns the run ID, phase, progress, completed steps, and terminal
+  result without starting another action;
+- `cancel` stops unsent arm/head frames and TTS, then restores the standby
+  light. Cancellation deliberately does not command a new reset pose.
+
+Only one of these routines can run at a time because they share the robot's
+head, arms, hands, speech, and system light. A second `run` is rejected with
+`RESOURCE_BUSY`. The routines check `system_inspection` before motion and every
+0.5 seconds while a semantic motion sequence is active. If the inspection
+blocks motion, or if arm/head feedback reports a failure or timeout, remaining
+motion frames are cancelled and the skill returns a stable error code.
+
+### Stage greeting
+
+`stage_greeting` provides a reusable entrance, exhibition, reception, or host
+greeting sequence:
+
+1. verify whole-robot motion readiness;
+2. start the blue breathing light and open both hands;
+3. speak the configurable greeting;
+4. perform one head nod and a configurable left/right/bilateral welcome wave;
+5. wait for both feedback-aware motion sequences and restore the standby light.
+
+The `text`, `side`, `cycles`, and `speed` inputs let an agent adapt one fixed,
+reviewable routine without generating raw joint trajectories.
+
+### Photo pose
+
+`photo_pose` prepares a recognizable pose for group photos or event check-in:
+
+1. verify whole-robot motion readiness and switch on the white scene light;
+2. center the head and form a left/right/bilateral Victory hand gesture;
+3. speak the configurable countdown and perform the matching high-five pose;
+4. wait for head and arm sequence feedback, reopen the selected hand, and
+   restore the standby light.
+
+This skill does **not** capture, store, or upload an image. A camera card,
+external shutter, or upstream workflow should trigger the actual photograph.
+The TTS and hand cards currently confirm command acceptance but expose no
+completion feedback; successful routine results state this explicitly, while
+head and arm sequence completion is monitored through their feedback-aware
+lifecycle seam.
+
 ## Raw arm joint card
 
 `arm` directly commands seven joints per selected arm in this canonical order:

--- a/x-humanoid/tianyi2.0/config.yaml
+++ b/x-humanoid/tianyi2.0/config.yaml
@@ -66,6 +66,22 @@ plugins:
   # dexterous-hand and wrist-force cards. The bundle loads it after all sources.
   system_inspection:
     enabled: true
+  # Fixed scene skills share one runtime and reuse the existing cards above.
+  # Only one routine may own the head/arm/hand/TTS/light resources at a time.
+  stage_greeting:
+    enabled: true
+    default_text: "您好，欢迎光临。"
+    default_side: "right"
+    default_cycles: 2
+    default_speed: 0.5
+    timeout: 30
+  photo_pose:
+    enabled: true
+    default_side: "right"
+    countdown_text: "准备拍照，三、二、一。"
+    default_speed: 0.4
+    light_duration: 8
+    timeout: 20
   laser_scan:
     enabled: true
   chassis_raw:

--- a/x-humanoid/tianyi2.0/config.yaml
+++ b/x-humanoid/tianyi2.0/config.yaml
@@ -62,6 +62,10 @@ plugins:
     native_slam_db_path: "/opt/phanthy-motus/data/controlled_spatial.db"
   robot_faults:
     enabled: true
+  # Read-only scene skill composed from the existing fault, power, motor,
+  # dexterous-hand and wrist-force cards. The bundle loads it after all sources.
+  system_inspection:
+    enabled: true
   laser_scan:
     enabled: true
   chassis_raw:

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -33,6 +33,7 @@ x-humanoid/tianyi2.0/device.py — 天轶2.0 Pro 设备插件。
   MotorStatePlugin    (sensor)             — 全身21电机状态(2Hz)
   HandStatePlugin     (sensor)             — 灵巧手状态(10Hz, tool name=hand_state)
   RemoteStatePlugin   (sensor)             — 遥控器SBUS事件(5Hz)
+  SystemInspectionSkillPlugin (actuator)   — 作业前全机自检组合 Skill
   StatePlugin      (sensor, multi-tool) — 关节/电池/急停/力传感器/URDF
   CameraPlugin     (sensor)             — Orbbec 头部相机
   AsrPlugin        (sensor)             — 语音识别结果
@@ -4679,6 +4680,357 @@ class RobotFaultsPlugin:
             return {"state": "running" if self._running else "idle"}
         with self._lock:
             return self._build_summary_locked()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SystemInspectionSkillPlugin — compose existing cards into one safety decision
+# ══════════════════════════════════════════════════════════════════════════════
+
+class SystemInspectionSkillPlugin:
+    """作业前全机自检 Skill。
+
+    该插件不重复订阅 ROS2 话题，而是直接读取同一 bundle 中已有插件的最新快照，
+    将多个原子卡片归一化为 ready_for_motion、blockers 和逐项 checks。
+    """
+
+    _VERSION = "1.0.0"
+    _STATUS_RANK = {"healthy": 0, "warning": 1, "critical": 2}
+    _EXPECTED_MOTOR_COUNTS = {
+        "head": 3,
+        "arm_left": 7,
+        "arm_right": 7,
+        "waist": 2,
+        "leg": 2,
+    }
+    _PROBES = (
+        ("robot_faults", "summary", True, "_check_robot_faults"),
+        ("estop", "estop", True, "_check_estop"),
+        ("battery", "battery", True, "_check_battery"),
+        ("power_board", "read", True, "_check_power_board"),
+        ("motors", "read", True, "_check_motors"),
+        ("hand_state", "read", False, "_check_hand_state"),
+        ("force_sensor", "force_sensor", False, "_check_force_sensor"),
+    )
+
+    def __init__(self, plugin_config: dict, source_plugins: list):
+        self._running = False
+        self._sources = {}
+        wanted = {probe[0] for probe in self._PROBES}
+        for plugin in source_plugins:
+            try:
+                tools = plugin.get_tools() if hasattr(plugin, "get_tools") else [plugin.get_tool()]
+            except Exception as e:
+                print(f"[SystemInspectionSkillPlugin] skip invalid plugin: {e}")
+                continue
+            for tool in tools:
+                name = tool.get("name") if isinstance(tool, dict) else None
+                if name in wanted:
+                    self._sources[name] = plugin
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "system_inspection",
+            "type": "actuator",
+            "readOnly": True,
+            "description": (
+                "天轶2.0 Pro 作业前全机自检 Skill。组合 robot_faults、estop、battery、"
+                "power_board、motors，并检查可选 hand_state/force_sensor；返回"
+                "ready_for_motion、阻断原因和逐项结果。本 Skill 只读，不发送运动指令。"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["inspect"],
+                        "description": "inspect=执行一次作业前全机自检",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "inspect": {
+                        "params": [],
+                        "description": "汇总安全、电源、电机、灵巧手和力反馈并判断是否允许运动",
+                    },
+                },
+            },
+        }
+
+    def start(self):
+        self._running = True
+
+    def stop(self):
+        self._running = False
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action == "inspect":
+            return self._inspect()
+        if action in ("start", "info"):
+            return {
+                "state": "running" if self._running else "idle",
+                "skill": "tianyi2_pro_system_inspection",
+                "version": self._VERSION,
+                "sources": sorted(self._sources),
+            }
+        if action == "stop":
+            return {"state": "idle"}
+        return {
+            "state": "error",
+            "error": "INVALID_ARGUMENT",
+            "message": f"unknown action: {action}",
+        }
+
+    def _inspect(self) -> dict:
+        checks = []
+        for name, source_action, required, evaluator_name in self._PROBES:
+            source = self._sources.get(name)
+            if source is None:
+                checks.append(self._check(
+                    name,
+                    "critical" if required else "warning",
+                    "required MCP card is missing" if required else "optional MCP card is unavailable",
+                    blockers=[f"required_tool_missing:{name}"] if required else [],
+                ))
+                continue
+            try:
+                data = source.dispatch(source_action, {"_tool_name": name})
+                if not isinstance(data, dict):
+                    raise ValueError("card result is not an object")
+                if data.get("state") == "error" or "error" in data:
+                    raise ValueError(str(data.get("message") or data.get("error")))
+                evaluator = getattr(self, evaluator_name)
+                checks.append(evaluator(data))
+            except (KeyError, TypeError, ValueError, RuntimeError) as e:
+                checks.append(self._check(
+                    name,
+                    "critical" if required else "warning",
+                    "MCP card read failed",
+                    details={"error": str(e)},
+                    blockers=[f"required_tool_failed:{name}"] if required else [],
+                ))
+            except Exception as e:
+                checks.append(self._check(
+                    name,
+                    "critical" if required else "warning",
+                    "MCP card raised an unexpected error",
+                    details={"error": str(e)},
+                    blockers=[f"required_tool_failed:{name}"] if required else [],
+                ))
+        return self._report(checks)
+
+    def _report(self, checks: list) -> dict:
+        blockers = list(dict.fromkeys(
+            blocker
+            for check in checks
+            for blocker in check.get("blockers", [])
+        ))
+        status = max(
+            (check["status"] for check in checks),
+            key=lambda value: self._STATUS_RANK[value],
+            default="critical",
+        )
+        counts = {
+            level: sum(check["status"] == level for check in checks)
+            for level in self._STATUS_RANK
+        }
+        return {
+            "skill": "tianyi2_pro_system_inspection",
+            "version": self._VERSION,
+            "status": status,
+            "ready_for_motion": not blockers,
+            "summary": {
+                "healthy": counts["healthy"],
+                "warning": counts["warning"],
+                "critical": counts["critical"],
+            },
+            "blockers": blockers,
+            "checks": checks,
+            "timestamp_ms": int(time.time() * 1000),
+        }
+
+    @staticmethod
+    def _check(source: str, status: str, message: str,
+               details: dict | None = None, blockers: list | None = None) -> dict:
+        return {
+            "source": source,
+            "status": status,
+            "message": message,
+            "details": details or {},
+            "blockers": blockers or [],
+        }
+
+    @staticmethod
+    def _number(value):
+        if value is None or isinstance(value, bool):
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _check_robot_faults(self, data: dict) -> dict:
+        chassis = data.get("chassis") or {}
+        body = data.get("body") or {}
+        unavailable = []
+        if chassis.get("available") is not True:
+            unavailable.append("chassis_fault_feedback_unavailable")
+        if body.get("available") is not True:
+            unavailable.append("body_fault_feedback_unavailable")
+        if unavailable:
+            return self._check(
+                "robot_faults", "critical", "whole-robot fault summary is partially unavailable",
+                {"chassis": chassis, "body": body}, unavailable)
+        faults = body.get("faults") or []
+        if chassis.get("emergency_stop"):
+            return self._check(
+                "robot_faults", "critical", "chassis emergency stop is active",
+                {"faults": faults}, ["chassis_emergency_stop", "robot_fault"])
+        if faults:
+            return self._check(
+                "robot_faults", "critical", "whole-robot fault summary contains active faults",
+                {"fault_count": len(faults), "faults": faults}, ["robot_fault"])
+        if chassis.get("healthy") is False:
+            return self._check(
+                "robot_faults", "critical", "chassis reports an active safety fault",
+                {"chassis": chassis}, ["chassis_fault", "robot_fault"])
+        if data.get("healthy") is True:
+            return self._check(
+                "robot_faults", "healthy", "whole-robot fault summary is clear")
+        return self._check(
+            "robot_faults", "critical",
+            str(data.get("summary_text") or "fault summary is not healthy"),
+            blockers=["robot_fault"])
+
+    def _check_estop(self, data: dict) -> dict:
+        fields = ("is_estop", "is_remote_estop", "is_power_on")
+        if (data.get("state") == "no_data"
+                or any(field not in data for field in fields)
+                or any(not isinstance(data[field], bool) for field in fields)):
+            return self._check(
+                "estop", "critical", "emergency-stop state has no feedback",
+                blockers=["estop_feedback_unavailable"])
+        blockers = []
+        if data.get("is_estop"):
+            blockers.append("physical_estop_active")
+        if data.get("is_remote_estop"):
+            blockers.append("remote_estop_active")
+        if data.get("is_power_on") is False:
+            blockers.append("robot_power_off")
+        if blockers:
+            return self._check(
+                "estop", "critical", "emergency-stop or power interlock blocks motion",
+                {"state": data}, blockers)
+        return self._check(
+            "estop", "healthy", "emergency stops are released and power is on")
+
+    def _check_battery(self, data: dict) -> dict:
+        power = self._number(data.get("master_power", data.get("master_battery_power")))
+        if power is None:
+            return self._check(
+                "battery", "critical", "main battery percentage is unavailable",
+                blockers=["battery_feedback_unavailable"])
+        if power < 0 or power > 100:
+            return self._check(
+                "battery", "critical", "main battery percentage is outside the valid range",
+                {"power_percent": power}, ["battery_feedback_invalid"])
+        if power < 10:
+            return self._check(
+                "battery", "critical", "main battery is critically low",
+                {"power_percent": power}, ["battery_critical"])
+        if power < 25:
+            return self._check(
+                "battery", "warning", "main battery is low", {"power_percent": power})
+        return self._check(
+            "battery", "healthy", "main battery level is sufficient", {"power_percent": power})
+
+    def _check_power_board(self, data: dict) -> dict:
+        temp = data.get("temp") or {}
+        battery = data.get("battery") or {}
+        temp_status = temp.get("status", "unknown")
+        battery_status = battery.get("status", "unknown")
+        details = {
+            "max_temp_c": temp.get("max"),
+            "temp_status": temp_status,
+            "battery_status": battery_status,
+        }
+        if (temp_status not in {"normal", "warm", "hot", "critical"}
+                or battery_status not in {"normal", "low", "critical"}):
+            return self._check(
+                "power_board", "critical", "power-board safety feedback is incomplete",
+                details, ["power_board_feedback_unavailable"])
+        if temp_status in ("hot", "critical"):
+            return self._check(
+                "power_board", "critical", "power-board temperature blocks motion",
+                details, ["power_board_overtemperature"])
+        if battery_status == "critical":
+            return self._check(
+                "power_board", "critical", "power-board battery state is critical",
+                details, ["battery_critical"])
+        if temp_status == "warm" or battery_status == "low":
+            return self._check(
+                "power_board", "warning", "power board needs attention", details)
+        return self._check(
+            "power_board", "healthy", "power board is within safe limits", details)
+
+    def _check_motors(self, data: dict) -> dict:
+        parts = data.get("parts") or {}
+        joints = [
+            joint
+            for part in parts.values()
+            if isinstance(part, dict)
+            for joint in (part.get("joints") or [])
+            if isinstance(joint, dict)
+        ]
+        if not joints:
+            return self._check(
+                "motors", "critical", "motor state has no joint feedback",
+                blockers=["motor_feedback_unavailable"])
+        counts = {
+            name: len((parts.get(name) or {}).get("joints") or [])
+            for name in self._EXPECTED_MOTOR_COUNTS
+        }
+        incomplete = {
+            name: {"expected": expected, "actual": counts[name]}
+            for name, expected in self._EXPECTED_MOTOR_COUNTS.items()
+            if counts[name] != expected
+        }
+        if incomplete:
+            return self._check(
+                "motors", "critical", "whole-body motor feedback is incomplete",
+                {"joint_count": len(joints), "incomplete_parts": incomplete},
+                ["motor_feedback_incomplete"])
+        faults = [joint for joint in joints if int(joint.get("error") or 0) != 0]
+        if faults:
+            return self._check(
+                "motors", "critical", "one or more motors report active faults",
+                {"fault_count": len(faults), "faults": faults}, ["motor_fault"])
+        return self._check(
+            "motors", "healthy", "all 21 motor feedback channels are fault-free",
+            {"joint_count": len(joints)})
+
+    def _check_hand_state(self, data: dict) -> dict:
+        hands = data.get("hands") or {}
+        counts = {
+            side: int((hands.get(side) or {}).get("count") or 0)
+            for side in ("left", "right")
+        }
+        if counts["left"] < 6 or counts["right"] < 6:
+            return self._check(
+                "hand_state", "warning", "dexterous-hand feedback is incomplete",
+                {"finger_counts": counts})
+        return self._check(
+            "hand_state", "healthy", "both dexterous hands report all fingers",
+            {"finger_counts": counts})
+
+    def _check_force_sensor(self, data: dict) -> dict:
+        available = {side: bool(data.get(side)) for side in ("left", "right")}
+        if not all(available.values()):
+            return self._check(
+                "force_sensor", "warning", "wrist force feedback is incomplete",
+                {"available": available})
+        return self._check(
+            "force_sensor", "healthy", "both wrist force sensors provide feedback",
+            {"available": available})
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -34,6 +34,7 @@ x-humanoid/tianyi2.0/device.py — 天轶2.0 Pro 设备插件。
   HandStatePlugin     (sensor)             — 灵巧手状态(10Hz, tool name=hand_state)
   RemoteStatePlugin   (sensor)             — 遥控器SBUS事件(5Hz)
   SystemInspectionSkillPlugin (actuator)   — 作业前全机自检组合 Skill
+  RoutineSkillsPlugin (actuator, multi-tool) — 舞台迎宾与合影姿态场景 Skill
   StatePlugin      (sensor, multi-tool) — 关节/电池/急停/力传感器/URDF
   CameraPlugin     (sensor)             — Orbbec 头部相机
   AsrPlugin        (sensor)             — 语音识别结果
@@ -58,6 +59,7 @@ import subprocess
 import struct
 import threading
 import time
+import uuid
 from pathlib import Path
 
 import rclpy
@@ -195,6 +197,7 @@ class _ActionSequence:
         self._lock = threading.Lock()
         self._cancel_event: threading.Event | None = None
         self._thread: threading.Thread | None = None
+        self._last_error: str | None = None
 
     def start(self, worker) -> None:
         self.cancel()
@@ -204,6 +207,9 @@ class _ActionSequence:
             try:
                 worker(cancel_event)
             except Exception as e:
+                with self._lock:
+                    if self._cancel_event is cancel_event:
+                        self._last_error = str(e)
                 print(f"[{self._name}] sequence failed: {e}")
             finally:
                 with self._lock:
@@ -216,7 +222,17 @@ class _ActionSequence:
         with self._lock:
             self._cancel_event = cancel_event
             self._thread = thread
+            self._last_error = None
         thread.start()
+
+    def snapshot(self) -> dict:
+        """Return lifecycle state without exposing the worker thread."""
+        with self._lock:
+            thread = self._thread
+            return {
+                "running": bool(thread and thread.is_alive()),
+                "error": self._last_error,
+            }
 
     def cancel(self) -> bool:
         with self._lock:
@@ -1740,6 +1756,10 @@ class HeadGesturePlugin:
     def stop(self):
         self._sequence.cancel()
 
+    def sequence_status(self) -> dict:
+        """Internal lifecycle seam used by composed routine skills."""
+        return self._sequence.snapshot()
+
     def dispatch(self, action: str, args: dict) -> dict:
         if action in ("start", "info"):
             return {
@@ -1807,7 +1827,9 @@ class HeadGesturePlugin:
                 if cancel_event.is_set():
                     return
                 result = self._publish_pose(yaw, pitch, roll, speed)
-                if "error" in result or cancel_event.wait(max(0.15, delay)):
+                if "error" in result:
+                    raise RuntimeError(str(result["error"]))
+                if cancel_event.wait(max(0.15, delay)):
                     return
 
         baseline_seq, baseline = self._feedback_snapshot()
@@ -2547,6 +2569,10 @@ class ArmGesturePlugin:
     def stop(self):
         self._sequence.cancel()
 
+    def sequence_status(self) -> dict:
+        """Internal lifecycle seam used by composed routine skills."""
+        return self._sequence.snapshot()
+
     def dispatch(self, action: str, args: dict) -> dict:
         if action in ("start", "info"):
             return {
@@ -2644,6 +2670,8 @@ class ArmGesturePlugin:
                 if cancel_event.is_set():
                     return
                 result = self._publish_pose(side, frame, speed)
+                if "error" in result:
+                    raise RuntimeError(str(result["error"]))
                 max_delta_rad = max(
                     abs(_deg2rad(float(current) - float(old)))
                     for current, old in zip(frame, previous)
@@ -2651,7 +2679,7 @@ class ArmGesturePlugin:
                 transition = max_delta_rad / speed if speed > 0 else 0
                 previous = frame
                 delay = max(0.12, transition * transition_ratio) + hold
-                if "error" in result or cancel_event.wait(delay):
+                if cancel_event.wait(delay):
                     return
 
         baseline_seq, baseline = self._feedback_snapshot(side)
@@ -5031,6 +5059,561 @@ class SystemInspectionSkillPlugin:
         return self._check(
             "force_sensor", "healthy", "both wrist force sensors provide feedback",
             {"available": available})
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# RoutineSkillsPlugin — shared lifecycle for short, fixed scene skills
+# ══════════════════════════════════════════════════════════════════════════════
+
+class _RoutineFailure(RuntimeError):
+    def __init__(self, code: str, message: str, details: dict | None = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = details or {}
+
+
+class _RoutineCancelled(RuntimeError):
+    pass
+
+
+class RoutineSkillsPlugin:
+    """Expose multiple fixed routines through one shared lifecycle module.
+
+    The external interface is intentionally small (run/status/cancel). The
+    implementation hides card lookup, safety checks, resource exclusion,
+    sequence completion, cancellation fan-out, and result normalization.
+    """
+
+    _VERSION = "1.0.0"
+    _SKILL_NAMES = ("stage_greeting", "photo_pose")
+    _SOURCE_TOOLS = {
+        "system_inspection", "light", "hand", "tts",
+        "head_gesture", "arm_gesture",
+    }
+    _OUTPUT_TOOLS = {"light", "hand", "tts", "head_gesture", "arm_gesture"}
+    _TERMINAL_STATES = {"succeeded", "failed", "cancelled"}
+
+    def __init__(self, plugin_config: dict, source_plugins: list):
+        self._config = {
+            name: dict(plugin_config.get(name) or {})
+            for name in self._SKILL_NAMES
+        }
+        self._enabled = {
+            name for name in self._SKILL_NAMES
+            if self._config[name].get("enabled", False)
+        }
+        self._sources = {}
+        for plugin in source_plugins:
+            try:
+                tools = plugin.get_tools() if hasattr(plugin, "get_tools") else [plugin.get_tool()]
+            except Exception as e:
+                print(f"[RoutineSkillsPlugin] skip invalid plugin: {e}")
+                continue
+            for tool in tools:
+                name = tool.get("name") if isinstance(tool, dict) else None
+                if name in self._SOURCE_TOOLS:
+                    self._sources[name] = plugin
+
+        self._running = False
+        self._state_lock = threading.Lock()
+        self._output_lock = threading.RLock()
+        self._active = None
+        self._last_results = {}
+
+    def get_tools(self) -> list:
+        tools = []
+        if "stage_greeting" in self._enabled:
+            tools.append(self._stage_greeting_tool())
+        if "photo_pose" in self._enabled:
+            tools.append(self._photo_pose_tool())
+        return tools
+
+    @staticmethod
+    def _lifecycle_property() -> dict:
+        return {
+            "type": "string",
+            "enum": ["run", "status", "cancel"],
+            "description": "run=启动，status=查询阶段/结果，cancel=取消尚未执行的动作",
+        }
+
+    def _stage_greeting_tool(self) -> dict:
+        cfg = self._config["stage_greeting"]
+        return {
+            "name": "stage_greeting",
+            "type": "actuator",
+            "description": (
+                "天轶2.0 Pro 舞台迎宾 Skill。安全自检后组合呼吸灯、张开手掌、"
+                "欢迎语、点头和欢迎挥手，并提供 run/status/cancel 生命周期。"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": self._lifecycle_property(),
+                    "text": {
+                        "type": "string", "maxLength": 200,
+                        "default": cfg.get("default_text", "您好，欢迎光临。"),
+                        "description": "迎宾播报文字",
+                    },
+                    "side": {
+                        "type": "string", "enum": ["left", "right", "both"],
+                        "default": cfg.get("default_side", "right"),
+                        "description": "执行欢迎动作的手臂",
+                    },
+                    "cycles": {
+                        "type": "integer", "minimum": 1, "maximum": 3,
+                        "default": cfg.get("default_cycles", 2),
+                        "description": "欢迎挥手次数",
+                    },
+                    "speed": {
+                        "type": "number", "minimum": 0.2, "maximum": 0.8,
+                        "default": cfg.get("default_speed", 0.5),
+                        "description": "欢迎手臂动作速度(rad/s)",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "run": {"params": ["text", "side", "cycles", "speed"],
+                            "description": "执行一次迎宾编排"},
+                    "status": {"params": [], "description": "查询当前或最近一次迎宾结果"},
+                    "cancel": {"params": [], "description": "取消迎宾后续动作，不强制回零"},
+                },
+            },
+        }
+
+    def _photo_pose_tool(self) -> dict:
+        cfg = self._config["photo_pose"]
+        return {
+            "name": "photo_pose",
+            "type": "actuator",
+            "description": (
+                "天轶2.0 Pro 合影姿态 Skill。安全自检后组合白色灯光、语音倒计时、"
+                "头部回正、Victory 手势和高举击掌姿态，完成后恢复手掌与待机灯。"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": self._lifecycle_property(),
+                    "side": {
+                        "type": "string", "enum": ["left", "right", "both"],
+                        "default": cfg.get("default_side", "right"),
+                        "description": "执行合影姿态的一侧或双侧",
+                    },
+                    "countdown_text": {
+                        "type": "string", "maxLength": 200,
+                        "default": cfg.get("countdown_text", "准备拍照，三、二、一。"),
+                        "description": "合影倒计时播报文字",
+                    },
+                    "speed": {
+                        "type": "number", "minimum": 0.2, "maximum": 0.8,
+                        "default": cfg.get("default_speed", 0.4),
+                        "description": "合影手臂动作速度(rad/s)",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "run": {"params": ["side", "countdown_text", "speed"],
+                            "description": "执行一次合影姿态编排"},
+                    "status": {"params": [], "description": "查询当前或最近一次合影结果"},
+                    "cancel": {"params": [], "description": "取消合影后续动作，不强制回零"},
+                },
+            },
+        }
+
+    def start(self):
+        self._running = True
+
+    def stop(self):
+        self._running = False
+        active = self._active_snapshot(include_private=True)
+        if active and active["state"] not in self._TERMINAL_STATES:
+            active["cancel_event"].set()
+            self._cancel_outputs(active["run_id"])
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        tool_name = args.get("_tool_name")
+        if tool_name not in self._enabled:
+            return self._error("UNKNOWN_SKILL", f"unknown or disabled skill: {tool_name}")
+        if action in ("start", "info"):
+            return {
+                "state": "ready" if self._running else "idle",
+                "skills": sorted(self._enabled),
+                "version": self._VERSION,
+            }
+        if action == "stop":
+            self._cancel(tool_name)
+            return {"state": "idle"}
+        if action == "run":
+            return self._start_run(tool_name, args)
+        if action == "status":
+            return self._status(tool_name)
+        if action == "cancel":
+            return self._cancel(tool_name)
+        return self._error("INVALID_ARGUMENT", f"unknown action: {action}")
+
+    @staticmethod
+    def _error(code: str, message: str, **details) -> dict:
+        result = {"state": "error", "code": code, "error": message}
+        if details:
+            result["details"] = details
+        return result
+
+    def _start_run(self, skill_name: str, raw_args: dict) -> dict:
+        try:
+            inputs = self._validate_inputs(skill_name, raw_args)
+        except _RoutineFailure as e:
+            return self._error(e.code, e.message, **e.details)
+
+        with self._state_lock:
+            if self._active and self._active["state"] not in self._TERMINAL_STATES:
+                return self._error(
+                    "RESOURCE_BUSY",
+                    f"{self._active['skill']} already owns the routine resources",
+                    active_run_id=self._active["run_id"],
+                    active_skill=self._active["skill"],
+                )
+            now_ms = int(time.time() * 1000)
+            state = {
+                "skill": skill_name,
+                "version": self._VERSION,
+                "run_id": f"{skill_name}-{uuid.uuid4().hex[:12]}",
+                "state": "running",
+                "phase": "accepted",
+                "progress": 0.0,
+                "started_at_ms": now_ms,
+                "finished_at_ms": None,
+                "completed_steps": [],
+                "claimed_sources": [],
+                "error": None,
+                "result": None,
+                "inputs": inputs,
+                "cancel_event": threading.Event(),
+                "thread": None,
+            }
+            thread = threading.Thread(
+                target=self._execute,
+                args=(state["run_id"],),
+                name=f"{skill_name}_routine",
+                daemon=True,
+            )
+            state["thread"] = thread
+            self._active = state
+            self._last_results[skill_name] = state
+            accepted = self._public_state(state)
+            thread.start()
+            return accepted
+
+    def _validate_inputs(self, skill_name: str, args: dict) -> dict:
+        cfg = self._config[skill_name]
+        side = args.get("side", cfg.get("default_side", "right"))
+        if side not in ("left", "right", "both"):
+            raise _RoutineFailure("INVALID_ARGUMENT", "side must be left, right, or both")
+        raw_speed = args.get("speed", cfg.get("default_speed", 0.5 if skill_name == "stage_greeting" else 0.4))
+        if isinstance(raw_speed, bool):
+            raise _RoutineFailure("INVALID_ARGUMENT", "speed must be numeric")
+        try:
+            speed = float(raw_speed)
+        except (TypeError, ValueError) as e:
+            raise _RoutineFailure("INVALID_ARGUMENT", "speed must be numeric") from e
+        if not math.isfinite(speed) or speed < 0.2 or speed > 0.8:
+            raise _RoutineFailure("INVALID_ARGUMENT", "speed must be in [0.2, 0.8] rad/s")
+
+        if skill_name == "stage_greeting":
+            text = args.get("text", cfg.get("default_text", "您好，欢迎光临。"))
+            cycles = args.get("cycles", cfg.get("default_cycles", 2))
+            if not isinstance(text, str) or not text.strip() or len(text) > 200:
+                raise _RoutineFailure("INVALID_ARGUMENT", "text must be 1-200 characters")
+            if isinstance(cycles, bool) or not isinstance(cycles, int) or not 1 <= cycles <= 3:
+                raise _RoutineFailure("INVALID_ARGUMENT", "cycles must be an integer in [1, 3]")
+            return {"text": text.strip(), "side": side, "cycles": cycles, "speed": speed}
+
+        countdown = args.get(
+            "countdown_text", cfg.get("countdown_text", "准备拍照，三、二、一。"))
+        if not isinstance(countdown, str) or not countdown.strip() or len(countdown) > 200:
+            raise _RoutineFailure(
+                "INVALID_ARGUMENT", "countdown_text must be 1-200 characters")
+        return {"side": side, "countdown_text": countdown.strip(), "speed": speed}
+
+    def _execute(self, run_id: str) -> None:
+        state = self._active_for_run(run_id)
+        if state is None:
+            return
+        try:
+            if state["skill"] == "stage_greeting":
+                self._run_stage_greeting(state)
+            else:
+                self._run_photo_pose(state)
+            if state["cancel_event"].is_set():
+                raise _RoutineCancelled()
+            self._finish(run_id, "succeeded", "completed", 1.0, result={
+                "motion_sequence_completed": True,
+                "motion_feedback_checked": True,
+                "tts_completion_verified": False,
+                "hand_completion_verified": False,
+            })
+        except _RoutineCancelled:
+            self._finish(run_id, "cancelled", "cancelled", state.get("progress", 0.0))
+        except _RoutineFailure as e:
+            self._cancel_outputs(run_id)
+            self._finish(run_id, "failed", "failed", state.get("progress", 0.0), error={
+                "code": e.code,
+                "message": e.message,
+                "details": e.details,
+            })
+        except Exception as e:
+            self._cancel_outputs(run_id)
+            self._finish(run_id, "failed", "failed", state.get("progress", 0.0), error={
+                "code": "INTERNAL_ERROR", "message": str(e), "details": {},
+            })
+
+    def _run_stage_greeting(self, state: dict) -> None:
+        inputs = state["inputs"]
+        cancel_event = state["cancel_event"]
+        self._set_phase(state["run_id"], "preflight", 0.05)
+        self._require_safe(cancel_event)
+        self._set_phase(state["run_id"], "scene_setup", 0.20)
+        self._invoke("light", "blue_breathing", {"duration": -1}, cancel_event)
+        self._invoke("hand", "open_palm", {"side": "both"}, cancel_event)
+        self._invoke("tts", "speak", {"text": inputs["text"], "force": True}, cancel_event)
+        self._set_phase(state["run_id"], "performing", 0.45)
+        self._invoke("head_gesture", "nod", {
+            "cycles": 1, "nod_amplitude": 12, "speed": 30,
+        }, cancel_event)
+        self._invoke("arm_gesture", "welcome", {
+            "side": inputs["side"], "cycles": inputs["cycles"], "speed": inputs["speed"],
+        }, cancel_event)
+        timeout = float(self._config["stage_greeting"].get("timeout", 30.0))
+        self._wait_sequences(
+            ("head_gesture", "arm_gesture"), timeout, cancel_event)
+        self._set_phase(state["run_id"], "cleanup", 0.90)
+        self._invoke("light", "blue_standby", {"duration": -1}, cancel_event)
+
+    def _run_photo_pose(self, state: dict) -> None:
+        inputs = state["inputs"]
+        cancel_event = state["cancel_event"]
+        self._set_phase(state["run_id"], "preflight", 0.05)
+        self._require_safe(cancel_event)
+        self._set_phase(state["run_id"], "scene_setup", 0.20)
+        light_duration = float(self._config["photo_pose"].get("light_duration", 8.0))
+        self._invoke("light", "white", {"duration": light_duration}, cancel_event)
+        self._invoke("head_gesture", "reset", {"speed": 25}, cancel_event)
+        self._invoke("hand", "victory", {"side": inputs["side"]}, cancel_event)
+        self._invoke("tts", "speak", {
+            "text": inputs["countdown_text"], "force": True,
+        }, cancel_event)
+        self._set_phase(state["run_id"], "performing", 0.50)
+        self._invoke("arm_gesture", "high_five", {
+            "side": inputs["side"], "speed": inputs["speed"],
+        }, cancel_event)
+        timeout = float(self._config["photo_pose"].get("timeout", 20.0))
+        self._wait_sequences(
+            ("head_gesture", "arm_gesture"), timeout, cancel_event)
+        self._set_phase(state["run_id"], "cleanup", 0.90)
+        self._invoke("hand", "open_palm", {"side": inputs["side"]}, cancel_event)
+        self._invoke("light", "blue_standby", {"duration": -1}, cancel_event)
+
+    def _require_safe(self, cancel_event: threading.Event) -> dict:
+        report = self._invoke("system_inspection", "inspect", {}, cancel_event)
+        if report.get("ready_for_motion") is not True:
+            raise _RoutineFailure(
+                "PRECHECK_FAILED",
+                "system inspection does not allow motion",
+                {"blockers": report.get("blockers", []), "report": report},
+            )
+        return report
+
+    def _wait_sequences(
+            self, source_names: tuple[str, ...], timeout: float,
+            cancel_event: threading.Event) -> None:
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise _RoutineFailure("INVALID_CONFIGURATION", "routine timeout must be positive")
+        deadline = time.monotonic() + timeout
+        next_safety_check = 0.0
+        while True:
+            if cancel_event.is_set():
+                raise _RoutineCancelled()
+            now = time.monotonic()
+            if now >= next_safety_check:
+                report = self._invoke("system_inspection", "inspect", {}, cancel_event)
+                if report.get("ready_for_motion") is not True:
+                    raise _RoutineFailure(
+                        "SAFETY_STOP",
+                        "system inspection blocked motion during the routine",
+                        {"blockers": report.get("blockers", [])},
+                    )
+                next_safety_check = now + 0.5
+
+            statuses = []
+            for name in source_names:
+                source = self._sources.get(name)
+                if source is None or not hasattr(source, "sequence_status"):
+                    raise _RoutineFailure(
+                        "DEPENDENCY_UNAVAILABLE",
+                        f"{name} does not expose sequence completion status",
+                    )
+                status = source.sequence_status()
+                if status.get("error"):
+                    raise _RoutineFailure(
+                        "STEP_FAILED", f"{name} sequence failed",
+                        {"source": name, "error": status["error"]})
+                statuses.append(status)
+            if statuses and all(not status.get("running") for status in statuses):
+                return
+            if now >= deadline:
+                raise _RoutineFailure(
+                    "STEP_TIMEOUT", "motion sequence did not finish before timeout",
+                    {"sources": list(source_names), "timeout": timeout})
+            cancel_event.wait(0.1)
+
+    def _invoke(
+            self, source_name: str, action: str, args: dict,
+            cancel_event: threading.Event) -> dict:
+        if cancel_event.is_set():
+            raise _RoutineCancelled()
+        source = self._sources.get(source_name)
+        if source is None:
+            raise _RoutineFailure(
+                "DEPENDENCY_UNAVAILABLE", f"required card is unavailable: {source_name}")
+        if source_name in self._OUTPUT_TOOLS:
+            # Serialize the cancellation boundary with actuator dispatch. If a
+            # cancel request wins the lock, no later output can be emitted; if
+            # dispatch wins, cancellation immediately stops its claimed card.
+            with self._output_lock:
+                if cancel_event.is_set():
+                    raise _RoutineCancelled()
+                self._claim_source(source_name)
+                result = source.dispatch(
+                    action, {**args, "_tool_name": source_name})
+        else:
+            result = source.dispatch(
+                action, {**args, "_tool_name": source_name})
+        if not isinstance(result, dict):
+            raise _RoutineFailure(
+                "STEP_FAILED", f"{source_name}.{action} returned a non-object result")
+        if (result.get("state") == "error"
+                or "error" in result
+                or result.get("ok") is False):
+            raise _RoutineFailure(
+                str(result.get("code") or "STEP_REJECTED"),
+                str(result.get("message") or result.get("error") or "card rejected the action"),
+                {"source": source_name, "action": action, "result": result},
+            )
+        self._append_step(f"{source_name}.{action}")
+        return result
+
+    def _safe_dispatch(self, source_name: str, action: str, args: dict) -> bool:
+        source = self._sources.get(source_name)
+        if source is None:
+            return False
+        try:
+            result = source.dispatch(action, {**args, "_tool_name": source_name})
+            return isinstance(result, dict) and "error" not in result
+        except Exception as e:
+            print(f"[RoutineSkillsPlugin] cleanup {source_name}.{action} failed: {e}")
+            return False
+
+    def _cancel_outputs(self, run_id: str) -> None:
+        # Cancellation never commands arm/head reset or any other new pose.
+        with self._output_lock:
+            claimed = self._claimed_sources_for_run(run_id)
+            if "arm_gesture" in claimed:
+                self._safe_dispatch("arm_gesture", "stop", {})
+            if "head_gesture" in claimed:
+                self._safe_dispatch("head_gesture", "stop", {})
+            if "tts" in claimed:
+                self._safe_dispatch("tts", "stop", {})
+            if "light" in claimed:
+                self._safe_dispatch("light", "blue_standby", {"duration": -1})
+
+    def _status(self, skill_name: str) -> dict:
+        with self._state_lock:
+            if self._active and self._active["skill"] == skill_name:
+                return self._public_state(self._active)
+            previous = self._last_results.get(skill_name)
+            if previous:
+                return self._public_state(previous)
+        return {
+            "skill": skill_name, "version": self._VERSION,
+            "state": "idle", "phase": "idle", "progress": 0.0,
+        }
+
+    def _cancel(self, skill_name: str) -> dict:
+        with self._state_lock:
+            active = self._active
+            if (active is None or active["skill"] != skill_name
+                    or active["state"] in self._TERMINAL_STATES):
+                return {
+                    "skill": skill_name, "version": self._VERSION,
+                    "state": "idle", "phase": "idle", "cancel_requested": False,
+                }
+            active["cancel_event"].set()
+            run_id = active["run_id"]
+        self._cancel_outputs(run_id)
+        return {
+            "skill": skill_name, "version": self._VERSION,
+            "run_id": run_id, "state": "running", "phase": "cancelling",
+            "cancel_requested": True,
+        }
+
+    def _active_for_run(self, run_id: str) -> dict | None:
+        with self._state_lock:
+            if self._active and self._active["run_id"] == run_id:
+                return self._active
+        return None
+
+    def _active_snapshot(self, include_private: bool = False) -> dict | None:
+        with self._state_lock:
+            if self._active is None:
+                return None
+            return self._active if include_private else self._public_state(self._active)
+
+    def _set_phase(self, run_id: str, phase: str, progress: float) -> None:
+        with self._state_lock:
+            if self._active and self._active["run_id"] == run_id:
+                self._active["phase"] = phase
+                self._active["progress"] = progress
+
+    def _append_step(self, step: str) -> None:
+        with self._state_lock:
+            if self._active and self._active["state"] == "running":
+                self._active["completed_steps"].append(step)
+
+    def _claim_source(self, source_name: str) -> None:
+        with self._state_lock:
+            if (self._active and self._active["state"] == "running"
+                    and source_name not in self._active["claimed_sources"]):
+                self._active["claimed_sources"].append(source_name)
+
+    def _claimed_sources_for_run(self, run_id: str) -> set[str]:
+        with self._state_lock:
+            if self._active is None or self._active["run_id"] != run_id:
+                return set()
+            return set(self._active["claimed_sources"])
+
+    def _finish(
+            self, run_id: str, state_name: str, phase: str, progress: float,
+            result: dict | None = None, error: dict | None = None) -> None:
+        with self._state_lock:
+            if self._active is None or self._active["run_id"] != run_id:
+                return
+            self._active["state"] = state_name
+            self._active["phase"] = phase
+            self._active["progress"] = progress
+            self._active["finished_at_ms"] = int(time.time() * 1000)
+            self._active["result"] = result
+            self._active["error"] = error
+            self._last_results[self._active["skill"]] = self._active
+
+    @staticmethod
+    def _public_state(state: dict) -> dict:
+        return {
+            key: json.loads(json.dumps(value))
+            for key, value in state.items()
+            if key not in {
+                "cancel_event", "thread", "inputs", "claimed_sources",
+            }
+            and not (key == "error" and value is None)
+        }
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -238,6 +238,16 @@ class TianyiDeviceBundle:
                 plugins_cfg["system_inspection"], self._plugins))
             print("[bundle] SystemInspectionSkillPlugin loaded")
 
+        routine_cfg = {
+            name: plugins_cfg.get(name, {})
+            for name in ("stage_greeting", "photo_pose")
+        }
+        if any(config.get("enabled", False) for config in routine_cfg.values()):
+            from device import RoutineSkillsPlugin
+            self._plugins.append(RoutineSkillsPlugin(
+                routine_cfg, self._plugins))
+            print("[bundle] RoutineSkillsPlugin loaded")
+
     def start_all(self) -> None:
         for i, p in enumerate(self._plugins):
             try:

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -229,6 +229,15 @@ class TianyiDeviceBundle:
             self._plugins.append(LightPlugin(plugins_cfg["light"], namespace, ros2))
             print("[bundle] LightPlugin loaded")
 
+        # Skills are loaded after their source cards so they can compose the
+        # existing plugin instances without opening a second MCP connection or
+        # duplicating ROS2 subscriptions.
+        if plugins_cfg.get("system_inspection", {}).get("enabled", False):
+            from device import SystemInspectionSkillPlugin
+            self._plugins.append(SystemInspectionSkillPlugin(
+                plugins_cfg["system_inspection"], self._plugins))
+            print("[bundle] SystemInspectionSkillPlugin loaded")
+
     def start_all(self) -> None:
         for i, p in enumerate(self._plugins):
             try:


### PR DESCRIPTION
## 功能概述

本 PR 为天轶 2.0 Pro Bundle 增加一张安全前置 Skill 和两张固定场景 Skill：

- `system_inspection`：作业前全机自检；
- `stage_greeting`：舞台、展会、前台等场景的迎宾编排；
- `photo_pose`：活动合影和签到场景的姿态编排。

三个 Skill 均直接组合同一 Tianyi Bundle 中已有的 MCP 原子卡片，不重复订阅 ROS2 话题，也不新建独立的设备连接。`stage_greeting` 与 `photo_pose` 共用一个 `RoutineSkillsPlugin`，没有按功能拆分多个 Python 文件。

## system_inspection：作业前全机自检

组合以下已有卡片形成统一的运动准入判断：

- 必需能力：`robot_faults`、`estop`、`battery`、`power_board`、`motors`；
- 可选能力：`hand_state`、`force_sensor`。

`inspect` 返回 `ready_for_motion`、`status`、`blockers` 和逐项 `checks`。必需卡片缺失或读取失败、急停/电源互锁、危险电量或温度、整机 21 路电机反馈不完整或存在故障时，均采用 fail-closed，禁止后续动作。灵巧手或腕部力反馈缺失只产生 warning，场景可根据任务需要进一步收紧条件。

该 Skill 全程只读，是另外两张场景 Skill 的统一安全入口。

## 实现机制

### 1. Bundle 内组合，而不是新增底层驱动

`main.py` 先实例化原有的状态、灯光、灵巧手、TTS、头部动作和手臂动作 Plugin，再加载 `SystemInspectionSkillPlugin`，最后加载共享的 `RoutineSkillsPlugin`。后者在初始化时通过 `get_tool()` / `get_tools()` 建立如下已有卡片索引：

```text
system_inspection  light  hand  tts  head_gesture  arm_gesture
```

Skill 在同一进程内直接调用这些 Plugin 的 `dispatch(action, args)`，不会通过 HTTP 反向调用自己的 MCP 服务，也不会创建重复 ROS2 Node、Publisher 或 Subscriber。真正的 ROS2 指令仍由已有原子卡片发布到原有话题，例如头部和手臂语义动作最终使用 `/head/cmd_pos` 与 `/arm/cmd_pos`。

### 2. 共享固定编排运行时

`stage_greeting` 与 `photo_pose` 由同一个 `RoutineSkillsPlugin` 暴露为两个 MCP Tool。`run` 会：

1. 校验场景参数；
2. 检查是否已有场景任务占用共享资源；
3. 创建形如 `stage_greeting-xxxxxxxxxxxx` 的唯一 `run_id`；
4. 保存任务状态并启动后台线程；
5. 立即返回 `state=running`，避免长动作阻塞 MCP HTTP 请求。

后台任务按以下状态推进：

```text
accepted → preflight → scene_setup → performing → cleanup
                                              └→ succeeded / failed / cancelled
```

`status` 只读取当前任务或该 Skill 最近一次任务的快照，不会重复启动动作。快照包括 `run_id`、`phase`、`progress`、`completed_steps`、开始/结束时间以及最终 `result` 或 `error`。

### 3. 动作完成状态

原有 `head_gesture` 和 `arm_gesture` 使用 `_ActionSequence` 后台发送多帧动作。此次为两张原子卡片增加内部 `sequence_status()` 接口：

```json
{"running": true, "error": null}
```

固定编排不是在第一帧被接受后立即返回成功，而是轮询头部/手臂序列，直到全部线程结束；后台发布异常返回 `STEP_FAILED`，超过配置时限返回 `STEP_TIMEOUT`。动作期间每 0.5 秒重新读取 `system_inspection`，若安全条件变化则返回 `SAFETY_STOP` 并停止后续动作帧。

TTS 和灵巧手原子卡片目前只能确认命令已接受，没有完成反馈，因此最终结果会如实区分：

```json
{
  "motion_sequence_completed": true,
  "motion_feedback_checked": true,
  "tts_completion_verified": false,
  "hand_completion_verified": false
}
```

### 4. 并发与取消

两张 Skill 共享一个任务互斥状态，重复 `run` 返回 `RESOURCE_BUSY`。动作下发与取消使用同一个输出锁建立串行边界：取消先获得锁时，后台不会再发送下一项输出；动作下发先获得锁时，取消会在该次下发结束后立即停止对应卡片。

运行状态会记录本次任务实际占用过的输出卡片。失败或取消时只清理这些卡片，避免在前置自检失败时误停其他场景的语音或灯效。取消仅调用 `arm_gesture.stop`、`head_gesture.stop`、`tts.stop` 和待机灯，不发送新的头部/手臂回零指令，防止取消后产生额外运动。

## MCP 调用逻辑

Agent Core 或维护者通过标准 `tools/call` 调用；`main.py` 从 `arguments.action` 取出生命周期动作，并向共享 Plugin 注入当前 Tool 名称进行分发。

启动一次舞台迎宾：

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "tools/call",
  "params": {
    "name": "stage_greeting",
    "arguments": {
      "action": "run",
      "text": "您好，欢迎来到展会现场。",
      "side": "right",
      "cycles": 2,
      "speed": 0.5
    }
  }
}
```

查询同一 Tool 当前或最近一次运行状态：

```json
{
  "jsonrpc": "2.0",
  "id": 2,
  "method": "tools/call",
  "params": {
    "name": "stage_greeting",
    "arguments": {"action": "status"}
  }
}
```

取消正在运行的舞台迎宾：

```json
{
  "jsonrpc": "2.0",
  "id": 3,
  "method": "tools/call",
  "params": {
    "name": "stage_greeting",
    "arguments": {"action": "cancel"}
  }
}
```

`photo_pose` 使用完全相同的生命周期，`run` 参数为 `side`、`countdown_text` 和 `speed`。例如：

```json
{
  "jsonrpc": "2.0",
  "id": 4,
  "method": "tools/call",
  "params": {
    "name": "photo_pose",
    "arguments": {
      "action": "run",
      "side": "both",
      "countdown_text": "准备拍照，三、二、一。",
      "speed": 0.4
    }
  }
}
```

常见失败码包括：`INVALID_ARGUMENT`、`RESOURCE_BUSY`、`DEPENDENCY_UNAVAILABLE`、`PRECHECK_FAILED`、`SAFETY_STOP`、`STEP_FAILED` 和 `STEP_TIMEOUT`。

## 内部原子卡片调用链

`stage_greeting`：

```text
system_inspection.inspect
→ light.blue_breathing(duration=-1)
→ hand.open_palm(side=both)
→ tts.speak(text, force=true)
→ head_gesture.nod(cycles=1, nod_amplitude=12°, speed=30°/s)
→ arm_gesture.welcome(side, cycles, speed)
→ 等待 head_gesture + arm_gesture 完成并持续安全检查
→ light.blue_standby(duration=-1)
```

`photo_pose`：

```text
system_inspection.inspect
→ light.white(duration=8s，默认)
→ head_gesture.reset(speed=25°/s)
→ hand.victory(side)
→ tts.speak(countdown_text, force=true)
→ arm_gesture.high_five(side, speed)
→ 等待 head_gesture + arm_gesture 完成并持续安全检查
→ hand.open_palm(side)
→ light.blue_standby(duration=-1)
```

## stage_greeting：舞台迎宾

适用于舞台出场、展会接待、门店迎宾和活动主持等场景。执行流程：

1. 调用 `system_inspection` 检查整机运动条件；
2. 开启蓝色呼吸灯并张开双手；
3. 播放可配置的迎宾语；
4. 并行执行一次点头和左侧、右侧或双侧欢迎挥手；
5. 等待头部与手臂动作序列完成，恢复蓝色待机灯。

可配置参数包括 `text`、`side`、`cycles` 和 `speed`，在保持固定、可审查编排的同时允许场景做有限调整。

## photo_pose：合影姿态

适用于活动合影、展台打卡和签到留影等场景。执行流程：

1. 调用 `system_inspection` 检查整机运动条件；
2. 开启白色场景灯并将头部回正；
3. 使用指定侧或双侧灵巧手做 Victory 手势；
4. 播放可配置的拍照倒计时，并执行对应侧高举合影姿态；
5. 等待头部与手臂动作序列完成，重新张开手掌并恢复待机灯。

`photo_pose` 只负责机器人灯光、语音和姿态编排，不宣称拍摄、保存或上传图片。实际快门应由相机卡片、外部拍摄设备或上层工作流触发。

## 统一生命周期与安全策略

两张场景 Skill 均提供：

- `run`：校验输入、申请共享动作资源并在后台启动编排；
- `status`：返回 `run_id`、当前阶段、进度、已完成步骤和最终结果；
- `cancel`：取消尚未下发的头部/手臂动作帧并停止本次 TTS，且不会额外执行回零动作。

关键安全措施：

- `stage_greeting` 与 `photo_pose` 共享互斥锁，同一时间只允许一个场景编排占用头部、手臂、灵巧手、语音和灯光资源；
- 动作开始前执行全机自检，语义动作运行期间每 0.5 秒重新检查安全状态；
- 等待 `head_gesture` 与 `arm_gesture` 的后台动作完成状态，传播发布失败和超时错误；
- 取消和动作下发通过输出锁串行化，避免取消后继续发送动作；
- 只清理当前运行已经占用的输出卡片，前置自检失败不会误停其他语音或灯效；
- 正常 MCP 结果不携带空 `error` 字段，避免被 HTTP 层错误标记为 `isError`。

头部和手臂具备动作反馈及序列完成检查；当前 TTS 和灵巧手原子卡片只能确认命令已接受，无法验证播放/手势最终完成，Skill 的成功结果会明确返回这一能力边界。

## 仓库集成方式

- `device.py`：新增 `SystemInspectionSkillPlugin` 与共享的 `RoutineSkillsPlugin`；为现有头部、手臂语义动作补充内部序列状态接口；
- `config.yaml`：默认启用三张 Skill，并提供迎宾和合影的受限默认参数；
- `main.py`：在原子卡片加载完成后注册组合 Skill，直接注入已有 Plugin 实例；
- `README.md`：补充使用场景、执行步骤、生命周期和安全边界；
- 未提交临时测试脚本，也未为每张 Skill 创建单独 Python 文件。

## 验证结果

- 10 项场景 Skill 临时契约测试通过：工具元数据、配置启停、画布生命周期、两条成功编排、前置检查失败、资源互斥、取消、后台动作失败传播和序列错误状态；
- 7 项 `system_inspection` 回归测试通过；
- Tianyi 目录 Python 文件通过 `py_compile`；
- `config.yaml` 通过 YAML 解析并确认三张 Skill 默认启用；
- `git diff --check` 通过；
- 临时测试脚本位于系统临时目录，未进入 PR。

## 待验证项

本 PR 先以 Draft 提交，等待维护者在天轶 2.0 Pro 真机环境验证：

- 欢迎挥手、点头、Victory 和合影姿态的空间安全性与视觉效果；
- TTS、动作和灯光的实际时序；
- 急停、故障和运行中取消的真机响应；
- Agent Core 画布中的卡片展示及 `run/status/cancel` 调用流程。
