### PR TITLE
fix(tianyi2.0): stop action rename, voice_play non-blocking, audio_sender auto-start

### DIFF
--- a/x-humanoid/tianyi2.0/audio_sender.py
+++ b/x-humanoid/tianyi2.0/audio_sender.py
@@ -32,7 +32,7 @@ def _detect_card(card_idx: int) -> dict:
         )
         output = result.stdout + result.stderr
         for line in output.splitlines():
-            if 'FORMAT:' in line:
+            if line.strip().startswith('FORMAT:'):
                 fmts = line.split('FORMAT:')[1].strip().split()
                 if 'S24_3LE' in fmts:
                     info["format"] = "S24_3LE"

--- a/x-humanoid/tianyi2.0/config.yaml
+++ b/x-humanoid/tianyi2.0/config.yaml
@@ -70,7 +70,7 @@ plugins:
     enabled: true
     network_sources:
       - name: "DJI Wireless Mic"
-        url: "tcp://192.168.41.1:9800"
+        url: "tcp://192.168.41.1:9800/pcm16k"
         # audio_sender auto-start: SSH to the host where the mic is plugged in
         ssh_host: "192.168.41.1"
         ssh_user: "ubuntu"

--- a/x-humanoid/tianyi2.0/config.yaml
+++ b/x-humanoid/tianyi2.0/config.yaml
@@ -71,5 +71,11 @@ plugins:
     network_sources:
       - name: "DJI Wireless Mic"
         url: "tcp://192.168.41.1:9800"
+        # audio_sender auto-start: SSH to the host where the mic is plugged in
+        ssh_host: "192.168.41.1"
+        ssh_user: "ubuntu"
+        ssh_password: "123"
+        card: 1
+        sender_path: "/home/ubuntu/audio_sender.py"
   light:
     enabled: true

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -1963,9 +1963,9 @@ class HeadGesturePlugin:
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["nod", "shake", "scan", "tilt", "reset", "stop"],
+                        "enum": ["nod", "shake", "scan", "tilt", "reset", "cancel"],
                         "default": "nod",
-                        "description": "头部动作，可选[nod, shake, scan, tilt, reset, stop]",
+                        "description": "头部动作，可选[nod, shake, scan, tilt, reset, cancel]",
                     },
                     "cycles": {
                         "type": "integer", "minimum": 1, "maximum": 5,
@@ -2019,7 +2019,7 @@ class HeadGesturePlugin:
                     "scan": {"params": ["cycles", "scan_amplitude", "speed", "scan_hold"], "description": "依次观察左侧并停留、回中、观察右侧并停留、回中"},
                     "tilt": {"params": ["side", "tilt_amplitude", "speed", "hold"], "description": "向指定方向歪头、保持后回正"},
                     "reset": {"params": ["speed"], "description": "取消序列并将头部回正"},
-                    "stop": {"params": [], "description": "取消尚未发送的后续动作帧"},
+                    "cancel": {"params": [], "description": "取消尚未发送的后续动作帧"},
                 },
             },
         }
@@ -2050,8 +2050,8 @@ class HeadGesturePlugin:
                 "feedback_supported": True,
                 "feedback_topic": "/head/status",
             }
-        if action == "stop":
-            return {"state": "stopped", "cancelled": self._sequence.cancel()}
+        if action == "cancel":
+            return {"state": "cancelled", "cancelled": self._sequence.cancel()}
         if action == "reset":
             self._sequence.cancel()
             check = self._preflight()
@@ -2792,10 +2792,10 @@ class ArmGesturePlugin:
                         "type": "string",
                         "enum": [
                             "salute", "welcome", "raise", "shake_hands",
-                            "high_five", "reset", "stop",
+                            "high_five", "reset", "cancel",
                         ],
                         "default": "welcome",
-                        "description": "手臂动作，可选[salute, welcome, raise, shake_hands, high_five, reset, stop]",
+                        "description": "手臂动作，可选[salute, welcome, raise, shake_hands, high_five, reset, cancel]",
                     },
                     "side": {
                         "type": "string", "enum": ["left", "right", "both"],
@@ -2826,7 +2826,7 @@ class ArmGesturePlugin:
                     "shake_hands": {"params": ["side", "cycles", "speed"], "description": "向前伸手并轻柔上下摆动，做出握手动作"},
                     "high_five": {"params": ["side", "speed"], "description": "将手掌伸到身体前方并保持在肩部附近，做出击掌等待姿势"},
                     "reset": {"params": ["side", "speed"], "description": "取消序列并回到中性姿态"},
-                    "stop": {"params": [], "description": "取消尚未发送的后续动作帧"},
+                    "cancel": {"params": [], "description": "取消尚未发送的后续动作帧"},
                 },
             },
         }
@@ -2857,8 +2857,8 @@ class ArmGesturePlugin:
                 "feedback_supported": True,
                 "feedback_topic": "/arm/status",
             }
-        if action == "stop":
-            return {"state": "stopped", "cancelled": self._sequence.cancel()}
+        if action == "cancel":
+            return {"state": "cancelled", "cancelled": self._sequence.cancel()}
         if action == "salute":
             # The salute card exposes a dedicated left/right-only selector.
             # Keep accepting the old `side` argument for direct MCP callers.
@@ -3697,7 +3697,7 @@ class TtsPlugin:
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "action": {"type": "string", "enum": ["speak", "stop", "pause", "resume"],
+                    "action": {"type": "string", "enum": ["speak", "interrupt", "pause", "resume"],
                                "description": "控制动作"},
                     "text": {"type": "string", "description": "要播放的文本"},
                     "force": {"type": "boolean", "description": "是否强制播放(打断当前播放)", "default": False},
@@ -3705,7 +3705,7 @@ class TtsPlugin:
                 "required": ["action"],
                 "x-action-params": {
                     "speak": {"params": ["text", "force"], "description": "合成并播放文本"},
-                    "stop": {"params": [], "description": "停止播放"},
+                    "interrupt": {"params": [], "description": "中止播放（不可恢复）"},
                     "pause": {"params": [], "description": "暂停播放"},
                     "resume": {"params": [], "description": "恢复播放"},
                 },
@@ -3733,8 +3733,8 @@ class TtsPlugin:
             if not text:
                 return {"error": "text is required"}
             return self._speak(text, force)
-        elif action == "stop":
-            return self._call_empty_service(self._stop_client, "stop")
+        elif action == "interrupt":
+            return self._call_empty_service(self._stop_client, "interrupt")
         elif action == "pause":
             return self._call_empty_service(self._pause_client, "pause")
         elif action == "resume":
@@ -3836,7 +3836,7 @@ class VoicePlayActuatorPlugin:
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["play_file", "play_url", "play_text", "stop", "pause", "resume"],
+                        "enum": ["play_file", "play_url", "play_text", "interrupt", "pause", "resume"],
                         "description": "控制模式",
                     },
                     "path": {"type": "string", "description": "本地音频文件绝对路径(play_file)"},
@@ -3849,7 +3849,7 @@ class VoicePlayActuatorPlugin:
                     "play_file": {"params": ["path", "force"], "description": "播放本地音频文件"},
                     "play_url":  {"params": ["url", "force"],  "description": "播放远程URL音频"},
                     "play_text": {"params": ["text", "force"], "description": "TTS合成并播放文本"},
-                    "stop":      {"params": [],                 "description": "停止播放(不可恢复)"},
+                    "interrupt":  {"params": [],                 "description": "中止播放(不可恢复)"},
                     "pause":     {"params": [],                 "description": "暂停播放(可恢复)"},
                     "resume":    {"params": [],                 "description": "恢复暂停的播放"},
                 },
@@ -3863,7 +3863,7 @@ class VoicePlayActuatorPlugin:
                 "play_file": ("/audio_play/play_file", PlayFile),
                 "play_url":  ("/audio_play/play_url",  PlayUrl),
                 "play_text": ("/audio_play/play_text", PlayText),
-                "stop":      ("/audio_play/stop",      PlayStop),
+                "interrupt":  ("/audio_play/stop",      PlayStop),
                 "pause":     ("/audio_play/pause",     PlayPause),
                 "resume":    ("/audio_play/resume",   PlayResume),
             }
@@ -3985,7 +3985,7 @@ class NavPlugin:
                 "type": "object",
                 "properties": {
                     "action": {"type": "string",
-                               "enum": ["move_to", "move_by", "rotate", "rotate_to", "go_home", "stop", "get_pose"],
+                               "enum": ["move_to", "move_by", "rotate", "rotate_to", "go_home", "cancel", "get_pose"],
                                "description": "导航动作"},
                     "x": {"type": "number", "description": "目标x坐标(米)"},
                     "y": {"type": "number", "description": "目标y坐标(米)"},
@@ -4010,8 +4010,8 @@ class NavPlugin:
                                   "description": "原地旋转到绝对角度(度)"},
                     "go_home": {"params": [],
                                 "description": "自主导航回充电桩"},
-                    "stop": {"params": [],
-                             "description": "停止当前导航动作"},
+                    "cancel": {"params": [],
+                             "description": "取消当前导航动作"},
                     "get_pose": {"params": [],
                                  "description": "获取当前位姿(x, y, yaw)"},
                 },
@@ -4060,7 +4060,7 @@ class NavPlugin:
             result = self._slamtec.go_home()
             return {"state": "going_home", "api_result": result}
 
-        elif action == "stop":
+        elif action == "cancel":
             result = self._slamtec.cancel_current_action()
             # Also stop cmd_vel
             if self._vel_pub:
@@ -5146,7 +5146,7 @@ class ChassisRawPlugin:
                 "type": "object",
                 "properties": {
                     "action": {"type": "string",
-                               "enum": ["move", "rotate", "stop"],
+                               "enum": ["move", "rotate", "brake"],
                                "description": "控制动作"},
                     "direction": {"type": "string",
                                   "enum": ["forward", "backward"],
@@ -5165,7 +5165,7 @@ class ChassisRawPlugin:
                                "description": "前进/后退, 固定速率 0.3 m/s, duration=-1 持续运动"},
                     "rotate": {"params": ["rotation", "angle", "duration"],
                                "description": "精确旋转: angle(度) 用 Slamtec RotateAction 闭环; duration 为持续旋转"},
-                    "stop":   {"params": [],
+                    "brake":  {"params": [],
                                "description": "立即停止移动"},
                 },
             },
@@ -5225,7 +5225,7 @@ class ChassisRawPlugin:
             except (TypeError, ValueError):
                 return {"error": "duration must be a number"}
             return self._start(direction, dur)
-        elif action == "stop":
+        elif action == "brake":
             return self._do_stop()
         elif action in ("start", "info"):
             return {"state": "ready"}

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -3934,9 +3934,16 @@ class VoicePlayActuatorPlugin:
 
         try:
             future = client.call_async(req)
-            # executor_tianyi is already spinning this node in background
-            # play_text may block until TTS synthesis completes — allow up to 60s
-            timeout = 60.0 if action == "play_text" else 3.0
+            # play_file/play_url/play_text: fire-and-forget, 不等合成完成
+            if action in ("play_file", "play_url", "play_text"):
+                return {
+                    "ok": True, "code": 0,
+                    "message": "submitted",
+                    "action": action,
+                    "timestamp_ms": int(time.time() * 1000),
+                }
+            # interrupt/pause/resume: 短超时等待确认
+            timeout = 3.0
             start = time.time()
             while not future.done() and time.time() - start < timeout:
                 time.sleep(0.05)

--- a/x-humanoid/tianyi2.0/ext_devices.py
+++ b/x-humanoid/tianyi2.0/ext_devices.py
@@ -590,6 +590,9 @@ class _NetworkMicNode(Node):
         TARGET_RATE = 16000
         PUB_CHUNK = 1024  # 512 int16 samples = 1024 bytes
 
+        connect_failures = 0
+        MAX_CONNECT_RETRIES = 3
+
         while self._running:
             sock = None
             try:
@@ -598,6 +601,7 @@ class _NetworkMicNode(Node):
                 sock.connect((host, port))
                 sock.settimeout(None)
                 sock.setsockopt(_socket.IPPROTO_TCP, _socket.TCP_NODELAY, 1)
+                connect_failures = 0  # reset on successful connect
                 print(f"[ext_mic/tcp] connected to {host}:{port} (pre_converted={pre_converted})", flush=True)
 
                 raw_buf = bytearray()
@@ -653,7 +657,12 @@ class _NetworkMicNode(Node):
                             first_publish = False
             except Exception as e:
                 if self._running:
-                    print(f"[ext_mic/tcp] error: {e}, reconnecting in 2s", flush=True)
+                    connect_failures += 1
+                    if connect_failures >= MAX_CONNECT_RETRIES:
+                        print(f"[ext_mic/tcp] failed to connect to {host}:{port} after {MAX_CONNECT_RETRIES} attempts, giving up", flush=True)
+                        self.state = "error"
+                        return
+                    print(f"[ext_mic/tcp] error: {e}, retrying ({connect_failures}/{MAX_CONNECT_RETRIES}) in 2s", flush=True)
             finally:
                 if sock:
                     try:

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -69,66 +69,73 @@ def _ensure_lyre_audio_mode():
 
 
 def _ensure_audio_sender(cfg: dict):
-    """Ensure audio_sender.py TCP server is running on the host for DJI wireless mic streaming."""
+    """Ensure audio_sender.py TCP server is running on remote hosts for network mic sources."""
     ext_mic_cfg = cfg.get("plugins", {}).get("ext_mic", {})
     if not ext_mic_cfg.get("enabled", False):
         return
     sources = ext_mic_cfg.get("network_sources", [])
-    tcp_sources = [s for s in sources if s.get("url", "").startswith("tcp://")]
-    if not tcp_sources:
-        return
 
-    _nsenter = ["nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p", "--"]
+    for src in sources:
+        url = src.get("url", "")
+        if not url.startswith("tcp://"):
+            continue
+        ssh_host = src.get("ssh_host")
+        if not ssh_host:
+            continue
 
-    # Check if already running
-    try:
-        result = subprocess.run(
-            _nsenter + ["pgrep", "-f", "audio_sender.py"],
-            capture_output=True, text=True, timeout=5)
-        if result.returncode == 0 and result.stdout.strip():
-            pid = result.stdout.strip().splitlines()[0]
-            print(f"[audio_sender] already running (pid={pid})")
-            return
-    except Exception:
-        pass
+        ssh_user = src.get("ssh_user", "ubuntu")
+        ssh_pass = src.get("ssh_password", "")
+        card = src.get("card", 1)
+        sender_path = src.get("sender_path", "/home/ubuntu/audio_sender.py")
+        port = url.rsplit(":", 1)[-1].split("/")[0] if ":" in url else "9800"
+        name = src.get("name", ssh_host)
 
-    # Deploy audio_sender.py to host
-    sender_src = str(Path(__file__).parent / "audio_sender.py")
-    host_dir = "/opt/phanthy-motus"
-    host_path = f"{host_dir}/audio_sender.py"
-    try:
-        subprocess.run(_nsenter + ["mkdir", "-p", host_dir], timeout=5)
-        with open(sender_src) as f:
-            content = f.read()
-        subprocess.run(
-            _nsenter + ["bash", "-c", f"cat > {host_path}"],
-            input=content, text=True, check=True, timeout=5)
-        print(f"[audio_sender] deployed to host:{host_path}")
-    except Exception as e:
-        print(f"[audio_sender] WARNING: could not deploy to host: {e}")
-        return
+        def _ssh(cmd: str, timeout: int = 10) -> subprocess.CompletedProcess:
+            return subprocess.run(
+                ["sshpass", "-p", ssh_pass, "ssh",
+                 "-o", "StrictHostKeyChecking=no", "-o", f"ConnectTimeout=3",
+                 f"{ssh_user}@{ssh_host}", cmd],
+                capture_output=True, text=True, timeout=timeout)
 
-    # Start in background
-    # Extract port from first TCP source URL (e.g. tcp://192.168.41.1:9800)
-    url = tcp_sources[0]["url"]
-    port = url.rsplit(":", 1)[-1].split("/")[0] if ":" in url else "9800"
-    try:
-        subprocess.run(
-            _nsenter + ["bash", "-c",
-                         f"nohup python3 {host_path} --port {port} "
-                         f"> /tmp/audio_sender.log 2>&1 &"],
-            timeout=5)
-        time.sleep(1)
-        result = subprocess.run(
-            _nsenter + ["pgrep", "-f", "audio_sender.py"],
-            capture_output=True, text=True, timeout=5)
-        if result.returncode == 0 and result.stdout.strip():
-            pid = result.stdout.strip().splitlines()[0]
-            print(f"[audio_sender] started on host (pid={pid}, port={port})")
-        else:
-            print(f"[audio_sender] WARNING: process did not start, check /tmp/audio_sender.log on host")
-    except Exception as e:
-        print(f"[audio_sender] WARNING: could not start: {e}")
+        # Check if already running
+        try:
+            result = _ssh("pgrep -f audio_sender.py")
+            if result.returncode == 0 and result.stdout.strip():
+                pid = result.stdout.strip().splitlines()[0]
+                print(f"[audio_sender] {name}: already running on {ssh_host} (pid={pid})")
+                continue
+        except Exception as e:
+            print(f"[audio_sender] {name}: WARNING: SSH check failed: {e}")
+            continue
+
+        # Deploy audio_sender.py if not present
+        try:
+            result = _ssh(f"test -f {sender_path} && echo EXISTS")
+            if "EXISTS" not in (result.stdout or ""):
+                local_src = str(Path(__file__).parent / "audio_sender.py")
+                subprocess.run(
+                    ["sshpass", "-p", ssh_pass, "scp",
+                     "-o", "StrictHostKeyChecking=no",
+                     local_src, f"{ssh_user}@{ssh_host}:{sender_path}"],
+                    check=True, timeout=15)
+                print(f"[audio_sender] {name}: deployed to {ssh_host}:{sender_path}")
+        except Exception as e:
+            print(f"[audio_sender] {name}: WARNING: deploy failed: {e}")
+            continue
+
+        # Start in background
+        try:
+            _ssh(f"nohup python3 {sender_path} --port {port} --card {card} "
+                 f"> /tmp/audio_sender.log 2>&1 &")
+            time.sleep(1)
+            result = _ssh("pgrep -f audio_sender.py")
+            if result.returncode == 0 and result.stdout.strip():
+                pid = result.stdout.strip().splitlines()[0]
+                print(f"[audio_sender] {name}: started on {ssh_host} (pid={pid}, port={port}, card={card})")
+            else:
+                print(f"[audio_sender] {name}: WARNING: did not start, check {ssh_host}:/tmp/audio_sender.log")
+        except Exception as e:
+            print(f"[audio_sender] {name}: WARNING: start failed: {e}")
 
 
 def _resolve_namespace(cfg: dict) -> str:

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -68,6 +68,69 @@ def _ensure_lyre_audio_mode():
         print(f"[lyre] WARNING: could not switch to {target} mode: {e}")
 
 
+def _ensure_audio_sender(cfg: dict):
+    """Ensure audio_sender.py TCP server is running on the host for DJI wireless mic streaming."""
+    ext_mic_cfg = cfg.get("plugins", {}).get("ext_mic", {})
+    if not ext_mic_cfg.get("enabled", False):
+        return
+    sources = ext_mic_cfg.get("network_sources", [])
+    tcp_sources = [s for s in sources if s.get("url", "").startswith("tcp://")]
+    if not tcp_sources:
+        return
+
+    _nsenter = ["nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p", "--"]
+
+    # Check if already running
+    try:
+        result = subprocess.run(
+            _nsenter + ["pgrep", "-f", "audio_sender.py"],
+            capture_output=True, text=True, timeout=5)
+        if result.returncode == 0 and result.stdout.strip():
+            pid = result.stdout.strip().splitlines()[0]
+            print(f"[audio_sender] already running (pid={pid})")
+            return
+    except Exception:
+        pass
+
+    # Deploy audio_sender.py to host
+    sender_src = str(Path(__file__).parent / "audio_sender.py")
+    host_dir = "/opt/phanthy-motus"
+    host_path = f"{host_dir}/audio_sender.py"
+    try:
+        subprocess.run(_nsenter + ["mkdir", "-p", host_dir], timeout=5)
+        with open(sender_src) as f:
+            content = f.read()
+        subprocess.run(
+            _nsenter + ["bash", "-c", f"cat > {host_path}"],
+            input=content, text=True, check=True, timeout=5)
+        print(f"[audio_sender] deployed to host:{host_path}")
+    except Exception as e:
+        print(f"[audio_sender] WARNING: could not deploy to host: {e}")
+        return
+
+    # Start in background
+    # Extract port from first TCP source URL (e.g. tcp://192.168.41.1:9800)
+    url = tcp_sources[0]["url"]
+    port = url.rsplit(":", 1)[-1].split("/")[0] if ":" in url else "9800"
+    try:
+        subprocess.run(
+            _nsenter + ["bash", "-c",
+                         f"nohup python3 {host_path} --port {port} "
+                         f"> /tmp/audio_sender.log 2>&1 &"],
+            timeout=5)
+        time.sleep(1)
+        result = subprocess.run(
+            _nsenter + ["pgrep", "-f", "audio_sender.py"],
+            capture_output=True, text=True, timeout=5)
+        if result.returncode == 0 and result.stdout.strip():
+            pid = result.stdout.strip().splitlines()[0]
+            print(f"[audio_sender] started on host (pid={pid}, port={port})")
+        else:
+            print(f"[audio_sender] WARNING: process did not start, check /tmp/audio_sender.log on host")
+    except Exception as e:
+        print(f"[audio_sender] WARNING: could not start: {e}")
+
+
 def _resolve_namespace(cfg: dict) -> str:
     ns = cfg.get("ros_namespace", "").strip()
     if ns:
@@ -457,6 +520,9 @@ def main():
 
     # Ensure host lyre service is in audio mode (ASR + TTS, no built-in dialogue)
     _ensure_lyre_audio_mode()
+
+    # Ensure TCP audio sender is running on host for DJI wireless mic
+    _ensure_audio_sender(cfg)
 
     # Dual-domain ROS2
     ros2 = DualDomainROS2()


### PR DESCRIPTION
## Summary
- **stop action 改名**: tts/voice_play → `interrupt`, head_gesture/arm_gesture/nav → `cancel`, chassis_raw → `brake`，避免与框架 stop 生命周期 action 冲突
- **voice_play 非阻塞**: play_file/play_url/play_text 改为 fire-and-forget，不再阻塞等待 lyre 合成完成（之前阻塞 15-21 秒）
- **audio_sender 自动启动**: driver 启动时通过 SSH 检查并启动远程 mic host 上的 audio_sender
- **audio_sender format 检测修复**: `SUBFORMAT:` 行误匹配 `FORMAT:` 导致 S24_3LE 被检测为 S16_LE
- **TCP mic 重试限制**: 连接失败 3 次后停止重试并报错，避免无限静默重试

## Test plan
- [x] voice_play interrupt/pause/resume 正常工作
- [x] play_text 非阻塞，毫秒级返回
- [x] audio_sender 自动启动，driver 重启后 TCP mic 恢复
- [x] audio_sender 格式检测正确（S24_3LE stereo 48kHz）
- [x] dashboard 订阅 ext_mic 波形正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)