### PR TITLE
feat(g1): 提供基于硬件状态的扬声器播放完成 MCP 查询

### DIFF
--- a/.github/workflows/g1-speaker-lifecycle.yml
+++ b/.github/workflows/g1-speaker-lifecycle.yml
@@ -1,0 +1,40 @@
+name: G1 speaker lifecycle
+
+on:
+  pull_request:
+    paths:
+      - unitree/g1/device.py
+      - unitree/g1/unitree_sdk2py/g1/audio/g1_audio_client.py
+      - unitree/g1/unitree_sdk2py/rpc/client.py
+      - unitree/g1/unitree_sdk2py/rpc/client_base.py
+      - unitree/g1/unitree_sdk2py/rpc/request_future.py
+      - unitree/g1/tests/test_speaker_lifecycle.py
+      - unitree/g1/SPEAKER_LIFECYCLE_PROTOCOL.md
+      - .github/workflows/g1-speaker-lifecycle.yml
+  push:
+    branches: [main]
+    paths:
+      - unitree/g1/device.py
+      - unitree/g1/unitree_sdk2py/g1/audio/g1_audio_client.py
+      - unitree/g1/unitree_sdk2py/rpc/client.py
+      - unitree/g1/unitree_sdk2py/rpc/client_base.py
+      - unitree/g1/unitree_sdk2py/rpc/request_future.py
+      - unitree/g1/tests/test_speaker_lifecycle.py
+      - unitree/g1/SPEAKER_LIFECYCLE_PROTOCOL.md
+      - .github/workflows/g1-speaker-lifecycle.yml
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run G1 speaker lifecycle tests
+        run: >-
+          PYTHONDONTWRITEBYTECODE=1 python -m unittest discover
+          -s unitree/g1/tests -p 'test_*.py' -v

--- a/.github/workflows/g1-speaker-lifecycle.yml
+++ b/.github/workflows/g1-speaker-lifecycle.yml
@@ -4,22 +4,40 @@ on:
   pull_request:
     paths:
       - unitree/g1/device.py
+      - unitree/g1/main.py
+      - unitree/g1/playback_state.py
+      - unitree/g1/config.yaml
+      - unitree/g1/Dockerfile
       - unitree/g1/unitree_sdk2py/g1/audio/g1_audio_client.py
       - unitree/g1/unitree_sdk2py/rpc/client.py
       - unitree/g1/unitree_sdk2py/rpc/client_base.py
       - unitree/g1/unitree_sdk2py/rpc/request_future.py
+      - unitree/g1/unitree_sdk2py/core/channel.py
       - unitree/g1/tests/test_speaker_lifecycle.py
+      - unitree/g1/tests/test_playback_state.py
+      - unitree/g1/tests/test_channel_matching.py
+      - unitree/g1/tests/test_hardware_smoke_contract.py
+      - unitree/g1/tools/g1_speaker_receipt_smoke.py
       - unitree/g1/SPEAKER_LIFECYCLE_PROTOCOL.md
       - .github/workflows/g1-speaker-lifecycle.yml
   push:
     branches: [main]
     paths:
       - unitree/g1/device.py
+      - unitree/g1/main.py
+      - unitree/g1/playback_state.py
+      - unitree/g1/config.yaml
+      - unitree/g1/Dockerfile
       - unitree/g1/unitree_sdk2py/g1/audio/g1_audio_client.py
       - unitree/g1/unitree_sdk2py/rpc/client.py
       - unitree/g1/unitree_sdk2py/rpc/client_base.py
       - unitree/g1/unitree_sdk2py/rpc/request_future.py
+      - unitree/g1/unitree_sdk2py/core/channel.py
       - unitree/g1/tests/test_speaker_lifecycle.py
+      - unitree/g1/tests/test_playback_state.py
+      - unitree/g1/tests/test_channel_matching.py
+      - unitree/g1/tests/test_hardware_smoke_contract.py
+      - unitree/g1/tools/g1_speaker_receipt_smoke.py
       - unitree/g1/SPEAKER_LIFECYCLE_PROTOCOL.md
       - .github/workflows/g1-speaker-lifecycle.yml
 

--- a/unitree/g1/Dockerfile
+++ b/unitree/g1/Dockerfile
@@ -47,6 +47,8 @@ COPY unitree_sdk2py/ /work/unitree_sdk2py/
 COPY resource/       /work/resource/
 COPY main.py   /work/main.py
 COPY device.py /work/device.py
+COPY playback_state.py /work/playback_state.py
+COPY tools/g1_speaker_receipt_smoke.py /work/tools/g1_speaker_receipt_smoke.py
 COPY rpc_proxy.py /work/rpc_proxy.py
 COPY ext_devices.py /work/ext_devices.py
 COPY safety_harness.py /work/safety_harness.py

--- a/unitree/g1/SPEAKER_LIFECYCLE_PROTOCOL.md
+++ b/unitree/g1/SPEAKER_LIFECYCLE_PROTOCOL.md
@@ -47,6 +47,60 @@ terminal. Terminal identity is `(session_id, utterance_id)`, and consumers must
 deduplicate it. A terminal receipt may arrive without `started` when delivery of
 the earlier event failed; consumers must accept that transition.
 
+## Direct MCP status and wait
+
+The `speaker` MCP tool exposes the same terminal state directly, so callers do
+not need to subscribe to ROS or repeatedly inspect the latest global status:
+
+```json
+{
+  "action": "wait_playback",
+  "session_id": "speaker:<value returned by speaker start>",
+  "utterance_id": "utt:<value carried by every PCM and EOF frame>",
+  "timeout_sec": 20
+}
+```
+
+For example, a direct JSON-RPC call is:
+
+```bash
+curl -sS http://127.0.0.1:15701/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0",
+    "id":"speaker-wait",
+    "method":"tools/call",
+    "params":{
+      "name":"speaker",
+      "arguments":{
+        "action":"wait_playback",
+        "session_id":"speaker:REPLACE_ME",
+        "utterance_id":"utt:REPLACE_ME",
+        "timeout_sec":20
+      }
+    }
+  }'
+```
+
+The terminal receipt is returned directly. In strict G1 mode,
+`state: completed`, `terminal: true`, and
+`completion_basis: g1_play_state_observed` mean the firmware player was
+observed returning to idle for that exact utterance. `cancelled` and `error`
+are also terminal. `timeout` means the utterance was observed but has not yet
+reached a terminal state; `unknown` means its `started` frame was not observed
+before the timeout. Both are non-terminal and retryable with the same identity.
+
+The default wait is 20 seconds and one call is capped at 25 seconds, below
+Core's 30-second MCP request timeout. Use the same identity in a later call for
+long audio; a terminal result retained in bounded history returns immediately.
+`timeout_sec: 0` performs an immediate correlated lookup. A stale or incorrect
+session returns a non-retryable session error instead of matching another
+utterance with the same ID.
+
+This action shape is suitable as a common Speaker contract for other robots,
+but this PR implements it only for the G1 plugin. Each other driver still needs
+to connect its own hardware/player acknowledgement to the terminal receipt.
+
 With `completion_mode: hardware_state`, the driver also subscribes to the G1
 controller's `rt/audio_msg` DDS topic. The body-speaker service publishes
 `{"play_state":1}` when its player starts and `{"play_state":0}` when it
@@ -92,8 +146,9 @@ cannot be resumed safely; callers should use interrupt/cancel instead.
 
 Run this only against a dedicated G1 test deployment. It replaces the active
 Speaker input topic, plays the normal startup beep, sends 1.5 seconds of
-near-silent non-zero PCM, validates a hardware-state `completed` receipt, and
-stops Speaker during cleanup:
+near-silent non-zero PCM, waits through the MCP `wait_playback` action, then
+cross-checks the matching ROS hardware-state receipt and stops Speaker during
+cleanup:
 
 ```bash
 docker exec -it embodied-unitree-g1 bash -lc '
@@ -105,11 +160,12 @@ docker exec -it embodied-unitree-g1 bash -lc '
 ```
 
 Success prints JSON containing `result: passed`, `play_state.ready: true`, at
-least one matched publisher, and a terminal receipt whose basis is
+least one matched publisher, an `mcp_wait_result`, and a matching
+`terminal_receipt`; both terminal results must use
 `g1_play_state_observed`. Missing DDS discovery, missing transitions, receipt
-timeout, non-hardware completion, and incomplete PCM delivery all fail with a
-non-zero exit code. The command is intentionally opt-in because it interrupts
-any existing Speaker session.
+timeout, non-hardware completion, inconsistent MCP/ROS results, and incomplete
+PCM delivery all fail with a non-zero exit code. The command is intentionally
+opt-in because it interrupts any existing Speaker session.
 
 ## Delivery and recovery
 
@@ -118,14 +174,14 @@ late-join replay must request compatible transient-local QoS. The driver keeps a
 bounded retry outbox for local publish exceptions and leaves the receipt
 publisher alive after `stop`.
 
-Consumers should still implement this recovery sequence:
+Consumers should implement this sequence:
 
-1. subscribe before submitting the utterance;
-2. wait for a matching terminal `(session_id, utterance_id)`;
-3. deduplicate retries;
-4. on timeout, call speaker `info` and reconcile against
-   `recent_terminal_receipts` and `pending_receipts`;
-5. treat a remaining timeout as unknown/error rather than assuming completion.
+1. use the `session_id` returned by speaker `start`;
+2. assign one `utt:` ID and carry it on every PCM frame and EOF;
+3. call `wait_playback` with that exact pair;
+4. retry the same pair after a non-terminal timeout/unknown result;
+5. use speaker `info` or the ROS receipt topic for diagnostics and recovery;
+6. never assume completion from elapsed audio duration alone.
 
 ## Rollout compatibility
 
@@ -137,6 +193,7 @@ Consumers should still implement this recovery sequence:
 | new | new | Correlated lifecycle receipts |
 
 The safe rollout order is speaker driver first, then a producer that assigns IDs
-and repeats them on EOF, then a Core receipt waiter with timeout-to-`info`
-reconciliation. Until the latter two changes ship, this driver PR is protocol
-foundation rather than an end-to-end fix for Core interaction ordering.
+and repeats them on EOF. At that point Core or any MCP client can invoke the
+Driver's `wait_playback` action directly; no separate ROS subscriber is needed
+in Core. Interaction logic must still call the wait action before advancing to
+the next dependent step.

--- a/unitree/g1/SPEAKER_LIFECYCLE_PROTOCOL.md
+++ b/unitree/g1/SPEAKER_LIFECYCLE_PROTOCOL.md
@@ -1,0 +1,83 @@
+# G1 speaker lifecycle protocol v1
+
+This protocol adds a correlatable lifecycle to PCM streamed through the G1
+`SpeakerPlugin`. It does not add a completion callback to Unitree's native
+`TtsMaker` API.
+
+## Audio input
+
+The producer publishes the existing `audio_msgs/AudioChunk` wire format:
+
+- `format`: `audio/pcm-16k`
+- `header.frame_id`: `utt:<producer-generated-id>` on every audio frame
+- EOF: the existing 8-byte `AUDIO_EOF_MAGIC`, with the same `header.frame_id`
+
+The producer must not reuse an utterance ID during one speaker session. A UUID
+is recommended. Adding `frame_id` is backward compatible with old speakers,
+which only inspect `data`. The PCM topic remains best-effort for compatibility;
+a correlated stream whose EOF is lost terminates with `missing_eof`, not a false
+`completed` receipt.
+
+An empty or non-`utt:` frame ID is treated as a legacy stream. It still plays,
+but its driver-generated `legacy:<n>` ID cannot be correlated with the original
+`speak` call.
+
+## Receipt output
+
+For input topic `<audio_topic>`, the speaker publishes JSON in
+`std_msgs/String` on `<audio_topic>/speaker_receipts`:
+
+```json
+{
+  "type": "speech_playback_receipt",
+  "version": 1,
+  "session_id": "speaker:<uuid>",
+  "utterance_id": "utt:<producer-generated-id>",
+  "state": "completed",
+  "completion_basis": "driver_drained_estimated",
+  "audio_bytes": 32000,
+  "ts": 1780000000.0,
+  "reason": "",
+  "receipt_topic": "/perception/tts/speaker_receipts"
+}
+```
+
+States are `started`, `completed`, `cancelled`, and `error`. The last three are
+terminal. Terminal identity is `(session_id, utterance_id)`, and consumers must
+deduplicate it. A terminal receipt may arrive without `started` when delivery of
+the earlier event failed; consumers must accept that transition.
+
+`completed` means the driver submitted all PCM, waited its calculated duration,
+and applied a short tail grace. Unitree exposes no hardware drain/audible-end
+acknowledgement, so this is deliberately reported as
+`driver_drained_estimated`, not exact acoustic completion.
+
+## Delivery and recovery
+
+Receipts use RELIABLE, TRANSIENT_LOCAL, KEEP_LAST(50) QoS. A consumer that needs
+late-join replay must request compatible transient-local QoS. The driver keeps a
+bounded retry outbox for local publish exceptions and leaves the receipt
+publisher alive after `stop`.
+
+Consumers should still implement this recovery sequence:
+
+1. subscribe before submitting the utterance;
+2. wait for a matching terminal `(session_id, utterance_id)`;
+3. deduplicate retries;
+4. on timeout, call speaker `info` and reconcile against
+   `recent_terminal_receipts` and `pending_receipts`;
+5. treat a remaining timeout as unknown/error rather than assuming completion.
+
+## Rollout compatibility
+
+| Producer | Speaker | Result |
+| --- | --- | --- |
+| old | old | Existing playback; no correlatable completion |
+| new | old | Playback remains compatible; receipt unavailable |
+| old | new | Playback plus legacy receipt; no call correlation |
+| new | new | Correlated lifecycle receipts |
+
+The safe rollout order is speaker driver first, then a producer that assigns IDs
+and repeats them on EOF, then a Core receipt waiter with timeout-to-`info`
+reconciliation. Until the latter two changes ship, this driver PR is protocol
+foundation rather than an end-to-end fix for Core interaction ordering.

--- a/unitree/g1/SPEAKER_LIFECYCLE_PROTOCOL.md
+++ b/unitree/g1/SPEAKER_LIFECYCLE_PROTOCOL.md
@@ -34,7 +34,7 @@ For input topic `<audio_topic>`, the speaker publishes JSON in
   "session_id": "speaker:<uuid>",
   "utterance_id": "utt:<producer-generated-id>",
   "state": "completed",
-  "completion_basis": "driver_drained_estimated",
+  "completion_basis": "g1_play_state_observed",
   "audio_bytes": 32000,
   "ts": 1780000000.0,
   "reason": "",
@@ -47,10 +47,69 @@ terminal. Terminal identity is `(session_id, utterance_id)`, and consumers must
 deduplicate it. A terminal receipt may arrive without `started` when delivery of
 the earlier event failed; consumers must accept that transition.
 
-`completed` means the driver submitted all PCM, waited its calculated duration,
-and applied a short tail grace. Unitree exposes no hardware drain/audible-end
-acknowledgement, so this is deliberately reported as
-`driver_drained_estimated`, not exact acoustic completion.
+With `completion_mode: hardware_state`, the driver also subscribes to the G1
+controller's `rt/audio_msg` DDS topic. The body-speaker service publishes
+`{"play_state":1}` when its player starts and `{"play_state":0}` when it
+becomes idle. Before the first and every subsequent successful `PlayStream`
+submission, the driver captures an event-sequence checkpoint. It also records
+the event sequence when each successful submission is acknowledged, so a late
+idle event from the preceding block cannot complete the stream. It reports
+`completed` only after observing a `1` after the first pre-submit checkpoint and
+a `0` after the final successful-submission checkpoint. The resulting basis is
+`g1_play_state_observed`.
+
+Before accepting the first audio block, strict mode waits for CycloneDDS to
+report that the `rt/audio_msg` reader has matched a firmware publisher. This
+distinguishes a constructed local reader from a usable state source and avoids
+turning DDS discovery delay into a false first-play timeout. State callbacks run
+directly on the DDS reader, and an idle transition must remain the newest state
+for a short settle window before it becomes terminal.
+
+This is a firmware player-idle acknowledgement, not an acoustic measurement:
+it cannot prove that a failed amplifier produced audible sound. The state topic
+is global rather than stream-ID keyed, so the driver keeps speaker playback
+serialized and fails closed on a missing transition or timeout. `PlayStop`
+during interrupt produces `play_state=0`, but generation invalidation prevents
+that event from becoming a false `completed` receipt.
+
+Because the topic is global, the bundled device also hides/rejects native
+`tts.speak` whenever strict Speaker completion is enabled; volume actions remain
+available. Audio writers outside this Driver bundle cannot be coordinated, so a
+deployment relying on these receipts must give the Speaker plugin exclusive
+ownership of the G1 body-speaker service.
+
+`completion_mode: estimated` remains available for older firmware. In that
+mode `completed` retains the previous `driver_drained_estimated` meaning: all
+PCM was submitted and its calculated duration plus tail grace elapsed. To
+restore native synthesis in such a configuration, also set
+`plugins.tts.speak_enabled: true` explicitly.
+
+Hardware-state mode does not offer resumable pause. Unitree exposes no playback
+cursor, so stopping during the final hardware tail would discard audio that
+cannot be resumed safely; callers should use interrupt/cancel instead.
+
+## Reviewer hardware smoke
+
+Run this only against a dedicated G1 test deployment. It replaces the active
+Speaker input topic, plays the normal startup beep, sends 1.5 seconds of
+near-silent non-zero PCM, validates a hardware-state `completed` receipt, and
+stops Speaker during cleanup:
+
+```bash
+docker exec -it embodied-unitree-g1 bash -lc '
+  source /opt/ros/humble/setup.bash &&
+  source /ros_ws/install/setup.bash &&
+  python3 /work/tools/g1_speaker_receipt_smoke.py \
+    --confirm-exclusive-hardware
+'
+```
+
+Success prints JSON containing `result: passed`, `play_state.ready: true`, at
+least one matched publisher, and a terminal receipt whose basis is
+`g1_play_state_observed`. Missing DDS discovery, missing transitions, receipt
+timeout, non-hardware completion, and incomplete PCM delivery all fail with a
+non-zero exit code. The command is intentionally opt-in because it interrupts
+any existing Speaker session.
 
 ## Delivery and recovery
 

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -6,8 +6,18 @@ plugins:
     enabled: true
   tts:
     enabled: true
+    # Native speak is hidden while strict Speaker completion is enabled;
+    # volume control remains available. If Speaker is changed to estimated,
+    # set this to true explicitly to restore native synthesis.
+    speak_enabled: false
   speaker:
     enabled: true
+    # G1 body-speaker firmware publishes {"play_state":1|0} on this DDS topic.
+    # Strict mode reports completed only after the matching playing -> idle cycle.
+    completion_mode: hardware_state
+    play_state_topic: rt/audio_msg
+    play_state_discovery_timeout_sec: 3.0
+    play_state_timeout_sec: 2.0
   led:
     enabled: true
   loco:

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -19,6 +19,7 @@ drivers/unitree/g1/device.py — Unitree G1 设备插件（重构版）。
 """
 
 import json
+import math
 import queue
 import socket
 import struct
@@ -348,6 +349,8 @@ class _SpeakerNode(Node):
     STREAM_RPC_TIMEOUT_SEC = 1.0
     CONTROL_RPC_TIMEOUT_SEC = 1.0
     TERMINAL_HISTORY_LIMIT = 256
+    DEFAULT_PLAYBACK_WAIT_SEC = 20.0
+    MAX_PLAYBACK_WAIT_SEC = 25.0
     COMPLETION_MODE_ESTIMATED = 'estimated'
     COMPLETION_MODE_HARDWARE_STATE = 'hardware_state'
 
@@ -393,6 +396,7 @@ class _SpeakerNode(Node):
         self._lock = threading.RLock()
         self._sdk_lock = threading.Lock()
         self._receipt_lock = threading.RLock()
+        self._receipt_cv = threading.Condition(self._receipt_lock)
         self._receipt_publish_lock = threading.Lock()
         self._control_in_progress = False
         self._accept_chunks = False
@@ -408,6 +412,7 @@ class _SpeakerNode(Node):
         self._legacy_counter = 0
         self._active_utterance_id: str | None = None
         self._session_id = ''
+        self._open_receipt_session_id = ''
         self._started_ids: dict[tuple[str, str], bool] = {}
         self._terminal_ids: dict[tuple[str, str], dict] = {}
         self._cancelled_ids: dict[str, bool] = {}
@@ -534,8 +539,9 @@ class _SpeakerNode(Node):
             self._cancelled_ids.clear()
             self._session_id = f"speaker:{uuid.uuid4()}"
             receipt_topic = f"{topic.rstrip('/')}/speaker_receipts"
-            with self._receipt_lock:
+            with self._receipt_cv:
                 self._started_ids.clear()
+                self._open_receipt_session_id = self._session_id
                 if (self._receipt_pub is not None
                         and self._receipt_topic != receipt_topic):
                     self.destroy_publisher(self._receipt_pub)
@@ -550,6 +556,7 @@ class _SpeakerNode(Node):
                     for pending in self._pending_receipts.values()
                 ):
                     self._ensure_receipt_retry_timer_locked()
+                self._receipt_cv.notify_all()
             self.get_logger().info(f"[speaker] creating subscription: topic={topic}, msg_type=AudioChunk, qos=LOW_LAT")
             self._sub = self.create_subscription(
                 AudioChunk, topic, self._on_chunk, _LOW_LAT_QOS,
@@ -607,7 +614,8 @@ class _SpeakerNode(Node):
         if not utterance_id:
             return None
         terminal = state in ('completed', 'cancelled', 'error')
-        with self._receipt_lock:
+        notify_waiters = False
+        with self._receipt_cv:
             session_key = (self._session_id, utterance_id)
             if session_key in self._terminal_ids:
                 # A terminal receipt is final for this session/utterance pair.
@@ -639,6 +647,7 @@ class _SpeakerNode(Node):
                 }
                 if state == 'started':
                     self._remember_bounded(self._started_ids, session_key, True)
+                    notify_waiters = True
                 if terminal:
                     started_pending_key = (
                         self._session_id, utterance_id, 'started',
@@ -647,13 +656,115 @@ class _SpeakerNode(Node):
                     self._receipt_publish_errors.pop(started_pending_key, None)
                     self._remember_bounded(self._terminal_ids, session_key, receipt)
                     self._last_terminal_receipt = receipt
+                    notify_waiters = True
                 pending_key = (self._session_id, utterance_id, state)
                 self._pending_receipts[pending_key] = receipt
                 while len(self._pending_receipts) > self.TERMINAL_HISTORY_LIMIT:
                     expired_key = next(iter(self._pending_receipts))
                     self._pending_receipts.pop(expired_key)
                     self._receipt_publish_errors.pop(expired_key, None)
+            if notify_waiters:
+                self._receipt_cv.notify_all()
         return receipt
+
+    def wait_for_playback(self, session_id, utterance_id,
+                          timeout_sec=DEFAULT_PLAYBACK_WAIT_SEC) -> dict:
+        """Wait for one exact playback receipt without blocking speaker work."""
+        if not isinstance(session_id, str) or not session_id:
+            return {
+                'state': 'error',
+                'terminal': False,
+                'error': 'missing_session_id',
+            }
+        if not session_id.startswith('speaker:') or len(session_id) == 8:
+            return {
+                'state': 'error',
+                'terminal': False,
+                'error': 'invalid_session_id',
+                'session_id': session_id,
+            }
+        if not isinstance(utterance_id, str) or not utterance_id:
+            return {
+                'state': 'error',
+                'terminal': False,
+                'error': 'missing_utterance_id',
+                'session_id': session_id,
+            }
+        if not utterance_id.startswith('utt:') or len(utterance_id) == 4:
+            return {
+                'state': 'error',
+                'terminal': False,
+                'error': 'invalid_utterance_id',
+                'session_id': session_id,
+                'utterance_id': utterance_id,
+            }
+        try:
+            if isinstance(timeout_sec, bool):
+                raise ValueError
+            timeout = float(timeout_sec)
+        except (TypeError, ValueError):
+            return {
+                'state': 'error',
+                'terminal': False,
+                'error': 'invalid_timeout_sec',
+                'session_id': session_id,
+                'utterance_id': utterance_id,
+                'max_timeout_sec': self.MAX_PLAYBACK_WAIT_SEC,
+            }
+        if (not math.isfinite(timeout) or timeout < 0
+                or timeout > self.MAX_PLAYBACK_WAIT_SEC):
+            return {
+                'state': 'error',
+                'terminal': False,
+                'error': 'timeout_out_of_range',
+                'session_id': session_id,
+                'utterance_id': utterance_id,
+                'max_timeout_sec': self.MAX_PLAYBACK_WAIT_SEC,
+            }
+
+        key = (session_id, utterance_id)
+        deadline = time.monotonic() + timeout
+        with self._receipt_cv:
+            while True:
+                receipt = self._terminal_ids.get(key)
+                if receipt is not None:
+                    result = dict(receipt)
+                    result['terminal'] = True
+                    return result
+
+                active_session_id = self._open_receipt_session_id
+                if session_id != active_session_id:
+                    error = (
+                        'session_mismatch' if active_session_id
+                        else 'speaker_session_not_active'
+                    )
+                    return {
+                        'state': 'error',
+                        'terminal': False,
+                        'error': error,
+                        'session_id': session_id,
+                        'utterance_id': utterance_id,
+                        'active_session_id': active_session_id or None,
+                        'last_session_id': self._session_id or None,
+                        'retryable': False,
+                    }
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    observed = key in self._started_ids
+                    return {
+                        'state': 'timeout' if observed else 'unknown',
+                        'terminal': False,
+                        'session_id': session_id,
+                        'utterance_id': utterance_id,
+                        'reason': (
+                            'playback_not_terminal' if observed else
+                            'utterance_not_observed_before_timeout'
+                        ),
+                        'retryable': True,
+                        'timeout_sec': timeout,
+                    }
+                self._receipt_cv.wait(timeout=remaining)
 
     def _publish_and_log_receipt(self, receipt: dict | None) -> None:
         if receipt is None:
@@ -858,8 +969,11 @@ class _SpeakerNode(Node):
             self._legacy_mute_deadline = 0.0
             self._cancelled_ids.clear()
             self._topic = None
-        with self._receipt_lock:
+        with self._receipt_cv:
             self._started_ids.clear()
+            if self._open_receipt_session_id == self._session_id:
+                self._open_receipt_session_id = ''
+            self._receipt_cv.notify_all()
         self.get_logger().info(f"Speaker stopped: state={self.state} code={stop_code}")
         return {
             'state': self.state,
@@ -1556,12 +1670,29 @@ class SpeakerPlugin:
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["start", "stop", "info"],
+                        "enum": ["start", "stop", "info", "wait_playback"],
                         "description": "Action to perform",
                     },
                     "input_topic": {
                         "type": "string",
                         "description": "ROS2 topic to subscribe for PCM audio (provided by canvas connection)",
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "pattern": "^speaker:.+",
+                        "description": "Exact session_id returned by speaker start",
+                    },
+                    "utterance_id": {
+                        "type": "string",
+                        "pattern": "^utt:.+",
+                        "description": "Exact utterance ID carried by every AudioChunk and EOF frame",
+                    },
+                    "timeout_sec": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": _SpeakerNode.MAX_PLAYBACK_WAIT_SEC,
+                        "default": _SpeakerNode.DEFAULT_PLAYBACK_WAIT_SEC,
+                        "description": "Seconds to wait; 0 performs an immediate correlated lookup",
                     },
                 },
                 "required": ["action"],
@@ -1735,6 +1866,12 @@ class SpeakerPlugin:
                 "completion_basis": self._node._completion_basis(),
                 "play_state": self._node._play_state_status(),
                 "receipt_recovery": "transient_local_then_info_poll",
+                "playback_wait": {
+                    "action": "wait_playback",
+                    "identity": ["session_id", "utterance_id"],
+                    "default_timeout_sec": self._node.DEFAULT_PLAYBACK_WAIT_SEC,
+                    "max_timeout_sec": self._node.MAX_PLAYBACK_WAIT_SEC,
+                },
                 "startup_warning": startup_error,
                 "topic_out": [{
                     "topic": self._node._receipt_topic,
@@ -1750,6 +1887,15 @@ class SpeakerPlugin:
             }
         elif action == "stop":
             return self._node.stop_play()
+        elif action == "wait_playback":
+            return self._node.wait_for_playback(
+                args.get('session_id'),
+                args.get('utterance_id'),
+                args.get(
+                    'timeout_sec',
+                    self._node.DEFAULT_PLAYBACK_WAIT_SEC,
+                ),
+            )
         elif action == "info":
             play_state_status = self._node._play_state_status()
             with self._node._lock:
@@ -1767,6 +1913,16 @@ class SpeakerPlugin:
                         "completion_basis": self._node._completion_basis(),
                         "play_state": play_state_status,
                         "receipt_recovery": "transient_local_then_info_poll",
+                        "playback_wait": {
+                            "action": "wait_playback",
+                            "identity": ["session_id", "utterance_id"],
+                            "default_timeout_sec": (
+                                self._node.DEFAULT_PLAYBACK_WAIT_SEC
+                            ),
+                            "max_timeout_sec": (
+                                self._node.MAX_PLAYBACK_WAIT_SEC
+                            ),
+                        },
                         "active_utterance_id": self._node._active_utterance_id,
                         "last_terminal_receipt": (
                             dict(last_terminal) if last_terminal else None
@@ -2964,7 +3120,6 @@ class LidarPlugin:
 
 # ── SpatialPlugin (actuator + sensor) ────────────────────────────────────────
 
-import math
 import os
 import sqlite3
 

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -25,6 +25,7 @@ import struct
 import subprocess
 import threading
 import time
+import uuid
 
 import rclpy
 from rclpy.node import Node
@@ -47,6 +48,13 @@ _LOW_LAT_QOS = QoSProfile(
     history=HistoryPolicy.KEEP_LAST,
     depth=200,
     durability=DurabilityPolicy.VOLATILE,
+)
+
+_CONTROL_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=50,
+    durability=DurabilityPolicy.TRANSIENT_LOCAL,
 )
 
 
@@ -309,235 +317,1008 @@ APP_NAME = "g1_speaker"
 class _SpeakerNode(Node):
     PREFILL = 3       # buffer 3 chunks (~300ms) before starting playback
     MERGE_BYTES = 9600  # merge into ~300ms blocks before calling PlayStream
+    PLAYBACK_GRACE_SEC = 0.05
+    LEGACY_NEW_UTTERANCE_GAP_SEC = 0.75
+    LEGACY_MUTE_TIMEOUT_SEC = 10.0
+    RPC_SEND_TIMEOUT_SEC = 0.25
+    STREAM_RPC_TIMEOUT_SEC = 1.0
+    CONTROL_RPC_TIMEOUT_SEC = 1.0
+    TERMINAL_HISTORY_LIMIT = 256
 
-    def __init__(self, audio_client: AudioClient):
+    # EOF magic: 8 bytes (4 samples [1,-1,1,-1])，标记 utterance 结束
+    AUDIO_EOF_MAGIC = b'\x01\x00\xff\xff\x01\x00\xff\xff'
+
+    def __init__(self, audio_client: AudioClient, *, monotonic=None,
+                 wall_time=None, waiter=None):
         super().__init__("g1_speaker")
         self._client = audio_client
+        self._monotonic = monotonic or time.monotonic
+        self._wall_time = wall_time or time.time
         self._topic: str | None = None
         self._sub    = None
+        self._receipt_topic: str | None = None
+        self._receipt_pub = None
         self._idx    = 0
         self.state   = "idle"
         self._buf = queue.Queue()
         self._draining = threading.Event()
         self._drain_thread: threading.Thread | None = None
+        self._drain_generation: int | None = None
+        self._generation = 0
+        self._generation_ids: dict[int, set[str]] = {0: set()}
         self._last_chunk_time = 0.0
         self._flush_timer = None
+        self._flush_token = 0
         # 打断/暂停控制
-        self._lock = threading.Lock()
+        self._lifecycle_lock = threading.RLock()
+        self._lock = threading.RLock()
+        self._sdk_lock = threading.Lock()
+        self._receipt_lock = threading.RLock()
+        self._receipt_publish_lock = threading.Lock()
+        self._control_in_progress = False
+        self._accept_chunks = False
         self._interrupt_flag = threading.Event()
+        self._waiter = waiter or self._interrupt_flag.wait
         self._pause_event = threading.Event()
         self._pause_event.set()  # 初始为非暂停状态
-        self._muted = False  # interrupt 后静默，丢弃后续 chunks 直到新 utterance
+        self._pause_epoch = 0
+        self._legacy_muted = False
+        self._legacy_last_dropped_time = 0.0
+        self._legacy_mute_deadline = 0.0
+        self._legacy_utterance_id: str | None = None
+        self._legacy_counter = 0
+        self._active_utterance_id: str | None = None
+        self._session_id = ''
+        self._started_ids: dict[tuple[str, str], bool] = {}
+        self._terminal_ids: dict[tuple[str, str], dict] = {}
+        self._cancelled_ids: dict[str, bool] = {}
+        self._last_terminal_receipt: dict | None = None
+        self._pending_receipts: dict[tuple[str, str, str], dict] = {}
+        self._receipt_publish_errors: dict[tuple[str, str, str], str] = {}
+        self._receipt_retry_timer = None
         # Clear stale PlayStream session from previous container run (MCU keeps state across reboot)
-        self._client.PlayStop(APP_NAME)
+        stop_code = self._call_play_stop('startup')
+        if stop_code != 0:
+            self.get_logger().warn(
+                f"[speaker] stale-session cleanup failed: code={stop_code}"
+            )
         self.get_logger().info("SpeakerNode ready")
 
     def start_play(self, topic: str) -> str:
-        if self._sub is not None:
-            if self._topic == topic:
-                self.get_logger().info(f"[speaker] already subscribing {topic}, skip")
-                return self._topic
-            # topic changed — stop old subscription first
-            self.get_logger().info(f"[speaker] topic changed {self._topic} → {topic}, re-subscribing")
-            self.stop_play()
-        self._topic = topic
-        self._muted = False  # 新 start 时清除静默
-        self.get_logger().info(f"[speaker] creating subscription: topic={topic}, msg_type=AudioChunk, qos=LOW_LAT")
-        self._sub = self.create_subscription(
-            AudioChunk, topic, self._on_chunk, _LOW_LAT_QOS,
-        )
-        self.state = "ready"
+        with self._lifecycle_lock:
+            return self._start_play_serialized(topic)
+
+    def _start_play_serialized(self, topic: str) -> str:
+        with self._lock:
+            if self.state == 'error':
+                raise RuntimeError('speaker is in error state; stop before restarting')
+            if self._sub is not None:
+                if self._topic == topic:
+                    self.get_logger().info(f"[speaker] already subscribing {topic}, skip")
+                    return self._topic
+                raise RuntimeError('speaker must be stopped before changing input_topic')
+            self._generation += 1
+            self._generation_ids = {self._generation: set()}
+            self._drain_buffer_locked()
+            self._buf = queue.Queue()
+            self._topic = topic
+            self._legacy_muted = False
+            self._legacy_last_dropped_time = 0.0
+            self._legacy_mute_deadline = 0.0
+            self._legacy_utterance_id = None
+            self._cancelled_ids.clear()
+            self._session_id = f"speaker:{uuid.uuid4()}"
+            receipt_topic = f"{topic.rstrip('/')}/speaker_receipts"
+            with self._receipt_lock:
+                self._started_ids.clear()
+                if (self._receipt_pub is not None
+                        and self._receipt_topic != receipt_topic):
+                    self.destroy_publisher(self._receipt_pub)
+                    self._receipt_pub = None
+                self._receipt_topic = receipt_topic
+                if self._receipt_pub is None:
+                    self._receipt_pub = self.create_publisher(
+                        String, self._receipt_topic, _CONTROL_QOS,
+                    )
+                if any(
+                    pending.get('receipt_topic') == self._receipt_topic
+                    for pending in self._pending_receipts.values()
+                ):
+                    self._ensure_receipt_retry_timer_locked()
+            self.get_logger().info(f"[speaker] creating subscription: topic={topic}, msg_type=AudioChunk, qos=LOW_LAT")
+            self._sub = self.create_subscription(
+                AudioChunk, topic, self._on_chunk, _LOW_LAT_QOS,
+            )
+            self._control_in_progress = False
+            self._accept_chunks = True
+            self._interrupt_flag.clear()
+            self.state = "ready"
         self.get_logger().info(f"[speaker] subscription created, waiting for chunks on {topic}")
         return topic
 
-    def stop_play(self) -> None:
-        if self._flush_timer is not None:
-            self._flush_timer.cancel()
-            self.destroy_timer(self._flush_timer)
-            self._flush_timer = None
-        if self._sub is not None:
-            self.destroy_subscription(self._sub)
-            self._sub = None
-        self._draining.clear()
-        self._pause_event.set()  # 确保 drain thread 不会卡在 pause wait
-        self._interrupt_flag.set()  # 确保 drain thread 退出
-        if self._drain_thread is not None:
-            self._drain_thread.join(timeout=2)
-            self._drain_thread = None
-        self._interrupt_flag.clear()
-        # flush remaining buffer
-        while not self._buf.empty():
+    def _cancel_flush_timer_locked(self) -> None:
+        # A cancelled ROS timer callback may already be queued. Advancing the
+        # token makes such callbacks harmless after a stop/start or debounce.
+        self._flush_token += 1
+        timer = self._flush_timer
+        self._flush_timer = None
+        if timer is None:
+            return
+        timer.cancel()
+        self.destroy_timer(timer)
+
+    def _schedule_flush_timer_locked(self, delay: float = 0.2) -> None:
+        self._cancel_flush_timer_locked()
+        token = self._flush_token
+        generation = self._generation
+        target_buffer = self._buf
+        self._flush_timer = self.create_timer(
+            max(0.01, delay),
+            lambda: self._check_flush(token, generation, target_buffer),
+        )
+
+    def _cancel_receipt_retry_timer_locked(self) -> None:
+        if self._receipt_retry_timer is None:
+            return
+        self._receipt_retry_timer.cancel()
+        self.destroy_timer(self._receipt_retry_timer)
+        self._receipt_retry_timer = None
+
+    def _ensure_receipt_retry_timer_locked(self) -> None:
+        if self._receipt_retry_timer is None and self._receipt_pub is not None:
+            self._receipt_retry_timer = self.create_timer(
+                0.5, self._retry_pending_receipts,
+            )
+
+    @staticmethod
+    def _remember_bounded(items: dict, key, value) -> None:
+        items[key] = value
+        while len(items) > _SpeakerNode.TERMINAL_HISTORY_LIMIT:
+            items.pop(next(iter(items)))
+
+    def _record_receipt(self, utterance_id: str, state: str, *,
+                        audio_bytes: int = 0, reason: str = '',
+                        completion_basis: str = '') -> dict | None:
+        if not utterance_id:
+            return None
+        terminal = state in ('completed', 'cancelled', 'error')
+        with self._receipt_lock:
+            session_key = (self._session_id, utterance_id)
+            if session_key in self._terminal_ids:
+                # A terminal receipt is final for this session/utterance pair.
+                # In particular, a delayed retry may never publish started
+                # after completed/cancelled/error has been recorded.
+                receipt = self._terminal_ids[session_key]
+                if not terminal:
+                    return None
+                pending_key = (self._session_id, utterance_id, receipt['state'])
+                if pending_key not in self._pending_receipts:
+                    return receipt
+            elif state == 'started' and session_key in self._started_ids:
+                pending_key = (self._session_id, utterance_id, state)
+                receipt = self._pending_receipts.get(pending_key)
+                if receipt is None:
+                    return None
+            else:
+                receipt = {
+                    'type': 'speech_playback_receipt',
+                    'version': 1,
+                    'session_id': self._session_id,
+                    'utterance_id': utterance_id,
+                    'state': state,
+                    'completion_basis': completion_basis,
+                    'audio_bytes': audio_bytes,
+                    'ts': self._wall_time(),
+                    'reason': reason,
+                    'receipt_topic': self._receipt_topic,
+                }
+                if state == 'started':
+                    self._remember_bounded(self._started_ids, session_key, True)
+                if terminal:
+                    started_pending_key = (
+                        self._session_id, utterance_id, 'started',
+                    )
+                    self._pending_receipts.pop(started_pending_key, None)
+                    self._receipt_publish_errors.pop(started_pending_key, None)
+                    self._remember_bounded(self._terminal_ids, session_key, receipt)
+                    self._last_terminal_receipt = receipt
+                pending_key = (self._session_id, utterance_id, state)
+                self._pending_receipts[pending_key] = receipt
+                while len(self._pending_receipts) > self.TERMINAL_HISTORY_LIMIT:
+                    expired_key = next(iter(self._pending_receipts))
+                    self._pending_receipts.pop(expired_key)
+                    self._receipt_publish_errors.pop(expired_key, None)
+        return receipt
+
+    def _publish_and_log_receipt(self, receipt: dict | None) -> None:
+        if receipt is None:
+            return
+        self._publish_receipt(receipt)
+        self.get_logger().info(
+            f"[speaker] receipt state={receipt['state']} "
+            f"utterance_id={receipt['utterance_id']} "
+            f"bytes={receipt['audio_bytes']} reason={receipt['reason']}"
+        )
+
+    def _emit_receipt(self, utterance_id: str, state: str, *,
+                      audio_bytes: int = 0, reason: str = '',
+                      completion_basis: str = '') -> dict | None:
+        receipt = self._record_receipt(
+            utterance_id, state, audio_bytes=audio_bytes, reason=reason,
+            completion_basis=completion_basis,
+        )
+        self._publish_and_log_receipt(receipt)
+        return receipt
+
+    def _publish_receipt(self, receipt: dict) -> bool:
+        key = (
+            receipt.get('session_id', ''),
+            receipt.get('utterance_id', ''),
+            receipt.get('state', ''),
+        )
+        with self._receipt_publish_lock:
+            with self._receipt_lock:
+                # A terminal event may supersede a failed started event after a
+                # retry callback took its snapshot. Never publish stale outbox data.
+                if self._pending_receipts.get(key) is not receipt:
+                    return False
+                publisher = self._receipt_pub
+                current_topic = self._receipt_topic
+            if publisher is None or receipt.get('receipt_topic') != current_topic:
+                with self._receipt_lock:
+                    self._receipt_publish_errors[key] = 'receipt_publisher_unavailable'
+                return False
+
             try:
-                self._buf.get_nowait()
+                msg = String()
+                msg.data = json.dumps(receipt, ensure_ascii=False)
+                publisher.publish(msg)
+            except Exception as e:
+                error = f'{type(e).__name__}: {e}'
+                with self._receipt_lock:
+                    if self._pending_receipts.get(key) is receipt:
+                        self._receipt_publish_errors[key] = error
+                        self._ensure_receipt_retry_timer_locked()
+                self.get_logger().warn(f"[speaker] receipt publish failed: {e}")
+                return False
+
+            with self._receipt_lock:
+                if self._pending_receipts.get(key) is receipt:
+                    self._pending_receipts.pop(key, None)
+                    self._receipt_publish_errors.pop(key, None)
+                has_retryable = any(
+                    pending.get('receipt_topic') == self._receipt_topic
+                    for pending in self._pending_receipts.values()
+                )
+                if not has_retryable:
+                    self._cancel_receipt_retry_timer_locked()
+            return True
+
+    def _retry_pending_receipts(self) -> None:
+        with self._receipt_lock:
+            current_topic = self._receipt_topic
+            pending = [
+                receipt for receipt in self._pending_receipts.values()
+                if receipt.get('receipt_topic') == current_topic
+            ]
+            if not pending:
+                self._cancel_receipt_retry_timer_locked()
+                return
+        for receipt in pending:
+            self._publish_receipt(receipt)
+
+    def _drain_buffer_locked(self, target_buffer=None) -> set[str]:
+        target_buffer = target_buffer or self._buf
+        utterance_ids: set[str] = set()
+        while not target_buffer.empty():
+            try:
+                _kind, utterance_id, _pcm, _generation, _legacy = target_buffer.get_nowait()
+                if utterance_id:
+                    utterance_ids.add(utterance_id)
             except queue.Empty:
                 break
+        return utterance_ids
+
+    def _discard_control_items_locked(self, generation: int,
+                                      target_buffer=None) -> None:
+        target_buffer = target_buffer or self._buf
+        retained = []
+        while True:
+            try:
+                item = target_buffer.get_nowait()
+            except queue.Empty:
+                break
+            kind, _utterance_id, _pcm, item_generation, _legacy = item
+            if kind != 'control' or item_generation != generation:
+                retained.append(item)
+        for item in retained:
+            target_buffer.put(item)
+
+    def _call_play_stop(self, context: str,
+                        expected_generation: int | None = None) -> int | None:
+        deadline = time.monotonic() + self.CONTROL_RPC_TIMEOUT_SEC
         try:
-            self._client.PlayStop(APP_NAME)
+            pending = None
+            with self._sdk_lock:
+                if expected_generation is not None:
+                    with self._lock:
+                        if (self._interrupt_flag.is_set()
+                                or expected_generation != self._generation):
+                            return None
+                if hasattr(self._client, 'PlayStopStart'):
+                    send_timeout = min(
+                        self.RPC_SEND_TIMEOUT_SEC,
+                        max(0.0, deadline - time.monotonic()),
+                    )
+                    code, pending = self._client.PlayStopStart(
+                        APP_NAME, send_timeout=send_timeout,
+                    )
+                else:
+                    code = self._client.PlayStop(APP_NAME)
+            if code == 0 and pending is not None:
+                code = self._client.PlayStopFinish(
+                    pending,
+                    timeout=max(0.0, deadline - time.monotonic()),
+                )
+            return code
         except Exception as e:
-            self.get_logger().warn(f"PlayStop error: {e}")
-        self.state = "idle"
-        self.get_logger().info("Speaker stopped")
+            self.get_logger().warn(f"[speaker] {context} PlayStop error: {e}")
+            return -1
+
+    def stop_play(self) -> dict:
+        with self._lifecycle_lock:
+            return self._stop_play_serialized()
+
+    def _stop_play_serialized(self) -> dict:
+        with self._lock:
+            self._control_in_progress = True
+            self._accept_chunks = False
+            self._cancel_flush_timer_locked()
+            if self._sub is not None:
+                self.destroy_subscription(self._sub)
+                self._sub = None
+            stopped_generation = self._generation
+            stopped_buffer = self._buf
+            self._generation += 1
+            self._generation_ids.setdefault(self._generation, set())
+            self._buf = queue.Queue()
+            self._interrupt_flag.set()
+            self._pause_event.set()
+            cancelled_ids = set(self._generation_ids.pop(stopped_generation, set()))
+            cancelled_ids.update(self._drain_buffer_locked(stopped_buffer))
+            if self._active_utterance_id:
+                cancelled_ids.add(self._active_utterance_id)
+            drain_thread = (self._drain_thread
+                            if self._drain_generation == stopped_generation else None)
+            if drain_thread is not None and drain_thread.is_alive():
+                # Wake a drain blocked in Queue.get(). The control item is queued
+                # before callbacks can enqueue a later generation.
+                stopped_buffer.put(
+                    ('control', '', b'', stopped_generation, False),
+                )
+
+        stop_code = self._call_play_stop('stop')
+
+        if drain_thread is not None and drain_thread.is_alive():
+            drain_thread.join(timeout=0.05)
+        with self._lock:
+            cancelled_ids.update(self._drain_buffer_locked(stopped_buffer))
+            if self._drain_generation == stopped_generation:
+                self._draining.clear()
+                self._drain_thread = None
+                self._drain_generation = None
+                self._active_utterance_id = None
+            # A successful hardware stop plus generation invalidation makes an
+            # old response waiter safe to detach; it cannot submit more audio.
+            success = stop_code == 0
+            self.state = 'idle' if success else 'error'
+
+        receipt_state = 'cancelled' if success else 'error'
+        receipt_reason = ('speaker_stopped' if success else
+                          f'play_stop_failed:{stop_code}')
+        for utterance_id in cancelled_ids:
+            self._emit_receipt(utterance_id, receipt_state, reason=receipt_reason,
+                               completion_basis='driver_control')
+
+        with self._lock:
+            if success:
+                self._interrupt_flag.clear()
+            self._control_in_progress = False
+            self._legacy_utterance_id = None
+            self._legacy_muted = False
+            self._legacy_last_dropped_time = 0.0
+            self._legacy_mute_deadline = 0.0
+            self._cancelled_ids.clear()
+            self._topic = None
+        with self._receipt_lock:
+            self._started_ids.clear()
+        self.get_logger().info(f"Speaker stopped: state={self.state} code={stop_code}")
+        return {
+            'state': self.state,
+            'play_stop_code': stop_code,
+            'error': receipt_reason if not success else '',
+        }
 
     def interrupt(self) -> dict:
         """立即中止播放：清空 buffer，停止 SDK，保持 subscription。"""
+        with self._lifecycle_lock:
+            return self._interrupt_serialized()
+
+    def _interrupt_serialized(self) -> dict:
         with self._lock:
+            if self.state == 'error':
+                return {
+                    "state": "error",
+                    "error": "speaker requires stop/start recovery",
+                }
+            if self._control_in_progress:
+                return {"state": self.state, "error": "speaker control already in progress"}
+            interrupted_generation = self._generation
+            had_subscription = self._sub is not None
+            self._control_in_progress = True
+            interrupted_buffer = self._buf
+            self._generation += 1
+            self._generation_ids.setdefault(self._generation, set())
+            self._buf = queue.Queue()
             self._interrupt_flag.set()
-            # 清空 buffer
-            while not self._buf.empty():
-                try:
-                    self._buf.get_nowait()
-                except queue.Empty:
-                    break
-            # 停止 SDK 播放
-            try:
-                self._client.PlayStop(APP_NAME)
-            except Exception as e:
-                self.get_logger().warn(f"[speaker] interrupt PlayStop error: {e}")
-            # 等 drain thread 退出
-            if self._drain_thread is not None and self._drain_thread.is_alive():
-                self._drain_thread.join(timeout=1)
-                self._drain_thread = None
-            self._interrupt_flag.clear()
             self._pause_event.set()
-            self._draining.clear()
-            self._muted = True  # 静默：丢弃后续 TTS chunks 直到新 utterance
-            self.state = "ready"
-        self.get_logger().info("[speaker] interrupted — buffer cleared, muted until new utterance")
-        return {"state": "ready", "action": "interrupted"}
+            self._cancel_flush_timer_locked()
+            cancelled_ids = set(self._generation_ids.pop(interrupted_generation, set()))
+            cancelled_ids.update(self._drain_buffer_locked(interrupted_buffer))
+            if self._active_utterance_id:
+                cancelled_ids.add(self._active_utterance_id)
+            for utterance_id in cancelled_ids:
+                self._remember_bounded(self._cancelled_ids, utterance_id, True)
+            # Legacy producers have no ID, so late chunks can only be isolated by EOF.
+            self._legacy_muted = self._legacy_utterance_id is not None
+            if self._legacy_muted:
+                now = self._monotonic()
+                self._legacy_last_dropped_time = now
+                self._legacy_mute_deadline = now + self.LEGACY_MUTE_TIMEOUT_SEC
+            drain_thread = (self._drain_thread
+                            if self._drain_generation == interrupted_generation else None)
+            if drain_thread is not None and drain_thread.is_alive():
+                # Keep a blocked old drain from consuming the first frame of the
+                # new generation while PlayStop is in progress.
+                interrupted_buffer.put(
+                    ('control', '', b'', interrupted_generation, False),
+                )
+
+        stop_code = self._call_play_stop('interrupt')
+
+        if drain_thread is not None and drain_thread.is_alive():
+            drain_thread.join(timeout=0.05)
+        with self._lock:
+            self._discard_control_items_locked(
+                interrupted_generation, interrupted_buffer,
+            )
+            if self._drain_generation == interrupted_generation:
+                self._draining.clear()
+                self._drain_thread = None
+                self._drain_generation = None
+                self._active_utterance_id = None
+            success = stop_code == 0
+            if not success:
+                self._accept_chunks = False
+                cancelled_ids.update(self._drain_buffer_locked())
+                cancelled_ids.update(self._generation_ids.pop(self._generation, set()))
+                self.state = 'error'
+
+        receipt_state = 'cancelled' if success else 'error'
+        receipt_reason = ('interrupted' if success else
+                          f'play_stop_failed:{stop_code}')
+        for utterance_id in cancelled_ids:
+            self._emit_receipt(utterance_id, receipt_state, reason=receipt_reason,
+                               completion_basis='driver_control')
+
+        with self._lock:
+            self._control_in_progress = False
+            if success:
+                self._interrupt_flag.clear()
+                if not had_subscription:
+                    self.state = 'idle'
+                else:
+                    self.state = "playing" if not self._buf.empty() else "ready"
+                if had_subscription and not self._buf.empty():
+                    self._start_drain_locked()
+        self.get_logger().info(
+            f"[speaker] interrupted — cancelled={sorted(cancelled_ids)} stop_code={stop_code}"
+        )
+        return {
+            "state": self.state,
+            "action": "interrupted",
+            "play_stop_code": stop_code,
+            "cancelled_utterance_ids": sorted(cancelled_ids),
+            "error": receipt_reason if not success else '',
+        }
 
     def pause(self) -> dict:
         """暂停播放：停止 SDK，保留 buffer 中未播放的内容。"""
+        with self._lifecycle_lock:
+            return self._pause_serialized()
+
+    def _pause_serialized(self) -> dict:
         with self._lock:
+            if self._control_in_progress:
+                return {"state": self.state, "error": "speaker control already in progress"}
             if self.state not in ("playing", "ready"):
                 return {"state": self.state, "error": "not playing"}
-            self._pause_event.clear()  # drain thread 将阻塞在 wait()
-            try:
-                self._client.PlayStop(APP_NAME)
-            except Exception as e:
-                self.get_logger().warn(f"[speaker] pause PlayStop error: {e}")
+            self._control_in_progress = True
+            self._pause_epoch += 1
+            self._pause_event.clear()
             self.state = "paused"
+        stop_code = self._call_play_stop('pause')
+        failed_ids: set[str] = set()
+        drain_thread = None
+        with self._lock:
+            if stop_code != 0:
+                failed_generation = self._generation
+                failed_buffer = self._buf
+                self._generation += 1
+                self._generation_ids.setdefault(self._generation, set())
+                self._buf = queue.Queue()
+                self._accept_chunks = False
+                self._interrupt_flag.set()
+                self._pause_event.set()
+                failed_ids.update(self._generation_ids.pop(failed_generation, set()))
+                failed_ids.update(self._drain_buffer_locked(failed_buffer))
+                if self._active_utterance_id:
+                    failed_ids.add(self._active_utterance_id)
+                drain_thread = (self._drain_thread
+                                if self._drain_generation == failed_generation else None)
+                if drain_thread is not None and drain_thread.is_alive():
+                    failed_buffer.put(
+                        ('control', '', b'', failed_generation, False),
+                    )
+                self.state = 'error'
+        if drain_thread is not None and drain_thread.is_alive():
+            drain_thread.join(timeout=1)
+        if stop_code != 0:
+            with self._lock:
+                failed_ids.update(self._drain_buffer_locked(failed_buffer))
+            for utterance_id in failed_ids:
+                self._emit_receipt(
+                    utterance_id, 'error', reason=f'play_stop_failed:{stop_code}',
+                    completion_basis='driver_control',
+                )
+        with self._lock:
+            self._control_in_progress = False
         self.get_logger().info(f"[speaker] paused — buffer size={self._buf.qsize()}")
-        return {"state": "paused", "buffer_chunks": self._buf.qsize()}
+        return {
+            "state": self.state,
+            "buffer_chunks": self._buf.qsize(),
+            "play_stop_code": stop_code,
+            "error": '' if stop_code == 0 else f'play_stop_failed:{stop_code}',
+        }
 
     def resume(self) -> dict:
         """恢复播放：从 buffer 中剩余内容继续。"""
+        with self._lifecycle_lock:
+            return self._resume_serialized()
+
+    def _resume_serialized(self) -> dict:
         with self._lock:
             if self.state != "paused":
                 return {"state": self.state, "error": "not paused"}
-            self.state = "playing"
+            has_pending_playback = (
+                not self._buf.empty()
+                or (self._drain_thread is not None and self._drain_thread.is_alive())
+            )
+            self.state = "playing" if has_pending_playback else "ready"
             self._pause_event.set()  # 唤醒 drain thread
             # 如果 drain thread 已经退出了（pause 时退出），重新启动
             if self._drain_thread is None or not self._drain_thread.is_alive():
                 if not self._buf.empty():
-                    self._start_drain()
+                    self._start_drain_locked()
         self.get_logger().info("[speaker] resumed")
-        return {"state": "playing"}
-
-    # EOF magic: 8 bytes (4 samples [1,-1,1,-1])，标记 utterance 结束
-    AUDIO_EOF_MAGIC = b'\x01\x00\xff\xff\x01\x00\xff\xff'
+        return {"state": self.state}
 
     def _on_chunk(self, msg: AudioChunk) -> None:
         pcm = bytes(msg.data)
-        now = time.monotonic()
-        self._idx += 1
+        now = self._monotonic()
+        is_eof = len(pcm) == 8 and pcm == self.AUDIO_EOF_MAGIC
+        frame_id = (getattr(getattr(msg, 'header', None), 'frame_id', '') or '').strip()
 
-        # 检测 EOF magic：utterance 结束标记
-        if len(pcm) == 8 and pcm == self.AUDIO_EOF_MAGIC:
-            if self._muted:
-                self._muted = False
-                self.get_logger().info("[speaker] unmuted — received EOF marker")
-            return  # EOF 不入 buffer、不播放
-
-        # Muted 状态：interrupt 后丢弃来自旧 utterance 的 chunks
-        if self._muted:
+        with self._lock:
+            if not self._accept_chunks:
+                return
+            self._idx += 1
             self._last_chunk_time = now
-            return  # 丢弃，等 EOF 到达
+            legacy = not frame_id.startswith('utt:') or len(frame_id) <= 4
 
-        self._buf.put(pcm)
-        self._last_chunk_time = now
-        # 更新状态：收到 chunk 时如果是 ready，变为 playing
-        if self.state == "ready":
-            self.state = "playing"
-        if not self._draining.is_set() and self.state == "playing" and self._buf.qsize() >= self.PREFILL:
-            self._start_drain()
-        elif not self._draining.is_set() and self.state == "playing" and self._flush_timer is None:
-            # start a flush timer — if no more chunks arrive, drain what we have
-            self._flush_timer = self.create_timer(0.2, self._check_flush)
+            if legacy:
+                if self._legacy_muted:
+                    if is_eof:
+                        self._legacy_muted = False
+                        self._legacy_last_dropped_time = 0.0
+                        self._legacy_mute_deadline = 0.0
+                        self._legacy_utterance_id = None
+                        self.get_logger().info("[speaker] legacy stream unmuted at EOF")
+                        return
+                    silence_gap = now - self._legacy_last_dropped_time
+                    if (silence_gap < self.LEGACY_NEW_UTTERANCE_GAP_SEC
+                            and now < self._legacy_mute_deadline):
+                        self._legacy_last_dropped_time = now
+                        return
+                    self._legacy_muted = False
+                    self._legacy_last_dropped_time = 0.0
+                    self._legacy_mute_deadline = 0.0
+                    self._legacy_utterance_id = None
+                    self.get_logger().warn(
+                        "[speaker] legacy mute watchdog opened a new utterance; "
+                        "upgrade the producer to AudioChunk frame_id protocol"
+                    )
+                if self._legacy_utterance_id is None:
+                    self._legacy_counter += 1
+                    self._legacy_utterance_id = f"legacy:{self._legacy_counter}"
+                utterance_id = self._legacy_utterance_id
+            else:
+                utterance_id = frame_id
+                if utterance_id in self._cancelled_ids:
+                    return
+
+            generation = self._generation
+            self._generation_ids.setdefault(generation, set()).add(utterance_id)
+            kind = 'eof' if is_eof else 'audio'
+            self._buf.put((kind, utterance_id, b'' if is_eof else pcm,
+                           generation, legacy))
+
+            if is_eof:
+                if legacy:
+                    self._legacy_utterance_id = None
+                self._cancel_flush_timer_locked()
+                self._start_drain_locked()
+                return
+
+            if self.state == "ready":
+                self.state = "playing"
+            if (not self._control_in_progress and not self._draining.is_set()
+                    and self._buf.qsize() >= self.PREFILL):
+                self._start_drain_locked()
+            elif not self._control_in_progress and not self._draining.is_set():
+                # Backward compatibility for producers that do not send EOF.
+                # Debounce on every chunk so a short stream cannot be stranded
+                # when an earlier timer fires before the idle threshold.
+                self._schedule_flush_timer_locked()
 
     def _start_drain(self) -> None:
-        if self._flush_timer is not None:
-            self._flush_timer.cancel()
-            self.destroy_timer(self._flush_timer)
-            self._flush_timer = None
+        with self._lock:
+            self._start_drain_locked()
+
+    def _start_drain_locked(self) -> None:
+        if self._control_in_progress or not self._accept_chunks:
+            return
+        if self._drain_thread is not None and self._drain_thread.is_alive():
+            return
+        self._cancel_flush_timer_locked()
         self._draining.set()
-        self._drain_thread = threading.Thread(target=self._drain, daemon=True)
+        generation = self._generation
+        drain_buffer = self._buf
+        self._drain_generation = generation
+        self._drain_thread = threading.Thread(
+            target=self._drain_guarded,
+            args=(generation, drain_buffer),
+            daemon=True,
+        )
         self._drain_thread.start()
 
-    def _check_flush(self) -> None:
+    def _check_flush(self, token: int, generation: int, target_buffer) -> None:
         """Timer callback: if no new chunks for 300ms and buffer non-empty, start drain."""
-        if self._flush_timer is not None:
-            self._flush_timer.cancel()
-            self.destroy_timer(self._flush_timer)
-            self._flush_timer = None
-        if not self._draining.is_set() and not self._buf.empty() and self.state == "playing":
-            idle = time.monotonic() - self._last_chunk_time
-            if idle >= 0.15:
-                self._start_drain()
+        with self._lock:
+            if (token != self._flush_token
+                    or generation != self._generation
+                    or target_buffer is not self._buf):
+                return
+            self._cancel_flush_timer_locked()
+            if (self._control_in_progress or self._draining.is_set()
+                    or target_buffer.empty() or self.state != "playing"):
+                return
+            idle = self._monotonic() - self._last_chunk_time
+            remaining = 0.15 - idle
+            if remaining > 0:
+                self._schedule_flush_timer_locked(remaining)
+                return
+            self._start_drain_locked()
 
-    def _drain(self) -> None:
+    def _drain_guarded(self, generation: int, drain_buffer) -> None:
+        try:
+            self._drain(generation, drain_buffer)
+        except Exception as e:
+            receipt = None
+            with self._lock:
+                utterance_id = self._active_utterance_id
+                current_generation = generation == self._generation
+                if utterance_id and current_generation:
+                    # Record while generation and session are protected. A stale
+                    # drain must never write an error into a later start session.
+                    receipt = self._record_receipt(
+                        utterance_id, 'error',
+                        reason=f'drain_exception:{type(e).__name__}',
+                        completion_basis='driver_control',
+                    )
+                    if receipt is not None:
+                        for generation_ids in self._generation_ids.values():
+                            generation_ids.discard(utterance_id)
+            self._publish_and_log_receipt(receipt)
+            with self._lock:
+                if self._drain_generation == generation:
+                    self._draining.clear()
+                    self._drain_thread = None
+                    self._drain_generation = None
+                    self._active_utterance_id = None
+                    self.state = 'error'
+            self.get_logger().error(f"[speaker] drain crashed: {e}")
+
+    def _drain(self, generation: int, drain_buffer) -> None:
         play_idx = 0
         merged = b''
         empty_count = 0
-        while self._draining.is_set():
+        current_id: str | None = None
+        current_legacy = False
+        current_bytes = 0
+        current_error = ''
+
+        def finish_current(*, saw_eof: bool) -> None:
+            nonlocal merged, play_idx, current_id, current_legacy
+            nonlocal current_bytes, current_error
+            if not current_id:
+                return
+            if (merged and not current_error
+                    and not self._interrupt_flag.is_set()):
+                play_idx += 1
+                ok, error = self._play_merged(merged, play_idx, current_id, generation)
+                if not ok and not current_error:
+                    current_error = error
+                    if error != 'interrupted':
+                        self._call_play_stop(
+                            'stream-error', expected_generation=generation,
+                        )
+                merged = b''
+            if not current_error and self.PLAYBACK_GRACE_SEC > 0:
+                while True:
+                    wait_state = self._wait_playback_interval(
+                        self.PLAYBACK_GRACE_SEC, generation,
+                    )
+                    if wait_state == 'paused':
+                        if not self._wait_until_resumed(generation):
+                            return
+                        continue
+                    if wait_state != 'done':
+                        return
+                    break
+            receipt = None
+            # Make the generation check and terminal receipt record atomic with
+            # interrupt(); DDS publication happens after releasing the state lock.
+            with self._lock:
+                if self._interrupt_flag.is_set() or generation != self._generation:
+                    return
+                if current_error:
+                    receipt = self._record_receipt(
+                        current_id, 'error', audio_bytes=current_bytes,
+                        reason=current_error, completion_basis='driver_drained_estimated',
+                    )
+                elif saw_eof or current_legacy:
+                    basis = 'driver_drained_estimated' if saw_eof else 'driver_idle_estimated'
+                    receipt = self._record_receipt(
+                        current_id, 'completed', audio_bytes=current_bytes,
+                        completion_basis=basis,
+                    )
+                else:
+                    receipt = self._record_receipt(
+                        current_id, 'error', audio_bytes=current_bytes,
+                        reason='missing_eof', completion_basis='driver_drained_estimated',
+                    )
+                if (current_legacy
+                        and self._legacy_utterance_id == current_id):
+                    self._legacy_utterance_id = None
+                if receipt is not None:
+                    for generation_ids in self._generation_ids.values():
+                        generation_ids.discard(current_id)
+            self._publish_and_log_receipt(receipt)
+            current_id = None
+            current_legacy = False
+            current_bytes = 0
+            current_error = ''
+
+        while self._draining.is_set() and generation == self._generation:
             # 检查 interrupt
             if self._interrupt_flag.is_set():
-                return
+                break
             # 检查 pause（阻塞等待 resume 或 interrupt）
             if not self._pause_event.wait(timeout=0.1):
                 continue  # 还在 paused，循环检查 interrupt
 
             try:
-                pcm = self._buf.get(timeout=0.1)
-                merged += pcm
+                kind, utterance_id, pcm, item_generation, legacy = drain_buffer.get(timeout=0.1)
+                if item_generation != generation:
+                    continue
+                if kind == 'control':
+                    break
                 empty_count = 0
             except queue.Empty:
                 empty_count += 1
                 if merged and empty_count >= 2:
                     play_idx += 1
-                    self._play_merged(merged, play_idx)
+                    ok, error = self._play_merged(merged, play_idx, current_id or '', generation)
+                    if not ok and not current_error:
+                        current_error = error
+                        if error != 'interrupted':
+                            self._call_play_stop(
+                                'stream-error', expected_generation=generation,
+                            )
                     merged = b''
                 elif not merged and empty_count >= 3:
+                    finish_current(saw_eof=False)
                     break
                 continue
+
+            if current_id is None:
+                current_id = utterance_id
+                current_legacy = legacy
+                with self._lock:
+                    if generation == self._generation:
+                        self._active_utterance_id = current_id
+            elif utterance_id != current_id:
+                finish_current(saw_eof=False)
+                current_id = utterance_id
+                current_legacy = legacy
+                with self._lock:
+                    if generation == self._generation:
+                        self._active_utterance_id = current_id
+
+            if kind == 'eof':
+                finish_current(saw_eof=True)
+                with self._lock:
+                    if (generation == self._generation
+                            and self._active_utterance_id == current_id):
+                        self._active_utterance_id = None
+                if drain_buffer.empty():
+                    break
+                continue
+
+            current_bytes += len(pcm)
+            if current_error:
+                continue
+            merged += pcm
             if len(merged) >= self.MERGE_BYTES:
                 play_idx += 1
-                self._play_merged(merged, play_idx)
+                ok, error = self._play_merged(merged, play_idx, current_id, generation)
+                if not ok and not current_error:
+                    current_error = error
+                    if error != 'interrupted':
+                        self._call_play_stop(
+                            'stream-error', expected_generation=generation,
+                        )
                 merged = b''
-        if merged and not self._interrupt_flag.is_set():
-            play_idx += 1
-            self._play_merged(merged, play_idx)
-        self._draining.clear()
-        # 播放完毕，回到 ready（如果没有被 interrupt/stop）
-        if self.state == "playing":
-            self.state = "ready"
+        if generation == self._generation and not self._interrupt_flag.is_set():
+            finish_current(saw_eof=False)
+        with self._lock:
+            if self._drain_generation == generation:
+                self._draining.clear()
+                self._drain_thread = None
+                self._drain_generation = None
+                self._active_utterance_id = None
+                if (not drain_buffer.empty() and self._accept_chunks
+                        and not self._control_in_progress):
+                    self.state = 'playing'
+                    self._start_drain_locked()
+                elif self.state == "playing":
+                    self.state = "ready"
         self.get_logger().info("[speaker] drain finished")
 
-    def _play_merged(self, pcm: bytes, idx: int) -> None:
-        # 播放前再次检查 interrupt
-        if self._interrupt_flag.is_set():
-            return
+    def _wait_until_resumed(self, generation: int) -> bool:
+        while not self._pause_event.wait(timeout=0.05):
+            with self._lock:
+                if self._interrupt_flag.is_set() or generation != self._generation:
+                    return False
+        with self._lock:
+            return not self._interrupt_flag.is_set() and generation == self._generation
+
+    def _wait_playback_interval(self, seconds: float, generation: int) -> str:
+        deadline = self._monotonic() + seconds
+        while True:
+            with self._lock:
+                if self._interrupt_flag.is_set() or generation != self._generation:
+                    return 'interrupted'
+                if not self._pause_event.is_set():
+                    return 'paused'
+            remaining = deadline - self._monotonic()
+            if remaining <= 0:
+                return 'done'
+            if self._waiter(min(0.05, remaining)):
+                return 'interrupted'
+
+    def _play_merged(self, pcm: bytes, idx: int, utterance_id: str,
+                     generation: int) -> tuple[bool, str]:
         duration = len(pcm) / 32000
-        t0 = time.monotonic()
-        try:
-            code, data = self._client.PlayStream(APP_NAME, "0", pcm)
+        while True:
+            if not self._wait_until_resumed(generation):
+                return False, 'interrupted'
+            # Serialize SDK submissions with PlayStop. The generation check must
+            # be inside the same critical section so an interrupted stream can
+            # never submit PlayStream after the matching PlayStop.
+            pending = None
+            started_receipt = None
+            with self._sdk_lock:
+                with self._lock:
+                    if self._interrupt_flag.is_set() or generation != self._generation:
+                        return False, 'interrupted'
+                    if not self._pause_event.is_set():
+                        continue
+                    pause_epoch = self._pause_epoch
+                t0 = self._monotonic()
+                try:
+                    if hasattr(self._client, 'PlayStreamStart'):
+                        code, pending = self._client.PlayStreamStart(
+                            APP_NAME, "0", pcm,
+                            send_timeout=self.RPC_SEND_TIMEOUT_SEC,
+                        )
+                        data = None
+                    else:
+                        code, data = self._client.PlayStream(APP_NAME, "0", pcm)
+                except Exception as e:
+                    with self._lock:
+                        if (self._interrupt_flag.is_set()
+                                or generation != self._generation):
+                            return False, 'interrupted'
+                        paused_since_submit = pause_epoch != self._pause_epoch
+                    if paused_since_submit:
+                        if not self._wait_until_resumed(generation):
+                            return False, 'interrupted'
+                        continue
+                    self.get_logger().error(f"[speaker] PlayStream error: {e}")
+                    return False, f'play_stream_exception:{type(e).__name__}'
+            if code == 0:
+                with self._lock:
+                    if (self._interrupt_flag.is_set()
+                            or generation != self._generation):
+                        return False, 'interrupted'
+                    started_receipt = self._record_receipt(
+                        utterance_id, 'started',
+                    )
+                self._publish_and_log_receipt(started_receipt)
+            if code == 0 and pending is not None:
+                try:
+                    code, data = self._client.PlayStreamFinish(
+                        pending, timeout=self.STREAM_RPC_TIMEOUT_SEC,
+                    )
+                except Exception as e:
+                    with self._lock:
+                        if (self._interrupt_flag.is_set()
+                                or generation != self._generation):
+                            return False, 'interrupted'
+                        paused_since_submit = pause_epoch != self._pause_epoch
+                    if paused_since_submit:
+                        if not self._wait_until_resumed(generation):
+                            return False, 'interrupted'
+                        continue
+                    self.get_logger().error(f"[speaker] PlayStream response error: {e}")
+                    return False, f'play_stream_exception:{type(e).__name__}'
+            with self._lock:
+                if (self._interrupt_flag.is_set()
+                        or generation != self._generation):
+                    return False, 'interrupted'
+                paused_since_submit = pause_epoch != self._pause_epoch
+            if paused_since_submit:
+                if not self._wait_until_resumed(generation):
+                    return False, 'interrupted'
+                continue
             if code != 0:
-                self.get_logger().error(f"[speaker] PlayStream error code={code}, data={data}")
-        except Exception as e:
-            self.get_logger().error(f"[speaker] PlayStream error: {e}")
-        elapsed = time.monotonic() - t0
-        remaining = duration - elapsed - 0.08
-        if remaining > 0 and not self._interrupt_flag.is_set():
-            time.sleep(remaining)
+                self.get_logger().error(
+                    f"[speaker] PlayStream error code={code}, data={data}"
+                )
+                return False, f'play_stream_failed:{code}'
+            elapsed = self._monotonic() - t0
+            wait_state = self._wait_playback_interval(
+                max(0.0, duration - elapsed), generation,
+            )
+            if wait_state == 'paused':
+                # PlayStop may have interrupted the current block. Re-submit it
+                # after resume; duplicate audio is preferable to a false complete.
+                continue
+            if wait_state != 'done':
+                return False, 'interrupted'
+            return True, ''
 
 
 class SpeakerPlugin:
@@ -569,31 +1350,80 @@ class SpeakerPlugin:
                 "required": ["action"],
             },
             "topic_in": [{"format": "audio/pcm-16k"}],
+            "topic_out": [{
+                "format": "data/json",
+                "schema": "speech_playback_receipt/v1",
+                "qos": {
+                    "reliability": "reliable",
+                    "durability": "transient_local",
+                    "depth": 50,
+                },
+                "desc": "per-utterance playback receipts",
+            }],
         }
 
     def start(self) -> None:
         pass  # startup sound is played on first dispatch(start) when project starts
 
-    def _play_startup_sound(self) -> None:
+    def _play_startup_sound(self, generation: int) -> tuple[bool, str]:
         """Play startup PCM by directly calling PlayStream in small blocks with pacing."""
         import pathlib
         pcm_path = pathlib.Path(__file__).parent / 'resource' / 'startup_beep.pcm'
         try:
             pcm = pcm_path.read_bytes()
+        except Exception as e:
+            self._node.get_logger().warn(f"[speaker] startup sound unavailable: {e}")
+            return True, f'startup_sound_skipped:{type(e).__name__}'
+        try:
             block_size = 9600  # ~300ms per block
             for offset in range(0, len(pcm), block_size):
                 block = pcm[offset:offset + block_size]
-                code, _ = self._node._client.PlayStream(APP_NAME, "0", block)
+                pending = None
+                with self._node._sdk_lock:
+                    with self._node._lock:
+                        if generation != self._node._generation:
+                            return False, 'startup_interrupted'
+                    if hasattr(self._node._client, 'PlayStreamStart'):
+                        code, pending = self._node._client.PlayStreamStart(
+                            APP_NAME, "0", block,
+                            send_timeout=self._node.RPC_SEND_TIMEOUT_SEC,
+                        )
+                        data = None
+                    else:
+                        code, data = self._node._client.PlayStream(
+                            APP_NAME, "0", block,
+                        )
+                if code == 0 and pending is not None:
+                    code, data = self._node._client.PlayStreamFinish(
+                        pending, timeout=self._node.CONTROL_RPC_TIMEOUT_SEC,
+                    )
+                with self._node._lock:
+                    if generation != self._node._generation:
+                        return False, 'startup_interrupted'
                 if code != 0:
                     self._node.get_logger().warn(f"[speaker] startup sound stopped at offset {offset}: code={code}")
-                    return
+                    self._node._call_play_stop(
+                        'startup-error', expected_generation=generation,
+                    )
+                    return False, f'startup_play_failed:{code}'
                 duration = len(block) / 32000
                 remaining = duration - 0.08
-                if remaining > 0:
-                    time.sleep(remaining)
+                if (remaining > 0
+                        and self._node._wait_playback_interval(
+                            remaining, generation,
+                        ) != 'done'):
+                    return False, 'startup_interrupted'
             self._node.get_logger().info(f"[speaker] startup sound OK ({len(pcm)} bytes)")
+            return True, ''
         except Exception as e:
+            with self._node._lock:
+                if generation != self._node._generation:
+                    return False, 'startup_interrupted'
             self._node.get_logger().warn(f"[speaker] startup sound error: {e}")
+            self._node._call_play_stop(
+                'startup-error', expected_generation=generation,
+            )
+            return False, f'startup_play_exception:{type(e).__name__}'
 
     def stop(self) -> None:
         self._node.stop_play()
@@ -606,20 +1436,97 @@ class SpeakerPlugin:
             if not topic:
                 return {"error": "Missing input_topic"}
             # Always stop first to ensure clean restart
-            self._node.stop_play()
+            stop_result = self._node.stop_play()
+            if stop_result.get('state') == 'error':
+                return stop_result
+            with self._node._lock:
+                startup_generation = self._node._generation
             # Play startup sound synchronously before starting subscription
-            self._play_startup_sound()
-            topic = self._node.start_play(topic)
-            return {"state": "ready", "topic": topic}
-        elif action == "stop":
-            self._node.stop_play()
-            return {"state": "idle"}
-        elif action == "info":
+            startup_ok, startup_error = self._play_startup_sound(startup_generation)
+            if not startup_ok:
+                return {
+                    "state": self._node.state,
+                    "error": startup_error,
+                }
+            with self._node._lifecycle_lock:
+                with self._node._lock:
+                    if startup_generation != self._node._generation:
+                        return {
+                            "state": self._node.state,
+                            "error": "startup_interrupted",
+                        }
+                topic = self._node._start_play_serialized(topic)
             return {
-                "state": self._node.state,
-                "topic": self._node._topic,
-                "buffer_chunks": self._node._buf.qsize(),
+                "state": "ready",
+                "topic": topic,
+                "speech_protocol": "audiochunk-frameid-v1",
+                "session_id": self._node._session_id,
+                "receipt_topic": self._node._receipt_topic,
+                "completion_basis": "driver_drained_estimated",
+                "receipt_recovery": "transient_local_then_info_poll",
+                "startup_warning": startup_error,
+                "topic_out": [{
+                    "topic": self._node._receipt_topic,
+                    "format": "data/json",
+                    "schema": "speech_playback_receipt/v1",
+                    "qos": {
+                        "reliability": "reliable",
+                        "durability": "transient_local",
+                        "depth": 50,
+                    },
+                    "desc": "per-utterance playback receipts",
+                }],
             }
+        elif action == "stop":
+            return self._node.stop_play()
+        elif action == "info":
+            with self._node._lock:
+                with self._node._receipt_lock:
+                    receipt_topic = self._node._receipt_topic
+                    last_terminal = self._node._last_terminal_receipt
+                    return {
+                        "state": self._node.state,
+                        "topic": self._node._topic,
+                        "buffer_chunks": self._node._buf.qsize(),
+                        "speech_protocol": "audiochunk-frameid-v1",
+                        "session_id": self._node._session_id,
+                        "receipt_topic": receipt_topic,
+                        "completion_basis": "driver_drained_estimated",
+                        "receipt_recovery": "transient_local_then_info_poll",
+                        "active_utterance_id": self._node._active_utterance_id,
+                        "last_terminal_receipt": (
+                            dict(last_terminal) if last_terminal else None
+                        ),
+                        "recent_terminal_receipts": [
+                            dict(receipt)
+                            for receipt in self._node._terminal_ids.values()
+                        ],
+                        "pending_receipts": [
+                            dict(receipt)
+                            for receipt in self._node._pending_receipts.values()
+                        ],
+                        "receipt_publish_errors": [
+                            {
+                                "session_id": key[0],
+                                "utterance_id": key[1],
+                                "state": key[2],
+                                "error": error,
+                            }
+                            for key, error
+                            in self._node._receipt_publish_errors.items()
+                        ],
+                        "topic_out": [{
+                            "topic": receipt_topic,
+                            "format": "data/json",
+                            "schema": "speech_playback_receipt/v1",
+                            "qos": {
+                                "reliability": "reliable",
+                                "durability": "transient_local",
+                                "depth": 50,
+                            },
+                            "desc": "per-utterance playback receipts",
+                        }] if receipt_topic else [],
+                    }
         return None
 
 

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -255,19 +255,42 @@ class NativeTtsPlugin:
 
     def __init__(self, plugin_config: dict, namespace: str, executor, audio_client: AudioClient):
         self._client = audio_client
+        self._speak_enabled = bool(plugin_config.get('speak_enabled', True))
+        self._speak_disabled_reason = str(
+            plugin_config.get(
+                'speak_disabled_reason',
+                'native_tts_speak_disabled',
+            )
+        )
 
     def get_tool(self) -> dict:
+        actions = ["get_volume", "set_volume"]
+        action_params = {
+            "get_volume": {"params": [],                 "description": "Get current speaker volume"},
+            "set_volume": {"params": ["volume"],         "description": "Set speaker volume (0-100)"},
+        }
+        if self._speak_enabled:
+            actions.insert(0, "speak")
+            action_params["speak"] = {
+                "params": ["text", "voice"],
+                "description": "Synthesize text to speech on the robot",
+            }
+        description = (
+            "G1 on-board TTS engine — synthesize text to robot speech, control volume"
+            if self._speak_enabled else
+            "G1 body-speaker volume control — native synthesis disabled while strict PCM completion owns the player"
+        )
         return {
             "name": "tts",
             "type": "actuator",
             "multiInstance": False,
-            "description": "G1 on-board TTS engine — synthesize text to robot speech, control volume",
+            "description": description,
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["speak", "get_volume", "set_volume"],
+                        "enum": actions,
                         "description": "Action to perform",
                     },
                     "text":   {"type": "string",  "description": "Text to speak"},
@@ -275,11 +298,7 @@ class NativeTtsPlugin:
                     "volume": {"type": "integer", "description": "Volume 0-100"},
                 },
                 "required": ["action"],
-                "x-action-params": {
-                    "speak":      {"params": ["text", "voice"],  "description": "Synthesize text to speech on the robot"},
-                    "get_volume": {"params": [],                 "description": "Get current speaker volume"},
-                    "set_volume": {"params": ["volume"],         "description": "Set speaker volume (0-100)"},
-                },
+                "x-action-params": action_params,
             },
         }
 
@@ -295,6 +314,11 @@ class NativeTtsPlugin:
         if action == "stop":
             return {"state": "idle"}
         if action == "speak":
+            if not self._speak_enabled:
+                return {
+                    "state": "error",
+                    "error": self._speak_disabled_reason,
+                }
             text  = args.get("text", "")
             voice = int(args.get("voice", 0))
             ret   = self._client.TtsMaker(text, voice)
@@ -324,16 +348,31 @@ class _SpeakerNode(Node):
     STREAM_RPC_TIMEOUT_SEC = 1.0
     CONTROL_RPC_TIMEOUT_SEC = 1.0
     TERMINAL_HISTORY_LIMIT = 256
+    COMPLETION_MODE_ESTIMATED = 'estimated'
+    COMPLETION_MODE_HARDWARE_STATE = 'hardware_state'
 
     # EOF magic: 8 bytes (4 samples [1,-1,1,-1])，标记 utterance 结束
     AUDIO_EOF_MAGIC = b'\x01\x00\xff\xff\x01\x00\xff\xff'
 
     def __init__(self, audio_client: AudioClient, *, monotonic=None,
-                 wall_time=None, waiter=None):
+                 wall_time=None, waiter=None, playback_state_monitor=None,
+                 completion_mode: str = COMPLETION_MODE_ESTIMATED,
+                 play_state_timeout_sec: float = 2.0,
+                 play_state_discovery_timeout_sec: float = 3.0):
         super().__init__("g1_speaker")
+        if completion_mode not in (
+                self.COMPLETION_MODE_ESTIMATED,
+                self.COMPLETION_MODE_HARDWARE_STATE):
+            raise ValueError(f'unsupported speaker completion_mode: {completion_mode}')
         self._client = audio_client
         self._monotonic = monotonic or time.monotonic
         self._wall_time = wall_time or time.time
+        self._playback_state_monitor = playback_state_monitor
+        self._completion_mode = completion_mode
+        self._play_state_timeout_sec = max(0.1, float(play_state_timeout_sec))
+        self._play_state_discovery_timeout_sec = max(
+            0.1, float(play_state_discovery_timeout_sec),
+        )
         self._topic: str | None = None
         self._sub    = None
         self._receipt_topic: str | None = None
@@ -383,6 +422,92 @@ class _SpeakerNode(Node):
                 f"[speaker] stale-session cleanup failed: code={stop_code}"
             )
         self.get_logger().info("SpeakerNode ready")
+
+    def _completion_basis(self, *, legacy: bool = False) -> str:
+        if self._completion_mode == self.COMPLETION_MODE_HARDWARE_STATE:
+            return (
+                'g1_play_state_observed_after_driver_idle'
+                if legacy else 'g1_play_state_observed'
+            )
+        return 'driver_idle_estimated' if legacy else 'driver_drained_estimated'
+
+    def _playback_observation_key(self, utterance_id: str,
+                                  generation: int) -> tuple[int, str]:
+        return generation, utterance_id
+
+    def _playback_checkpoint(self) -> int | None:
+        monitor = self._playback_state_monitor
+        if (self._completion_mode != self.COMPLETION_MODE_HARDWARE_STATE
+                or monitor is None):
+            return None
+        return monitor.checkpoint()
+
+    def _note_playback_submission(self, utterance_id: str, generation: int,
+                                  checkpoint: int | None) -> None:
+        monitor = self._playback_state_monitor
+        if monitor is None or checkpoint is None:
+            return
+        monitor.note_submission(
+            self._playback_observation_key(utterance_id, generation),
+            checkpoint,
+        )
+
+    def _forget_playback_observation(self, utterance_id: str,
+                                     generation: int) -> None:
+        monitor = self._playback_state_monitor
+        if monitor is None or not utterance_id:
+            return
+        monitor.forget(
+            self._playback_observation_key(utterance_id, generation),
+        )
+
+    def _hardware_wait_cancelled(self, generation: int) -> bool:
+        with self._lock:
+            return (
+                self._interrupt_flag.is_set()
+                or generation != self._generation
+            )
+
+    def _wait_for_hardware_completion(self, utterance_id: str,
+                                      generation: int) -> dict:
+        monitor = self._playback_state_monitor
+        if monitor is None:
+            return {
+                'state': 'error',
+                'reason': 'play_state_monitor_unavailable',
+            }
+        return monitor.wait_for_completion(
+            self._playback_observation_key(utterance_id, generation),
+            timeout=self._play_state_timeout_sec,
+            cancelled=lambda: self._hardware_wait_cancelled(generation),
+        )
+
+    def _wait_for_play_state_ready(self, generation: int) -> dict:
+        monitor = self._playback_state_monitor
+        if monitor is None:
+            return {
+                'state': 'error',
+                'reason': 'play_state_monitor_unavailable',
+            }
+        return monitor.wait_until_ready(
+            timeout=self._play_state_discovery_timeout_sec,
+            cancelled=lambda: self._hardware_wait_cancelled(generation),
+        )
+
+    def _play_state_status(self) -> dict:
+        monitor = self._playback_state_monitor
+        if monitor is None:
+            return {
+                'available': False,
+                'ready': False,
+                'matched_publishers': 0,
+                'topic': None,
+                'current_state': None,
+                'event_seq': 0,
+                'last_event_ts': None,
+                'connect_error': 'play_state_monitor_not_configured',
+            }
+        return monitor.status()
 
     def start_play(self, topic: str) -> str:
         with self._lifecycle_lock:
@@ -719,6 +844,9 @@ class _SpeakerNode(Node):
         for utterance_id in cancelled_ids:
             self._emit_receipt(utterance_id, receipt_state, reason=receipt_reason,
                                completion_basis='driver_control')
+            self._forget_playback_observation(
+                utterance_id, stopped_generation,
+            )
 
         with self._lock:
             if success:
@@ -810,6 +938,9 @@ class _SpeakerNode(Node):
         for utterance_id in cancelled_ids:
             self._emit_receipt(utterance_id, receipt_state, reason=receipt_reason,
                                completion_basis='driver_control')
+            self._forget_playback_observation(
+                utterance_id, interrupted_generation,
+            )
 
         with self._lock:
             self._control_in_progress = False
@@ -839,6 +970,14 @@ class _SpeakerNode(Node):
 
     def _pause_serialized(self) -> dict:
         with self._lock:
+            if self._completion_mode == self.COMPLETION_MODE_HARDWARE_STATE:
+                # Unitree reports only global playing/idle, not a playback
+                # cursor. PlayStop during the final hardware tail would discard
+                # audio that cannot be resumed without replaying the block.
+                return {
+                    "state": self.state,
+                    "error": "pause_not_supported_with_hardware_state",
+                }
             if self._control_in_progress:
                 return {"state": self.state, "error": "speaker control already in progress"}
             if self.state not in ("playing", "ready"):
@@ -1040,6 +1179,10 @@ class _SpeakerNode(Node):
                         for generation_ids in self._generation_ids.values():
                             generation_ids.discard(utterance_id)
             self._publish_and_log_receipt(receipt)
+            if utterance_id:
+                self._forget_playback_observation(
+                    utterance_id, generation,
+                )
             with self._lock:
                 if self._drain_generation == generation:
                     self._draining.clear()
@@ -1074,7 +1217,22 @@ class _SpeakerNode(Node):
                             'stream-error', expected_generation=generation,
                         )
                 merged = b''
-            if not current_error and self.PLAYBACK_GRACE_SEC > 0:
+            if (not current_error
+                    and self._completion_mode == self.COMPLETION_MODE_HARDWARE_STATE):
+                hardware_result = self._wait_for_hardware_completion(
+                    current_id, generation,
+                )
+                if hardware_result.get('state') == 'interrupted':
+                    return
+                if hardware_result.get('state') != 'completed':
+                    current_error = (
+                        hardware_result.get('reason')
+                        or f"play_state_{hardware_result.get('state', 'error')}"
+                    )
+                    self._call_play_stop(
+                        'play-state-error', expected_generation=generation,
+                    )
+            elif not current_error and self.PLAYBACK_GRACE_SEC > 0:
                 while True:
                     wait_state = self._wait_playback_interval(
                         self.PLAYBACK_GRACE_SEC, generation,
@@ -1087,6 +1245,10 @@ class _SpeakerNode(Node):
                         return
                     break
             receipt = None
+            finished_id = current_id
+            completion_basis = self._completion_basis(
+                legacy=current_legacy and not saw_eof,
+            )
             # Make the generation check and terminal receipt record atomic with
             # interrupt(); DDS publication happens after releasing the state lock.
             with self._lock:
@@ -1095,18 +1257,17 @@ class _SpeakerNode(Node):
                 if current_error:
                     receipt = self._record_receipt(
                         current_id, 'error', audio_bytes=current_bytes,
-                        reason=current_error, completion_basis='driver_drained_estimated',
+                        reason=current_error, completion_basis=completion_basis,
                     )
                 elif saw_eof or current_legacy:
-                    basis = 'driver_drained_estimated' if saw_eof else 'driver_idle_estimated'
                     receipt = self._record_receipt(
                         current_id, 'completed', audio_bytes=current_bytes,
-                        completion_basis=basis,
+                        completion_basis=completion_basis,
                     )
                 else:
                     receipt = self._record_receipt(
                         current_id, 'error', audio_bytes=current_bytes,
-                        reason='missing_eof', completion_basis='driver_drained_estimated',
+                        reason='missing_eof', completion_basis=completion_basis,
                     )
                 if (current_legacy
                         and self._legacy_utterance_id == current_id):
@@ -1114,7 +1275,10 @@ class _SpeakerNode(Node):
                 if receipt is not None:
                     for generation_ids in self._generation_ids.values():
                         generation_ids.discard(current_id)
+                if self._active_utterance_id == current_id:
+                    self._active_utterance_id = None
             self._publish_and_log_receipt(receipt)
+            self._forget_playback_observation(finished_id, generation)
             current_id = None
             current_legacy = False
             current_bytes = 0
@@ -1246,6 +1410,7 @@ class _SpeakerNode(Node):
                     if not self._pause_event.is_set():
                         continue
                     pause_epoch = self._pause_epoch
+                play_state_checkpoint = self._playback_checkpoint()
                 t0 = self._monotonic()
                 try:
                     if hasattr(self._client, 'PlayStreamStart'):
@@ -1298,6 +1463,15 @@ class _SpeakerNode(Node):
                 if (self._interrupt_flag.is_set()
                         or generation != self._generation):
                     return False, 'interrupted'
+                if code == 0:
+                    # The response, rather than the transport send, is the
+                    # successful-submission boundary. Keep generation
+                    # validation and observation insertion under one lock so
+                    # a stale response cannot recreate an observation that
+                    # interrupt already forgot.
+                    self._note_playback_submission(
+                        utterance_id, generation, play_state_checkpoint,
+                    )
                 paused_since_submit = pause_epoch != self._pause_epoch
             if paused_since_submit:
                 if not self._wait_until_resumed(generation):
@@ -1324,9 +1498,52 @@ class _SpeakerNode(Node):
 class SpeakerPlugin:
     PREFIX = "speaker"
 
-    def __init__(self, plugin_config: dict, namespace: str, executor, audio_client: AudioClient):
-        self._node = _SpeakerNode(audio_client)
+    def __init__(self, plugin_config: dict, namespace: str, executor,
+                 audio_client: AudioClient, *, playback_state_monitor=None):
+        completion_mode = str(
+            plugin_config.get('completion_mode', 'estimated')
+        ).strip().lower()
+        play_state_topic = str(
+            plugin_config.get('play_state_topic', 'rt/audio_msg')
+        ).strip() or 'rt/audio_msg'
+        play_state_timeout_sec = float(
+            plugin_config.get('play_state_timeout_sec', 2.0)
+        )
+        play_state_discovery_timeout_sec = float(
+            plugin_config.get('play_state_discovery_timeout_sec', 3.0)
+        )
+        if (completion_mode == _SpeakerNode.COMPLETION_MODE_HARDWARE_STATE
+                and playback_state_monitor is None):
+            try:
+                from playback_state import G1PlaybackStateMonitor
+                playback_state_monitor = G1PlaybackStateMonitor.connect_dds(
+                    play_state_topic,
+                )
+            except Exception as exc:
+                playback_state_monitor = None
+                print(
+                    '[speaker] G1 play-state monitor load failed: '
+                    f'{type(exc).__name__}: {exc}',
+                    flush=True,
+                )
+        self._node = _SpeakerNode(
+            audio_client,
+            playback_state_monitor=playback_state_monitor,
+            completion_mode=completion_mode,
+            play_state_timeout_sec=play_state_timeout_sec,
+            play_state_discovery_timeout_sec=(
+                play_state_discovery_timeout_sec
+            ),
+        )
         executor.add_node(self._node)
+        if completion_mode == _SpeakerNode.COMPLETION_MODE_HARDWARE_STATE:
+            state_status = self._node._play_state_status()
+            self._node.get_logger().info(
+                '[speaker] hardware completion monitor '
+                f'topic={state_status["topic"]} '
+                f'available={state_status["available"]} '
+                f'error={state_status["connect_error"]}'
+            )
 
     def get_tool(self) -> dict:
         return {
@@ -1374,11 +1591,13 @@ class SpeakerPlugin:
         except Exception as e:
             self._node.get_logger().warn(f"[speaker] startup sound unavailable: {e}")
             return True, f'startup_sound_skipped:{type(e).__name__}'
+        startup_id = f'startup:{generation}'
         try:
             block_size = 9600  # ~300ms per block
             for offset in range(0, len(pcm), block_size):
                 block = pcm[offset:offset + block_size]
                 pending = None
+                play_state_checkpoint = self._node._playback_checkpoint()
                 with self._node._sdk_lock:
                     with self._node._lock:
                         if generation != self._node._generation:
@@ -1406,6 +1625,9 @@ class SpeakerPlugin:
                         'startup-error', expected_generation=generation,
                     )
                     return False, f'startup_play_failed:{code}'
+                self._node._note_playback_submission(
+                    startup_id, generation, play_state_checkpoint,
+                )
                 duration = len(block) / 32000
                 remaining = duration - 0.08
                 if (remaining > 0
@@ -1413,6 +1635,23 @@ class SpeakerPlugin:
                             remaining, generation,
                         ) != 'done'):
                     return False, 'startup_interrupted'
+            if (self._node._completion_mode
+                    == self._node.COMPLETION_MODE_HARDWARE_STATE):
+                hardware_result = self._node._wait_for_hardware_completion(
+                    startup_id, generation,
+                )
+                if hardware_result.get('state') == 'interrupted':
+                    return False, 'startup_interrupted'
+                if hardware_result.get('state') != 'completed':
+                    error = (
+                        hardware_result.get('reason')
+                        or f"play_state_{hardware_result.get('state', 'error')}"
+                    )
+                    self._node._call_play_stop(
+                        'startup-play-state-error',
+                        expected_generation=generation,
+                    )
+                    return False, f'startup_{error}'
             self._node.get_logger().info(f"[speaker] startup sound OK ({len(pcm)} bytes)")
             return True, ''
         except Exception as e:
@@ -1424,6 +1663,10 @@ class SpeakerPlugin:
                 'startup-error', expected_generation=generation,
             )
             return False, f'startup_play_exception:{type(e).__name__}'
+        finally:
+            self._node._forget_playback_observation(
+                startup_id, generation,
+            )
 
     def stop(self) -> None:
         self._node.stop_play()
@@ -1435,12 +1678,38 @@ class SpeakerPlugin:
             topic = args.get("input_topic", "")
             if not topic:
                 return {"error": "Missing input_topic"}
-            # Always stop first to ensure clean restart
-            stop_result = self._node.stop_play()
-            if stop_result.get('state') == 'error':
-                return stop_result
-            with self._node._lock:
-                startup_generation = self._node._generation
+            # Always stop first to ensure clean restart. Snapshot the resulting
+            # generation before releasing the same lifecycle lock, so another
+            # control call cannot slip between stop and ownership capture.
+            with self._node._lifecycle_lock:
+                stop_result = self._node._stop_play_serialized()
+                if stop_result.get('state') == 'error':
+                    return stop_result
+                with self._node._lock:
+                    startup_generation = self._node._generation
+            play_state_status = self._node._play_state_status()
+            if (self._node._completion_mode
+                    == self._node.COMPLETION_MODE_HARDWARE_STATE
+                    and not play_state_status.get('available')):
+                return {
+                    "state": "error",
+                    "error": "play_state_monitor_unavailable",
+                    "play_state": play_state_status,
+                }
+            if (self._node._completion_mode
+                    == self._node.COMPLETION_MODE_HARDWARE_STATE):
+                ready_result = self._node._wait_for_play_state_ready(
+                    startup_generation,
+                )
+                if ready_result.get('state') != 'ready':
+                    return {
+                        "state": "error",
+                        "error": (
+                            ready_result.get('reason')
+                            or 'play_state_publisher_unavailable'
+                        ),
+                        "play_state": self._node._play_state_status(),
+                    }
             # Play startup sound synchronously before starting subscription
             startup_ok, startup_error = self._play_startup_sound(startup_generation)
             if not startup_ok:
@@ -1462,7 +1731,9 @@ class SpeakerPlugin:
                 "speech_protocol": "audiochunk-frameid-v1",
                 "session_id": self._node._session_id,
                 "receipt_topic": self._node._receipt_topic,
-                "completion_basis": "driver_drained_estimated",
+                "completion_mode": self._node._completion_mode,
+                "completion_basis": self._node._completion_basis(),
+                "play_state": self._node._play_state_status(),
                 "receipt_recovery": "transient_local_then_info_poll",
                 "startup_warning": startup_error,
                 "topic_out": [{
@@ -1480,6 +1751,7 @@ class SpeakerPlugin:
         elif action == "stop":
             return self._node.stop_play()
         elif action == "info":
+            play_state_status = self._node._play_state_status()
             with self._node._lock:
                 with self._node._receipt_lock:
                     receipt_topic = self._node._receipt_topic
@@ -1491,7 +1763,9 @@ class SpeakerPlugin:
                         "speech_protocol": "audiochunk-frameid-v1",
                         "session_id": self._node._session_id,
                         "receipt_topic": receipt_topic,
-                        "completion_basis": "driver_drained_estimated",
+                        "completion_mode": self._node._completion_mode,
+                        "completion_basis": self._node._completion_basis(),
+                        "play_state": play_state_status,
                         "receipt_recovery": "transient_local_then_info_poll",
                         "active_utterance_id": self._node._active_utterance_id,
                         "last_terminal_receipt": (
@@ -1542,30 +1816,47 @@ class SmartMotionPlugin:
         self._loco = loco_plugin
 
     def get_tool(self) -> dict:
+        pause_supported = not (
+            self._speaker is not None
+            and self._speaker._node._completion_mode
+            == self._speaker._node.COMPLETION_MODE_HARDWARE_STATE
+        )
+        actions = [
+            "interrupt_all", "interrupt_speak", "interrupt_motion", "status",
+        ]
+        action_params = {
+            "interrupt_all":    {"params": [], "description": "中止所有输出（语音+动作同时停止）"},
+            "interrupt_speak":  {"params": [], "description": "中止语音播放，清空待播队列"},
+            "interrupt_motion": {"params": [], "description": "停止机器人当前运动"},
+            "status":           {"params": [], "description": "查询当前输出状态（语音/运动）"},
+        }
+        if pause_supported:
+            actions[3:3] = ["pause_speak", "resume_speak"]
+            action_params.update({
+                "pause_speak":  {"params": [], "description": "暂停语音播放（保留未播内容，可恢复）"},
+                "resume_speak": {"params": [], "description": "恢复之前暂停的语音播放"},
+            })
+        description = (
+            "SmartMotion — 统一运动/输出控制，提供打断、暂停、恢复能力"
+            if pause_supported else
+            "SmartMotion — 统一运动/输出控制；硬件完成模式支持打断和状态查询，不支持无损暂停"
+        )
         return {
             "name": "smart_motion",
             "type": "actuator",
             "multiInstance": False,
-            "description": "SmartMotion — 统一运动/输出控制，提供打断、暂停、恢复能力",
+            "description": description,
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["interrupt_all", "interrupt_speak", "interrupt_motion",
-                                 "pause_speak", "resume_speak", "status"],
+                        "enum": actions,
                         "description": "Action to perform",
                     },
                 },
                 "required": ["action"],
-                "x-action-params": {
-                    "interrupt_all":    {"params": [], "description": "中止所有输出（语音+动作同时停止）"},
-                    "interrupt_speak":  {"params": [], "description": "中止语音播放，清空待播队列"},
-                    "interrupt_motion": {"params": [], "description": "停止机器人当前运动"},
-                    "pause_speak":      {"params": [], "description": "暂停语音播放（保留未播内容，可恢复）"},
-                    "resume_speak":     {"params": [], "description": "恢复之前暂停的语音播放"},
-                    "status":           {"params": [], "description": "查询当前输出状态（语音/运动）"},
-                },
+                "x-action-params": action_params,
             },
         }
 

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -76,8 +76,26 @@ class G1DeviceBundle:
 
         if plugins_cfg.get("tts", {}).get("enabled", False):
             from device import NativeTtsPlugin
-            self._plugins.append(NativeTtsPlugin(plugins_cfg["tts"], namespace, executor, audio_client))
-            print("[bundle] NativeTtsPlugin loaded")
+            native_tts_cfg = dict(plugins_cfg["tts"])
+            speaker_cfg = plugins_cfg.get("speaker", {})
+            if (speaker_cfg.get("enabled", False)
+                    and str(speaker_cfg.get(
+                        "completion_mode", "estimated",
+                    )).strip().lower() == "hardware_state"):
+                # rt/audio_msg is global and carries no app/stream identity.
+                # Keep the strict PCM speaker path exclusive inside this
+                # bundle so Native TTS cannot supply a foreign 1 -> 0 cycle.
+                native_tts_cfg["speak_enabled"] = False
+                native_tts_cfg["speak_disabled_reason"] = (
+                    "native_tts_conflicts_with_hardware_state_speaker"
+                )
+            self._plugins.append(NativeTtsPlugin(
+                native_tts_cfg, namespace, executor, audio_client,
+            ))
+            print(
+                "[bundle] NativeTtsPlugin loaded "
+                f"(speak={'enabled' if native_tts_cfg.get('speak_enabled', True) else 'disabled'})"
+            )
 
         if plugins_cfg.get("speaker", {}).get("enabled", False):
             from device import SpeakerPlugin

--- a/unitree/g1/playback_state.py
+++ b/unitree/g1/playback_state.py
@@ -1,0 +1,270 @@
+"""G1 body-speaker playback state observed from Unitree DDS.
+
+The G1 controller publishes JSON messages on ``rt/audio_msg`` with
+``{"play_state": 1}`` when its body-speaker player starts and
+``{"play_state": 0}`` when the player becomes idle.  Unitree's public
+``AudioClient`` does not expose that state through its RPC API, so the speaker
+driver correlates the global state transitions with its serialized PCM
+submissions.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+import json
+import threading
+import time
+from typing import Callable
+
+
+class G1PlaybackStateMonitor:
+    """Track body-speaker state transitions and correlate one serial stream."""
+
+    def __init__(self, topic: str = "rt/audio_msg", *, available: bool = False,
+                 connect_error: str = "not_connected", monotonic=None,
+                 history_limit: int = 256, ready: bool | None = None,
+                 idle_settle_sec: float = 0.1):
+        self.topic = topic
+        self._monotonic = monotonic or time.monotonic
+        self._cv = threading.Condition(threading.RLock())
+        self._events = deque(maxlen=max(8, int(history_limit)))
+        self._observations: dict[tuple[int, str], dict[str, int]] = {}
+        self._event_seq = 0
+        self._current_state: int | None = None
+        self._last_event_ts: float | None = None
+        self._available = bool(available)
+        self._connect_error = "" if available else connect_error
+        self._ready = bool(available) if ready is None else bool(ready)
+        self._matched_publishers = 1 if self._ready else 0
+        self._idle_settle_sec = max(0.0, float(idle_settle_sec))
+        self._subscriber = None
+
+    @classmethod
+    def connect_dds(cls, topic: str = "rt/audio_msg", *, monotonic=None):
+        """Create the real Unitree DDS subscriber without failing bundle load."""
+        monitor = cls(topic, monotonic=monotonic)
+        try:
+            from unitree_sdk2py.core.channel import ChannelSubscriber
+            from unitree_sdk2py.idl.std_msgs.msg.dds_ import String_
+
+            subscriber = ChannelSubscriber(topic, String_)
+            # play_state is sparse and ordering-sensitive. Handle it directly
+            # in the DDS callback instead of adding a second SDK queue whose
+            # scheduling could move a pre-ACK idle event past the ACK gate.
+            subscriber.Init(
+                monitor.on_dds_message, 0,
+                monitor.on_subscription_matched,
+            )
+            monitor._subscriber = subscriber
+            with monitor._cv:
+                monitor._available = True
+                monitor._connect_error = ""
+        except Exception as exc:
+            with monitor._cv:
+                monitor._available = False
+                monitor._ready = False
+                monitor._matched_publishers = 0
+                monitor._connect_error = (
+                    f"dds_subscribe_failed:{type(exc).__name__}:{exc}"
+                )
+        return monitor
+
+    @property
+    def available(self) -> bool:
+        with self._cv:
+            return self._available
+
+    def checkpoint(self) -> int:
+        """Return an event sequence checkpoint captured before a PCM submit."""
+        with self._cv:
+            return self._event_seq
+
+    def on_subscription_matched(self, current_count: int) -> None:
+        with self._cv:
+            self._matched_publishers = max(0, int(current_count))
+            self._ready = self._matched_publishers > 0
+            self._cv.notify_all()
+
+    def wait_until_ready(self, *, timeout: float,
+                         cancelled: Callable[[], bool] | None = None,
+                         poll_interval: float = 0.05) -> dict:
+        """Wait until DDS discovery has matched the firmware state writer."""
+        if cancelled is None:
+            cancelled = lambda: False
+        deadline = self._monotonic() + max(0.0, float(timeout))
+        while True:
+            if cancelled():
+                return {"state": "interrupted", "reason": "interrupted"}
+            with self._cv:
+                if not self._available:
+                    return {
+                        "state": "error",
+                        "reason": self._connect_error or "play_state_unavailable",
+                    }
+                if self._ready:
+                    return {"state": "ready", "reason": ""}
+                remaining = deadline - self._monotonic()
+                if remaining <= 0:
+                    return {
+                        "state": "timeout",
+                        "reason": "play_state_publisher_timeout",
+                    }
+                self._cv.wait(timeout=min(max(0.001, poll_interval), remaining))
+
+    def note_submission(self, key: tuple[int, str], checkpoint: int) -> None:
+        """Record a successful PCM submission and its pre-submit checkpoint."""
+        with self._cv:
+            # A previous block can become idle after the caller's pre-submit
+            # checkpoint but before PlayStream acknowledges the new block.  An
+            # idle from that window belongs to the previous block and must not
+            # complete the utterance.  Requiring the final idle to follow the
+            # successful acknowledgement checkpoint fails closed for that race.
+            acknowledged_seq = max(int(checkpoint), self._event_seq)
+            observation = self._observations.get(key)
+            if observation is None:
+                observation = {
+                    "first_after_seq": int(checkpoint),
+                    "idle_after_seq": acknowledged_seq,
+                }
+                self._observations[key] = observation
+            else:
+                observation["idle_after_seq"] = acknowledged_seq
+            self._cv.notify_all()
+
+    def forget(self, key: tuple[int, str]) -> None:
+        with self._cv:
+            self._observations.pop(key, None)
+
+    def on_dds_message(self, msg) -> None:
+        raw = getattr(msg, "data", None)
+        if raw is None:
+            # Some older generated Unitree IDL bindings use a trailing suffix.
+            raw = getattr(msg, "data_", None)
+        self.on_raw_message(raw)
+
+    def on_raw_message(self, raw) -> bool:
+        """Accept one JSON String_ payload; return whether it was play state."""
+        if not isinstance(raw, str):
+            return False
+        try:
+            payload = json.loads(raw)
+        except (TypeError, json.JSONDecodeError):
+            return False
+        if not isinstance(payload, dict):
+            return False
+        state = payload.get("play_state")
+        if isinstance(state, bool) or state not in (0, 1):
+            return False
+        with self._cv:
+            self._event_seq += 1
+            timestamp = self._monotonic()
+            self._current_state = int(state)
+            self._last_event_ts = timestamp
+            self._events.append((self._event_seq, int(state), timestamp))
+            self._cv.notify_all()
+        return True
+
+    def _evaluate_locked(self, key: tuple[int, str]) -> dict:
+        observation = self._observations.get(key)
+        if observation is None:
+            return {
+                "state": "error",
+                "reason": "play_state_observation_missing",
+            }
+
+        first_after = observation["first_after_seq"]
+        idle_after = observation["idle_after_seq"]
+        started = None
+        idle = None
+        for sequence, state, timestamp in self._events:
+            if sequence <= first_after:
+                continue
+            if state == 1:
+                # A later playing transition invalidates an earlier idle
+                # candidate. This covers a delayed start notification for the
+                # final block without losing the initial stream start.
+                started = (sequence, timestamp)
+                idle = None
+                continue
+            if (started is not None and sequence > idle_after
+                    and sequence > started[0] and state == 0):
+                idle = (sequence, timestamp)
+
+        if idle is not None:
+            settled_for = self._monotonic() - idle[1]
+            if settled_for >= self._idle_settle_sec:
+                return {
+                    "state": "completed",
+                    "reason": "",
+                    "playing_seq": started[0],
+                    "idle_seq": idle[0],
+                    "playing_ts": started[1],
+                    "idle_ts": idle[1],
+                }
+
+        return {
+            "state": "waiting",
+            "reason": "",
+            "playing_seq": started[0] if started else None,
+            "idle_seq": idle[0] if idle else None,
+        }
+
+    def wait_for_completion(self, key: tuple[int, str], *, timeout: float,
+                            cancelled: Callable[[], bool] | None = None,
+                            poll_interval: float = 0.05) -> dict:
+        """Wait for playing→idle after the first and last PCM submissions."""
+        if cancelled is None:
+            cancelled = lambda: False
+        with self._cv:
+            if not self._available:
+                return {
+                    "state": "error",
+                    "reason": self._connect_error or "play_state_unavailable",
+                }
+
+        deadline = self._monotonic() + max(0.0, float(timeout))
+        while True:
+            if cancelled():
+                return {"state": "interrupted", "reason": "interrupted"}
+            with self._cv:
+                result = self._evaluate_locked(key)
+                if result["state"] != "waiting":
+                    return result
+                remaining = deadline - self._monotonic()
+                if remaining <= 0:
+                    return {
+                        "state": "timeout",
+                        "reason": (
+                            "play_state_idle_timeout"
+                            if result.get("playing_seq") is not None
+                            else "play_state_start_timeout"
+                        ),
+                    }
+                self._cv.wait(timeout=min(max(0.001, poll_interval), remaining))
+
+    def status(self) -> dict:
+        with self._cv:
+            return {
+                "available": self._available,
+                "ready": self._ready,
+                "matched_publishers": self._matched_publishers,
+                "topic": self.topic,
+                "current_state": self._current_state,
+                "event_seq": self._event_seq,
+                "last_event_ts": self._last_event_ts,
+                "connect_error": self._connect_error,
+            }
+
+    def close(self) -> None:
+        subscriber = self._subscriber
+        self._subscriber = None
+        if subscriber is not None:
+            try:
+                subscriber.Close()
+            except Exception:
+                pass
+        with self._cv:
+            self._available = False
+            self._ready = False
+            self._matched_publishers = 0
+            self._cv.notify_all()

--- a/unitree/g1/tests/test_channel_matching.py
+++ b/unitree/g1/tests/test_channel_matching.py
@@ -1,0 +1,143 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+G1_DIR = Path(__file__).resolve().parents[1]
+
+
+class _Listener:
+    def __init__(self, **callbacks):
+        for name, callback in callbacks.items():
+            setattr(self, name, callback)
+
+
+class _DataReader:
+    instances = []
+
+    def __init__(self, _participant, _topic, _qos=None, listener=None):
+        self.listener = listener
+        self.samples = []
+        self.instances.append(self)
+
+    def take(self, _count):
+        samples, self.samples = self.samples, []
+        return samples
+
+
+def _module(name, **attributes):
+    module = types.ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    return module
+
+
+def _load_channel_module():
+    class _DDSException(Exception):
+        msg = ''
+
+    class _DDSCTypes:
+        class publication_matched_status:
+            pass
+
+    class _Singleton:
+        pass
+
+    class _BQueue:
+        pass
+
+    cyclonedds_modules = {
+        'cyclonedds': _module('cyclonedds'),
+        'cyclonedds.domain': _module(
+            'cyclonedds.domain', Domain=type('Domain', (), {}),
+            DomainParticipant=type('DomainParticipant', (), {}),
+        ),
+        'cyclonedds.internal': _module(
+            'cyclonedds.internal', dds_c_t=_DDSCTypes,
+            InvalidSample=type('InvalidSample', (), {}),
+        ),
+        'cyclonedds.pub': _module(
+            'cyclonedds.pub', DataWriter=type('DataWriter', (), {}),
+        ),
+        'cyclonedds.sub': _module(
+            'cyclonedds.sub', DataReader=_DataReader,
+        ),
+        'cyclonedds.topic': _module(
+            'cyclonedds.topic', Topic=type('Topic', (), {}),
+        ),
+        'cyclonedds.qos': _module(
+            'cyclonedds.qos', Qos=type('Qos', (), {}),
+        ),
+        'cyclonedds.core': _module(
+            'cyclonedds.core', DDSException=_DDSException,
+            Listener=_Listener,
+        ),
+        'cyclonedds.util': _module(
+            'cyclonedds.util', duration=lambda **kwargs: kwargs,
+        ),
+    }
+    package_modules = {
+        'unitree_sdk2py': _module('unitree_sdk2py'),
+        'unitree_sdk2py.core': _module('unitree_sdk2py.core'),
+        'unitree_sdk2py.core.channel_config': _module(
+            'unitree_sdk2py.core.channel_config',
+            ChannelConfigAutoDetermine='', ChannelConfigHasInterface='',
+        ),
+        'unitree_sdk2py.utils': _module('unitree_sdk2py.utils'),
+        'unitree_sdk2py.utils.singleton': _module(
+            'unitree_sdk2py.utils.singleton', Singleton=_Singleton,
+        ),
+        'unitree_sdk2py.utils.bqueue': _module(
+            'unitree_sdk2py.utils.bqueue', BQueue=_BQueue,
+        ),
+    }
+    name = 'unitree_sdk2py.core.channel_under_test'
+    spec = importlib.util.spec_from_file_location(
+        name, G1_DIR / 'unitree_sdk2py/core/channel.py',
+    )
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(
+        sys.modules, {**cyclonedds_modules, **package_modules},
+    ):
+        spec.loader.exec_module(module)
+    return module
+
+
+class ChannelMatchingTests(unittest.TestCase):
+    def setUp(self):
+        _DataReader.instances.clear()
+        self.channel = _load_channel_module()
+
+    def test_reader_reports_publisher_matching_and_direct_data(self):
+        received = []
+        matches = []
+        reader_wrapper = self.channel.Channel._Channel__Reader()
+        reader_wrapper.Init(
+            object(), object(), handler=received.append, queueLen=0,
+            matchHandler=matches.append,
+        )
+        reader = _DataReader.instances[-1]
+
+        reader.listener.on_subscription_matched(
+            reader, types.SimpleNamespace(current_count=1),
+        )
+        sample = types.SimpleNamespace(data='{"play_state":1}')
+        reader.samples.append(sample)
+        reader.listener.on_data_available(reader)
+
+        self.assertTrue(reader_wrapper.WaitForPublisher(timeout=0))
+        self.assertEqual(matches, [1])
+        self.assertEqual(received, [sample])
+
+        reader.listener.on_subscription_matched(
+            reader, types.SimpleNamespace(current_count=0),
+        )
+        self.assertFalse(reader_wrapper.WaitForPublisher(timeout=0))
+        self.assertEqual(matches, [1, 0])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unitree/g1/tests/test_hardware_smoke_contract.py
+++ b/unitree/g1/tests/test_hardware_smoke_contract.py
@@ -161,14 +161,20 @@ class HardwareSmokeContractTests(unittest.TestCase):
         node.publisher.subscription_count = 0
         self.assertIsNone(node.wait_for_graph(0.001))
 
-    def test_mcp_call_decodes_speaker_result(self):
+    def test_mcp_wait_call_sends_correlated_identity_and_timeout(self):
+        wait_result = {
+            'session_id': 'speaker:test',
+            'utterance_id': 'utt:review-smoke',
+            'state': 'completed',
+            'terminal': True,
+        }
         response_body = json.dumps({
             'jsonrpc': '2.0',
             'id': 'test',
             'result': {
                 'content': [{
                     'type': 'text',
-                    'text': json.dumps({'state': 'ready'}),
+                    'text': json.dumps(wait_result),
                 }],
             },
         }).encode()
@@ -187,18 +193,23 @@ class HardwareSmokeContractTests(unittest.TestCase):
             self.smoke.urllib.request, 'urlopen', return_value=_Response(),
         ) as urlopen:
             result = self.smoke._speaker_call(
-                'http://127.0.0.1:15701/mcp', 'start', timeout=3,
-                input_topic='/review/smoke',
+                'http://127.0.0.1:15701/mcp', 'wait_playback', timeout=15,
+                session_id='speaker:test',
+                utterance_id='utt:review-smoke',
+                timeout_sec=10,
             )
 
-        self.assertEqual(result, {'state': 'ready'})
+        self.assertEqual(result, wait_result)
         request = urlopen.call_args.args[0]
         body = json.loads(request.data.decode())
         self.assertEqual(body['params']['name'], 'speaker')
         self.assertEqual(body['params']['arguments'], {
-            'action': 'start',
-            'input_topic': '/review/smoke',
+            'action': 'wait_playback',
+            'session_id': 'speaker:test',
+            'utterance_id': 'utt:review-smoke',
+            'timeout_sec': 10,
         })
+        self.assertEqual(urlopen.call_args.kwargs['timeout'], 15)
 
     def _main_args(self):
         return argparse.Namespace(
@@ -228,7 +239,85 @@ class HardwareSmokeContractTests(unittest.TestCase):
         self.assertEqual(result, 1)
         self.assertEqual(calls, ['start', 'stop'])
 
+    def test_success_reports_mcp_and_ros_terminal_evidence(self):
+        calls = []
+        smoke = self.smoke
+
+        class _HappyNode:
+            def __init__(self, input_topic):
+                self.input_topic = input_topic
+
+            def spin_for(self, _seconds):
+                pass
+
+            def wait_for_graph(self, _timeout):
+                return {
+                    'speaker_input_subscriptions': 1,
+                    'receipt_publishers': 1,
+                }
+
+            def publish(self, _utterance_id, _payload):
+                pass
+
+            def wait_for_terminal(self, session_id, utterance_id, _timeout):
+                return {
+                    'session_id': session_id,
+                    'utterance_id': utterance_id,
+                    'state': 'completed',
+                    'completion_basis': 'g1_play_state_observed',
+                    'audio_bytes': 5 * len(smoke.PCM_BLOCK),
+                }
+
+            def destroy_node(self):
+                pass
+
+        def speaker_call(_url, action, **kwargs):
+            calls.append((action, kwargs))
+            if action == 'start':
+                return {
+                    'state': 'ready',
+                    'completion_mode': 'hardware_state',
+                    'play_state': {'ready': True, 'matched_publishers': 1},
+                    'session_id': 'speaker:test',
+                }
+            if action == 'wait_playback':
+                return {
+                    'session_id': kwargs['session_id'],
+                    'utterance_id': kwargs['utterance_id'],
+                    'state': 'completed',
+                    'terminal': True,
+                    'completion_basis': 'g1_play_state_observed',
+                    'audio_bytes': 5 * len(smoke.PCM_BLOCK),
+                }
+            if action == 'stop':
+                return {'state': 'idle'}
+            self.fail(f'unexpected speaker action: {action}')
+
+        with mock.patch.object(smoke, '_parse_args', self._main_args), \
+                mock.patch.object(smoke, '_SmokeNode', _HappyNode), \
+                mock.patch.object(smoke, '_speaker_call', speaker_call), \
+                mock.patch('builtins.print') as print_output:
+            result = smoke.main()
+
+        self.assertEqual(result, 0)
+        self.assertEqual([action for action, _kwargs in calls], [
+            'start', 'wait_playback', 'stop',
+        ])
+        evidence = json.loads(print_output.call_args.args[0])
+        self.assertEqual(evidence['result'], 'passed')
+        self.assertTrue(evidence['mcp_wait_result']['terminal'])
+        self.assertEqual(
+            evidence['mcp_wait_result']['utterance_id'],
+            evidence['terminal_receipt']['utterance_id'],
+        )
+        self.assertEqual(
+            evidence['mcp_wait_result']['completion_basis'],
+            evidence['terminal_receipt']['completion_basis'],
+        )
+
     def test_cleanup_failure_turns_success_into_failure(self):
+        calls = []
+
         class _HappyNode:
             def __init__(self, input_topic):
                 self.input_topic = input_topic
@@ -262,12 +351,22 @@ class HardwareSmokeContractTests(unittest.TestCase):
         _HappyNode.smoke = smoke
 
         def speaker_call(_url, action, **_kwargs):
+            calls.append((action, _kwargs))
             if action == 'start':
                 return {
                     'state': 'ready',
                     'completion_mode': 'hardware_state',
                     'play_state': {'ready': True, 'matched_publishers': 1},
                     'session_id': 'speaker:test',
+                }
+            if action == 'wait_playback':
+                return {
+                    'session_id': _kwargs['session_id'],
+                    'utterance_id': _kwargs['utterance_id'],
+                    'state': 'completed',
+                    'terminal': True,
+                    'completion_basis': 'g1_play_state_observed',
+                    'audio_bytes': 5 * len(smoke.PCM_BLOCK),
                 }
             raise TimeoutError('stop response timed out')
 
@@ -278,6 +377,18 @@ class HardwareSmokeContractTests(unittest.TestCase):
             result = smoke.main()
 
         self.assertEqual(result, 1)
+        self.assertEqual([action for action, _kwargs in calls], [
+            'start', 'wait_playback', 'stop',
+        ])
+        wait_args = calls[1][1]
+        self.assertEqual(wait_args['session_id'], 'speaker:test')
+        self.assertTrue(wait_args['utterance_id'].startswith('utt:hardware-smoke-'))
+        self.assertEqual(wait_args['timeout_sec'], self._main_args().timeout)
+        self.assertEqual(
+            wait_args['timeout'],
+            self._main_args().timeout
+            + smoke.MCP_WAIT_TRANSPORT_MARGIN_SEC,
+        )
 
 
 if __name__ == '__main__':

--- a/unitree/g1/tests/test_hardware_smoke_contract.py
+++ b/unitree/g1/tests/test_hardware_smoke_contract.py
@@ -1,0 +1,284 @@
+import importlib.util
+import argparse
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+G1_DIR = Path(__file__).resolve().parents[1]
+
+
+class _Header:
+    def __init__(self):
+        self.frame_id = ''
+        self.stamp = None
+
+
+class _AudioChunk:
+    def __init__(self):
+        self.header = _Header()
+        self.format = ''
+        self.data = []
+
+
+class _String:
+    def __init__(self, data=''):
+        self.data = data
+
+
+class _Publisher:
+    def __init__(self):
+        self.messages = []
+        self.subscription_count = 1
+
+    def publish(self, msg):
+        self.messages.append(msg)
+
+    def get_subscription_count(self):
+        return self.subscription_count
+
+
+class _Subscription:
+    def __init__(self):
+        self.publisher_count = 1
+
+    def get_publisher_count(self):
+        return self.publisher_count
+
+
+class _Node:
+    def __init__(self, _name):
+        self.publisher = None
+        self.callback = None
+
+    def create_publisher(self, *_args):
+        self.publisher = _Publisher()
+        return self.publisher
+
+    def create_subscription(self, _type, _topic, callback, _qos):
+        self.callback = callback
+        return _Subscription()
+
+    def get_clock(self):
+        return types.SimpleNamespace(
+            now=lambda: types.SimpleNamespace(to_msg=lambda: 'stamp'),
+        )
+
+    def destroy_node(self):
+        pass
+
+
+class _QoSProfile:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _package(name):
+    module = types.ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+def _load_smoke_module():
+    rclpy = _package('rclpy')
+    rclpy.init = lambda **_kwargs: None
+    rclpy.shutdown = lambda: None
+    rclpy.spin_once = lambda *_args, **_kwargs: None
+    rclpy_node = types.ModuleType('rclpy.node')
+    rclpy_node.Node = _Node
+    rclpy_qos = types.ModuleType('rclpy.qos')
+    rclpy_qos.QoSProfile = _QoSProfile
+    rclpy_qos.ReliabilityPolicy = types.SimpleNamespace(
+        BEST_EFFORT='best_effort', RELIABLE='reliable',
+    )
+    rclpy_qos.HistoryPolicy = types.SimpleNamespace(KEEP_LAST='keep_last')
+    rclpy_qos.DurabilityPolicy = types.SimpleNamespace(
+        VOLATILE='volatile', TRANSIENT_LOCAL='transient_local',
+    )
+    audio_msgs = _package('audio_msgs')
+    audio_msg = types.ModuleType('audio_msgs.msg')
+    audio_msg.AudioChunk = _AudioChunk
+    std_msgs = _package('std_msgs')
+    std_msg = types.ModuleType('std_msgs.msg')
+    std_msg.String = _String
+    modules = {
+        'rclpy': rclpy,
+        'rclpy.node': rclpy_node,
+        'rclpy.qos': rclpy_qos,
+        'audio_msgs': audio_msgs,
+        'audio_msgs.msg': audio_msg,
+        'std_msgs': std_msgs,
+        'std_msgs.msg': std_msg,
+    }
+    spec = importlib.util.spec_from_file_location(
+        'g1_hardware_smoke_under_test',
+        G1_DIR / 'tools/g1_speaker_receipt_smoke.py',
+    )
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(sys.modules, modules):
+        spec.loader.exec_module(module)
+    return module
+
+
+class HardwareSmokeContractTests(unittest.TestCase):
+    def setUp(self):
+        self.smoke = _load_smoke_module()
+
+    def test_publishes_correlated_nonzero_pcm_and_finds_terminal(self):
+        node = self.smoke._SmokeNode('/review/smoke/')
+        utterance_id = 'utt:review-smoke'
+
+        node.publish(utterance_id, self.smoke.PCM_BLOCK)
+        message = node.publisher.messages[-1]
+        self.assertEqual(message.header.frame_id, utterance_id)
+        self.assertEqual(message.format, 'audio/pcm-16k')
+        self.assertEqual(len(message.data), 9600)
+        self.assertNotEqual(bytes(message.data), bytes(9600))
+        self.assertNotEqual(bytes(message.data), self.smoke.AUDIO_EOF_MAGIC)
+
+        terminal = {
+            'session_id': 'speaker:test',
+            'utterance_id': utterance_id,
+            'state': 'completed',
+            'completion_basis': 'g1_play_state_observed',
+        }
+        node._on_receipt(_String(json.dumps(terminal)))
+        self.assertEqual(
+            node.wait_for_terminal('speaker:test', utterance_id, 0.01),
+            terminal,
+        )
+
+    def test_waits_for_both_ros_graph_directions(self):
+        node = self.smoke._SmokeNode('/review/smoke/')
+        self.assertEqual(node.wait_for_graph(0.01), {
+            'speaker_input_subscriptions': 1,
+            'receipt_publishers': 1,
+        })
+
+        node.publisher.subscription_count = 0
+        self.assertIsNone(node.wait_for_graph(0.001))
+
+    def test_mcp_call_decodes_speaker_result(self):
+        response_body = json.dumps({
+            'jsonrpc': '2.0',
+            'id': 'test',
+            'result': {
+                'content': [{
+                    'type': 'text',
+                    'text': json.dumps({'state': 'ready'}),
+                }],
+            },
+        }).encode()
+
+        class _Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                pass
+
+            def read(self):
+                return response_body
+
+        with mock.patch.object(
+            self.smoke.urllib.request, 'urlopen', return_value=_Response(),
+        ) as urlopen:
+            result = self.smoke._speaker_call(
+                'http://127.0.0.1:15701/mcp', 'start', timeout=3,
+                input_topic='/review/smoke',
+            )
+
+        self.assertEqual(result, {'state': 'ready'})
+        request = urlopen.call_args.args[0]
+        body = json.loads(request.data.decode())
+        self.assertEqual(body['params']['name'], 'speaker')
+        self.assertEqual(body['params']['arguments'], {
+            'action': 'start',
+            'input_topic': '/review/smoke',
+        })
+
+    def _main_args(self):
+        return argparse.Namespace(
+            confirm_exclusive_hardware=True,
+            mcp_url='http://127.0.0.1:15701/mcp',
+            input_topic='/review/smoke',
+            timeout=0.01,
+            start_timeout=30.0,
+            cleanup_timeout=30.0,
+            discovery_timeout=0.01,
+        )
+
+    def test_start_timeout_still_stops_speaker(self):
+        calls = []
+
+        def speaker_call(_url, action, **_kwargs):
+            calls.append(action)
+            if action == 'start':
+                raise TimeoutError('start response timed out')
+            return {'state': 'idle'}
+
+        with mock.patch.object(self.smoke, '_parse_args', self._main_args), \
+                mock.patch.object(self.smoke, '_speaker_call', speaker_call), \
+                mock.patch('sys.stderr'):
+            result = self.smoke.main()
+
+        self.assertEqual(result, 1)
+        self.assertEqual(calls, ['start', 'stop'])
+
+    def test_cleanup_failure_turns_success_into_failure(self):
+        class _HappyNode:
+            def __init__(self, input_topic):
+                self.input_topic = input_topic
+
+            def spin_for(self, _seconds):
+                pass
+
+            def wait_for_graph(self, _timeout):
+                return {
+                    'speaker_input_subscriptions': 1,
+                    'receipt_publishers': 1,
+                }
+
+            def publish(self, _utterance_id, _payload):
+                pass
+
+            def wait_for_terminal(self, session_id, utterance_id, _timeout):
+                return {
+                    'session_id': session_id,
+                    'utterance_id': utterance_id,
+                    'state': 'completed',
+                    'completion_basis': 'g1_play_state_observed',
+                    'audio_bytes': 5 * len(self.smoke.PCM_BLOCK),
+                }
+
+            def destroy_node(self):
+                pass
+
+        # Bind the module through the fake instance without depending on ROS.
+        smoke = self.smoke
+        _HappyNode.smoke = smoke
+
+        def speaker_call(_url, action, **_kwargs):
+            if action == 'start':
+                return {
+                    'state': 'ready',
+                    'completion_mode': 'hardware_state',
+                    'play_state': {'ready': True, 'matched_publishers': 1},
+                    'session_id': 'speaker:test',
+                }
+            raise TimeoutError('stop response timed out')
+
+        with mock.patch.object(smoke, '_parse_args', self._main_args), \
+                mock.patch.object(smoke, '_SmokeNode', _HappyNode), \
+                mock.patch.object(smoke, '_speaker_call', speaker_call), \
+                mock.patch('sys.stderr'):
+            result = smoke.main()
+
+        self.assertEqual(result, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unitree/g1/tests/test_playback_state.py
+++ b/unitree/g1/tests/test_playback_state.py
@@ -1,0 +1,284 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+G1_DIR = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    'g1_playback_state_under_test', G1_DIR / 'playback_state.py',
+)
+PLAYBACK_STATE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PLAYBACK_STATE)
+
+
+class _Clock:
+    def __init__(self):
+        self.value = 10.0
+
+    def monotonic(self):
+        return self.value
+
+    def advance(self, seconds):
+        self.value += seconds
+
+
+class PlaybackStateMonitorTests(unittest.TestCase):
+    def setUp(self):
+        self.clock = _Clock()
+        self.monitor = PLAYBACK_STATE.G1PlaybackStateMonitor(
+            available=True,
+            monotonic=self.clock.monotonic,
+            idle_settle_sec=0,
+        )
+        self.key = (7, 'utt:test')
+
+    def test_correlates_playing_then_idle_after_final_submission(self):
+        first_checkpoint = self.monitor.checkpoint()
+        self.monitor.note_submission(self.key, first_checkpoint)
+        self.assertTrue(self.monitor.on_raw_message('{"play_state":1}'))
+
+        final_checkpoint = self.monitor.checkpoint()
+        self.monitor.note_submission(self.key, final_checkpoint)
+        self.clock.advance(1.2)
+        self.assertTrue(self.monitor.on_raw_message('{"play_state":0}'))
+
+        result = self.monitor.wait_for_completion(self.key, timeout=0)
+
+        self.assertEqual(result['state'], 'completed')
+        self.assertEqual(result['playing_seq'], 1)
+        self.assertEqual(result['idle_seq'], 2)
+        self.assertAlmostEqual(
+            result['idle_ts'] - result['playing_ts'], 1.2,
+        )
+
+    def test_idle_before_final_submission_cannot_complete(self):
+        self.monitor.note_submission(self.key, self.monitor.checkpoint())
+        self.monitor.on_raw_message('{"play_state":1}')
+        self.monitor.on_raw_message('{"play_state":0}')
+        self.monitor.note_submission(self.key, self.monitor.checkpoint())
+
+        result = self.monitor.wait_for_completion(self.key, timeout=0)
+
+        self.assertEqual(result, {
+            'state': 'timeout',
+            'reason': 'play_state_idle_timeout',
+        })
+
+        self.monitor.on_raw_message('{"play_state":1}')
+        self.monitor.on_raw_message('{"play_state":0}')
+        self.assertEqual(
+            self.monitor.wait_for_completion(self.key, timeout=0)['state'],
+            'completed',
+        )
+
+    def test_idle_racing_between_checkpoint_and_submit_ack_cannot_complete(self):
+        self.monitor.note_submission(self.key, self.monitor.checkpoint())
+        self.monitor.on_raw_message('{"play_state":1}')
+
+        final_checkpoint = self.monitor.checkpoint()
+        # The preceding block drains while the next PlayStream RPC is in
+        # flight. note_submission happens only after that RPC succeeds.
+        self.monitor.on_raw_message('{"play_state":0}')
+        self.monitor.note_submission(self.key, final_checkpoint)
+
+        self.assertEqual(
+            self.monitor.wait_for_completion(self.key, timeout=0),
+            {'state': 'timeout', 'reason': 'play_state_idle_timeout'},
+        )
+
+        self.monitor.on_raw_message('{"play_state":1}')
+        self.monitor.on_raw_message('{"play_state":0}')
+        self.assertEqual(
+            self.monitor.wait_for_completion(self.key, timeout=0)['state'],
+            'completed',
+        )
+
+    def test_later_playing_invalidates_idle_until_a_new_idle_arrives(self):
+        self.monitor.note_submission(self.key, self.monitor.checkpoint())
+        self.monitor.on_raw_message('{"play_state":1}')
+        self.monitor.on_raw_message('{"play_state":0}')
+        self.monitor.on_raw_message('{"play_state":1}')
+
+        self.assertEqual(
+            self.monitor.wait_for_completion(self.key, timeout=0),
+            {'state': 'timeout', 'reason': 'play_state_idle_timeout'},
+        )
+
+        self.monitor.on_raw_message('{"play_state":0}')
+        self.assertEqual(
+            self.monitor.wait_for_completion(self.key, timeout=0)['state'],
+            'completed',
+        )
+
+    def test_idle_must_remain_stable_for_settle_window(self):
+        monitor = PLAYBACK_STATE.G1PlaybackStateMonitor(
+            available=True,
+            monotonic=self.clock.monotonic,
+            idle_settle_sec=0.1,
+        )
+        monitor.note_submission(self.key, monitor.checkpoint())
+        monitor.on_raw_message('{"play_state":1}')
+        monitor.on_raw_message('{"play_state":0}')
+
+        self.assertEqual(
+            monitor.wait_for_completion(self.key, timeout=0)['state'],
+            'timeout',
+        )
+        self.clock.advance(0.11)
+        self.assertEqual(
+            monitor.wait_for_completion(self.key, timeout=0)['state'],
+            'completed',
+        )
+
+    def test_idle_without_playing_fails_start_timeout(self):
+        self.monitor.note_submission(self.key, self.monitor.checkpoint())
+        self.monitor.on_raw_message('{"play_state":0}')
+
+        self.assertEqual(
+            self.monitor.wait_for_completion(self.key, timeout=0),
+            {'state': 'timeout', 'reason': 'play_state_start_timeout'},
+        )
+
+    def test_unavailable_monitor_fails_closed(self):
+        monitor = PLAYBACK_STATE.G1PlaybackStateMonitor(
+            connect_error='dds_subscribe_failed:RuntimeError',
+        )
+
+        self.assertEqual(
+            monitor.wait_for_completion(self.key, timeout=0),
+            {
+                'state': 'error',
+                'reason': 'dds_subscribe_failed:RuntimeError',
+            },
+        )
+
+    def test_missing_observation_is_error(self):
+        self.assertEqual(
+            self.monitor.wait_for_completion(self.key, timeout=0),
+            {
+                'state': 'error',
+                'reason': 'play_state_observation_missing',
+            },
+        )
+
+    def test_cancel_wins_over_a_late_idle(self):
+        self.monitor.note_submission(self.key, self.monitor.checkpoint())
+        self.monitor.on_raw_message('{"play_state":1}')
+        self.monitor.on_raw_message('{"play_state":0}')
+
+        self.assertEqual(
+            self.monitor.wait_for_completion(
+                self.key, timeout=1, cancelled=lambda: True,
+            ),
+            {'state': 'interrupted', 'reason': 'interrupted'},
+        )
+
+    def test_parses_both_generated_string_field_names(self):
+        self.monitor.on_dds_message(types.SimpleNamespace(
+            data='{"play_state":1}',
+        ))
+        self.monitor.on_dds_message(types.SimpleNamespace(
+            data_='{"play_state":0}',
+        ))
+
+        status = self.monitor.status()
+        self.assertEqual(status['event_seq'], 2)
+        self.assertEqual(status['current_state'], 0)
+
+    def test_subscription_matching_controls_readiness(self):
+        self.monitor.on_subscription_matched(0)
+        self.assertEqual(
+            self.monitor.wait_until_ready(timeout=0),
+            {'state': 'timeout', 'reason': 'play_state_publisher_timeout'},
+        )
+
+        self.monitor.on_subscription_matched(1)
+        self.assertEqual(
+            self.monitor.wait_until_ready(timeout=0),
+            {'state': 'ready', 'reason': ''},
+        )
+        self.assertTrue(self.monitor.status()['ready'])
+        self.assertEqual(self.monitor.status()['matched_publishers'], 1)
+
+    def test_connect_dds_uses_direct_callback_and_match_handler(self):
+        created = []
+
+        class _Subscriber:
+            def __init__(self, topic, message_type):
+                self.topic = topic
+                self.message_type = message_type
+                self.init_args = None
+                created.append(self)
+
+            def Init(self, handler, queue_len, match_handler):
+                self.init_args = (handler, queue_len, match_handler)
+                match_handler(1)
+
+            def Close(self):
+                pass
+
+        channel_module = types.ModuleType('unitree_sdk2py.core.channel')
+        channel_module.ChannelSubscriber = _Subscriber
+        message_module = types.ModuleType(
+            'unitree_sdk2py.idl.std_msgs.msg.dds_',
+        )
+        message_module.String_ = type('String_', (), {})
+        modules = {
+            'unitree_sdk2py': types.ModuleType('unitree_sdk2py'),
+            'unitree_sdk2py.core': types.ModuleType('unitree_sdk2py.core'),
+            'unitree_sdk2py.core.channel': channel_module,
+            'unitree_sdk2py.idl': types.ModuleType('unitree_sdk2py.idl'),
+            'unitree_sdk2py.idl.std_msgs': types.ModuleType(
+                'unitree_sdk2py.idl.std_msgs',
+            ),
+            'unitree_sdk2py.idl.std_msgs.msg': types.ModuleType(
+                'unitree_sdk2py.idl.std_msgs.msg',
+            ),
+            'unitree_sdk2py.idl.std_msgs.msg.dds_': message_module,
+        }
+
+        with mock.patch.dict(sys.modules, modules):
+            monitor = PLAYBACK_STATE.G1PlaybackStateMonitor.connect_dds()
+
+        self.assertTrue(monitor.available)
+        self.assertTrue(monitor.status()['ready'])
+        self.assertEqual(created[0].init_args[1], 0)
+        self.assertEqual(
+            created[0].init_args[2].__self__, monitor,
+        )
+
+    def test_ignores_non_state_audio_messages(self):
+        invalid = [
+            None,
+            '',
+            'not-json',
+            '[]',
+            '{"text":"hello"}',
+            '{"play_state":true}',
+            '{"play_state":2}',
+            '{"play_state":"1"}',
+        ]
+
+        self.assertEqual(
+            [self.monitor.on_raw_message(value) for value in invalid],
+            [False] * len(invalid),
+        )
+        self.assertEqual(self.monitor.status()['event_seq'], 0)
+
+    def test_forget_prevents_stale_session_reuse(self):
+        self.monitor.note_submission(self.key, self.monitor.checkpoint())
+        self.monitor.on_raw_message('{"play_state":1}')
+        self.monitor.on_raw_message('{"play_state":0}')
+        self.monitor.forget(self.key)
+
+        self.assertEqual(
+            self.monitor.wait_for_completion(self.key, timeout=0)['reason'],
+            'play_state_observation_missing',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unitree/g1/tests/test_speaker_lifecycle.py
+++ b/unitree/g1/tests/test_speaker_lifecycle.py
@@ -259,6 +259,99 @@ class _AudioClient:
         return self.stop_code
 
 
+class _PlaybackStateMonitor:
+    def __init__(self, result=None, *, available=True, ready=None):
+        self.result = result or {
+            'state': 'completed',
+            'reason': '',
+            'playing_seq': 1,
+            'idle_seq': 2,
+        }
+        self.available = available
+        self.ready = available if ready is None else ready
+        self.sequence = 0
+        self.submissions = []
+        self.wait_calls = []
+        self.forgotten = []
+        self.ready_waits = []
+
+    def checkpoint(self):
+        checkpoint = self.sequence
+        self.sequence += 1
+        return checkpoint
+
+    def note_submission(self, key, checkpoint):
+        self.submissions.append((key, checkpoint))
+
+    def wait_for_completion(self, key, *, timeout, cancelled):
+        self.wait_calls.append((key, timeout))
+        if cancelled():
+            return {'state': 'interrupted', 'reason': 'interrupted'}
+        return dict(self.result)
+
+    def wait_until_ready(self, *, timeout, cancelled=None):
+        self.ready_waits.append(timeout)
+        if cancelled is not None and cancelled():
+            return {'state': 'interrupted', 'reason': 'interrupted'}
+        if not self.available:
+            return {'state': 'error', 'reason': 'injected_unavailable'}
+        if not self.ready:
+            return {
+                'state': 'timeout',
+                'reason': 'play_state_publisher_timeout',
+            }
+        return {'state': 'ready', 'reason': ''}
+
+    def forget(self, key):
+        self.forgotten.append(key)
+
+    def status(self):
+        return {
+            'available': self.available,
+            'ready': self.ready,
+            'matched_publishers': 1 if self.ready else 0,
+            'topic': 'rt/audio_msg',
+            'current_state': 0,
+            'event_seq': self.sequence,
+            'last_event_ts': 123.0,
+            'connect_error': '' if self.available else 'injected_unavailable',
+        }
+
+
+class _BlockingPlaybackStateMonitor(_PlaybackStateMonitor):
+    def __init__(self):
+        super().__init__()
+        self.wait_entered = threading.Event()
+        self.release_wait = threading.Event()
+
+    def wait_for_completion(self, key, *, timeout, cancelled):
+        self.wait_calls.append((key, timeout))
+        self.wait_entered.set()
+        while not self.release_wait.wait(timeout=0.005):
+            if cancelled():
+                return {'state': 'interrupted', 'reason': 'interrupted'}
+        if cancelled():
+            return {'state': 'interrupted', 'reason': 'interrupted'}
+        return dict(self.result)
+
+
+class _BlockingReadyPlaybackStateMonitor(_PlaybackStateMonitor):
+    def __init__(self):
+        super().__init__(ready=False)
+        self.ready_wait_entered = threading.Event()
+        self.ready_wait_release = threading.Event()
+
+    def wait_until_ready(self, *, timeout, cancelled=None):
+        self.ready_waits.append(timeout)
+        self.ready_wait_entered.set()
+        while not self.ready_wait_release.wait(timeout=0.005):
+            if cancelled is not None and cancelled():
+                return {'state': 'interrupted', 'reason': 'interrupted'}
+        if cancelled is not None and cancelled():
+            return {'state': 'interrupted', 'reason': 'interrupted'}
+        return {'state': 'ready', 'reason': ''}
+
+
 class _StopFirstSdkLock:
     """Force interrupt's PlayStop to linearize before a pending PlayStream."""
 
@@ -511,6 +604,215 @@ class SpeakerLifecycleTests(unittest.TestCase):
         self.assertLessEqual(
             self.client.stop_finish_timeouts[-1], self.node.CONTROL_RPC_TIMEOUT_SEC,
         )
+
+    def test_hardware_completion_waits_for_g1_play_state(self):
+        monitor = _PlaybackStateMonitor()
+        client = _AudioClient()
+        node = DEVICE._SpeakerNode(
+            client,
+            monotonic=self.clock.monotonic,
+            wall_time=self.clock.wall_time,
+            waiter=self.clock.wait,
+            playback_state_monitor=monitor,
+            completion_mode='hardware_state',
+        )
+        client.stop_calls.clear()
+        node.start_play('/perception/hardware-state')
+        pcm = b'\x10\x20' * 1600
+
+        node._on_chunk(_chunk('utt:hardware', pcm))
+        node._on_chunk(_chunk('utt:hardware', node.AUDIO_EOF_MAGIC))
+        self._join_drain(node)
+
+        terminal = [
+            receipt for receipt in _receipts(node)
+            if receipt['utterance_id'] == 'utt:hardware'
+            and receipt['state'] == 'completed'
+        ][0]
+        generation = node._generation
+        self.assertEqual(
+            monitor.submissions,
+            [((generation, 'utt:hardware'), 0)],
+        )
+        self.assertEqual(
+            monitor.wait_calls,
+            [((generation, 'utt:hardware'), node._play_state_timeout_sec)],
+        )
+        self.assertEqual(terminal['completion_basis'], 'g1_play_state_observed')
+        self.assertIn((generation, 'utt:hardware'), monitor.forgotten)
+
+    def test_hardware_idle_gate_advances_only_after_stream_response(self):
+        monitor = _PlaybackStateMonitor()
+        client = _DelayedFinishClient()
+        node = DEVICE._SpeakerNode(
+            client,
+            monotonic=self.clock.monotonic,
+            wall_time=self.clock.wall_time,
+            waiter=self.clock.wait,
+            playback_state_monitor=monitor,
+            completion_mode='hardware_state',
+        )
+        client.stop_calls.clear()
+        node.start_play('/perception/hardware-response-boundary')
+
+        node._on_chunk(_chunk(
+            'utt:hardware-response-boundary', b'R' * 3200,
+        ))
+        node._on_chunk(_chunk(
+            'utt:hardware-response-boundary', node.AUDIO_EOF_MAGIC,
+        ))
+        self.assertTrue(client.finish_entered.wait(timeout=1))
+
+        self.assertEqual(monitor.submissions, [])
+        client.finish_release.set()
+        self._join_drain(node)
+
+        generation = node._generation
+        self.assertEqual(
+            monitor.submissions,
+            [((generation, 'utt:hardware-response-boundary'), 0)],
+        )
+        self.assertTrue(any(
+            receipt['utterance_id'] == 'utt:hardware-response-boundary'
+            and receipt['state'] == 'completed'
+            for receipt in _receipts(node)
+        ))
+
+    def test_hardware_state_timeout_is_error_and_stops_player(self):
+        monitor = _PlaybackStateMonitor({
+            'state': 'timeout',
+            'reason': 'play_state_idle_timeout',
+        })
+        client = _AudioClient()
+        node = DEVICE._SpeakerNode(
+            client,
+            monotonic=self.clock.monotonic,
+            wall_time=self.clock.wall_time,
+            waiter=self.clock.wait,
+            playback_state_monitor=monitor,
+            completion_mode='hardware_state',
+        )
+        client.stop_calls.clear()
+        node.start_play('/perception/hardware-timeout')
+
+        node._on_chunk(_chunk('utt:hardware-timeout', b'T' * 3200))
+        node._on_chunk(_chunk(
+            'utt:hardware-timeout', node.AUDIO_EOF_MAGIC,
+        ))
+        self._join_drain(node)
+
+        terminal = [
+            receipt for receipt in _receipts(node)
+            if receipt['utterance_id'] == 'utt:hardware-timeout'
+            and receipt['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual([item['state'] for item in terminal], ['error'])
+        self.assertEqual(terminal[0]['reason'], 'play_state_idle_timeout')
+        self.assertEqual(
+            terminal[0]['completion_basis'], 'g1_play_state_observed',
+        )
+        self.assertEqual(client.stop_calls, [DEVICE.APP_NAME])
+
+    def test_hardware_wait_interrupted_cannot_emit_completed(self):
+        monitor = _BlockingPlaybackStateMonitor()
+        client = _AudioClient()
+        node = DEVICE._SpeakerNode(
+            client,
+            playback_state_monitor=monitor,
+            completion_mode='hardware_state',
+        )
+        client.stop_calls.clear()
+        node.start_play('/perception/hardware-interrupt')
+        node._on_chunk(_chunk('utt:hardware-interrupt', b'I' * 3200))
+        node._on_chunk(_chunk(
+            'utt:hardware-interrupt', node.AUDIO_EOF_MAGIC,
+        ))
+        self.assertTrue(monitor.wait_entered.wait(timeout=1))
+
+        result = node.interrupt()
+        monitor.release_wait.set()
+        thread = node._drain_thread
+        if thread is not None:
+            thread.join(timeout=1)
+
+        terminals = [
+            receipt['state'] for receipt in _receipts(node)
+            if receipt['utterance_id'] == 'utt:hardware-interrupt'
+            and receipt['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual(result['cancelled_utterance_ids'], [
+            'utt:hardware-interrupt',
+        ])
+        self.assertEqual(terminals, ['cancelled'])
+
+    def test_stale_stream_response_cannot_recreate_hardware_observation(self):
+        monitor = _PlaybackStateMonitor()
+        client = _DelayedFinishClient()
+        node = DEVICE._SpeakerNode(
+            client,
+            playback_state_monitor=monitor,
+            completion_mode='hardware_state',
+        )
+        client.stop_calls.clear()
+        node.start_play('/perception/hardware-stale-response')
+        node._on_chunk(_chunk(
+            'utt:hardware-stale-response', b'S' * 3200,
+        ))
+        node._on_chunk(_chunk(
+            'utt:hardware-stale-response', node.AUDIO_EOF_MAGIC,
+        ))
+        self.assertTrue(client.finish_entered.wait(timeout=1))
+
+        node.interrupt()
+        client.finish_release.set()
+        thread = node._drain_thread
+        if thread is not None:
+            thread.join(timeout=1)
+
+        self.assertEqual(monitor.submissions, [])
+        terminals = [
+            receipt['state'] for receipt in _receipts(node)
+            if receipt['utterance_id'] == 'utt:hardware-stale-response'
+            and receipt['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual(terminals, ['cancelled'])
+
+    def test_hardware_mode_rejects_lossy_pause(self):
+        monitor = _PlaybackStateMonitor()
+        node = DEVICE._SpeakerNode(
+            _AudioClient(),
+            playback_state_monitor=monitor,
+            completion_mode='hardware_state',
+        )
+        node.start_play('/perception/hardware-pause')
+        node._on_chunk(_chunk('utt:hardware-pause', b'P' * 3200))
+
+        result = node.pause()
+
+        self.assertEqual(
+            result['error'], 'pause_not_supported_with_hardware_state',
+        )
+        self.assertEqual(node.state, 'playing')
+        node.interrupt()
+
+    def test_smart_motion_does_not_advertise_unsupported_hardware_pause(self):
+        executor = types.SimpleNamespace(add_node=lambda _node: None)
+        speaker = DEVICE.SpeakerPlugin(
+            {'completion_mode': 'hardware_state'},
+            '', executor, _AudioClient(),
+            playback_state_monitor=_PlaybackStateMonitor(),
+        )
+        smart_motion = DEVICE.SmartMotionPlugin(
+            {}, '', executor, speaker_plugin=speaker,
+        )
+
+        actions = smart_motion.get_tool()['inputSchema']['properties'][
+            'action'
+        ]['enum']
+
+        self.assertNotIn('pause_speak', actions)
+        self.assertNotIn('resume_speak', actions)
+        self.assertIn('interrupt_speak', actions)
 
     def test_playback_grace_is_applied_once_per_utterance(self):
         self.node.PREFILL = 100
@@ -1455,6 +1757,181 @@ class SpeakerLifecycleTests(unittest.TestCase):
         self.assertEqual(info['receipt_recovery'],
                          'transient_local_then_info_poll')
         self.assertEqual(info['topic_out'][0]['qos']['reliability'], 'reliable')
+
+    def test_native_tts_speak_can_be_hidden_for_strict_speaker_ownership(self):
+        plugin = DEVICE.NativeTtsPlugin(
+            {
+                'speak_enabled': False,
+                'speak_disabled_reason': 'strict_speaker_owns_body_audio',
+            },
+            '', None, _AudioClient(),
+        )
+
+        actions = plugin.get_tool()['inputSchema']['properties']['action'][
+            'enum'
+        ]
+        result = plugin.dispatch('speak', {'text': 'must not play'})
+
+        self.assertNotIn('speak', actions)
+        self.assertIn('get_volume', actions)
+        self.assertEqual(result, {
+            'state': 'error',
+            'error': 'strict_speaker_owns_body_audio',
+        })
+
+    def test_hardware_info_advertises_g1_play_state_evidence(self):
+        executor = types.SimpleNamespace(add_node=lambda _node: None)
+        monitor = _PlaybackStateMonitor()
+        plugin = DEVICE.SpeakerPlugin(
+            {
+                'completion_mode': 'hardware_state',
+                'play_state_timeout_sec': 1.5,
+            },
+            '', executor, _AudioClient(),
+            playback_state_monitor=monitor,
+        )
+        plugin._node.start_play('/perception/hardware-info')
+
+        info = plugin.dispatch('info', {})
+
+        self.assertEqual(info['completion_mode'], 'hardware_state')
+        self.assertEqual(info['completion_basis'], 'g1_play_state_observed')
+        self.assertTrue(info['play_state']['available'])
+        self.assertEqual(info['play_state']['topic'], 'rt/audio_msg')
+        self.assertEqual(plugin._node._play_state_timeout_sec, 1.5)
+
+    def test_hardware_start_fails_before_audio_when_monitor_unavailable(self):
+        executor = types.SimpleNamespace(add_node=lambda _node: None)
+        monitor = _PlaybackStateMonitor(available=False)
+        client = _AudioClient()
+        plugin = DEVICE.SpeakerPlugin(
+            {'completion_mode': 'hardware_state'},
+            '', executor, client,
+            playback_state_monitor=monitor,
+        )
+        client.stop_calls.clear()
+
+        result = plugin.dispatch(
+            'start', {'input_topic': '/perception/unavailable'},
+        )
+
+        self.assertEqual(result['state'], 'error')
+        self.assertEqual(result['error'], 'play_state_monitor_unavailable')
+        self.assertEqual(client.stream_calls, [])
+
+    def test_hardware_start_waits_for_matched_state_publisher(self):
+        executor = types.SimpleNamespace(add_node=lambda _node: None)
+        monitor = _PlaybackStateMonitor(ready=False)
+        client = _AudioClient()
+        plugin = DEVICE.SpeakerPlugin(
+            {
+                'completion_mode': 'hardware_state',
+                'play_state_discovery_timeout_sec': 1.25,
+            },
+            '', executor, client,
+            playback_state_monitor=monitor,
+        )
+        client.stop_calls.clear()
+
+        result = plugin.dispatch(
+            'start', {'input_topic': '/perception/unmatched-state'},
+        )
+
+        self.assertEqual(result['state'], 'error')
+        self.assertEqual(result['error'], 'play_state_publisher_timeout')
+        self.assertEqual(monitor.ready_waits, [1.25])
+        self.assertEqual(client.stream_calls, [])
+
+    def test_stop_during_discovery_cannot_resurrect_stale_start(self):
+        executor = types.SimpleNamespace(add_node=lambda _node: None)
+        monitor = _BlockingReadyPlaybackStateMonitor()
+        client = _AudioClient()
+        plugin = DEVICE.SpeakerPlugin(
+            {'completion_mode': 'hardware_state'},
+            '', executor, client,
+            playback_state_monitor=monitor,
+        )
+        client.stop_calls.clear()
+        result_holder = {}
+        start_thread = threading.Thread(
+            target=lambda: result_holder.setdefault(
+                'value', plugin.dispatch(
+                    'start', {'input_topic': '/perception/stale-discovery'},
+                ),
+            ),
+        )
+        start_thread.start()
+        self.assertTrue(monitor.ready_wait_entered.wait(timeout=1))
+
+        self.assertEqual(plugin._node.stop_play()['state'], 'idle')
+        monitor.ready_wait_release.set()
+        start_thread.join(timeout=1)
+
+        self.assertFalse(start_thread.is_alive())
+        self.assertEqual(result_holder['value']['error'], 'interrupted')
+        self.assertEqual(client.stream_calls, [])
+        self.assertIsNone(plugin._node._sub)
+        self.assertIsNone(plugin._node._topic)
+
+    def test_hardware_startup_sound_waits_for_g1_play_state(self):
+        executor = types.SimpleNamespace(add_node=lambda _node: None)
+        monitor = _PlaybackStateMonitor()
+        client = _AudioClient()
+        plugin = DEVICE.SpeakerPlugin(
+            {'completion_mode': 'hardware_state'},
+            '', executor, client,
+            playback_state_monitor=monitor,
+        )
+        client.stop_calls.clear()
+        plugin._node._monotonic = self.clock.monotonic
+        plugin._node._waiter = self.clock.wait
+
+        result = plugin.dispatch(
+            'start', {'input_topic': '/perception/hardware-startup'},
+        )
+
+        startup_key = monitor.wait_calls[0][0]
+        self.assertEqual(result['state'], 'ready')
+        self.assertEqual(result['completion_basis'], 'g1_play_state_observed')
+        self.assertTrue(client.stream_calls)
+        self.assertEqual(startup_key[1], f'startup:{startup_key[0]}')
+        self.assertEqual(
+            {key for key, _checkpoint in monitor.submissions},
+            {startup_key},
+        )
+        self.assertEqual(
+            monitor.wait_calls,
+            [(startup_key, plugin._node._play_state_timeout_sec)],
+        )
+        self.assertIn(startup_key, monitor.forgotten)
+
+    def test_hardware_startup_state_timeout_fails_before_subscription(self):
+        executor = types.SimpleNamespace(add_node=lambda _node: None)
+        monitor = _PlaybackStateMonitor({
+            'state': 'timeout',
+            'reason': 'play_state_idle_timeout',
+        })
+        client = _AudioClient()
+        plugin = DEVICE.SpeakerPlugin(
+            {'completion_mode': 'hardware_state'},
+            '', executor, client,
+            playback_state_monitor=monitor,
+        )
+        client.stop_calls.clear()
+        plugin._node._monotonic = self.clock.monotonic
+        plugin._node._waiter = self.clock.wait
+
+        result = plugin.dispatch(
+            'start', {'input_topic': '/perception/hardware-startup-timeout'},
+        )
+
+        self.assertEqual(
+            result['error'], 'startup_play_state_idle_timeout',
+        )
+        self.assertIsNone(plugin._node._sub)
+        self.assertIsNone(plugin._node._topic)
+        self.assertTrue(client.stream_calls)
+        self.assertEqual(client.stop_calls, [DEVICE.APP_NAME, DEVICE.APP_NAME])
 
 
 class AudioClientWrapperTests(unittest.TestCase):

--- a/unitree/g1/tests/test_speaker_lifecycle.py
+++ b/unitree/g1/tests/test_speaker_lifecycle.py
@@ -1,0 +1,1829 @@
+import importlib.util
+import json
+import queue
+import sys
+import threading
+import time
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+G1_DIR = Path(__file__).resolve().parents[1]
+
+
+class _Logger:
+    def info(self, *_args, **_kwargs):
+        pass
+
+    def warn(self, *_args, **_kwargs):
+        pass
+
+    def error(self, *_args, **_kwargs):
+        pass
+
+
+class _Publisher:
+    def __init__(self, topic, qos):
+        self.topic = topic
+        self.qos = qos
+        self.messages = []
+
+    def publish(self, msg):
+        self.messages.append(msg)
+
+
+class _FailingPublisher(_Publisher):
+    def __init__(self, topic, qos, fail_attempts):
+        super().__init__(topic, qos)
+        self.fail_attempts = set(fail_attempts)
+        self.attempts = 0
+
+    def publish(self, msg):
+        self.attempts += 1
+        if self.attempts in self.fail_attempts:
+            raise RuntimeError('injected publish failure')
+        super().publish(msg)
+
+
+class _GatePublisher(_Publisher):
+    def __init__(self, topic, qos):
+        super().__init__(topic, qos)
+        self.attempts = 0
+        self.retry_entered = threading.Event()
+        self.retry_release = threading.Event()
+
+    def publish(self, msg):
+        self.attempts += 1
+        if self.attempts == 1:
+            raise RuntimeError('injected first publish failure')
+        if self.attempts == 2:
+            self.retry_entered.set()
+            self.retry_release.wait(timeout=1)
+        super().publish(msg)
+
+
+class _Timer:
+    def __init__(self, callback):
+        self.callback = callback
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+
+class _Node:
+    def __init__(self, name):
+        self.name = name
+        self.publishers = []
+        self.timers = []
+        self._logger = _Logger()
+
+    def create_publisher(self, _msg_type, topic, _qos):
+        publisher = _Publisher(topic, _qos)
+        self.publishers.append(publisher)
+        return publisher
+
+    def destroy_publisher(self, publisher):
+        if publisher in self.publishers:
+            self.publishers.remove(publisher)
+
+    def create_subscription(self, _msg_type, topic, callback, _qos):
+        return types.SimpleNamespace(topic=topic, callback=callback)
+
+    def destroy_subscription(self, _subscription):
+        pass
+
+    def create_timer(self, _period, callback):
+        timer = _Timer(callback)
+        self.timers.append(timer)
+        return timer
+
+    def destroy_timer(self, timer):
+        if timer in self.timers:
+            self.timers.remove(timer)
+
+    def get_logger(self):
+        return self._logger
+
+
+class _Header:
+    def __init__(self):
+        self.frame_id = ''
+        self.stamp = None
+
+
+class _String:
+    def __init__(self):
+        self.data = ''
+
+
+class _AudioChunk:
+    def __init__(self):
+        self.header = _Header()
+        self.format = 'audio/pcm-16k'
+        self.data = []
+
+
+class _QoSProfile:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _package(name):
+    module = types.ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+def _load_device_module():
+    rclpy = _package('rclpy')
+    rclpy_node = types.ModuleType('rclpy.node')
+    rclpy_node.Node = _Node
+    rclpy_qos = types.ModuleType('rclpy.qos')
+    rclpy_qos.QoSProfile = _QoSProfile
+    rclpy_qos.ReliabilityPolicy = types.SimpleNamespace(
+        BEST_EFFORT='best_effort', RELIABLE='reliable',
+    )
+    rclpy_qos.HistoryPolicy = types.SimpleNamespace(KEEP_LAST='keep_last')
+    rclpy_qos.DurabilityPolicy = types.SimpleNamespace(
+        VOLATILE='volatile', TRANSIENT_LOCAL='transient_local',
+    )
+
+    std_msgs = _package('std_msgs')
+    std_msgs_msg = types.ModuleType('std_msgs.msg')
+    std_msgs_msg.Header = _Header
+    std_msgs_msg.String = _String
+    audio_msgs = _package('audio_msgs')
+    audio_msgs_msg = types.ModuleType('audio_msgs.msg')
+    audio_msgs_msg.AudioChunk = _AudioChunk
+
+    sdk = _package('unitree_sdk2py')
+    sdk_g1 = _package('unitree_sdk2py.g1')
+    sdk_audio = _package('unitree_sdk2py.g1.audio')
+    sdk_client = types.ModuleType('unitree_sdk2py.g1.audio.g1_audio_client')
+    sdk_client.AudioClient = object
+    pointcloud = types.ModuleType('pointcloud_utils')
+    pointcloud.gravity_align_inplace = lambda *args, **kwargs: None
+    numpy = types.ModuleType('numpy')
+
+    stubs = {
+        'rclpy': rclpy,
+        'rclpy.node': rclpy_node,
+        'rclpy.qos': rclpy_qos,
+        'std_msgs': std_msgs,
+        'std_msgs.msg': std_msgs_msg,
+        'audio_msgs': audio_msgs,
+        'audio_msgs.msg': audio_msgs_msg,
+        'unitree_sdk2py': sdk,
+        'unitree_sdk2py.g1': sdk_g1,
+        'unitree_sdk2py.g1.audio': sdk_audio,
+        'unitree_sdk2py.g1.audio.g1_audio_client': sdk_client,
+        'pointcloud_utils': pointcloud,
+        'numpy': numpy,
+    }
+    spec = importlib.util.spec_from_file_location(
+        'g1_device_under_test', G1_DIR / 'device.py',
+    )
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(sys.modules, stubs):
+        spec.loader.exec_module(module)
+    return module
+
+
+DEVICE = _load_device_module()
+
+
+class _Clock:
+    def __init__(self):
+        self.value = 100.0
+
+    def monotonic(self):
+        return self.value
+
+    def wall_time(self):
+        return 1_780_000_000.0 + self.value
+
+    def wait(self, seconds):
+        self.value += seconds
+        return False
+
+
+class _AudioClient:
+    def __init__(self):
+        self.stream_calls = []
+        self.stop_calls = []
+        self.stream_send_timeouts = []
+        self.stream_finish_timeouts = []
+        self.stop_send_timeouts = []
+        self.stop_finish_timeouts = []
+        self.stream_code = 0
+        self.stop_code = 0
+        self.block_stream = False
+        self.stream_entered = threading.Event()
+        self.stream_release = threading.Event()
+
+    def PlayStream(self, app_name, stream_id, pcm):
+        self.stream_calls.append((app_name, stream_id, bytes(pcm)))
+        self.stream_entered.set()
+        if self.block_stream:
+            self.stream_release.wait(timeout=1)
+        return self.stream_code, {}
+
+    def PlayStreamStart(self, app_name, stream_id, pcm, send_timeout=None):
+        self.stream_calls.append((app_name, stream_id, bytes(pcm)))
+        self.stream_send_timeouts.append(send_timeout)
+        self.stream_entered.set()
+        return 0, object()
+
+    def PlayStreamFinish(self, _pending, timeout=None):
+        self.stream_finish_timeouts.append(timeout)
+        if self.block_stream:
+            self.stream_release.wait(timeout=1)
+        return self.stream_code, {}
+
+    def PlayStop(self, app_name):
+        self.stop_calls.append(app_name)
+        self.stream_release.set()
+        return self.stop_code
+
+    def PlayStopStart(self, app_name, send_timeout=None):
+        self.stop_calls.append(app_name)
+        self.stop_send_timeouts.append(send_timeout)
+        self.stream_release.set()
+        return 0, object()
+
+    def PlayStopFinish(self, _pending, timeout=None):
+        self.stop_finish_timeouts.append(timeout)
+        return self.stop_code
+
+
+class _StopFirstSdkLock:
+    """Force interrupt's PlayStop to linearize before a pending PlayStream."""
+
+    def __init__(self):
+        self.play_waiting = threading.Event()
+        self.allow_play = threading.Event()
+
+    def __enter__(self):
+        if threading.current_thread().name == 'late-play':
+            self.play_waiting.set()
+            self.allow_play.wait(timeout=1)
+        return self
+
+    def __exit__(self, *_args):
+        if threading.current_thread().name != 'late-play':
+            self.allow_play.set()
+
+
+class _BlockingGetQueue(queue.Queue):
+    def __init__(self):
+        super().__init__()
+        self.item_popped = threading.Event()
+        self.release_item = threading.Event()
+        self._blocked_once = False
+
+    def get(self, block=True, timeout=None):
+        item = super().get(block=block, timeout=timeout)
+        if (block and not self._blocked_once
+                and threading.current_thread() is not threading.main_thread()):
+            self._blocked_once = True
+            self.item_popped.set()
+            self.release_item.wait(timeout=1)
+        return item
+
+
+class _EmptyRaceQueue(queue.Queue):
+    def __init__(self):
+        super().__init__()
+        self.empty_observed = threading.Event()
+        self.release_empty = threading.Event()
+        self._armed = False
+
+    def arm(self):
+        self._armed = True
+
+    def empty(self):
+        result = super().empty()
+        if (self._armed and result
+                and threading.current_thread() is not threading.main_thread()):
+            self._armed = False
+            self.empty_observed.set()
+            self.release_empty.wait(timeout=1)
+        return result
+
+
+class _GetWaitingQueue(queue.Queue):
+    def __init__(self):
+        super().__init__()
+        self.get_waiting = threading.Event()
+
+    def get(self, block=True, timeout=None):
+        if block and self.empty():
+            self.get_waiting.set()
+        return super().get(block=block, timeout=timeout)
+
+
+class _PreGetGateQueue(queue.Queue):
+    def __init__(self):
+        super().__init__()
+        self.before_get = threading.Event()
+        self.release_get = threading.Event()
+        self._gated_once = False
+
+    def get(self, block=True, timeout=None):
+        if (block and not self._gated_once
+                and threading.current_thread() is not threading.main_thread()):
+            self._gated_once = True
+            self.before_get.set()
+            self.release_get.wait(timeout=1)
+        return super().get(block=block, timeout=timeout)
+
+
+class _BlockingStopClient(_AudioClient):
+    def __init__(self):
+        super().__init__()
+        self.stop_entered = threading.Event()
+        self.stop_release = threading.Event()
+        self.block_stop = False
+
+    def PlayStop(self, app_name):
+        self.stop_calls.append(app_name)
+        self.stop_entered.set()
+        if self.block_stop:
+            self.stop_release.wait(timeout=1)
+        return self.stop_code
+
+    def PlayStopStart(self, app_name, send_timeout=None):
+        self.stop_calls.append(app_name)
+        self.stop_send_timeouts.append(send_timeout)
+        self.stream_release.set()
+        self.stop_entered.set()
+        return 0, object()
+
+    def PlayStopFinish(self, _pending, timeout=None):
+        if self.block_stop:
+            self.stop_release.wait(timeout=1)
+        return self.stop_code
+
+
+class _DelayedFinishClient(_AudioClient):
+    def __init__(self):
+        super().__init__()
+        self.finish_entered = threading.Event()
+        self.finish_release = threading.Event()
+        self.finish_calls = 0
+
+    def PlayStreamFinish(self, _pending, timeout=None):
+        self.finish_calls += 1
+        if self.finish_calls == 1:
+            self.finish_entered.set()
+            self.finish_release.wait(timeout=2)
+        return self.stream_code, {}
+
+
+class _SequenceStreamClient(_AudioClient):
+    def __init__(self, stream_codes):
+        super().__init__()
+        self.stream_codes = list(stream_codes)
+
+    def PlayStreamFinish(self, _pending, timeout=None):
+        if self.stream_codes:
+            return self.stream_codes.pop(0), {}
+        return 0, {}
+
+
+class _StaleErrorClient(_AudioClient):
+    def __init__(self):
+        super().__init__()
+        self.first_finish_entered = threading.Event()
+        self.first_finish_release = threading.Event()
+        self.finish_calls = 0
+
+    def PlayStreamFinish(self, _pending, timeout=None):
+        self.finish_calls += 1
+        if self.finish_calls == 1:
+            self.first_finish_entered.set()
+            self.first_finish_release.wait(timeout=2)
+            return 17, {}
+        return 0, {}
+
+
+class _StaleExceptionClient(_AudioClient):
+    def __init__(self):
+        super().__init__()
+        self.first_finish_entered = threading.Event()
+        self.first_finish_release = threading.Event()
+        self.finish_calls = 0
+
+    def PlayStreamFinish(self, _pending, timeout=None):
+        self.finish_calls += 1
+        if self.finish_calls == 1:
+            self.first_finish_entered.set()
+            self.first_finish_release.wait(timeout=2)
+            raise RuntimeError('stale response failure')
+        return 0, {}
+
+
+def _chunk(utterance_id, pcm):
+    msg = _AudioChunk()
+    msg.header.frame_id = utterance_id
+    msg.data = list(pcm)
+    return msg
+
+
+def _receipts(node):
+    return [json.loads(msg.data) for msg in node._receipt_pub.messages]
+
+
+class SpeakerLifecycleTests(unittest.TestCase):
+    def setUp(self):
+        self.clock = _Clock()
+        self.client = _AudioClient()
+        self.node = DEVICE._SpeakerNode(
+            self.client,
+            monotonic=self.clock.monotonic,
+            wall_time=self.clock.wall_time,
+            waiter=self.clock.wait,
+        )
+        self.client.stop_calls.clear()  # Ignore stale-session cleanup in __init__.
+        self.client.stop_send_timeouts.clear()
+        self.client.stop_finish_timeouts.clear()
+        self.client.stream_release.clear()
+        self.node.start_play('/perception/tts')
+
+    def _eof(self, utterance_id):
+        return _chunk(utterance_id, self.node.AUDIO_EOF_MAGIC)
+
+    def _join_drain(self, node=None):
+        node = node or self.node
+        thread = node._drain_thread
+        self.assertIsNotNone(thread)
+        thread.join(timeout=1)
+        self.assertFalse(thread.is_alive(), 'speaker drain thread did not finish')
+
+    def _wait_for(self, predicate, message, timeout=1):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            time.sleep(0.001)
+        self.fail(message)
+
+    def test_eof_forces_short_utterance_drain(self):
+        pcm = b'\x11\x22' * 1600
+        self.node._on_chunk(_chunk('utt:short', pcm))
+        self.assertEqual(self.client.stream_calls, [])
+
+        self.node._on_chunk(self._eof('utt:short'))
+        self._join_drain()
+
+        self.assertEqual([call[2] for call in self.client.stream_calls], [pcm])
+        self.assertNotIn(self.node.AUDIO_EOF_MAGIC,
+                         [call[2] for call in self.client.stream_calls])
+        self.assertEqual(self.node.state, 'ready')
+
+    def test_completion_emitted_once_after_driver_drained(self):
+        pcm = b'\x01\x02' * 1600
+        self.node._on_chunk(_chunk('utt:one', pcm))
+        self.node._on_chunk(self._eof('utt:one'))
+        self._join_drain()
+
+        events = [r for r in _receipts(self.node) if r['utterance_id'] == 'utt:one']
+        self.assertEqual([r['state'] for r in events], ['started', 'completed'])
+        terminal = events[-1]
+        self.assertEqual(terminal['session_id'], self.node._session_id)
+        self.assertEqual(terminal['completion_basis'], 'driver_drained_estimated')
+        self.assertEqual(terminal['audio_bytes'], len(pcm))
+        self.assertGreaterEqual(self.clock.value, 100.0 + len(pcm) / 32000)
+        self.assertEqual(
+            self.client.stream_send_timeouts, [self.node.RPC_SEND_TIMEOUT_SEC],
+        )
+        self.assertEqual(
+            self.client.stream_finish_timeouts, [self.node.STREAM_RPC_TIMEOUT_SEC],
+        )
+        self.assertEqual(self.node._generation_ids[self.node._generation], set())
+        self.assertEqual(self.node.interrupt()['cancelled_utterance_ids'], [])
+        self.assertLessEqual(
+            self.client.stop_send_timeouts[-1], self.node.RPC_SEND_TIMEOUT_SEC,
+        )
+        self.assertLessEqual(
+            self.client.stop_finish_timeouts[-1], self.node.CONTROL_RPC_TIMEOUT_SEC,
+        )
+
+    def test_playback_grace_is_applied_once_per_utterance(self):
+        self.node.PREFILL = 100
+        for _ in range(6):
+            self.node._on_chunk(_chunk('utt:multi-block', b'M' * 3200))
+        self.node._on_chunk(self._eof('utt:multi-block'))
+        self._join_drain()
+
+        self.assertEqual([len(call[2]) for call in self.client.stream_calls],
+                         [9600, 9600])
+        self.assertAlmostEqual(self.clock.value, 100.65, places=6)
+
+    def test_receipt_qos_is_reliable_and_transient_local(self):
+        qos = self.node._receipt_pub.qos.kwargs
+
+        self.assertEqual(qos['reliability'], 'reliable')
+        self.assertEqual(qos['durability'], 'transient_local')
+        self.assertEqual(qos['depth'], 50)
+
+    def test_terminal_publish_failure_is_retried_from_outbox(self):
+        publisher = _FailingPublisher(
+            self.node._receipt_topic, self.node._receipt_pub.qos,
+            fail_attempts={2},
+        )
+        self.node._receipt_pub = publisher
+        self.node._on_chunk(_chunk('utt:retry', b'R' * 3200))
+        self.node._on_chunk(self._eof('utt:retry'))
+        self._join_drain()
+
+        self.assertEqual(
+            [receipt['state'] for receipt in _receipts(self.node)], ['started'],
+        )
+        self.assertEqual(len(self.node._pending_receipts), 1)
+        self.assertIsNotNone(self.node._receipt_retry_timer)
+
+        self.node._retry_pending_receipts()
+
+        self.assertEqual(
+            [receipt['state'] for receipt in _receipts(self.node)],
+            ['started', 'completed'],
+        )
+        self.assertEqual(self.node._pending_receipts, {})
+        self.assertEqual(self.node._receipt_publish_errors, {})
+        self.assertIsNone(self.node._receipt_retry_timer)
+
+    def test_terminal_supersedes_failed_started_receipt(self):
+        publisher = _FailingPublisher(
+            self.node._receipt_topic, self.node._receipt_pub.qos,
+            fail_attempts={1},
+        )
+        self.node._receipt_pub = publisher
+        self.node._on_chunk(_chunk('utt:no-late-start', b'S' * 3200))
+        self.node._on_chunk(self._eof('utt:no-late-start'))
+        self._join_drain()
+
+        self.assertEqual(
+            [receipt['state'] for receipt in _receipts(self.node)], ['completed'],
+        )
+
+    def test_concurrent_retry_cannot_publish_started_after_terminal(self):
+        publisher = _GatePublisher(
+            self.node._receipt_topic, self.node._receipt_pub.qos,
+        )
+        self.node._receipt_pub = publisher
+        self.node._emit_receipt('utt:monotonic', 'started')
+        retry_thread = threading.Thread(
+            target=self.node._retry_pending_receipts,
+        )
+        retry_thread.start()
+        self.assertTrue(publisher.retry_entered.wait(timeout=1))
+        def emit_terminal_while_holding_state_lock():
+            # Reproduce the drain's historical outer-lock call pattern. Receipt
+            # publication must never form state-lock/publish-lock ABBA.
+            with self.node._lock:
+                self.node._emit_receipt(
+                    'utt:monotonic', 'completed',
+                    completion_basis='driver_drained_estimated',
+                )
+
+        terminal_thread = threading.Thread(
+            target=emit_terminal_while_holding_state_lock,
+        )
+        terminal_thread.start()
+        time.sleep(0.02)
+        publisher.retry_release.set()
+        retry_thread.join(timeout=1)
+        terminal_thread.join(timeout=1)
+
+        self.assertFalse(retry_thread.is_alive())
+        self.assertFalse(terminal_thread.is_alive())
+        states = [receipt['state'] for receipt in _receipts(self.node)]
+        self.assertIn(states, (['started', 'completed'], ['completed']))
+        self.assertEqual(states[-1], 'completed')
+
+    def test_returning_to_topic_restarts_matching_receipt_outbox(self):
+        publisher = _FailingPublisher(
+            self.node._receipt_topic, self.node._receipt_pub.qos,
+            fail_attempts={2},
+        )
+        self.node._receipt_pub = publisher
+        self.node._on_chunk(_chunk('utt:topic-a', b'A'))
+        self.node._on_chunk(self._eof('utt:topic-a'))
+        self._join_drain()
+        self.assertEqual(len(self.node._pending_receipts), 1)
+
+        self.assertEqual(self.node.stop_play()['state'], 'idle')
+        self.node.start_play('/perception/topic-b')
+        self.node._retry_pending_receipts()
+        self.assertIsNone(self.node._receipt_retry_timer)
+        self.assertEqual(len(self.node._pending_receipts), 1)
+
+        self.assertEqual(self.node.stop_play()['state'], 'idle')
+        self.node.start_play('/perception/tts')
+
+        self.assertIsNotNone(self.node._receipt_retry_timer)
+        self.node._retry_pending_receipts()
+        self.assertEqual(self.node._pending_receipts, {})
+        terminals = [
+            receipt for receipt in _receipts(self.node)
+            if receipt['utterance_id'] == 'utt:topic-a'
+            and receipt['state'] == 'completed'
+        ]
+        self.assertEqual(len(terminals), 1)
+        self.node._retry_pending_receipts()
+        self.assertEqual(
+            [receipt['state'] for receipt in _receipts(self.node)], ['completed'],
+        )
+
+    def test_stop_keeps_transient_receipt_publisher_for_late_subscriber(self):
+        publisher = self.node._receipt_pub
+        receipt_topic = self.node._receipt_topic
+        self.node._on_chunk(_chunk('utt:retained', b'T' * 3200))
+        self.node._on_chunk(self._eof('utt:retained'))
+        self._join_drain()
+
+        result = self.node.stop_play()
+
+        self.assertEqual(result['state'], 'idle')
+        self.assertIs(self.node._receipt_pub, publisher)
+        self.assertEqual(self.node._receipt_topic, receipt_topic)
+        self.assertIn(publisher, self.node.publishers)
+
+    def test_short_stream_flush_debounces_until_idle(self):
+        self.node._on_chunk(_chunk('utt:debounce', b'A'))
+        first_timer = self.node._flush_timer
+        self.clock.value += 0.1
+        self.node._on_chunk(_chunk('utt:debounce', b'B'))
+        second_timer = self.node._flush_timer
+
+        self.assertTrue(first_timer.cancelled)
+        self.assertIsNot(first_timer, second_timer)
+        # A cancelled callback may already be queued; it must not cancel the
+        # replacement timer.
+        first_timer.callback()
+        self.assertIs(self.node._flush_timer, second_timer)
+        self.assertFalse(second_timer.cancelled)
+
+        # If a timer is delivered early, re-arm for the remaining idle window.
+        second_timer.callback()
+        third_timer = self.node._flush_timer
+        self.assertIsNotNone(third_timer)
+        self.assertIsNot(third_timer, second_timer)
+        self.clock.value += 0.16
+        third_timer.callback()
+        self._join_drain()
+
+        self.assertEqual([call[2] for call in self.client.stream_calls], [b'AB'])
+        terminal = [
+            receipt for receipt in _receipts(self.node)
+            if receipt['utterance_id'] == 'utt:debounce'
+            and receipt['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual([receipt['reason'] for receipt in terminal], ['missing_eof'])
+
+    def test_stale_flush_callback_cannot_cancel_new_session_timer(self):
+        self.node._on_chunk(_chunk('utt:old-timer', b'A'))
+        stale_timer = self.node._flush_timer
+        self.assertEqual(self.node.stop_play()['state'], 'idle')
+        self.node.start_play('/perception/tts')
+        self.node._on_chunk(_chunk('utt:new-timer', b'B'))
+        current_timer = self.node._flush_timer
+
+        stale_timer.callback()
+
+        self.assertIs(self.node._flush_timer, current_timer)
+        self.assertFalse(current_timer.cancelled)
+        self.clock.value += 0.2
+        current_timer.callback()
+        self._join_drain()
+        self.assertEqual([call[2] for call in self.client.stream_calls], [b'B'])
+
+    def test_interrupt_drops_old_tail_and_next_utterance_survives(self):
+        self.client.block_stream = True
+        pcm_a = b'A' * 3200
+        for _ in range(3):
+            self.node._on_chunk(_chunk('utt:a', pcm_a))
+        self.assertTrue(self.client.stream_entered.wait(timeout=1))
+
+        result = self.node.interrupt()
+        self.assertEqual(result['play_stop_code'], 0)
+        self.assertEqual(result['cancelled_utterance_ids'], ['utt:a'])
+
+        # Late frames and EOF from A must not leak into the next session.
+        self.node._on_chunk(_chunk('utt:a', b'LATE'))
+        self.node._on_chunk(self._eof('utt:a'))
+
+        self.client.block_stream = False
+        self.client.stream_entered.clear()
+        pcm_b = b'B' * 3200
+        self.node._on_chunk(_chunk('utt:b', pcm_b))
+        self.node._on_chunk(self._eof('utt:b'))
+        self._join_drain()
+
+        streamed = [call[2] for call in self.client.stream_calls]
+        self.assertNotIn(b'LATE', streamed)
+        self.assertEqual(streamed[-1], pcm_b)
+        terminals = {
+            r['utterance_id']: r['state']
+            for r in _receipts(self.node)
+            if r['state'] in ('completed', 'cancelled', 'error')
+        }
+        self.assertEqual(terminals['utt:a'], 'cancelled')
+        self.assertEqual(terminals['utt:b'], 'completed')
+
+    def test_interrupt_linearizes_stop_before_pending_stream(self):
+        sdk_lock = _StopFirstSdkLock()
+        self.node._sdk_lock = sdk_lock
+        generation = self.node._generation
+        with self.node._lock:
+            self.node._generation_ids[generation].add('utt:race')
+        result_holder = {}
+
+        def late_play():
+            result_holder['value'] = self.node._play_merged(
+                b'RACE', 1, 'utt:race', generation,
+            )
+
+        play_thread = threading.Thread(target=late_play, name='late-play')
+        play_thread.start()
+        self.assertTrue(sdk_lock.play_waiting.wait(timeout=1))
+
+        result = self.node.interrupt()
+        play_thread.join(timeout=1)
+
+        self.assertFalse(play_thread.is_alive())
+        self.assertEqual(result['play_stop_code'], 0)
+        self.assertEqual(result['cancelled_utterance_ids'], ['utt:race'])
+        self.assertEqual(result_holder['value'], (False, 'interrupted'))
+        self.assertEqual(self.client.stream_calls, [])
+
+    def test_interrupt_does_not_wait_for_stalled_stream_response(self):
+        client = _DelayedFinishClient()
+        node = DEVICE._SpeakerNode(client)
+        client.stop_calls.clear()
+        node.start_play('/perception/stalled-response')
+        for _ in range(3):
+            node._on_chunk(_chunk('utt:stalled', b'S' * 3200))
+        self.assertTrue(client.finish_entered.wait(timeout=1))
+        old_drain = node._drain_thread
+
+        started = time.monotonic()
+        result = node.interrupt()
+        elapsed = time.monotonic() - started
+
+        self.assertLess(elapsed, 0.25)
+        self.assertEqual(result['state'], 'ready')
+        self.assertEqual(result['play_stop_code'], 0)
+        self.assertEqual(result['cancelled_utterance_ids'], ['utt:stalled'])
+        client.finish_release.set()
+        old_drain.join(timeout=1)
+        self.assertFalse(old_drain.is_alive())
+
+    def test_stale_stream_error_cannot_stop_new_generation(self):
+        client = _StaleErrorClient()
+        node = DEVICE._SpeakerNode(
+            client,
+            monotonic=self.clock.monotonic,
+            wall_time=self.clock.wall_time,
+            waiter=self.clock.wait,
+        )
+        client.stop_calls.clear()
+        node.start_play('/perception/stale-error')
+        for _ in range(3):
+            node._on_chunk(_chunk('utt:a', b'A' * 3200))
+        self.assertTrue(client.first_finish_entered.wait(timeout=1))
+        old_drain = node._drain_thread
+        self.assertEqual(node.interrupt()['state'], 'ready')
+        stop_count_after_interrupt = len(client.stop_calls)
+
+        node._on_chunk(_chunk('utt:b', b'B' * 3200))
+        node._on_chunk(_chunk('utt:b', node.AUDIO_EOF_MAGIC))
+        self._wait_for(
+            lambda: len(client.stream_calls) == 2,
+            'new generation did not submit before stale response release',
+        )
+        client.first_finish_release.set()
+        old_drain.join(timeout=1)
+        self.assertFalse(old_drain.is_alive())
+        self._wait_for(
+            lambda: node._drain_thread is None,
+            'new-generation drain did not finish',
+        )
+
+        self.assertEqual(len(client.stop_calls), stop_count_after_interrupt)
+        terminals = {
+            receipt['utterance_id']: receipt['state']
+            for receipt in _receipts(node)
+            if receipt['state'] in ('completed', 'cancelled', 'error')
+        }
+        self.assertEqual(terminals['utt:a'], 'cancelled')
+        self.assertEqual(terminals['utt:b'], 'completed')
+
+    def test_interrupt_receipts_item_already_popped_from_queue(self):
+        handoff_queue = _BlockingGetQueue()
+        self.node._buf = handoff_queue
+        for _ in range(3):
+            self.node._on_chunk(_chunk('utt:handoff', b'H' * 3200))
+        self.assertTrue(handoff_queue.item_popped.wait(timeout=1))
+        interrupted_generation = self.node._generation
+        result_holder = {}
+
+        interrupt_thread = threading.Thread(
+            target=lambda: result_holder.setdefault('value', self.node.interrupt()),
+        )
+        interrupt_thread.start()
+        self._wait_for(
+            lambda: self.node._generation != interrupted_generation,
+            'interrupt did not advance the speaker generation',
+        )
+        handoff_queue.release_item.set()
+        interrupt_thread.join(timeout=1)
+
+        self.assertFalse(interrupt_thread.is_alive())
+        self.assertEqual(
+            result_holder['value']['cancelled_utterance_ids'], ['utt:handoff'],
+        )
+        terminals = [
+            receipt for receipt in _receipts(self.node)
+            if receipt['utterance_id'] == 'utt:handoff'
+            and receipt['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual([receipt['state'] for receipt in terminals], ['cancelled'])
+
+    def test_interrupt_does_not_let_old_drain_consume_new_generation(self):
+        client = _BlockingStopClient()
+        node = DEVICE._SpeakerNode(
+            client,
+            monotonic=self.clock.monotonic,
+            wall_time=self.clock.wall_time,
+            waiter=self.clock.wait,
+        )
+        client.stop_calls.clear()
+        client.stop_entered.clear()
+        node.start_play('/perception/generation-race')
+        waiting_queue = _GetWaitingQueue()
+        node._buf = waiting_queue
+        node._start_drain()
+        self.assertTrue(waiting_queue.get_waiting.wait(timeout=1))
+
+        client.block_stop = True
+        result_holder = {}
+        interrupt_thread = threading.Thread(
+            target=lambda: result_holder.setdefault('value', node.interrupt()),
+        )
+        interrupt_thread.start()
+        self.assertTrue(client.stop_entered.wait(timeout=1))
+
+        pcm = b'NEW-GENERATION'
+        node._on_chunk(_chunk('utt:new-generation', pcm))
+        node._on_chunk(_chunk('utt:new-generation', node.AUDIO_EOF_MAGIC))
+        client.stop_release.set()
+        interrupt_thread.join(timeout=1)
+        self.assertFalse(interrupt_thread.is_alive())
+        self.assertEqual(result_holder['value']['play_stop_code'], 0)
+        self._wait_for(
+            lambda: any(
+                receipt['utterance_id'] == 'utt:new-generation'
+                and receipt['state'] == 'completed'
+                for receipt in _receipts(node)
+            ),
+            'new-generation utterance was consumed by the old drain',
+        )
+        self._wait_for(
+            lambda: node._drain_thread is None,
+            'new-generation drain thread did not finish',
+        )
+
+        self.assertEqual([call[2] for call in client.stream_calls], [pcm])
+
+    def test_interrupt_before_queue_get_detaches_old_buffer(self):
+        gated_buffer = _PreGetGateQueue()
+        self.node._buf = gated_buffer
+        self.node._start_drain()
+        self.assertTrue(gated_buffer.before_get.wait(timeout=1))
+        old_drain = self.node._drain_thread
+
+        result = self.node.interrupt()
+        pcm = b'NEW-AFTER-PRE-GET'
+        self.node._on_chunk(_chunk('utt:after-pre-get', pcm))
+        self.node._on_chunk(self._eof('utt:after-pre-get'))
+        gated_buffer.release_get.set()
+
+        old_drain.join(timeout=1)
+        self.assertFalse(old_drain.is_alive())
+        self._wait_for(
+            lambda: any(
+                receipt['utterance_id'] == 'utt:after-pre-get'
+                and receipt['state'] == 'completed'
+                for receipt in _receipts(self.node)
+            ),
+            'old pre-get drain consumed the new generation buffer',
+        )
+        self._wait_for(
+            lambda: self.node._drain_thread is None,
+            'new-generation drain did not finish',
+        )
+
+        self.assertEqual(result['state'], 'ready')
+        self.assertEqual([call[2] for call in self.client.stream_calls], [pcm])
+
+    def test_back_to_back_utterances_have_one_terminal_each(self):
+        for utterance_id, byte in [('utt:a', b'A'), ('utt:b', b'B')]:
+            self.node._on_chunk(_chunk(utterance_id, byte * 3200))
+            self.node._on_chunk(self._eof(utterance_id))
+            self._join_drain()
+
+        terminals = [
+            (r['utterance_id'], r['state'])
+            for r in _receipts(self.node)
+            if r['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual(terminals, [('utt:a', 'completed'), ('utt:b', 'completed')])
+
+    def test_same_utterance_id_can_be_reused_after_restart(self):
+        self.node._on_chunk(_chunk('utt:1', b'FIRST'))
+        self.node._on_chunk(self._eof('utt:1'))
+        self._join_drain()
+        first_session = self.node._session_id
+        self.assertEqual(self.node.stop_play()['state'], 'idle')
+        self.node.start_play('/perception/tts')
+        second_session = self.node._session_id
+
+        self.node._on_chunk(_chunk('utt:1', b'SECOND'))
+        self.node._on_chunk(self._eof('utt:1'))
+        self._join_drain()
+
+        terminals = [
+            receipt for receipt in _receipts(self.node)
+            if receipt['utterance_id'] == 'utt:1'
+            and receipt['state'] == 'completed'
+        ]
+        self.assertEqual(len(terminals), 2)
+        self.assertNotEqual(first_session, second_session)
+        self.assertEqual(
+            {receipt['session_id'] for receipt in terminals},
+            {first_session, second_session},
+        )
+        self.assertEqual(
+            [call[2] for call in self.client.stream_calls], [b'FIRST', b'SECOND'],
+        )
+
+    def test_eof_tail_race_restarts_drain_for_next_utterance(self):
+        race_queue = _EmptyRaceQueue()
+        self.node._buf = race_queue
+        self.node._on_chunk(_chunk('utt:a', b'A' * 3200))
+        race_queue.arm()
+        self.node._on_chunk(self._eof('utt:a'))
+        self.assertTrue(race_queue.empty_observed.wait(timeout=1))
+
+        self.node._on_chunk(_chunk('utt:b', b'B' * 3200))
+        self.node._on_chunk(self._eof('utt:b'))
+        race_queue.release_empty.set()
+        self._wait_for(
+            lambda: any(
+                receipt['utterance_id'] == 'utt:b'
+                and receipt['state'] == 'completed'
+                for receipt in _receipts(self.node)
+            ),
+            'next utterance was stranded at the previous EOF boundary',
+        )
+        self._wait_for(
+            lambda: self.node._drain_thread is None,
+            'replacement drain thread did not finish',
+        )
+
+        terminals = [
+            (receipt['utterance_id'], receipt['state'])
+            for receipt in _receipts(self.node)
+            if receipt['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual(terminals, [('utt:a', 'completed'), ('utt:b', 'completed')])
+
+    def test_sdk_error_is_error_not_completed(self):
+        self.client.stream_code = 17
+        self.node._on_chunk(_chunk('utt:error', b'E' * 3200))
+        self.node._on_chunk(self._eof('utt:error'))
+        self._join_drain()
+
+        terminals = [
+            r for r in _receipts(self.node)
+            if r['utterance_id'] == 'utt:error'
+            and r['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual(len(terminals), 1)
+        self.assertEqual(terminals[0]['state'], 'error')
+        self.assertEqual(terminals[0]['reason'], 'play_stream_failed:17')
+
+    def test_stream_error_drops_remaining_blocks(self):
+        client = _SequenceStreamClient([17, 0])
+        node = DEVICE._SpeakerNode(
+            client,
+            monotonic=self.clock.monotonic,
+            wall_time=self.clock.wall_time,
+            waiter=self.clock.wait,
+        )
+        client.stop_calls.clear()
+        node.start_play('/perception/stream-error')
+        node.PREFILL = 100
+        for _ in range(6):
+            node._on_chunk(_chunk('utt:partial-failure', b'X' * 3200))
+        node._on_chunk(_chunk(
+            'utt:partial-failure', node.AUDIO_EOF_MAGIC,
+        ))
+        self._join_drain(node)
+
+        self.assertEqual(len(client.stream_calls), 1)
+        terminals = [
+            receipt for receipt in _receipts(node)
+            if receipt['utterance_id'] == 'utt:partial-failure'
+            and receipt['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual(len(terminals), 1)
+        self.assertEqual(terminals[0]['state'], 'error')
+        self.assertEqual(terminals[0]['reason'], 'play_stream_failed:17')
+
+    def test_play_stop_failure_fails_closed(self):
+        self.client.stop_code = 9
+        self.node._on_chunk(_chunk('utt:stop-failure', b'F' * 3200))
+
+        result = self.node.interrupt()
+        self.node._on_chunk(_chunk('utt:must-drop', b'DROP'))
+        self.node._on_chunk(self._eof('utt:must-drop'))
+
+        self.assertEqual(result['state'], 'error')
+        self.assertEqual(result['play_stop_code'], 9)
+        self.assertEqual(result['error'], 'play_stop_failed:9')
+        self.assertFalse(self.node._accept_chunks)
+        self.assertEqual(self.client.stream_calls, [])
+        terminal = [
+            receipt for receipt in _receipts(self.node)
+            if receipt['utterance_id'] == 'utt:stop-failure'
+            and receipt['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual(len(terminal), 1)
+        self.assertEqual(terminal[0]['state'], 'error')
+        self.assertEqual(terminal[0]['reason'], 'play_stop_failed:9')
+
+    def test_second_interrupt_cannot_fake_recovery_from_error(self):
+        self.client.stop_code = 9
+        self.node._on_chunk(_chunk('utt:failed-stop', b'F'))
+        self.assertEqual(self.node.interrupt()['state'], 'error')
+        stop_call_count = len(self.client.stop_calls)
+        self.client.stop_code = 0
+
+        retry = self.node.interrupt()
+
+        self.assertEqual(retry['state'], 'error')
+        self.assertEqual(retry['error'], 'speaker requires stop/start recovery')
+        self.assertEqual(len(self.client.stop_calls), stop_call_count)
+        self.assertFalse(self.node._accept_chunks)
+
+        self.assertEqual(self.node.stop_play()['state'], 'idle')
+        self.node.start_play('/perception/recovered')
+        self.node._on_chunk(_chunk('utt:recovered', b'OK'))
+        self.node._on_chunk(_chunk('utt:recovered', self.node.AUDIO_EOF_MAGIC))
+        self._join_drain()
+        self.assertEqual(self.client.stream_calls[-1][2], b'OK')
+
+    def test_pause_stop_failure_errors_pending_utterance(self):
+        self.client.stop_code = 13
+        self.node._on_chunk(_chunk('utt:pause-failure', b'F' * 3200))
+
+        result = self.node.pause()
+
+        self.assertEqual(result['state'], 'error')
+        self.assertEqual(result['play_stop_code'], 13)
+        self.assertEqual(result['error'], 'play_stop_failed:13')
+        self.assertFalse(self.node._accept_chunks)
+        self.assertTrue(self.node._buf.empty())
+        terminal = [
+            receipt for receipt in _receipts(self.node)
+            if receipt['utterance_id'] == 'utt:pause-failure'
+            and receipt['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual(len(terminal), 1)
+        self.assertEqual(terminal[0]['state'], 'error')
+        self.assertEqual(terminal[0]['reason'], 'play_stop_failed:13')
+
+    def test_resume_without_pending_audio_returns_ready(self):
+        self.assertEqual(self.node.pause()['state'], 'paused')
+
+        self.assertEqual(self.node.resume()['state'], 'ready')
+
+    def test_duplicate_eof_does_not_duplicate_terminal_receipt(self):
+        self.node._on_chunk(_chunk('utt:once', b'O' * 3200))
+        self.node._on_chunk(self._eof('utt:once'))
+        self._join_drain()
+        self.node._on_chunk(self._eof('utt:once'))
+        self._join_drain()
+
+        terminals = [
+            r for r in _receipts(self.node)
+            if r['utterance_id'] == 'utt:once'
+            and r['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual(len(terminals), 1)
+        self.assertEqual(terminals[0]['state'], 'completed')
+
+    def test_correlated_stream_without_eof_fails_closed(self):
+        self.node._on_chunk(_chunk('utt:no-eof', b'N' * 3200))
+        self.clock.value += 0.2
+        self.node.timers[-1].callback()
+        self._join_drain()
+
+        terminals = [
+            r for r in _receipts(self.node)
+            if r['utterance_id'] == 'utt:no-eof'
+            and r['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual(len(terminals), 1)
+        self.assertEqual(terminals[0]['state'], 'error')
+        self.assertEqual(terminals[0]['reason'], 'missing_eof')
+
+    def test_legacy_mute_watchdog_accepts_new_utterance_after_gap(self):
+        self.node._on_chunk(_chunk('', b'OLD' * 1000))
+        result = self.node.interrupt()
+        self.assertEqual(result['cancelled_utterance_ids'], ['legacy:1'])
+
+        self.node._on_chunk(_chunk('', b'LATE'))
+        self.clock.value += self.node.LEGACY_NEW_UTTERANCE_GAP_SEC + 0.01
+        pcm = b'NEW' * 1000
+        self.node._on_chunk(_chunk('', pcm))
+        self.node._on_chunk(self._eof(''))
+        self._join_drain()
+
+        self.assertEqual([call[2] for call in self.client.stream_calls], [pcm])
+        terminals = {
+            r['utterance_id']: r['state']
+            for r in _receipts(self.node)
+            if r['state'] in ('completed', 'cancelled', 'error')
+        }
+        self.assertEqual(terminals['legacy:1'], 'cancelled')
+        self.assertEqual(terminals['legacy:2'], 'completed')
+
+    def test_legacy_idle_completion_resets_id_after_lost_eof(self):
+        self.node._on_chunk(_chunk('', b'FIRST'))
+        self.clock.value += 0.2
+        self.node.timers[-1].callback()
+        self._join_drain()
+
+        self.node._on_chunk(_chunk('', b'SECOND'))
+        self.node._on_chunk(self._eof(''))
+        self._join_drain()
+
+        terminals = [
+            (receipt['utterance_id'], receipt['state'])
+            for receipt in _receipts(self.node)
+            if receipt['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual(
+            terminals, [('legacy:1', 'completed'), ('legacy:2', 'completed')],
+        )
+        self.assertEqual(
+            [call[2] for call in self.client.stream_calls], [b'FIRST', b'SECOND'],
+        )
+
+    def test_non_protocol_frame_id_is_treated_as_legacy(self):
+        self.node._on_chunk(_chunk('request-123', b'L' * 3200))
+        self.node._on_chunk(self._eof('request-123'))
+        self._join_drain()
+
+        utterance_ids = {receipt['utterance_id'] for receipt in _receipts(self.node)}
+        self.assertEqual(utterance_ids, {'legacy:1'})
+
+    def test_stop_drops_callback_racing_with_sdk_stop(self):
+        client = _BlockingStopClient()
+        node = DEVICE._SpeakerNode(
+            client,
+            monotonic=self.clock.monotonic,
+            wall_time=self.clock.wall_time,
+            waiter=self.clock.wait,
+        )
+        client.stop_calls.clear()
+        client.stop_entered.clear()
+        node.start_play('/perception/old')
+        client.block_stop = True
+        result_holder = {}
+        stop_thread = threading.Thread(
+            target=lambda: result_holder.setdefault('value', node.stop_play()),
+        )
+        stop_thread.start()
+        self.assertTrue(client.stop_entered.wait(timeout=1))
+
+        node._on_chunk(_chunk('utt:stale', b'STALE'))
+        node._on_chunk(_chunk('utt:stale', node.AUDIO_EOF_MAGIC))
+        client.stop_release.set()
+        stop_thread.join(timeout=1)
+
+        self.assertFalse(stop_thread.is_alive())
+        self.assertEqual(result_holder['value']['state'], 'idle')
+        self.assertTrue(node._buf.empty())
+
+        client.block_stop = False
+        node.start_play('/perception/new')
+        node._on_chunk(_chunk('utt:new', b'NEW'))
+        node._on_chunk(_chunk('utt:new', node.AUDIO_EOF_MAGIC))
+        self._join_drain(node)
+
+        self.assertEqual([call[2] for call in client.stream_calls], [b'NEW'])
+
+    def test_stop_and_start_are_lifecycle_serialized(self):
+        client = _BlockingStopClient()
+        node = DEVICE._SpeakerNode(client)
+        client.stop_calls.clear()
+        client.stop_entered.clear()
+        node.start_play('/perception/old')
+        client.block_stop = True
+        stop_result = {}
+        start_result = {}
+        stop_thread = threading.Thread(
+            target=lambda: stop_result.setdefault('value', node.stop_play()),
+        )
+        stop_thread.start()
+        self.assertTrue(client.stop_entered.wait(timeout=1))
+        start_thread = threading.Thread(
+            target=lambda: start_result.setdefault(
+                'value', node.start_play('/perception/new'),
+            ),
+        )
+        start_thread.start()
+        time.sleep(0.05)
+
+        self.assertTrue(start_thread.is_alive())
+        client.stop_release.set()
+        stop_thread.join(timeout=1)
+        start_thread.join(timeout=1)
+
+        self.assertFalse(stop_thread.is_alive())
+        self.assertFalse(start_thread.is_alive())
+        self.assertEqual(stop_result['value']['state'], 'idle')
+        self.assertEqual(start_result['value'], '/perception/new')
+        self.assertEqual(node.state, 'ready')
+        self.assertEqual(node._topic, '/perception/new')
+        self.assertEqual(node._sub.topic, '/perception/new')
+        self.assertTrue(node._accept_chunks)
+        self.assertIsNotNone(node._receipt_pub)
+
+    def test_pause_does_not_complete_until_resumed(self):
+        client = _AudioClient()
+        node = DEVICE._SpeakerNode(client)
+        client.stop_calls.clear()
+        client.stream_entered.clear()
+        node.start_play('/perception/pause')
+        pcm = b'P' * 9600
+        node._on_chunk(_chunk('utt:pause', pcm))
+        node._on_chunk(_chunk('utt:pause', node.AUDIO_EOF_MAGIC))
+        self.assertTrue(client.stream_entered.wait(timeout=1))
+
+        pause_result = node.pause()
+        time.sleep(0.08)
+
+        self.assertEqual(pause_result['state'], 'paused')
+        self.assertFalse(any(
+            receipt['utterance_id'] == 'utt:pause'
+            and receipt['state'] == 'completed'
+            for receipt in _receipts(node)
+        ))
+
+        self.assertEqual(node.resume()['state'], 'playing')
+        self._join_drain(node)
+        terminals = [
+            receipt['state'] for receipt in _receipts(node)
+            if receipt['utterance_id'] == 'utt:pause'
+            and receipt['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual(terminals, ['completed'])
+        self.assertEqual([call[2] for call in client.stream_calls], [pcm, pcm])
+
+    def test_pause_epoch_replays_block_when_finish_arrives_after_resume(self):
+        client = _DelayedFinishClient()
+        node = DEVICE._SpeakerNode(client)
+        client.stop_calls.clear()
+        node.start_play('/perception/pause-epoch')
+        pcm = b'E' * 9600
+        node._on_chunk(_chunk('utt:pause-epoch', pcm))
+        node._on_chunk(_chunk('utt:pause-epoch', node.AUDIO_EOF_MAGIC))
+        self.assertTrue(client.finish_entered.wait(timeout=1))
+
+        self.assertEqual(node.pause()['state'], 'paused')
+        self.assertEqual(node.resume()['state'], 'playing')
+        self.assertEqual(len(client.stream_calls), 1)
+        client.finish_release.set()
+        self._wait_for(
+            lambda: len(client.stream_calls) == 2,
+            'paused in-flight block was not replayed after resume',
+        )
+        self._wait_for(
+            lambda: node._drain_thread is None,
+            'pause-epoch drain did not finish',
+            timeout=2,
+        )
+
+        terminals = [
+            receipt['state'] for receipt in _receipts(node)
+            if receipt['utterance_id'] == 'utt:pause-epoch'
+            and receipt['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual(terminals, ['completed'])
+        self.assertEqual([call[2] for call in client.stream_calls], [pcm, pcm])
+
+    def test_pause_epoch_ignores_cancelled_stream_error_response(self):
+        client = _StaleErrorClient()
+        node = DEVICE._SpeakerNode(client)
+        client.stop_calls.clear()
+        node.start_play('/perception/pause-error-response')
+        pcm = b'C' * 9600
+        node._on_chunk(_chunk('utt:pause-cancelled-rpc', pcm))
+        node._on_chunk(_chunk(
+            'utt:pause-cancelled-rpc', node.AUDIO_EOF_MAGIC,
+        ))
+        self.assertTrue(client.first_finish_entered.wait(timeout=1))
+
+        self.assertEqual(node.pause()['state'], 'paused')
+        self.assertEqual(node.resume()['state'], 'playing')
+        client.first_finish_release.set()
+        self._wait_for(
+            lambda: len(client.stream_calls) == 2,
+            'cancelled stream response was not replayed after resume',
+        )
+        self._wait_for(
+            lambda: node._drain_thread is None,
+            'pause error-response drain did not finish',
+            timeout=2,
+        )
+
+        terminals = [
+            receipt['state'] for receipt in _receipts(node)
+            if receipt['utterance_id'] == 'utt:pause-cancelled-rpc'
+            and receipt['state'] in ('completed', 'cancelled', 'error')
+        ]
+        self.assertEqual(terminals, ['completed'])
+        self.assertEqual(len(client.stop_calls), 1)
+
+    def test_interrupt_invalidates_remaining_startup_sound(self):
+        client = _DelayedFinishClient()
+        executor = types.SimpleNamespace(add_node=lambda _node: None)
+        plugin = DEVICE.SpeakerPlugin({}, '', executor, client)
+        client.stop_calls.clear()
+        plugin._node._monotonic = self.clock.monotonic
+        plugin._node._waiter = self.clock.wait
+        result_holder = {}
+        start_thread = threading.Thread(
+            target=lambda: result_holder.setdefault(
+                'value', plugin.dispatch(
+                    'start', {'input_topic': '/perception/startup'},
+                ),
+            ),
+        )
+        start_thread.start()
+        self.assertTrue(client.finish_entered.wait(timeout=1))
+
+        interrupt_result = plugin._node.interrupt()
+        stream_count_at_interrupt = len(client.stream_calls)
+        client.finish_release.set()
+        start_thread.join(timeout=1)
+
+        self.assertFalse(start_thread.is_alive())
+        self.assertEqual(interrupt_result['state'], 'idle')
+        self.assertEqual(stream_count_at_interrupt, 1)
+        self.assertEqual(len(client.stream_calls), 1)
+        self.assertEqual(result_holder['value']['error'], 'startup_interrupted')
+        self.assertIsNone(plugin._node._sub)
+        self.assertIsNone(plugin._node._topic)
+
+    def test_stale_startup_exception_cannot_stop_new_generation(self):
+        client = _StaleExceptionClient()
+        executor = types.SimpleNamespace(add_node=lambda _node: None)
+        plugin = DEVICE.SpeakerPlugin({}, '', executor, client)
+        client.stop_calls.clear()
+        plugin._node._monotonic = self.clock.monotonic
+        plugin._node._waiter = self.clock.wait
+        result_holder = {}
+        start_thread = threading.Thread(
+            target=lambda: result_holder.setdefault(
+                'value', plugin.dispatch(
+                    'start', {'input_topic': '/perception/stale-startup'},
+                ),
+            ),
+        )
+        start_thread.start()
+        self.assertTrue(client.first_finish_entered.wait(timeout=1))
+
+        self.assertEqual(plugin._node.interrupt()['state'], 'idle')
+        stop_count_after_interrupt = len(client.stop_calls)
+        plugin._node.start_play('/perception/new-session')
+        pcm = b'NEW-SESSION'
+        plugin._node._on_chunk(_chunk('utt:new-session', pcm))
+        plugin._node._on_chunk(_chunk(
+            'utt:new-session', plugin._node.AUDIO_EOF_MAGIC,
+        ))
+        self._wait_for(
+            lambda: any(
+                receipt['utterance_id'] == 'utt:new-session'
+                and receipt['state'] == 'completed'
+                for receipt in _receipts(plugin._node)
+            ),
+            'new session did not complete while startup response was stale',
+        )
+
+        client.first_finish_release.set()
+        start_thread.join(timeout=1)
+
+        self.assertFalse(start_thread.is_alive())
+        self.assertEqual(result_holder['value']['error'], 'startup_interrupted')
+        self.assertEqual(len(client.stop_calls), stop_count_after_interrupt)
+        self.assertEqual([call[2] for call in client.stream_calls], [
+            mock.ANY, pcm,
+        ])
+
+    def test_info_advertises_receipt_capability(self):
+        executor = types.SimpleNamespace(add_node=lambda _node: None)
+        plugin = DEVICE.SpeakerPlugin({}, '', executor, _AudioClient())
+        plugin._node.start_play('/perception/tts')
+
+        info = plugin.dispatch('info', {})
+
+        self.assertEqual(info['speech_protocol'], 'audiochunk-frameid-v1')
+        self.assertEqual(info['receipt_topic'],
+                         '/perception/tts/speaker_receipts')
+        self.assertEqual(info['completion_basis'], 'driver_drained_estimated')
+        self.assertEqual(info['session_id'], plugin._node._session_id)
+        self.assertEqual(info['receipt_recovery'],
+                         'transient_local_then_info_poll')
+        self.assertEqual(info['topic_out'][0]['qos']['reliability'], 'reliable')
+
+
+class AudioClientWrapperTests(unittest.TestCase):
+    def _load_client(self):
+        class _Client:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+        packages = {
+            'unitree_sdk2py': _package('unitree_sdk2py'),
+            'unitree_sdk2py.g1': _package('unitree_sdk2py.g1'),
+            'unitree_sdk2py.g1.audio': _package('unitree_sdk2py.g1.audio'),
+        }
+        rpc = types.ModuleType('unitree_sdk2py.rpc.client')
+        rpc.Client = _Client
+        packages['unitree_sdk2py.rpc'] = _package('unitree_sdk2py.rpc')
+        packages['unitree_sdk2py.rpc.client'] = rpc
+        api = types.ModuleType('unitree_sdk2py.g1.audio.g1_audio_api')
+        api.AUDIO_SERVICE_NAME = 'audio'
+        api.AUDIO_API_VERSION = '1.0'
+        api.ROBOT_API_ID_AUDIO_TTS = 1001
+        api.ROBOT_API_ID_AUDIO_ASR = 1002
+        api.ROBOT_API_ID_AUDIO_START_PLAY = 1003
+        api.ROBOT_API_ID_AUDIO_STOP_PLAY = 1004
+        api.ROBOT_API_ID_AUDIO_GET_VOLUME = 1005
+        api.ROBOT_API_ID_AUDIO_SET_VOLUME = 1006
+        api.ROBOT_API_ID_AUDIO_SET_RGB_LED = 1007
+        packages['unitree_sdk2py.g1.audio.g1_audio_api'] = api
+
+        name = 'unitree_sdk2py.g1.audio.g1_audio_client_under_test'
+        spec = importlib.util.spec_from_file_location(
+            name, G1_DIR / 'unitree_sdk2py/g1/audio/g1_audio_client.py',
+        )
+        module = importlib.util.module_from_spec(spec)
+        with mock.patch.dict(sys.modules, packages):
+            spec.loader.exec_module(module)
+        return module.AudioClient()
+
+    def test_play_stop_returns_sdk_code(self):
+        client = self._load_client()
+        client._Call = lambda *_args, **_kwargs: (23, {'ignored': True})
+
+        self.assertEqual(client.PlayStop('g1_speaker'), 23)
+
+    def test_native_tts_uses_monotonic_request_indices(self):
+        client = self._load_client()
+        parameters = []
+
+        def call(_api_id, parameter):
+            parameters.append(json.loads(parameter))
+            return 0, {}
+
+        client._Call = call
+
+        self.assertEqual(client.TtsMaker('first', 0), 0)
+        self.assertEqual(client.TtsMaker('second', 1), 0)
+        self.assertEqual([parameter['index'] for parameter in parameters], [1, 2])
+
+    def test_async_audio_wrappers_forward_send_and_finish_timeouts(self):
+        client = self._load_client()
+        calls = []
+        client._CallRequestWithParamAndBinStart = (
+            lambda *args: calls.append(('stream_start', args)) or (0, 'stream')
+        )
+        client._CallRequestWithParamAndBinFinish = (
+            lambda *args: calls.append(('stream_finish', args)) or (0, {})
+        )
+        client._CallStart = (
+            lambda *args: calls.append(('stop_start', args)) or (0, 'stop')
+        )
+        client._CallFinish = (
+            lambda *args: calls.append(('stop_finish', args)) or (0, {})
+        )
+
+        self.assertEqual(
+            client.PlayStreamStart('speaker', '0', b'PCM', send_timeout=0.025),
+            (0, 'stream'),
+        )
+        self.assertEqual(client.PlayStreamFinish('stream', timeout=0.5), (0, {}))
+        self.assertEqual(
+            client.PlayStopStart('speaker', send_timeout=0.03), (0, 'stop'),
+        )
+        self.assertEqual(client.PlayStopFinish('stop', timeout=0.4), 0)
+
+        self.assertEqual(calls[0][1][-1], 0.025)
+        self.assertEqual(calls[1][1], ('stream', 0.5))
+        self.assertEqual(calls[2][1][-1], 0.03)
+        self.assertEqual(calls[3][1], ('stop', 0.4))
+
+
+class ClientForwardingTests(unittest.TestCase):
+    def _load_client(self):
+        class _ClientBase:
+            def __init__(self, _service_name):
+                self.base_calls = []
+
+            def _CallStartBase(self, *args):
+                self.base_calls.append(('parameter', args))
+                return 0, 'parameter-pending'
+
+            def _CallRequestWithParamAndBinStartBase(self, *args):
+                self.base_calls.append(('binary', args))
+                return 0, 'binary-pending'
+
+        packages = {
+            'unitree_sdk2py': _package('unitree_sdk2py'),
+            'unitree_sdk2py.rpc': _package('unitree_sdk2py.rpc'),
+        }
+        client_base = types.ModuleType('unitree_sdk2py.rpc.client_base')
+        client_base.ClientBase = _ClientBase
+        packages[client_base.__name__] = client_base
+        lease_client = types.ModuleType('unitree_sdk2py.rpc.lease_client')
+        lease_client.LeaseClient = object
+        packages[lease_client.__name__] = lease_client
+        internal = types.ModuleType('unitree_sdk2py.rpc.internal')
+        internal.RPC_INTERNAL_API_ID_MAX = 100
+        internal.RPC_ERR_CLIENT_API_NOT_REG = -1
+        packages[internal.__name__] = internal
+
+        name = 'unitree_sdk2py.rpc.client_under_test'
+        spec = importlib.util.spec_from_file_location(
+            name, G1_DIR / 'unitree_sdk2py/rpc/client.py',
+        )
+        module = importlib.util.module_from_spec(spec)
+        with mock.patch.dict(sys.modules, packages):
+            spec.loader.exec_module(module)
+        return module.Client('audio')
+
+    def test_client_forwards_optional_send_timeout_to_both_start_paths(self):
+        client = self._load_client()
+        client._RegistApi(1003, 7)
+        client._RegistApi(1004, 9)
+
+        self.assertEqual(
+            client._CallStart(1004, '{}', send_timeout=0.03),
+            (0, 'parameter-pending'),
+        )
+        self.assertEqual(
+            client._CallRequestWithParamAndBinStart(
+                1003, '{}', [1, 2], send_timeout=0.025,
+            ),
+            (0, 'binary-pending'),
+        )
+
+        self.assertEqual(
+            client.base_calls,
+            [
+                ('parameter', (1004, '{}', 9, 0, 0.03)),
+                ('binary', (1003, '{}', [1, 2], 7, 0, 0.025)),
+            ],
+        )
+
+
+class _RpcFutureResult:
+    FUTURE_SUCC = 0
+    FUTUTE_ERR_TIMEOUT = 1
+
+
+class _RpcFuture:
+    def __init__(self, result):
+        self.result = result
+        self.timeouts = []
+
+    def GetResult(self, timeout):
+        self.timeouts.append(timeout)
+        return self.result
+
+
+class _RpcClientStub:
+    def __init__(self, _service_name):
+        self.future = None
+        self.requests = []
+        self.removed = []
+
+    def Init(self):
+        pass
+
+    def SendRequest(self, request, timeout):
+        self.requests.append((request, timeout))
+        return self.future
+
+    def RemoveFuture(self, request_id):
+        self.removed.append(request_id)
+
+
+class ClientBaseAsyncTests(unittest.TestCase):
+    SEND_ERROR = -101
+    TIMEOUT_ERROR = -102
+    API_MISMATCH_ERROR = -103
+
+    def _load_client_base(self):
+        class _Identity:
+            def __init__(self, request_id, api_id):
+                self.id = request_id
+                self.api_id = api_id
+
+        class _Lease:
+            def __init__(self, lease_id):
+                self.id = lease_id
+
+        class _Policy:
+            def __init__(self, priority, no_reply):
+                self.priority = priority
+                self.no_reply = no_reply
+
+        class _Header:
+            def __init__(self, identity, lease, policy):
+                self.identity = identity
+                self.lease = lease
+                self.policy = policy
+
+        class _Request:
+            def __init__(self, header, parameter, binary):
+                self.header = header
+                self.parameter = parameter
+                self.binary = binary
+
+        packages = {
+            'unitree_sdk2py': _package('unitree_sdk2py'),
+            'unitree_sdk2py.rpc': _package('unitree_sdk2py.rpc'),
+            'unitree_sdk2py.idl': _package('unitree_sdk2py.idl'),
+            'unitree_sdk2py.idl.unitree_api': _package(
+                'unitree_sdk2py.idl.unitree_api',
+            ),
+            'unitree_sdk2py.idl.unitree_api.msg': _package(
+                'unitree_sdk2py.idl.unitree_api.msg',
+            ),
+            'unitree_sdk2py.utils': _package('unitree_sdk2py.utils'),
+        }
+        dds = types.ModuleType('unitree_sdk2py.idl.unitree_api.msg.dds_')
+        dds.Request_ = _Request
+        dds.RequestHeader_ = _Header
+        dds.RequestLease_ = _Lease
+        dds.RequestIdentity_ = _Identity
+        dds.RequestPolicy_ = _Policy
+        packages[dds.__name__] = dds
+        future = types.ModuleType('unitree_sdk2py.utils.future')
+        future.FutureResult = _RpcFutureResult
+        packages[future.__name__] = future
+        client_stub = types.ModuleType('unitree_sdk2py.rpc.client_stub')
+        client_stub.ClientStub = _RpcClientStub
+        packages[client_stub.__name__] = client_stub
+        internal = types.ModuleType('unitree_sdk2py.rpc.internal')
+        internal.RPC_ERR_CLIENT_SEND = self.SEND_ERROR
+        internal.RPC_ERR_CLIENT_API_TIMEOUT = self.TIMEOUT_ERROR
+        internal.RPC_ERR_UNKNOWN = -104
+        internal.RPC_ERR_CLIENT_API_NOT_MATCH = self.API_MISMATCH_ERROR
+        packages[internal.__name__] = internal
+
+        name = 'unitree_sdk2py.rpc.client_base_under_test'
+        spec = importlib.util.spec_from_file_location(
+            name, G1_DIR / 'unitree_sdk2py/rpc/client_base.py',
+        )
+        module = importlib.util.module_from_spec(spec)
+        with mock.patch.dict(sys.modules, packages):
+            spec.loader.exec_module(module)
+        client = module.ClientBase('audio')
+        stub = client._ClientBase__stub
+        return client, stub
+
+    @staticmethod
+    def _response(api_id, status=0, data='ok'):
+        return types.SimpleNamespace(
+            header=types.SimpleNamespace(
+                identity=types.SimpleNamespace(api_id=api_id),
+                status=types.SimpleNamespace(code=status),
+            ),
+            data=data,
+        )
+
+    def test_binary_rpc_start_returns_before_finish_waits(self):
+        client, stub = self._load_client_base()
+        client.SetTimeout(10.0)
+        future = _RpcFuture(types.SimpleNamespace(
+            code=_RpcFutureResult.FUTURE_SUCC,
+            value=self._response(1003, status=7, data='accepted'),
+        ))
+        stub.future = future
+
+        code, pending = client._CallRequestWithParamAndBinStartBase(
+            1003, '{"app_name":"g1_speaker"}', [1, 2, 3],
+            send_timeout=0.025,
+        )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(future.timeouts, [])
+        self.assertEqual(stub.requests[0][1], 0.025)
+        self.assertEqual(stub.requests[0][0].binary, [1, 2, 3])
+        self.assertEqual(
+            client._CallRequestWithParamAndBinFinishBase(pending),
+            (7, 'accepted'),
+        )
+        self.assertEqual(future.timeouts, [10.0])
+
+    def test_parameter_rpc_start_send_timeout_is_optional_and_compatible(self):
+        client, stub = self._load_client_base()
+        client.SetTimeout(10.0)
+        stub.future = _RpcFuture(types.SimpleNamespace(
+            code=_RpcFutureResult.FUTURE_SUCC,
+            value=self._response(1004),
+        ))
+
+        self.assertEqual(client._CallStartBase(
+            1004, '{}', send_timeout=0.04,
+        )[0], 0)
+        self.assertEqual(stub.requests[-1][1], 0.04)
+        self.assertEqual(client._CallStartBase(1004, '{}')[0], 0)
+        self.assertEqual(stub.requests[-1][1], 10.0)
+
+    def test_control_rpc_finish_uses_short_timeout_and_removes_future(self):
+        client, stub = self._load_client_base()
+        future = _RpcFuture(types.SimpleNamespace(
+            code=_RpcFutureResult.FUTUTE_ERR_TIMEOUT,
+            value=None,
+        ))
+        stub.future = future
+        code, pending = client._CallStartBase(1004, '{}')
+        request_id = pending[1]
+
+        result = client._CallFinishBase(pending, timeout=0.25)
+
+        self.assertEqual(code, 0)
+        self.assertEqual(result, (self.TIMEOUT_ERROR, None))
+        self.assertEqual(future.timeouts, [0.25])
+        self.assertEqual(stub.removed, [request_id])
+
+    def test_binary_finish_timeout_removes_future(self):
+        client, stub = self._load_client_base()
+        future = _RpcFuture(types.SimpleNamespace(
+            code=_RpcFutureResult.FUTUTE_ERR_TIMEOUT,
+            value=None,
+        ))
+        stub.future = future
+        code, pending = client._CallRequestWithParamAndBinStartBase(
+            1003, '{}', [], send_timeout=0.02,
+        )
+        request_id = pending[1]
+
+        result = client._CallRequestWithParamAndBinFinishBase(
+            pending, timeout=0.5,
+        )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(result, (self.TIMEOUT_ERROR, None))
+        self.assertEqual(future.timeouts, [0.5])
+        self.assertEqual(stub.removed, [request_id])
+
+    def test_async_finish_rejects_mismatched_response_api(self):
+        client, stub = self._load_client_base()
+        stub.future = _RpcFuture(types.SimpleNamespace(
+            code=_RpcFutureResult.FUTURE_SUCC,
+            value=self._response(9999),
+        ))
+        code, pending = client._CallStartBase(1004, '{}')
+
+        self.assertEqual(code, 0)
+        self.assertEqual(
+            client._CallFinishBase(pending),
+            (self.API_MISMATCH_ERROR, None),
+        )
+
+    def test_async_start_propagates_send_failure(self):
+        client, _stub = self._load_client_base()
+
+        self.assertEqual(
+            client._CallRequestWithParamAndBinStartBase(1003, '{}', []),
+            (self.SEND_ERROR, None),
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unitree/g1/tests/test_speaker_lifecycle.py
+++ b/unitree/g1/tests/test_speaker_lifecycle.py
@@ -564,6 +564,23 @@ class SpeakerLifecycleTests(unittest.TestCase):
             time.sleep(0.001)
         self.fail(message)
 
+    def _speaker_plugin(self, node=None):
+        plugin = object.__new__(DEVICE.SpeakerPlugin)
+        plugin._node = node or self.node
+        return plugin
+
+    def _observe_receipt_wait(self, node=None):
+        node = node or self.node
+        wait_entered = threading.Event()
+        original_wait = node._receipt_cv.wait
+
+        def observed_wait(timeout=None):
+            wait_entered.set()
+            return original_wait(timeout=timeout)
+
+        node._receipt_cv.wait = observed_wait
+        return wait_entered
+
     def test_eof_forces_short_utterance_drain(self):
         pcm = b'\x11\x22' * 1600
         self.node._on_chunk(_chunk('utt:short', pcm))
@@ -1757,6 +1774,277 @@ class SpeakerLifecycleTests(unittest.TestCase):
         self.assertEqual(info['receipt_recovery'],
                          'transient_local_then_info_poll')
         self.assertEqual(info['topic_out'][0]['qos']['reliability'], 'reliable')
+
+    def test_wait_playback_blocks_until_matching_completion(self):
+        plugin = self._speaker_plugin()
+        session_id = self.node._session_id
+        utterance_id = 'utt:wait-completed'
+        wait_entered = self._observe_receipt_wait()
+        result_holder = {}
+
+        def wait_for_terminal():
+            result_holder['value'] = plugin.dispatch('wait_playback', {
+                'session_id': session_id,
+                'utterance_id': utterance_id,
+                'timeout_sec': 1,
+            })
+
+        wait_thread = threading.Thread(target=wait_for_terminal)
+        wait_thread.start()
+        self.assertTrue(wait_entered.wait(timeout=1))
+        self.assertTrue(wait_thread.is_alive())
+
+        pcm = b'W' * 3200
+        self.node._on_chunk(_chunk(utterance_id, pcm))
+        self.node._on_chunk(self._eof(utterance_id))
+        self._join_drain()
+        wait_thread.join(timeout=1)
+
+        self.assertFalse(wait_thread.is_alive())
+        result = result_holder['value']
+        self.assertEqual(result['state'], 'completed')
+        self.assertTrue(result['terminal'])
+        self.assertEqual(result['session_id'], session_id)
+        self.assertEqual(result['utterance_id'], utterance_id)
+        self.assertEqual(result['completion_basis'],
+                         'driver_drained_estimated')
+        self.assertEqual(result['audio_bytes'], len(pcm))
+
+    def test_wait_playback_returns_terminal_history_immediately(self):
+        plugin = self._speaker_plugin()
+        session_id = self.node._session_id
+        utterance_id = 'utt:history'
+        pcm = b'HISTORY'
+        self.node._on_chunk(_chunk(utterance_id, pcm))
+        self.node._on_chunk(self._eof(utterance_id))
+        self._join_drain()
+
+        result = plugin.dispatch('wait_playback', {
+            'session_id': session_id,
+            'utterance_id': utterance_id,
+            'timeout_sec': 0,
+        })
+
+        terminal = self.node._terminal_ids[(session_id, utterance_id)]
+        self.assertEqual(
+            {key: result[key] for key in terminal}, terminal,
+        )
+        self.assertTrue(result['terminal'])
+
+    def test_wait_playback_started_and_unseen_time_out_without_terminal(self):
+        plugin = self._speaker_plugin()
+        session_id = self.node._session_id
+        started_id = 'utt:started-only'
+        unseen_id = 'utt:unseen'
+        self.node._emit_receipt(started_id, 'started')
+
+        started = plugin.dispatch('wait_playback', {
+            'session_id': session_id,
+            'utterance_id': started_id,
+            'timeout_sec': 0,
+        })
+        unseen = plugin.dispatch('wait_playback', {
+            'session_id': session_id,
+            'utterance_id': unseen_id,
+            'timeout_sec': 0,
+        })
+
+        self.assertEqual(started['state'], 'timeout')
+        self.assertFalse(started['terminal'])
+        self.assertEqual(started['reason'], 'playback_not_terminal')
+        self.assertTrue(started['retryable'])
+        self.assertEqual(unseen['state'], 'unknown')
+        self.assertFalse(unseen['terminal'])
+        self.assertEqual(
+            unseen['reason'], 'utterance_not_observed_before_timeout',
+        )
+        self.assertTrue(unseen['retryable'])
+        self.assertNotIn((session_id, started_id), self.node._terminal_ids)
+        self.assertNotIn((session_id, unseen_id), self.node._terminal_ids)
+
+    def test_wait_playback_returns_cancelled_after_interrupt(self):
+        plugin = self._speaker_plugin()
+        session_id = self.node._session_id
+        utterance_id = 'utt:wait-interrupt'
+        self.node._on_chunk(_chunk(utterance_id, b'I' * 3200))
+        wait_entered = self._observe_receipt_wait()
+        result_holder = {}
+        wait_thread = threading.Thread(
+            target=lambda: result_holder.setdefault(
+                'value', plugin.dispatch('wait_playback', {
+                    'session_id': session_id,
+                    'utterance_id': utterance_id,
+                    'timeout_sec': 1,
+                }),
+            ),
+        )
+        wait_thread.start()
+        self.assertTrue(wait_entered.wait(timeout=1))
+        self.assertTrue(wait_thread.is_alive())
+
+        interrupt_result = self.node.interrupt()
+        wait_thread.join(timeout=1)
+
+        self.assertFalse(wait_thread.is_alive())
+        self.assertEqual(
+            interrupt_result['cancelled_utterance_ids'], [utterance_id],
+        )
+        result = result_holder['value']
+        self.assertEqual(result['state'], 'cancelled')
+        self.assertTrue(result['terminal'])
+        self.assertEqual(result['reason'], 'interrupted')
+        self.assertEqual(result['completion_basis'], 'driver_control')
+        self.assertEqual(result['session_id'], session_id)
+        self.assertEqual(result['utterance_id'], utterance_id)
+
+    def test_wait_playback_returns_recorded_playback_error(self):
+        plugin = self._speaker_plugin()
+        session_id = self.node._session_id
+        utterance_id = 'utt:wait-error'
+        self.client.stream_code = 17
+        self.node._on_chunk(_chunk(utterance_id, b'E' * 3200))
+        self.node._on_chunk(self._eof(utterance_id))
+        self._join_drain()
+
+        result = plugin.dispatch('wait_playback', {
+            'session_id': session_id,
+            'utterance_id': utterance_id,
+            'timeout_sec': 0,
+        })
+
+        self.assertEqual(result['state'], 'error')
+        self.assertTrue(result['terminal'])
+        self.assertEqual(result['reason'], 'play_stream_failed:17')
+        self.assertEqual(result['session_id'], session_id)
+        self.assertEqual(result['utterance_id'], utterance_id)
+
+    def test_wait_playback_validates_identity_timeout_and_session(self):
+        plugin = self._speaker_plugin()
+        session_id = self.node._session_id
+        valid_identity = {
+            'session_id': session_id,
+            'utterance_id': 'utt:validation',
+        }
+        cases = [
+            ({}, 'missing_session_id'),
+            ({'session_id': 'not-a-session'}, 'invalid_session_id'),
+            ({'session_id': 'speaker:'}, 'invalid_session_id'),
+            ({'session_id': session_id}, 'missing_utterance_id'),
+            ({
+                'session_id': session_id,
+                'utterance_id': 'utt:',
+            }, 'invalid_utterance_id'),
+            ({**valid_identity, 'timeout_sec': True}, 'invalid_timeout_sec'),
+            ({**valid_identity, 'timeout_sec': 'later'},
+             'invalid_timeout_sec'),
+            ({**valid_identity, 'timeout_sec': -0.1},
+             'timeout_out_of_range'),
+            ({
+                **valid_identity,
+                'timeout_sec': self.node.MAX_PLAYBACK_WAIT_SEC + 0.1,
+            }, 'timeout_out_of_range'),
+        ]
+
+        for args, expected_error in cases:
+            with self.subTest(error=expected_error, args=args):
+                result = plugin.dispatch('wait_playback', args)
+                self.assertEqual(result['state'], 'error')
+                self.assertFalse(result['terminal'])
+                self.assertEqual(result['error'], expected_error)
+
+        mismatch = plugin.dispatch('wait_playback', {
+            'session_id': 'speaker:not-current',
+            'utterance_id': 'utt:validation',
+            'timeout_sec': 0,
+        })
+        self.assertEqual(mismatch['state'], 'error')
+        self.assertFalse(mismatch['terminal'])
+        self.assertEqual(mismatch['error'], 'session_mismatch')
+        self.assertEqual(mismatch['active_session_id'], session_id)
+        self.assertFalse(mismatch['retryable'])
+
+    def test_wait_playback_old_history_wins_without_crossing_sessions(self):
+        plugin = self._speaker_plugin()
+        utterance_id = 'utt:reused-wait-id'
+        old_session_id = self.node._session_id
+        self.node._on_chunk(_chunk(utterance_id, b'OLD'))
+        self.node._on_chunk(self._eof(utterance_id))
+        self._join_drain()
+        self.assertEqual(self.node.stop_play()['state'], 'idle')
+        self.node.start_play('/perception/new-wait-session')
+        new_session_id = self.node._session_id
+
+        old_result = plugin.dispatch('wait_playback', {
+            'session_id': old_session_id,
+            'utterance_id': utterance_id,
+            'timeout_sec': 0,
+        })
+        before_new_audio = plugin.dispatch('wait_playback', {
+            'session_id': new_session_id,
+            'utterance_id': utterance_id,
+            'timeout_sec': 0,
+        })
+
+        self.assertEqual(old_result['state'], 'completed')
+        self.assertTrue(old_result['terminal'])
+        self.assertEqual(old_result['session_id'], old_session_id)
+        self.assertEqual(before_new_audio['state'], 'unknown')
+        self.assertFalse(before_new_audio['terminal'])
+        self.assertEqual(before_new_audio['session_id'], new_session_id)
+
+        self.node._on_chunk(_chunk(utterance_id, b'NEW'))
+        self.node._on_chunk(self._eof(utterance_id))
+        self._join_drain()
+        new_result = plugin.dispatch('wait_playback', {
+            'session_id': new_session_id,
+            'utterance_id': utterance_id,
+            'timeout_sec': 0,
+        })
+
+        self.assertEqual(new_result['state'], 'completed')
+        self.assertTrue(new_result['terminal'])
+        self.assertEqual(new_result['session_id'], new_session_id)
+        self.assertNotEqual(old_session_id, new_session_id)
+        self.assertEqual(
+            [call[2] for call in self.client.stream_calls], [b'OLD', b'NEW'],
+        )
+
+    def test_speaker_tool_advertises_and_dispatches_wait_playback(self):
+        plugin = self._speaker_plugin()
+        tool = plugin.get_tool()
+        schema = tool['inputSchema']
+        properties = schema['properties']
+
+        self.assertIn('wait_playback', properties['action']['enum'])
+        self.assertEqual(properties['session_id']['type'], 'string')
+        self.assertEqual(properties['session_id']['pattern'], '^speaker:.+')
+        self.assertEqual(properties['utterance_id']['type'], 'string')
+        self.assertEqual(properties['utterance_id']['pattern'], '^utt:.+')
+        self.assertEqual(properties['timeout_sec']['minimum'], 0)
+        self.assertEqual(
+            properties['timeout_sec']['maximum'],
+            self.node.MAX_PLAYBACK_WAIT_SEC,
+        )
+        self.assertEqual(
+            properties['timeout_sec']['default'],
+            self.node.DEFAULT_PLAYBACK_WAIT_SEC,
+        )
+
+        result = plugin.dispatch('wait_playback', {
+            'session_id': self.node._session_id,
+            'utterance_id': 'utt:schema-dispatch',
+            'timeout_sec': 0,
+        })
+        info = plugin.dispatch('info', {})
+
+        self.assertEqual(result['state'], 'unknown')
+        self.assertFalse(result['terminal'])
+        self.assertEqual(info['playback_wait'], {
+            'action': 'wait_playback',
+            'identity': ['session_id', 'utterance_id'],
+            'default_timeout_sec': self.node.DEFAULT_PLAYBACK_WAIT_SEC,
+            'max_timeout_sec': self.node.MAX_PLAYBACK_WAIT_SEC,
+        })
 
     def test_native_tts_speak_can_be_hidden_for_strict_speaker_ownership(self):
         plugin = DEVICE.NativeTtsPlugin(

--- a/unitree/g1/tools/g1_speaker_receipt_smoke.py
+++ b/unitree/g1/tools/g1_speaker_receipt_smoke.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Manual G1 hardware smoke for correlated Speaker playback receipts.
+
+Run this only in a dedicated test deployment. It replaces the Speaker input
+topic, plays the normal startup beep, streams near-silent PCM through the real
+body-speaker service, validates the hardware-state receipt, and stops Speaker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.request
+import uuid
+
+import rclpy
+from audio_msgs.msg import AudioChunk
+from rclpy.node import Node
+from rclpy.qos import (
+    DurabilityPolicy,
+    HistoryPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+from std_msgs.msg import String
+
+
+AUDIO_EOF_MAGIC = b'\x01\x00\xff\xff\x01\x00\xff\xff'
+PCM_BLOCK = b'\x01\x00\xff\xff' * 2400  # 9600 bytes, samples +1/-1
+TERMINAL_STATES = {'completed', 'cancelled', 'error'}
+
+INPUT_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=200,
+    durability=DurabilityPolicy.VOLATILE,
+)
+RECEIPT_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=50,
+    durability=DurabilityPolicy.TRANSIENT_LOCAL,
+)
+
+
+def _speaker_call(url: str, action: str, *, timeout: float, **arguments) -> dict:
+    request_body = {
+        'jsonrpc': '2.0',
+        'id': str(uuid.uuid4()),
+        'method': 'tools/call',
+        'params': {
+            'name': 'speaker',
+            'arguments': {'action': action, **arguments},
+        },
+    }
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(request_body).encode(),
+        headers={'Content-Type': 'application/json'},
+        method='POST',
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        rpc = json.loads(response.read().decode())
+    if 'error' in rpc:
+        raise RuntimeError(f'MCP speaker {action} failed: {rpc["error"]}')
+    content = rpc.get('result', {}).get('content', [])
+    if not content or content[0].get('type') != 'text':
+        raise RuntimeError(f'MCP speaker {action} returned invalid content: {rpc}')
+    result = json.loads(content[0].get('text', '{}'))
+    if not isinstance(result, dict):
+        raise RuntimeError(f'MCP speaker {action} returned non-object: {result!r}')
+    return result
+
+
+class _SmokeNode(Node):
+    def __init__(self, input_topic: str):
+        super().__init__('g1_speaker_receipt_smoke')
+        self.input_topic = input_topic.rstrip('/')
+        self.receipt_topic = f'{self.input_topic}/speaker_receipts'
+        self.receipts: list[dict] = []
+        self.publisher = self.create_publisher(
+            AudioChunk, self.input_topic, INPUT_QOS,
+        )
+        self.subscription = self.create_subscription(
+            String, self.receipt_topic, self._on_receipt, RECEIPT_QOS,
+        )
+
+    def _on_receipt(self, msg: String) -> None:
+        try:
+            receipt = json.loads(msg.data)
+        except (TypeError, json.JSONDecodeError):
+            return
+        if isinstance(receipt, dict):
+            self.receipts.append(receipt)
+
+    def spin_for(self, seconds: float) -> None:
+        deadline = time.monotonic() + max(0.0, seconds)
+        while time.monotonic() < deadline:
+            rclpy.spin_once(
+                self,
+                timeout_sec=min(0.05, max(0.0, deadline - time.monotonic())),
+            )
+
+    def wait_for_graph(self, timeout: float) -> dict | None:
+        """Wait until both smoke directions are matched before publishing PCM."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            counts = {
+                'speaker_input_subscriptions': (
+                    self.publisher.get_subscription_count()
+                ),
+                'receipt_publishers': self.subscription.get_publisher_count(),
+            }
+            if all(count > 0 for count in counts.values()):
+                return counts
+            rclpy.spin_once(
+                self,
+                timeout_sec=min(0.05, max(0.0, deadline - time.monotonic())),
+            )
+        return None
+
+    def publish(self, utterance_id: str, payload: bytes) -> None:
+        msg = AudioChunk()
+        msg.header.frame_id = utterance_id
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.format = 'audio/pcm-16k'
+        msg.data = list(payload)
+        self.publisher.publish(msg)
+
+    def wait_for_terminal(self, session_id: str, utterance_id: str,
+                          timeout: float) -> dict | None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            for receipt in self.receipts:
+                if (receipt.get('session_id') == session_id
+                        and receipt.get('utterance_id') == utterance_id
+                        and receipt.get('state') in TERMINAL_STATES):
+                    return receipt
+            rclpy.spin_once(
+                self,
+                timeout_sec=min(0.05, max(0.0, deadline - time.monotonic())),
+            )
+        return None
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--confirm-exclusive-hardware', action='store_true',
+        help='confirm this is a dedicated test deployment and Speaker may be stopped',
+    )
+    parser.add_argument(
+        '--mcp-url', default='http://127.0.0.1:15701/mcp',
+    )
+    parser.add_argument(
+        '--input-topic', default='/g1/reviewer/speaker_receipt_smoke',
+    )
+    parser.add_argument(
+        '--timeout', type=float, default=10.0,
+        help='seconds to wait for the terminal receipt',
+    )
+    parser.add_argument(
+        '--start-timeout', type=float, default=30.0,
+        help='MCP start timeout; includes DDS discovery and the startup sound',
+    )
+    parser.add_argument(
+        '--cleanup-timeout', type=float, default=30.0,
+        help='MCP stop timeout used after every attempted start',
+    )
+    parser.add_argument(
+        '--discovery-timeout', type=float, default=10.0,
+        help='seconds to wait for ROS input and receipt graph matches',
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    if not args.confirm_exclusive_hardware:
+        print(
+            'Refusing to run without --confirm-exclusive-hardware; '
+            'the smoke replaces and then stops the active Speaker session.',
+            file=sys.stderr,
+        )
+        return 2
+
+    utterance_id = f'utt:hardware-smoke-{uuid.uuid4()}'
+    node = None
+    speaker_start_attempted = False
+    evidence = None
+    primary_error = None
+    cleanup_error = None
+    cleanup_result = None
+    rclpy.init(args=None)
+    try:
+        node = _SmokeNode(args.input_topic)
+        node.spin_for(0.5)
+        # Mark the attempt before the RPC. A timed-out client request can still
+        # leave a server-side start handler running, so cleanup is mandatory
+        # even when start never returned a response.
+        speaker_start_attempted = True
+        start = _speaker_call(
+            args.mcp_url, 'start', timeout=args.start_timeout,
+            input_topic=node.input_topic,
+        )
+        if start.get('state') != 'ready':
+            raise RuntimeError(f'speaker did not become ready: {start}')
+        if start.get('completion_mode') != 'hardware_state':
+            raise RuntimeError(f'speaker is not in hardware_state mode: {start}')
+        play_state = start.get('play_state') or {}
+        if not play_state.get('ready') or play_state.get('matched_publishers', 0) < 1:
+            raise RuntimeError(f'play-state publisher is not ready: {play_state}')
+        session_id = start.get('session_id', '')
+        if not session_id:
+            raise RuntimeError(f'speaker returned no session_id: {start}')
+        graph = node.wait_for_graph(args.discovery_timeout)
+        if graph is None:
+            raise RuntimeError(
+                'ROS graph did not match both Speaker input and receipt paths '
+                f'within {args.discovery_timeout}s'
+            )
+        # Stream 1.5 seconds of effectively inaudible PCM. Non-zero samples
+        # avoid firmware silence suppression.
+        for _ in range(5):
+            node.publish(utterance_id, PCM_BLOCK)
+            node.spin_for(0.3)
+        node.publish(utterance_id, AUDIO_EOF_MAGIC)
+
+        terminal = node.wait_for_terminal(
+            session_id, utterance_id, args.timeout,
+        )
+        if terminal is None:
+            info = _speaker_call(args.mcp_url, 'info', timeout=args.timeout)
+            raise RuntimeError(
+                f'no terminal receipt within {args.timeout}s; speaker info={info}'
+            )
+        if terminal.get('state') != 'completed':
+            raise RuntimeError(f'non-success terminal receipt: {terminal}')
+        if terminal.get('completion_basis') != 'g1_play_state_observed':
+            raise RuntimeError(f'non-hardware completion basis: {terminal}')
+        if terminal.get('audio_bytes') != 5 * len(PCM_BLOCK):
+            raise RuntimeError(f'unexpected audio byte count: {terminal}')
+
+        evidence = {
+            'result': 'passed',
+            'session_id': session_id,
+            'utterance_id': utterance_id,
+            'play_state': play_state,
+            'ros_graph': graph,
+            'terminal_receipt': terminal,
+        }
+    except Exception as exc:
+        primary_error = f'{type(exc).__name__}: {exc}'
+    finally:
+        if speaker_start_attempted:
+            try:
+                cleanup_result = _speaker_call(
+                    args.mcp_url, 'stop', timeout=args.cleanup_timeout,
+                )
+                if cleanup_result.get('state') != 'idle':
+                    raise RuntimeError(
+                        f'speaker cleanup did not become idle: {cleanup_result}'
+                    )
+            except Exception as exc:
+                cleanup_error = f'{type(exc).__name__}: {exc}'
+        if node is not None:
+            node.destroy_node()
+        rclpy.shutdown()
+
+    if primary_error is not None or cleanup_error is not None:
+        failure = {
+            'result': 'failed',
+            'utterance_id': utterance_id,
+        }
+        if primary_error is not None:
+            failure['error'] = primary_error
+        if cleanup_error is not None:
+            failure['cleanup_error'] = cleanup_error
+        print(json.dumps(failure, ensure_ascii=False, indent=2), file=sys.stderr)
+        return 1
+
+    evidence['cleanup'] = cleanup_result
+    print(json.dumps(evidence, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/unitree/g1/tools/g1_speaker_receipt_smoke.py
+++ b/unitree/g1/tools/g1_speaker_receipt_smoke.py
@@ -30,6 +30,7 @@ from std_msgs.msg import String
 AUDIO_EOF_MAGIC = b'\x01\x00\xff\xff\x01\x00\xff\xff'
 PCM_BLOCK = b'\x01\x00\xff\xff' * 2400  # 9600 bytes, samples +1/-1
 TERMINAL_STATES = {'completed', 'cancelled', 'error'}
+MCP_WAIT_TRANSPORT_MARGIN_SEC = 5.0
 
 INPUT_QOS = QoSProfile(
     reliability=ReliabilityPolicy.BEST_EFFORT,
@@ -159,7 +160,7 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         '--timeout', type=float, default=10.0,
-        help='seconds to wait for the terminal receipt',
+        help='seconds to wait for MCP playback completion and the ROS receipt (max 25)',
     )
     parser.add_argument(
         '--start-timeout', type=float, default=30.0,
@@ -228,6 +229,42 @@ def main() -> int:
             node.spin_for(0.3)
         node.publish(utterance_id, AUDIO_EOF_MAGIC)
 
+        # Use the public MCP contract as the primary completion signal. Keep the
+        # HTTP timeout slightly above the requested server-side wait so response
+        # serialization and transport do not race the client deadline.
+        mcp_wait_result = _speaker_call(
+            args.mcp_url,
+            'wait_playback',
+            timeout=max(0.1, args.timeout + MCP_WAIT_TRANSPORT_MARGIN_SEC),
+            session_id=session_id,
+            utterance_id=utterance_id,
+            timeout_sec=args.timeout,
+        )
+        if not mcp_wait_result.get('terminal'):
+            raise RuntimeError(
+                f'MCP wait_playback did not return a terminal result: '
+                f'{mcp_wait_result}'
+            )
+        if mcp_wait_result.get('state') != 'completed':
+            raise RuntimeError(
+                f'MCP wait_playback returned non-success terminal: '
+                f'{mcp_wait_result}'
+            )
+        if (mcp_wait_result.get('completion_basis')
+                != 'g1_play_state_observed'):
+            raise RuntimeError(
+                f'MCP wait_playback returned non-hardware completion: '
+                f'{mcp_wait_result}'
+            )
+        if mcp_wait_result.get('audio_bytes') != 5 * len(PCM_BLOCK):
+            raise RuntimeError(
+                f'MCP wait_playback returned unexpected audio byte count: '
+                f'{mcp_wait_result}'
+            )
+
+        # Cross-check the push path independently. The MCP request blocks this
+        # process's ROS executor, so spin after it returns; TRANSIENT_LOCAL keeps
+        # the terminal receipt available for this reconciliation.
         terminal = node.wait_for_terminal(
             session_id, utterance_id, args.timeout,
         )
@@ -242,6 +279,14 @@ def main() -> int:
             raise RuntimeError(f'non-hardware completion basis: {terminal}')
         if terminal.get('audio_bytes') != 5 * len(PCM_BLOCK):
             raise RuntimeError(f'unexpected audio byte count: {terminal}')
+        for field in (
+                'session_id', 'utterance_id', 'state',
+                'completion_basis', 'audio_bytes'):
+            if mcp_wait_result.get(field) != terminal.get(field):
+                raise RuntimeError(
+                    f'MCP/ROS terminal mismatch for {field}: '
+                    f'mcp={mcp_wait_result}, ros={terminal}'
+                )
 
         evidence = {
             'result': 'passed',
@@ -249,6 +294,7 @@ def main() -> int:
             'utterance_id': utterance_id,
             'play_state': play_state,
             'ros_graph': graph,
+            'mcp_wait_result': mcp_wait_result,
             'terminal_receipt': terminal,
         }
     except Exception as exc:

--- a/unitree/g1/unitree_sdk2py/core/channel.py
+++ b/unitree/g1/unitree_sdk2py/core/channel.py
@@ -37,23 +37,37 @@ class Channel:
         def __init__(self):
             self.__reader = None
             self.__handler = None
+            self.__matchHandler = None
             self.__queue = None
             self.__queueEnable = False
             self.__threadEvent = None
             self.__threadReader = None
+            self.__subscriptionMatchedCount = 0
+            self.__subscriptionMatchedEvent = Event()
         
-        def Init(self, participant: DomainParticipant, topic: Topic, qos: Qos = None, handler: Callable = None, queueLen: int = 0):
-            if handler is None:
-                self.__reader = DataReader(participant, topic, qos)
-            else:
-                self.__handler = handler
-                if queueLen > 0:
-                    self.__queueEnable = True
-                    self.__queue = BQueue(queueLen)
-                    self.__threadEvent = Event()
-                    self.__threadReader = Thread(target=self.__ChannelReaderThreadFunc, name="ch_reader", daemon=True)
-                    self.__threadReader.start()
-                self.__reader = DataReader(participant, topic, qos, Listener(on_data_available=self.__OnDataAvailable))
+        def Init(self, participant: DomainParticipant, topic: Topic,
+                 qos: Qos = None, handler: Callable = None,
+                 queueLen: int = 0, matchHandler: Callable = None):
+            self.__handler = handler
+            self.__matchHandler = matchHandler
+            self.__queueEnable = False
+            self.__queue = None
+            self.__threadEvent = None
+            self.__threadReader = None
+            if handler is not None and queueLen > 0:
+                self.__queueEnable = True
+                self.__queue = BQueue(queueLen)
+                self.__threadEvent = Event()
+                self.__threadReader = Thread(target=self.__ChannelReaderThreadFunc, name="ch_reader", daemon=True)
+                self.__threadReader.start()
+            listener_args = {
+                "on_subscription_matched": self.__OnSubscriptionMatched,
+            }
+            if handler is not None:
+                listener_args["on_data_available"] = self.__OnDataAvailable
+            self.__reader = DataReader(
+                participant, topic, qos, Listener(**listener_args),
+            )
 
         def Read(self, timeout: float = None):
             sample = None
@@ -74,12 +88,36 @@ class Channel:
         def Close(self):
             if self.__reader is not None:
                 del self.__reader
+                self.__reader = None
+
+            self.__subscriptionMatchedCount = 0
+            self.__subscriptionMatchedEvent.clear()
 
             if self.__queueEnable:
                 self.__threadEvent.set()
                 self.__queue.Interrupt()
                 self.__queue.Clear()
                 self.__threadReader.join()
+                self.__queueEnable = False
+                self.__queue = None
+                self.__threadEvent = None
+                self.__threadReader = None
+
+        def WaitForPublisher(self, timeout: float = None):
+            if self.__subscriptionMatchedCount > 0:
+                return True
+            if not self.__subscriptionMatchedEvent.wait(timeout=timeout):
+                return False
+            return self.__subscriptionMatchedCount > 0
+
+        def __OnSubscriptionMatched(self, reader: DataReader, status):
+            self.__subscriptionMatchedCount = status.current_count
+            if status.current_count > 0:
+                self.__subscriptionMatchedEvent.set()
+            else:
+                self.__subscriptionMatchedEvent.clear()
+            if self.__matchHandler is not None:
+                self.__matchHandler(status.current_count)
 
         def __OnDataAvailable(self, reader: DataReader):
             samples = []
@@ -169,8 +207,12 @@ class Channel:
     def SetWriter(self, qos: Qos = None):
         self.__writer.Init(self.__participant, self.__topic, qos)
 
-    def SetReader(self, qos: Qos = None, handler: Callable = None, queueLen: int = 0):
-        self.__reader.Init(self.__participant, self.__topic, qos, handler, queueLen)
+    def SetReader(self, qos: Qos = None, handler: Callable = None,
+                  queueLen: int = 0, matchHandler: Callable = None):
+        self.__reader.Init(
+            self.__participant, self.__topic, qos, handler, queueLen,
+            matchHandler,
+        )
         
     def Write(self, sample: Any, timeout: float = None):
         return self.__writer.Write(sample, timeout)
@@ -180,6 +222,9 @@ class Channel:
 
     def CloseReader(self):
         self.__reader.Close()
+
+    def WaitForReaderPublisher(self, timeout: float = None):
+        return self.__reader.WaitForPublisher(timeout)
 
     def CloseWriter(self):
         self.__writer.Close()
@@ -280,9 +325,10 @@ class ChannelSubscriber:
         self.__channel = factory.CreateChannel(name, type)
         self.__inited = False
 
-    def Init(self, handler: Callable = None, queueLen: int = 0):
+    def Init(self, handler: Callable = None, queueLen: int = 0,
+             matchHandler: Callable = None):
         if not self.__inited:
-            self.__channel.SetReader(None, handler, queueLen)
+            self.__channel.SetReader(None, handler, queueLen, matchHandler)
             self.__inited = True
 
     def Close(self):
@@ -291,6 +337,9 @@ class ChannelSubscriber:
 
     def Read(self, timeout: int = None):
         return self.__channel.Read(timeout)
+
+    def WaitForPublisher(self, timeout: float = None):
+        return self.__channel.WaitForReaderPublisher(timeout)
 
 """
 " function ChannelFactoryInitialize. used to intialize channel everenment.

--- a/unitree/g1/unitree_sdk2py/g1/audio/g1_audio_client.py
+++ b/unitree/g1/unitree_sdk2py/g1/audio/g1_audio_client.py
@@ -26,7 +26,7 @@ class AudioClient(Client):
 
     ## API Call ##
     def TtsMaker(self, text: str, speaker_id: int):
-        self.tts_index += self.tts_index
+        self.tts_index += 1
         p = {}
         p["index"] = self.tts_index
         p["text"] = text
@@ -64,8 +64,29 @@ class AudioClient(Client):
         param = json.dumps({"app_name": app_name, "stream_id": stream_id})
         pcm_list = list(pcm_data)
         return self._CallRequestWithParamAndBin(ROBOT_API_ID_AUDIO_START_PLAY, param, pcm_list)
+
+    def PlayStreamStart(self, app_name: str, stream_id: str, pcm_data: bytes,
+                        send_timeout: float = None):
+        param = json.dumps({"app_name": app_name, "stream_id": stream_id})
+        pcm_list = list(pcm_data)
+        return self._CallRequestWithParamAndBinStart(
+            ROBOT_API_ID_AUDIO_START_PLAY, param, pcm_list, send_timeout,
+        )
+
+    def PlayStreamFinish(self, pending, timeout: float = None):
+        return self._CallRequestWithParamAndBinFinish(pending, timeout)
     
     def PlayStop(self, app_name: str):
         parameter = json.dumps({"app_name": app_name})
-        self._Call(ROBOT_API_ID_AUDIO_STOP_PLAY, parameter)
-        return 0
+        code, _ = self._Call(ROBOT_API_ID_AUDIO_STOP_PLAY, parameter)
+        return code
+
+    def PlayStopStart(self, app_name: str, send_timeout: float = None):
+        parameter = json.dumps({"app_name": app_name})
+        return self._CallStart(
+            ROBOT_API_ID_AUDIO_STOP_PLAY, parameter, send_timeout,
+        )
+
+    def PlayStopFinish(self, pending, timeout: float = None):
+        code, _ = self._CallFinish(pending, timeout)
+        return code

--- a/unitree/g1/unitree_sdk2py/rpc/client.py
+++ b/unitree/g1/unitree_sdk2py/rpc/client.py
@@ -48,6 +48,18 @@ class Client(ClientBase):
             return self._CallBase(apiId, parameter, proirity, leaseId)
         else:
             return RPC_ERR_CLIENT_API_NOT_REG, None
+
+    def _CallStart(self, apiId: int, parameter: str,
+                   send_timeout: float = None):
+        ret, proirity, leaseId = self.__CheckApi(apiId)
+        if ret == 0:
+            return self._CallStartBase(
+                apiId, parameter, proirity, leaseId, send_timeout,
+            )
+        return RPC_ERR_CLIENT_API_NOT_REG, None
+
+    def _CallFinish(self, pending, timeout: float = None):
+        return self._CallFinishBase(pending, timeout)
             
     def _CallNoReply(self, apiId: int, parameter: str):
         ret, proirity, leaseId = self.__CheckApi(apiId)
@@ -65,6 +77,22 @@ class Client(ClientBase):
                                                         leaseId)
         else:
             return RPC_ERR_CLIENT_API_NOT_REG, None
+
+    def _CallRequestWithParamAndBinStart(self, apiId: int,
+                                         requestParamter: str,
+                                         requestBinary: list,
+                                         send_timeout: float = None):
+        ret, proirity, leaseId = self.__CheckApi(apiId)
+        if ret == 0:
+            return self._CallRequestWithParamAndBinStartBase(
+                apiId, requestParamter, requestBinary, proirity, leaseId,
+                send_timeout,
+            )
+        return RPC_ERR_CLIENT_API_NOT_REG, None
+
+    def _CallRequestWithParamAndBinFinish(self, pending,
+                                          timeout: float = None):
+        return self._CallRequestWithParamAndBinFinishBase(pending, timeout)
 
     def _CallRequestWithParamAndBinNoReply(self, apiId: int, requestParamter: str,
                                            requestBinary: list):

--- a/unitree/g1/unitree_sdk2py/rpc/client_base.py
+++ b/unitree/g1/unitree_sdk2py/rpc/client_base.py
@@ -55,6 +55,33 @@ class ClientBase:
         else:
             return response.header.status.code, response.data
 
+    def _CallStartBase(self, apiId: int, parameter: str,
+                       proirity: int = 0, leaseId: int = 0,
+                       send_timeout: float = None):
+        """Submit a parameter-only RPC and return before waiting."""
+        header = self.__SetHeader(apiId, leaseId, proirity, False)
+        request = Request(header, parameter, [])
+        timeout = self.__timeout if send_timeout is None else send_timeout
+        future = self.__stub.SendRequest(request, timeout)
+        if future is None:
+            return RPC_ERR_CLIENT_SEND, None
+        return 0, (future, request.header.identity.id, apiId)
+
+    def _CallFinishBase(self, pending, timeout: float = None):
+        future, request_id, apiId = pending
+        result = future.GetResult(self.__timeout if timeout is None else timeout)
+        if result.code != FutureResult.FUTURE_SUCC:
+            self.__stub.RemoveFuture(request_id)
+            code = (RPC_ERR_CLIENT_API_TIMEOUT
+                    if result.code == FutureResult.FUTUTE_ERR_TIMEOUT
+                    else RPC_ERR_UNKNOWN)
+            return code, None
+
+        response = result.value
+        if response.header.identity.api_id != apiId:
+            return RPC_ERR_CLIENT_API_NOT_MATCH, None
+        return response.header.status.code, response.data
+
     def _CallNoReplyBase(self, apiId: int, parameter: str, proirity: int, leaseId: int):
         header = self.__SetHeader(apiId, leaseId, proirity, True)
         request = Request(header, parameter, [])
@@ -87,6 +114,38 @@ class ClientBase:
             return RPC_ERR_CLIENT_API_NOT_MATCH, None
         else:
             return response.header.status.code, response.data
+
+    def _CallRequestWithParamAndBinStartBase(self, apiId: int,
+                                             requestParamter: str,
+                                             requestBinary: list,
+                                             proirity: int = 0,
+                                             leaseId: int = 0,
+                                             send_timeout: float = None):
+        """Submit a binary RPC and return before waiting for its response."""
+        header = self.__SetHeader(apiId, leaseId, proirity, False)
+        request = Request(header, requestParamter, requestBinary)
+        timeout = self.__timeout if send_timeout is None else send_timeout
+        future = self.__stub.SendRequest(request, timeout)
+        if future is None:
+            return RPC_ERR_CLIENT_SEND, None
+        return 0, (future, request.header.identity.id, apiId)
+
+    def _CallRequestWithParamAndBinFinishBase(self, pending,
+                                              timeout: float = None):
+        """Wait for a binary RPC previously returned by StartBase."""
+        future, request_id, apiId = pending
+        result = future.GetResult(self.__timeout if timeout is None else timeout)
+        if result.code != FutureResult.FUTURE_SUCC:
+            self.__stub.RemoveFuture(request_id)
+            code = (RPC_ERR_CLIENT_API_TIMEOUT
+                    if result.code == FutureResult.FUTUTE_ERR_TIMEOUT
+                    else RPC_ERR_UNKNOWN)
+            return code, None
+
+        response = result.value
+        if response.header.identity.api_id != apiId:
+            return RPC_ERR_CLIENT_API_NOT_MATCH, None
+        return response.header.status.code, response.data
 
     def _CallRequestWithParamAndBinNoReplyBase(self, apiId: int, requestParamter: str,
                                                requestBinary: list, proirity: int,

--- a/unitree/g1/unitree_sdk2py/rpc/request_future.py
+++ b/unitree/g1/unitree_sdk2py/rpc/request_future.py
@@ -42,5 +42,5 @@ class RequestFutureQueue:
 
     def Remove(self, requestId: int):
         with self.__lock:
-            if id in self.__data:
+            if requestId in self.__data:
                 self.__data.pop(requestId)


### PR DESCRIPTION
## 这个 PR 现在能解决什么

这是 **Drivers 仓库的 G1 Speaker PR**。当前提交在原有“读取 G1 固件播放器状态”的基础上，新增了一个可以直接调用的 MCP 动作：

```text
speaker(action="wait_playback", session_id, utterance_id, timeout_sec)
```

调用方不需要订阅 ROS receipt，也不用按音频时长猜什么时候播完。Driver 会按精确的 `(session_id, utterance_id)` 等待，并直接返回：

- `completed + terminal: true`：这一句已经结束；严格模式下必须观察到 G1 固件播放器 `play_state: 1 -> 0`
- `cancelled + terminal: true`：这一句被 stop/interrupt 取消
- `error + terminal: true`：这一句播放失败
- `timeout + terminal: false`：已看到这一句开始，但本次等待时间内还没结束，可以用同一组 ID 继续等
- `unknown + terminal: false`：等待时间内还没看到这一句进入 Speaker，通常需要检查上游音频或稍后重试

本 PR 不修改 Core，也不修改 Motus TTS。

## MCP 怎么直接用

`session_id` 使用 `speaker start` 返回的值（也可以从 `speaker info` 查看）；`utterance_id` 是音频生产方为这一句话生成的 `utt:<id>`，同一句的所有 PCM 分块和 EOF 必须携带同一个 ID。

```bash
curl -sS http://127.0.0.1:15701/mcp \
  -H 'Content-Type: application/json' \
  -d '{
    "jsonrpc":"2.0",
    "id":"speaker-wait",
    "method":"tools/call",
    "params":{
      "name":"speaker",
      "arguments":{
        "action":"wait_playback",
        "session_id":"speaker:替换为实际值",
        "utterance_id":"utt:替换为实际值",
        "timeout_sec":20
      }
    }
  }'
```

成功时，MCP 返回内容中的业务 JSON 类似：

```json
{
  "state": "completed",
  "terminal": true,
  "session_id": "speaker:<uuid>",
  "utterance_id": "utt:<id>",
  "completion_basis": "g1_play_state_observed",
  "audio_bytes": 48000
}
```

默认等待 20 秒，单次最多 25 秒，低于 Core 的 30 秒 MCP 总超时。长音频超时后，用同一组 ID 再调用即可；如果终态已经进入 Driver 历史，会立即返回。`timeout_sec: 0` 可做一次不阻塞的精确状态查询。

## 底层实现

- G1 严格模式直接订阅固件 DDS topic `rt/audio_msg`
- 只有当前音频提交期间观察到完整 `play_state: 1 -> 0`，才产生 `completed`
- terminal receipt 在 Driver 内部按 `(session_id, utterance_id)` 保存，跨 session 重用相同 utterance ID 不会串结果
- MCP waiter 使用独立 `Condition` 等待，不持有播放状态锁；stop、interrupt、错误和 session 切换都会唤醒 waiter
- MCP 服务使用 `ThreadingHTTPServer`，一个等待请求不会阻塞 Speaker 收音频或其他 MCP 请求
- 原有 ROS receipt 仍保留，QoS 为 `RELIABLE + TRANSIENT_LOCAL + KEEP_LAST(50)`，用于推送和诊断

## Reviewer 在真实 G1 上怎么验

把本 PR 当前提交 `816ebf1` 构建并部署到专用 G1 后，运行：

```bash
docker exec -it embodied-unitree-g1 bash -lc '
  source /opt/ros/humble/setup.bash &&
  source /ros_ws/install/setup.bash &&
  python3 /work/tools/g1_speaker_receipt_smoke.py \
    --confirm-exclusive-hardware
'
```

脚本会走真实完整链路：

```text
speaker start
  -> 发布带 utterance_id 的 ROS AudioChunk + EOF
  -> Unitree PlayStream
  -> G1 rt/audio_msg 的 1 -> 0
  -> MCP wait_playback 返回 completed
  -> ROS terminal receipt 交叉核对
  -> speaker stop 清理
```

通过时退出码为 `0`，输出 JSON 同时包含：

- `result: "passed"`
- `mcp_wait_result.state: "completed"`
- `mcp_wait_result.terminal: true`
- `mcp_wait_result.completion_basis: "g1_play_state_observed"`
- `terminal_receipt` 与 MCP 结果的 session、utterance、state、完成依据和字节数完全一致
- `cleanup.state: "idle"`

所以 reviewer 不是只看内部 topic，而是在真机上直接验证新增 MCP 工具确实可用。脚本会占用并停止当前 Speaker session，只能在专用测试环境运行。

## 自动化验证

当前提交已本地复跑：

```text
Python 3.10: 93 tests passed
Python 3.12: 93 tests passed
git diff --check: passed
```

测试覆盖 MCP schema/dispatch、阻塞等待与唤醒、历史立即查询、timeout/unknown、interrupt cancellation、播放错误、参数校验、跨 session 隔离，以及 hardware smoke 的 MCP/ROS 双路一致性。

## 边界与后续使用

- 当前真正接上硬件完成信号的是 **Unitree G1**；`wait_playback` 的 action 和返回结构可以作为其他带音频机器人共用的 Speaker 契约，但每个机器人仍需接入自己的播放器状态来源，不能在本 PR 中假装已经支持。
- `g1_play_state_observed` 证明固件播放器回到 idle，不是麦克风声学检测，不能证明功放一定产生了可听声音。
- 当前 Motus TTS 还没有给 AudioChunk/EOF 写入稳定 `utt:` ID。因此 reviewer smoke 可以独立验证 Driver MCP 全链路；展厅正式链路要做到“某次 TTS 调用与某个完成结果精确对应”，仍需 Motus 补这个 ID。Core 无需实现 ROS subscriber，之后直接调用本 PR 的 MCP `wait_playback` 即可。
- PR 保持 Draft；在真实 G1 部署并通过上述 smoke 前，不标记 Ready。

完整协议与异常语义见 `unitree/g1/SPEAKER_LIFECYCLE_PROTOCOL.md`。
