### PR TITLE
feat(tianyi2.0): add SmartMotion unified voice control plugin

### DIFF
--- a/x-humanoid/tianyi2.0/config.yaml
+++ b/x-humanoid/tianyi2.0/config.yaml
@@ -73,3 +73,5 @@ plugins:
         url: "tcp://192.168.41.1:9800"
   light:
     enabled: true
+  smart_motion:
+    enabled: true

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -5332,10 +5332,6 @@ class SmartMotionPlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict | None:
-        if action == "start":
-            return {"state": "ready"}
-        if action == "stop":
-            return {"state": "idle"}
         if action == "interrupt_speak":
             r1 = self._do_tts("stop")
             r2 = self._do_voice_play("stop")

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -5285,3 +5285,82 @@ class ChassisRawPlugin:
     @staticmethod
     def _clamp(value: float, low: float, high: float) -> float:
         return max(low, min(high, value))
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SmartMotionPlugin (actuator) — 卡名: smart_motion
+# ══════════════════════════════════════════════════════════════════════════════
+
+class SmartMotionPlugin:
+    """统一打断/暂停控制卡片。协调语音的中止、暂停和恢复。"""
+    PREFIX = "smart_motion"
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2,
+                 tts_plugin=None, voice_play_plugin=None):
+        self._tts = tts_plugin
+        self._voice_play = voice_play_plugin
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "smart_motion",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "SmartMotion — 统一语音输出控制，提供打断、暂停、恢复能力",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["interrupt_speak", "pause_speak", "resume_speak", "status"],
+                        "description": "控制动作",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "interrupt_speak": {"params": [], "description": "中止语音播放（不可恢复当前播放，可发新指令）"},
+                    "pause_speak":     {"params": [], "description": "暂停语音播放（保留未播内容，可恢复）"},
+                    "resume_speak":    {"params": [], "description": "恢复之前暂停的语音播放"},
+                    "status":          {"params": [], "description": "查询当前语音输出状态"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "interrupt_speak":
+            r1 = self._do_tts("stop")
+            r2 = self._do_voice_play("stop")
+            return {"tts": r1, "voice_play": r2}
+        elif action == "pause_speak":
+            r1 = self._do_tts("pause")
+            r2 = self._do_voice_play("pause")
+            return {"tts": r1, "voice_play": r2}
+        elif action == "resume_speak":
+            r1 = self._do_tts("resume")
+            r2 = self._do_voice_play("resume")
+            return {"tts": r1, "voice_play": r2}
+        elif action == "status":
+            return {
+                "tts": self._tts.dispatch("info", {}) if self._tts else None,
+                "voice_play": self._voice_play.dispatch("info", {}) if self._voice_play else None,
+            }
+        return None
+
+    def _do_tts(self, action: str) -> dict | None:
+        if self._tts:
+            return self._tts.dispatch(action, {})
+        return {"error": "no tts plugin"}
+
+    def _do_voice_play(self, action: str) -> dict | None:
+        if self._voice_play:
+            return self._voice_play.dispatch(action, {})
+        return {"error": "no voice_play plugin"}

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -5332,6 +5332,10 @@ class SmartMotionPlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "stop":
+            return {"state": "idle"}
         if action == "interrupt_speak":
             r1 = self._do_tts("stop")
             r2 = self._do_voice_play("stop")

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -266,6 +266,15 @@ class TianyiDeviceBundle:
             self._plugins.append(LightPlugin(plugins_cfg["light"], namespace, ros2))
             print("[bundle] LightPlugin loaded")
 
+        if plugins_cfg.get("smart_motion", {}).get("enabled", False):
+            from device import SmartMotionPlugin
+            tts_p = next((p for p in self._plugins if type(p).__name__ == "TtsPlugin"), None)
+            vp_p = next((p for p in self._plugins if type(p).__name__ == "VoicePlayActuatorPlugin"), None)
+            self._plugins.append(SmartMotionPlugin(
+                plugins_cfg["smart_motion"], namespace, ros2,
+                tts_plugin=tts_p, voice_play_plugin=vp_p))
+            print("[bundle] SmartMotionPlugin loaded")
+
     def start_all(self) -> None:
         for i, p in enumerate(self._plugins):
             try:


### PR DESCRIPTION
## Summary
- Add `SmartMotionPlugin` to Tianyi 2.0 driver with unified voice control
- Actions: `interrupt_speak` (stop), `pause_speak`, `resume_speak`, `status`
- Coordinates both TTS and VoicePlay audio channels through a single card

## Test plan
- [ ] Deploy to Tianyi robot, verify `smart_motion` card appears in dashboard
- [ ] Test `pause_speak` → voice pauses → `resume_speak` → voice resumes
- [ ] Test `interrupt_speak` → voice stops, new speak commands still work
- [ ] Test `status` → returns TTS and voice_play state

🤖 Generated with [Claude Code](https://claude.com/claude-code)