### PR TITLE
feat(g1): 基于硬件播放状态提供扬声器完成等待接口

### DIFF
--- a/unitree/g1/Dockerfile
+++ b/unitree/g1/Dockerfile
@@ -47,6 +47,7 @@ COPY unitree_sdk2py/ /work/unitree_sdk2py/
 COPY resource/       /work/resource/
 COPY main.py   /work/main.py
 COPY device.py /work/device.py
+COPY playback_state.py /work/playback_state.py
 COPY rpc_proxy.py /work/rpc_proxy.py
 COPY ext_devices.py /work/ext_devices.py
 COPY safety_harness.py /work/safety_harness.py

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -18,6 +18,8 @@ drivers/unitree/g1/device.py — Unitree G1 设备插件（重构版）。
   StatePlugin        (sensor)    — DDS LowState → IMU/battery ROS2 topic
 """
 
+from __future__ import annotations
+
 import json
 import queue
 import socket
@@ -33,6 +35,7 @@ from std_msgs.msg import Header, String
 from audio_msgs.msg import AudioChunk
 
 from unitree_sdk2py.g1.audio.g1_audio_client import AudioClient
+from playback_state import G1PlaybackStateMonitor
 from pointcloud_utils import gravity_align_inplace
 
 # ── 常量 ──────────────────────────────────────────────────────────────────────
@@ -48,6 +51,13 @@ _LOW_LAT_QOS = QoSProfile(
     depth=200,
     durability=DurabilityPolicy.VOLATILE,
 )
+
+# rt/audio_msg reports one global G1 audio-player state without app/stream ID.
+# When the PCM Speaker plugin is enabled, native TTS must stay disabled for the
+# process lifetime; otherwise a TtsMaker RPC can return while its audio keeps
+# playing and forge the PCM stream's finish events.  If Speaker is disabled in
+# config, NativeTtsPlugin retains its original behavior.
+_G1_PCM_COMPLETION_MODE_ENABLED = threading.Event()
 
 
 # ── 工具函数 ──────────────────────────────────────────────────────────────────
@@ -289,7 +299,15 @@ class NativeTtsPlugin:
         if action == "speak":
             text  = args.get("text", "")
             voice = int(args.get("voice", 0))
-            ret   = self._client.TtsMaker(text, voice)
+            if _G1_PCM_COMPLETION_MODE_ENABLED.is_set():
+                return {
+                    "ret": -1,
+                    "state": "error",
+                    "reason": "native_tts_disabled_for_pcm_completion",
+                    "message": "disable the Speaker plugin to use native TTS",
+                    "text": text,
+                }
+            ret = self._client.TtsMaker(text, voice)
             return {"ret": ret, "text": text}
         elif action == "get_volume":
             ret = self._client.GetVolume()
@@ -309,115 +327,460 @@ APP_NAME = "g1_speaker"
 class _SpeakerNode(Node):
     PREFILL = 3       # buffer 3 chunks (~300ms) before starting playback
     MERGE_BYTES = 9600  # merge into ~300ms blocks before calling PlayStream
+    NATURAL_IDLE_TIMEOUT = 3.0
+    STOP_IDLE_TIMEOUT = 2.0
+    PLAYBACK_HISTORY_LIMIT = 32
+    TERMINAL_STATES = frozenset(("completed", "cancelled", "error"))
 
-    def __init__(self, audio_client: AudioClient):
+    # EOF magic: 8 bytes (4 samples [1,-1,1,-1])，标记 utterance 结束
+    AUDIO_EOF_MAGIC = b'\x01\x00\xff\xff\x01\x00\xff\xff'
+
+    def __init__(self, audio_client: AudioClient, playback_monitor=None):
         super().__init__("g1_speaker")
         self._client = audio_client
+        _G1_PCM_COMPLETION_MODE_ENABLED.set()
+        self._playback_monitor = (
+            playback_monitor or G1PlaybackStateMonitor.connect_dds()
+        )
         self._topic: str | None = None
         self._sub    = None
         self._idx    = 0
         self.state   = "idle"
         self._buf = queue.Queue()
         self._draining = threading.Event()
+        self._drain_guard = threading.Lock()
         self._drain_thread: threading.Thread | None = None
         self._last_chunk_time = 0.0
         self._flush_timer = None
         # 打断/暂停控制
-        self._lock = threading.Lock()
+        # All public speaker lifecycle operations share this lock.  SmartMotion
+        # calls the node directly, while the speaker MCP calls through the
+        # plugin, so a node-owned re-entrant lock is the only common boundary.
+        self._lifecycle_lock = threading.RLock()
+        self._lock = self._lifecycle_lock
         self._interrupt_flag = threading.Event()
+        self._startup_cancel = threading.Event()
         self._pause_event = threading.Event()
         self._pause_event.set()  # 初始为非暂停状态
         self._muted = False  # interrupt 后静默，丢弃后续 chunks 直到新 utterance
+        # Playback records back the reviewer-facing wait_playback MCP action.
+        self._playback_cv = threading.Condition(threading.RLock())
+        self._playback_sequence = 0
+        self._playbacks: dict[int, dict] = {}
+        self._current_input_id: int | None = None
+        self._failed_playback_ids: set[int] = set()
+        self._stream_prefix = f"{int(time.time() * 1000):x}"
+        # ROS may already be executing a callback when its subscription is
+        # destroyed.  A generation captured by each callback prevents that
+        # stale callback from writing into a stopped or restarted session.
+        self._subscription_generation = 0
+        self._active_subscription_generation: int | None = None
+        self._fail_closed_reason: str | None = None
         # Clear stale PlayStream session from previous container run (MCU keeps state across reboot)
-        self._client.PlayStop(APP_NAME)
+        stop_code = self._safe_play_stop()
+        if stop_code != 0:
+            self.get_logger().warn(
+                f"[speaker] initial PlayStop failed: code={stop_code}"
+            )
         self.get_logger().info("SpeakerNode ready")
 
-    def start_play(self, topic: str) -> str:
-        if self._sub is not None:
-            if self._topic == topic:
-                self.get_logger().info(f"[speaker] already subscribing {topic}, skip")
-                return self._topic
-            # topic changed — stop old subscription first
-            self.get_logger().info(f"[speaker] topic changed {self._topic} → {topic}, re-subscribing")
-            self.stop_play()
-        self._topic = topic
-        self._muted = False  # 新 start 时清除静默
-        self.get_logger().info(f"[speaker] creating subscription: topic={topic}, msg_type=AudioChunk, qos=LOW_LAT")
-        self._sub = self.create_subscription(
-            AudioChunk, topic, self._on_chunk, _LOW_LAT_QOS,
-        )
-        self.state = "ready"
-        self.get_logger().info(f"[speaker] subscription created, waiting for chunks on {topic}")
-        return topic
-
-    def stop_play(self) -> None:
-        if self._flush_timer is not None:
-            self._flush_timer.cancel()
-            self.destroy_timer(self._flush_timer)
-            self._flush_timer = None
-        if self._sub is not None:
-            self.destroy_subscription(self._sub)
-            self._sub = None
-        self._draining.clear()
-        self._pause_event.set()  # 确保 drain thread 不会卡在 pause wait
-        self._interrupt_flag.set()  # 确保 drain thread 退出
-        if self._drain_thread is not None:
-            self._drain_thread.join(timeout=2)
-            self._drain_thread = None
-        self._interrupt_flag.clear()
-        # flush remaining buffer
-        while not self._buf.empty():
-            try:
-                self._buf.get_nowait()
-            except queue.Empty:
-                break
+    def _safe_play_stop(self) -> int:
         try:
-            self._client.PlayStop(APP_NAME)
-        except Exception as e:
-            self.get_logger().warn(f"PlayStop error: {e}")
-        self.state = "idle"
-        self.get_logger().info("Speaker stopped")
+            result = self._client.PlayStop(APP_NAME)
+            if isinstance(result, tuple):
+                result = result[0]
+            return int(result)
+        except Exception as exc:
+            self.get_logger().warn(f"[speaker] PlayStop error: {exc}")
+            return -1
 
-    def interrupt(self) -> dict:
-        """立即中止播放：清空 buffer，停止 SDK，保持 subscription。"""
-        with self._lock:
-            self._interrupt_flag.set()
-            # 清空 buffer
+    def _new_playback(self) -> int:
+        with self._playback_cv:
+            self._playback_sequence += 1
+            playback_id = self._playback_sequence
+            self._playbacks[playback_id] = {
+                "playback_id": playback_id,
+                "stream_id": f"{self._stream_prefix}-{playback_id}",
+                "state": "receiving",
+                "reason": "",
+                "audio_bytes": 0,
+                "submitted_blocks": 0,
+                "eof_received": False,
+                "created_monotonic": time.monotonic(),
+                "start_event_seq": None,
+                "final_submit_seq": None,
+                "final_pcm_deadline": None,
+                "completion_basis": "",
+                "forced_stream_close": False,
+            }
+            self._current_input_id = playback_id
+            self._prune_playbacks_locked()
+            self._playback_cv.notify_all()
+            return playback_id
+
+    def _prune_playbacks_locked(self) -> None:
+        if len(self._playbacks) <= self.PLAYBACK_HISTORY_LIMIT:
+            return
+        for playback_id in list(self._playbacks):
+            if len(self._playbacks) <= self.PLAYBACK_HISTORY_LIMIT:
+                break
+            record = self._playbacks[playback_id]
+            if record["state"] in self.TERMINAL_STATES:
+                self._playbacks.pop(playback_id, None)
+
+    def _playback_snapshot_locked(self, playback_id: int) -> dict | None:
+        record = self._playbacks.get(playback_id)
+        return dict(record) if record is not None else None
+
+    def _set_terminal(self, playback_id: int, state: str, reason: str = "",
+                      **details) -> None:
+        with self._playback_cv:
+            record = self._playbacks.get(playback_id)
+            if record is None or record["state"] in self.TERMINAL_STATES:
+                return
+            record.update(details)
+            record["state"] = state
+            record["reason"] = reason
+            record["finished_monotonic"] = time.monotonic()
+            self._failed_playback_ids.discard(playback_id)
+            self._prune_playbacks_locked()
+            self._playback_cv.notify_all()
+
+    def _cancel_open_playbacks(self, reason: str) -> None:
+        with self._playback_cv:
+            for playback_id, record in self._playbacks.items():
+                if record["state"] not in self.TERMINAL_STATES:
+                    record["state"] = "cancelled"
+                    record["reason"] = reason
+                    record["finished_monotonic"] = time.monotonic()
+            self._current_input_id = None
+            self._failed_playback_ids.clear()
+            self._playback_cv.notify_all()
+
+    def _enter_fail_closed(self, reason: str) -> None:
+        """Block all further PCM after hardware ownership becomes uncertain."""
+        self._interrupt_flag.set()
+        with self._playback_cv:
             while not self._buf.empty():
                 try:
                     self._buf.get_nowait()
                 except queue.Empty:
                     break
-            # 停止 SDK 播放
+            self._cancel_open_playbacks(reason)
+            self._fail_closed_reason = reason
+            self.state = "error"
+            self._playback_cv.notify_all()
+        self.get_logger().error(
+            f"[speaker] hardware completion unknown; reuse blocked: {reason}"
+        )
+
+    def _latch_fail_closed(self, reason: str) -> None:
+        """Quarantine immediately; unlike interrupt, only stop may clear it."""
+        with self._playback_cv:
+            if self._fail_closed_reason is None:
+                self._fail_closed_reason = reason
+            self.state = "error"
+            self._playback_cv.notify_all()
+
+    def wait_for_playback(self, *, playback_id=None, after_playback_id=None,
+                          timeout: float = 30.0) -> dict:
+        """Wait for one local utterance to reach a terminal state."""
+        if playback_id is None and after_playback_id is None:
+            return {
+                "state": "error",
+                "reason": "playback_id_or_after_playback_id_required",
+            }
+        if playback_id is not None and after_playback_id is not None:
+            return {
+                "state": "error",
+                "reason": "choose_playback_id_or_after_playback_id",
+            }
+        deadline = time.monotonic() + max(0.0, float(timeout))
+        target_id = int(playback_id) if playback_id is not None else None
+        after_id = (
+            int(after_playback_id)
+            if after_playback_id is not None else None
+        )
+
+        with self._playback_cv:
+            while True:
+                if target_id is None:
+                    if after_id is not None:
+                        candidates = [
+                            item for item in self._playbacks if item > after_id
+                        ]
+                        if candidates:
+                            target_id = min(candidates)
+                if target_id is not None:
+                    record = self._playbacks.get(target_id)
+                    if record is not None:
+                        if record["state"] in self.TERMINAL_STATES:
+                            result = dict(record)
+                            result["hardware_playback"] = (
+                                self._playback_monitor.status()
+                            )
+                            return result
+                    elif playback_id is not None and target_id <= self._playback_sequence:
+                        return {
+                            "state": "error",
+                            "reason": "playback_id_not_found",
+                            "playback_id": target_id,
+                        }
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return {
+                        "state": "timeout",
+                        "reason": (
+                            "playback_not_finished"
+                            if target_id is not None
+                            else "playback_not_started"
+                        ),
+                        "playback_id": target_id,
+                        "after_playback_id": after_id,
+                        "last_playback_id": self._playback_sequence,
+                        "hardware_playback": self._playback_monitor.status(),
+                    }
+                self._playback_cv.wait(timeout=min(0.1, remaining))
+
+    def start_play(self, topic: str) -> str:
+        with self._lifecycle_lock:
+            if self._interrupt_flag.is_set():
+                raise RuntimeError("speaker worker is still stopping")
+            if self._drain_thread is not None and self._drain_thread.is_alive():
+                raise RuntimeError("speaker worker is already active")
+            if self._sub is not None:
+                if self._topic == topic:
+                    self.get_logger().info(
+                        f"[speaker] already subscribing {topic}, skip"
+                    )
+                    return self._topic
+                # topic changed — stop old subscription first
+                self.get_logger().info(
+                    f"[speaker] topic changed {self._topic} → {topic}, "
+                    "re-subscribing"
+                )
+                stopped = self.stop_play()
+                if stopped["state"] == "error":
+                    raise RuntimeError(stopped["reason"])
+
+            with self._playback_cv:
+                self._subscription_generation += 1
+                generation = self._subscription_generation
+                self._active_subscription_generation = generation
+                self._topic = topic
+                self._muted = False  # 新 start 时清除静默
+                self.state = "ready"
+
+            def on_chunk(msg, subscription_generation=generation):
+                self._on_chunk(msg, subscription_generation)
+
+            self.get_logger().info(
+                f"[speaker] creating subscription: topic={topic}, "
+                "msg_type=AudioChunk, qos=LOW_LAT"
+            )
             try:
-                self._client.PlayStop(APP_NAME)
-            except Exception as e:
-                self.get_logger().warn(f"[speaker] interrupt PlayStop error: {e}")
+                subscription = self.create_subscription(
+                    AudioChunk, topic, on_chunk, _LOW_LAT_QOS,
+                )
+            except Exception:
+                with self._playback_cv:
+                    if self._active_subscription_generation == generation:
+                        self._active_subscription_generation = None
+                        self._topic = None
+                        self.state = "error"
+                raise
+            with self._playback_cv:
+                if self._active_subscription_generation != generation:
+                    # Defensive only: lifecycle operations are serialized, but
+                    # never publish a handle for an invalidated generation.
+                    self.destroy_subscription(subscription)
+                    raise RuntimeError("speaker subscription was cancelled")
+                self._sub = subscription
+            self.get_logger().info(
+                f"[speaker] subscription created, waiting for chunks on {topic}"
+            )
+            return topic
+
+    def stop_play(self, *, cancel_startup: bool = True) -> dict:
+        if cancel_startup:
+            self._startup_cancel.set()
+        with self._lifecycle_lock:
+            self._interrupt_flag.set()  # 先阻止 worker 和 callback 接收新数据
+            with self._playback_cv:
+                # Invalidate the callback generation before destroying the ROS
+                # subscription.  A callback already inside bytes(msg.data)
+                # will be rejected when it reaches the lifecycle check.
+                self._subscription_generation += 1
+                self._active_subscription_generation = None
+                subscription = self._sub
+                self._sub = None
+                self._topic = None
+                self.state = "stopping"
+            if self._flush_timer is not None:
+                self._flush_timer.cancel()
+                self.destroy_timer(self._flush_timer)
+                self._flush_timer = None
+            if subscription is not None:
+                self.destroy_subscription(subscription)
+            with self._drain_guard:
+                self._draining.clear()
+            self._pause_event.set()  # 确保 drain thread 不会卡在 pause wait
+            stop_code = self._safe_play_stop()
+            if self._drain_thread is not None:
+                self._drain_thread.join(timeout=3)
+            worker_alive = (
+                self._drain_thread is not None
+                and self._drain_thread.is_alive()
+            )
+            with self._playback_cv:
+                # Serialize queue clearing with _on_chunk lifecycle updates.
+                while not self._buf.empty():
+                    try:
+                        self._buf.get_nowait()
+                    except queue.Empty:
+                        break
+                self._cancel_open_playbacks("speaker_stopped")
+                if worker_alive or stop_code != 0:
+                    # PlayStream may still be inside its SDK timeout. Keep this
+                    # generation cancelled and retain audio ownership until a
+                    # later PlayStop succeeds.
+                    self._fail_closed_reason = (
+                        "speaker_worker_stop_timeout"
+                        if worker_alive else f"play_stop_failed:{stop_code}"
+                    )
+                    self.state = "error"
+                else:
+                    self._drain_thread = None
+                    # Publish idle before clearing cancellation.  Even a
+                    # callback without a generation can never observe an
+                    # accepting state after this subscription was stopped.
+                    self._fail_closed_reason = None
+                    self.state = "idle"
+                    self._interrupt_flag.clear()
+                self._playback_cv.notify_all()
+            if worker_alive or stop_code != 0:
+                self.get_logger().error(
+                    f"[speaker] stop failed: worker_alive={worker_alive}, "
+                    f"PlayStop={stop_code}; reuse blocked"
+                )
+                return {
+                    "state": "error",
+                    "reason": (
+                        "speaker_worker_stop_timeout"
+                        if worker_alive else f"play_stop_failed:{stop_code}"
+                    ),
+                    "play_stop_code": stop_code,
+                }
+            self.get_logger().info(
+                f"Speaker stopped (PlayStop code={stop_code})"
+            )
+            return {"state": "idle", "play_stop_code": stop_code}
+
+    def interrupt(self) -> dict:
+        """立即中止播放：清空 buffer，停止 SDK，保持 subscription。"""
+        self._startup_cancel.set()
+        with self._lifecycle_lock:
+            self._startup_cancel.set()
+            self._interrupt_flag.set()
+            with self._playback_cv:
+                fail_closed_reason = self._fail_closed_reason
+                had_open_input = self._current_input_id is not None
+                # Serialize this transition with EOF handling.  If EOF wins,
+                # current_input_id is already None; if interrupt wins, that
+                # same EOF observes _muted and opens the next generation.
+                self._muted = had_open_input
+                self._cancel_open_playbacks("interrupted")
+                # 清空 buffer；与 _on_chunk 的 queue.put 使用同一把锁。
+                while not self._buf.empty():
+                    try:
+                        self._buf.get_nowait()
+                    except queue.Empty:
+                        break
+            # 停止 SDK 播放
+            stop_code = self._safe_play_stop()
+            with self._drain_guard:
+                self._draining.clear()
             # 等 drain thread 退出
             if self._drain_thread is not None and self._drain_thread.is_alive():
                 self._drain_thread.join(timeout=1)
-                self._drain_thread = None
-            self._interrupt_flag.clear()
+            worker_alive = (
+                self._drain_thread is not None
+                and self._drain_thread.is_alive()
+            )
+            if worker_alive or stop_code != 0:
+                reason = (
+                    "speaker_worker_stop_timeout"
+                    if worker_alive else f"play_stop_failed:{stop_code}"
+                )
+                with self._playback_cv:
+                    self._fail_closed_reason = (
+                        self._fail_closed_reason
+                        or fail_closed_reason
+                        or reason
+                    )
+                    self.state = "error"
+                    self._playback_cv.notify_all()
+                return {
+                    "state": "error",
+                    "reason": reason,
+                    "play_stop_code": stop_code,
+                }
+            self._drain_thread = None
             self._pause_event.set()
-            self._draining.clear()
-            self._muted = True  # 静默：丢弃后续 TTS chunks 直到新 utterance
-            self.state = "ready"
-        self.get_logger().info("[speaker] interrupted — buffer cleared, muted until new utterance")
-        return {"state": "ready", "action": "interrupted"}
+            with self._playback_cv:
+                current_fail_closed_reason = (
+                    self._fail_closed_reason or fail_closed_reason
+                )
+                if current_fail_closed_reason is not None:
+                    # SmartMotion interrupt may issue a defensive PlayStop, but
+                    # it cannot recover a quarantined session.  Only the
+                    # speaker stop/start lifecycle boundary may do that.
+                    self._fail_closed_reason = current_fail_closed_reason
+                    self.state = "error"
+                    self._playback_cv.notify_all()
+                    return {
+                        "state": "error",
+                        "reason": "speaker_stop_required",
+                        "fail_closed_reason": current_fail_closed_reason,
+                        "play_stop_code": stop_code,
+                    }
+                # stop_play may have run immediately before this interrupt.
+                # An unsubscribed node must never advertise a false ready state.
+                has_subscription = (
+                    self._sub is not None
+                    and self._active_subscription_generation is not None
+                )
+                self.state = "ready" if has_subscription else "idle"
+                self._interrupt_flag.clear()
+                self._playback_cv.notify_all()
+        self.get_logger().info(
+            f"[speaker] interrupted — buffer cleared, muted={self._muted}"
+        )
+        return {
+            "state": self.state,
+            "action": "interrupted",
+            "play_stop_code": stop_code,
+        }
 
     def pause(self) -> dict:
-        """暂停播放：停止 SDK，保留 buffer 中未播放的内容。"""
+        """Pause before playback starts; active PCM cannot be resumed losslessly."""
         with self._lock:
-            if self.state not in ("playing", "ready"):
+            if self.state == "playing":
+                return {
+                    "state": "error",
+                    "reason": "active_pcm_pause_unsupported",
+                    "message": "interrupt the utterance or let it finish",
+                }
+            if self.state != "ready":
                 return {"state": self.state, "error": "not playing"}
-            self._pause_event.clear()  # drain thread 将阻塞在 wait()
-            try:
-                self._client.PlayStop(APP_NAME)
-            except Exception as e:
-                self.get_logger().warn(f"[speaker] pause PlayStop error: {e}")
+            self._pause_event.clear()
             self.state = "paused"
         self.get_logger().info(f"[speaker] paused — buffer size={self._buf.qsize()}")
-        return {"state": "paused", "buffer_chunks": self._buf.qsize()}
+        return {
+            "state": "paused",
+            "buffer_chunks": self._buf.qsize(),
+        }
 
     def resume(self) -> dict:
         """恢复播放：从 buffer 中剩余内容继续。"""
@@ -433,45 +796,110 @@ class _SpeakerNode(Node):
         self.get_logger().info("[speaker] resumed")
         return {"state": "playing"}
 
-    # EOF magic: 8 bytes (4 samples [1,-1,1,-1])，标记 utterance 结束
-    AUDIO_EOF_MAGIC = b'\x01\x00\xff\xff\x01\x00\xff\xff'
-
-    def _on_chunk(self, msg: AudioChunk) -> None:
+    def _on_chunk(self, msg: AudioChunk,
+                  subscription_generation: int | None = None) -> None:
         pcm = bytes(msg.data)
         now = time.monotonic()
-        self._idx += 1
+        is_eof = len(pcm) == 8 and pcm == self.AUDIO_EOF_MAGIC
+        with self._playback_cv:
+            active_generation = self._active_subscription_generation
+            if subscription_generation is None:
+                # Direct calls are retained for tests; production callbacks
+                # always carry the generation captured by start_play().
+                subscription_generation = active_generation
+            if (active_generation is None
+                    or subscription_generation != active_generation
+                    or self.state in ("idle", "stopping", "error")):
+                return
+            self._idx += 1
 
-        # 检测 EOF magic：utterance 结束标记
-        if len(pcm) == 8 and pcm == self.AUDIO_EOF_MAGIC:
-            if self._muted:
-                self._muted = False
-                self.get_logger().info("[speaker] unmuted — received EOF marker")
-            return  # EOF 不入 buffer、不播放
+            # 检测 EOF magic：utterance 结束标记
+            if is_eof:
+                if self._muted:
+                    self._muted = False
+                    self._playback_cv.notify_all()
+                    unmuted = True
+                    playback_id = None
+                elif self._interrupt_flag.is_set():
+                    unmuted = False
+                    playback_id = None
+                else:
+                    unmuted = False
+                    playback_id = self._current_input_id
+                    if playback_id is not None:
+                        record = self._playbacks[playback_id]
+                        record["eof_received"] = True
+                        record["eof_monotonic"] = now
+                        self._current_input_id = None
+                        # Queue the boundary under the same lifecycle lock so
+                        # interrupt cannot miss it between state and queue.
+                        self._buf.put(("eof", playback_id, b""))
+                        self._playback_cv.notify_all()
+            elif not pcm:
+                return
+            else:
+                # Muted 状态：interrupt 后丢弃来自旧 utterance 的 chunks
+                if self._muted:
+                    self._last_chunk_time = now
+                    return  # 丢弃，等 EOF 到达
+                if self._interrupt_flag.is_set():
+                    return
+                playback_id = self._current_input_id
+                if playback_id is None:
+                    playback_id = self._new_playback()
+                record = self._playbacks[playback_id]
+                record["audio_bytes"] += len(pcm)
+                self._buf.put(("audio", playback_id, pcm))
+                self._last_chunk_time = now
+                # 更新状态：收到 chunk 时如果是 ready，变为 playing
+                if self.state == "ready":
+                    self.state = "playing"
+                self._playback_cv.notify_all()
 
-        # Muted 状态：interrupt 后丢弃来自旧 utterance 的 chunks
-        if self._muted:
-            self._last_chunk_time = now
-            return  # 丢弃，等 EOF 到达
+        if is_eof:
+            if unmuted:
+                self.get_logger().info(
+                    "[speaker] unmuted — received EOF marker"
+                )
+                return
+            if playback_id is None:
+                self.get_logger().warn("[speaker] ignored EOF without audio")
+                return
+            if not self._draining.is_set():
+                self._start_drain()
+            return
 
-        self._buf.put(pcm)
-        self._last_chunk_time = now
-        # 更新状态：收到 chunk 时如果是 ready，变为 playing
-        if self.state == "ready":
-            self.state = "playing"
-        if not self._draining.is_set() and self.state == "playing" and self._buf.qsize() >= self.PREFILL:
+        if (not self._draining.is_set() and self.state == "playing"
+                and self._buf.qsize() >= self.PREFILL):
             self._start_drain()
-        elif not self._draining.is_set() and self.state == "playing" and self._flush_timer is None:
+        elif (not self._draining.is_set() and self.state == "playing"
+              and self._flush_timer is None):
             # start a flush timer — if no more chunks arrive, drain what we have
             self._flush_timer = self.create_timer(0.2, self._check_flush)
 
-    def _start_drain(self) -> None:
-        if self._flush_timer is not None:
-            self._flush_timer.cancel()
-            self.destroy_timer(self._flush_timer)
-            self._flush_timer = None
-        self._draining.set()
-        self._drain_thread = threading.Thread(target=self._drain, daemon=True)
-        self._drain_thread.start()
+    def _start_drain(self) -> bool:
+        with self._drain_guard:
+            if (self._interrupt_flag.is_set()
+                    or self.state != "playing"
+                    or self._active_subscription_generation is None
+                    or self._buf.empty()):
+                return False
+            if (self._draining.is_set()
+                    or (self._drain_thread is not None
+                        and self._drain_thread.is_alive())):
+                return False
+            if self._flush_timer is not None:
+                self._flush_timer.cancel()
+                self.destroy_timer(self._flush_timer)
+                self._flush_timer = None
+            self._draining.set()
+            self._drain_thread = threading.Thread(
+                target=self._drain,
+                daemon=True,
+                name="g1_speaker_drain",
+            )
+            self._drain_thread.start()
+            return True
 
     def _check_flush(self) -> None:
         """Timer callback: if no new chunks for 300ms and buffer non-empty, start drain."""
@@ -487,57 +915,285 @@ class _SpeakerNode(Node):
     def _drain(self) -> None:
         play_idx = 0
         merged = b''
+        current_id = None
         empty_count = 0
-        while self._draining.is_set():
-            # 检查 interrupt
-            if self._interrupt_flag.is_set():
-                return
-            # 检查 pause（阻塞等待 resume 或 interrupt）
-            if not self._pause_event.wait(timeout=0.1):
-                continue  # 还在 paused，循环检查 interrupt
+        try:
+            while self._draining.is_set():
+                if self._interrupt_flag.is_set():
+                    return
+                if not self._pause_event.wait(timeout=0.1):
+                    continue
 
-            try:
-                pcm = self._buf.get(timeout=0.1)
-                merged += pcm
-                empty_count = 0
-            except queue.Empty:
-                empty_count += 1
-                if merged and empty_count >= 2:
-                    play_idx += 1
-                    self._play_merged(merged, play_idx)
-                    merged = b''
-                elif not merged and empty_count >= 3:
-                    break
-                continue
-            if len(merged) >= self.MERGE_BYTES:
+                try:
+                    kind, playback_id, pcm = self._buf.get(timeout=0.1)
+                    empty_count = 0
+                except queue.Empty:
+                    empty_count += 1
+                    if merged and empty_count >= 2:
+                        play_idx += 1
+                        if not self._play_merged(merged, play_idx, current_id):
+                            if self._interrupt_flag.is_set():
+                                return
+                            self._failed_playback_ids.add(current_id)
+                        merged = b''
+                        empty_count = 0
+                    elif not merged and empty_count >= 3:
+                        break
+                    continue
+
+                if current_id is None:
+                    current_id = playback_id
+                elif playback_id != current_id:
+                    if merged:
+                        play_idx += 1
+                        if not self._play_merged(merged, play_idx, current_id):
+                            if self._interrupt_flag.is_set():
+                                return
+                            self._failed_playback_ids.add(current_id)
+                        merged = b''
+                    self._set_terminal(
+                        current_id, "error", "utterance_boundary_missing_eof",
+                    )
+                    current_id = playback_id
+
+                if kind == "audio":
+                    merged += pcm
+                    if len(merged) >= self.MERGE_BYTES:
+                        play_idx += 1
+                        if not self._play_merged(merged, play_idx, current_id):
+                            if self._interrupt_flag.is_set():
+                                return
+                            self._failed_playback_ids.add(current_id)
+                        merged = b''
+                elif kind == "eof":
+                    if merged:
+                        play_idx += 1
+                        if not self._play_merged(merged, play_idx, current_id):
+                            if self._interrupt_flag.is_set():
+                                return
+                            self._failed_playback_ids.add(current_id)
+                        merged = b''
+                    if current_id in self._failed_playback_ids:
+                        self._set_terminal(
+                            current_id, "error", "play_stream_failed",
+                        )
+                    else:
+                        self._finish_playback(current_id)
+                    current_id = None
+                    play_idx = 0
+        finally:
+            if merged and current_id is not None and not self._interrupt_flag.is_set():
                 play_idx += 1
-                self._play_merged(merged, play_idx)
-                merged = b''
-        if merged and not self._interrupt_flag.is_set():
-            play_idx += 1
-            self._play_merged(merged, play_idx)
-        self._draining.clear()
-        # 播放完毕，回到 ready（如果没有被 interrupt/stop）
-        if self.state == "playing":
-            self.state = "ready"
-        self.get_logger().info("[speaker] drain finished")
+                if not self._play_merged(merged, play_idx, current_id):
+                    if not self._interrupt_flag.is_set():
+                        self._failed_playback_ids.add(current_id)
+            interrupted = self._interrupt_flag.is_set()
+            with self._drain_guard:
+                self._draining.clear()
+                if self._drain_thread is threading.current_thread():
+                    self._drain_thread = None
+                should_restart = (
+                    not interrupted
+                    and not self._buf.empty()
+                    and self.state == "playing"
+                )
+            if interrupted:
+                return
+            with self._playback_cv:
+                has_open_input = self._current_input_id is not None
+            if self.state == "playing" and not has_open_input and self._buf.empty():
+                self.state = "ready"
+            self.get_logger().info("[speaker] drain finished")
+            # Worker start/idle transitions are serialized and the queue is
+            # rechecked after clearing _draining, closing the last-item race.
+            if should_restart:
+                self._start_drain()
 
-    def _play_merged(self, pcm: bytes, idx: int) -> None:
+    def _play_merged(self, pcm: bytes, idx: int,
+                     playback_id: int | None) -> bool:
         # 播放前再次检查 interrupt
-        if self._interrupt_flag.is_set():
-            return
+        if self._interrupt_flag.is_set() or playback_id is None:
+            return False
         duration = len(pcm) / 32000
+        submission_checkpoint = self._playback_monitor.checkpoint()
+        with self._playback_cv:
+            record = self._playbacks.get(playback_id)
+            if record is None or record["state"] in self.TERMINAL_STATES:
+                return False
+            if record["start_event_seq"] is None:
+                record["start_event_seq"] = submission_checkpoint
+                record["state"] = "playing"
+            stream_id = record["stream_id"]
         t0 = time.monotonic()
         try:
-            code, data = self._client.PlayStream(APP_NAME, "0", pcm)
+            code, data = self._client.PlayStream(APP_NAME, stream_id, pcm)
             if code != 0:
                 self.get_logger().error(f"[speaker] PlayStream error code={code}, data={data}")
-        except Exception as e:
-            self.get_logger().error(f"[speaker] PlayStream error: {e}")
+                self._handle_play_stream_failure(
+                    playback_id, f"rpc_code:{code}",
+                )
+                return False
+        except Exception as exc:
+            self.get_logger().error(f"[speaker] PlayStream error: {exc}")
+            self._handle_play_stream_failure(
+                playback_id,
+                f"{type(exc).__name__}:{exc}",
+            )
+            return False
         elapsed = time.monotonic() - t0
-        remaining = duration - elapsed - 0.08
+        remaining = duration - elapsed
         if remaining > 0 and not self._interrupt_flag.is_set():
-            time.sleep(remaining)
+            self._interrupt_flag.wait(timeout=remaining)
+        pcm_deadline = max(t0 + duration, time.monotonic())
+        with self._playback_cv:
+            record = self._playbacks.get(playback_id)
+            if record is not None and record["state"] not in self.TERMINAL_STATES:
+                record["submitted_blocks"] += 1
+                record["final_submit_seq"] = submission_checkpoint
+                record["final_pcm_deadline"] = pcm_deadline
+                self._playback_cv.notify_all()
+        return not self._interrupt_flag.is_set()
+
+    def _handle_play_stream_failure(self, playback_id: int,
+                                    stream_error: str) -> None:
+        """Stop and quarantine the session after an ambiguous stream RPC."""
+        # Latch before any cleanup call/wait.  SmartMotion interrupt can cancel
+        # the wait below, but it must never erase the ambiguous RPC failure.
+        self._latch_fail_closed("play_stream_failed")
+        if self._interrupt_flag.is_set():
+            return
+        with self._playback_cv:
+            record = self._playbacks.get(playback_id)
+            if record is None or record["state"] in self.TERMINAL_STATES:
+                return
+            after_seq = record["start_event_seq"]
+
+        stop_checkpoint = self._playback_monitor.checkpoint()
+        stop_started = time.monotonic()
+        stop_code = self._safe_play_stop()
+        cleanup_result = {
+            "state": "error",
+            "reason": f"play_stop_failed:{stop_code}",
+        }
+        if stop_code == 0 and after_seq is not None:
+            cleanup_result = self._playback_monitor.wait_for_stable_idle(
+                after_seq=after_seq,
+                idle_after_seq=stop_checkpoint,
+                not_before=stop_started,
+                timeout=self.STOP_IDLE_TIMEOUT,
+                cancelled=self._interrupt_flag.is_set,
+            )
+        if cleanup_result["state"] == "interrupted":
+            # The explicit interrupt/stop owns cancellation and recovery.
+            return
+
+        self._set_terminal(
+            playback_id,
+            "error",
+            "play_stream_failed",
+            stream_error=stream_error,
+            forced_stream_close=True,
+            play_stop_code=stop_code,
+            cleanup_state=cleanup_result.get("state"),
+            cleanup_reason=cleanup_result.get("reason", ""),
+            firmware_playing_seq=cleanup_result.get("playing_seq"),
+            firmware_idle_seq=cleanup_result.get("idle_seq"),
+        )
+        # Even a confirmed Stop cannot prove whether the failed RPC was
+        # accepted before its ACK was lost.  Require an explicit stop/restart
+        # boundary instead of ever sending a later utterance in this session.
+        self._enter_fail_closed("play_stream_failed")
+
+    def _finish_playback(self, playback_id: int) -> None:
+        with self._playback_cv:
+            record = self._playbacks.get(playback_id)
+            if record is None or record["state"] in self.TERMINAL_STATES:
+                return
+            after_seq = record["start_event_seq"]
+            idle_after_seq = record["final_submit_seq"]
+            pcm_deadline = record["final_pcm_deadline"]
+            if (after_seq is None or idle_after_seq is None
+                    or pcm_deadline is None):
+                self._set_terminal(
+                    playback_id, "error", "no_successful_pcm_submission",
+                )
+                return
+            record["state"] = "finishing"
+            self._playback_cv.notify_all()
+
+        result = self._playback_monitor.wait_for_stable_idle(
+            after_seq=after_seq,
+            idle_after_seq=idle_after_seq,
+            not_before=pcm_deadline,
+            timeout=self.NATURAL_IDLE_TIMEOUT,
+            cancelled=self._interrupt_flag.is_set,
+        )
+        if result["state"] == "interrupted":
+            self._set_terminal(playback_id, "cancelled", "interrupted")
+            return
+
+        if result["state"] == "completed":
+            basis = "g1_audio_service_stable_idle"
+            self._set_terminal(
+                playback_id,
+                "completed",
+                completion_basis=basis,
+                forced_stream_close=False,
+                firmware_playing_seq=result.get("playing_seq"),
+                firmware_idle_seq=result.get("idle_seq"),
+                firmware_playing_ts=result.get("playing_ts"),
+                firmware_idle_ts=result.get("idle_ts"),
+            )
+            self.get_logger().info(
+                f"[speaker] playback {playback_id} completed ({basis})"
+            )
+            return
+
+        natural_failure = result
+        stop_code = self._safe_play_stop()
+        if stop_code != 0:
+            self._set_terminal(
+                playback_id,
+                "error",
+                f"play_stop_failed:{stop_code}",
+                forced_stream_close=True,
+            )
+            self._enter_fail_closed(f"play_stop_failed:{stop_code}")
+            return
+
+        cleanup_result = self._playback_monitor.wait_for_stable_idle(
+            after_seq=after_seq,
+            idle_after_seq=idle_after_seq,
+            not_before=pcm_deadline,
+            timeout=self.STOP_IDLE_TIMEOUT,
+            cancelled=self._interrupt_flag.is_set,
+        )
+        if cleanup_result["state"] == "interrupted":
+            self._set_terminal(
+                playback_id,
+                "cancelled",
+                "interrupted_during_forced_close",
+                forced_stream_close=True,
+                play_stop_code=stop_code,
+            )
+            return
+
+        self._set_terminal(
+            playback_id,
+            "error",
+            "playback_not_complete_before_forced_close",
+            forced_stream_close=True,
+            play_stop_code=stop_code,
+            natural_wait_reason=natural_failure.get("reason", ""),
+            cleanup_state=cleanup_result.get("state"),
+            cleanup_reason=cleanup_result.get("reason", ""),
+            firmware_playing_seq=cleanup_result.get("playing_seq"),
+            firmware_idle_seq=cleanup_result.get("idle_seq"),
+        )
+        if cleanup_result["state"] != "completed":
+            self._enter_fail_closed(
+                "hardware_idle_unconfirmed_after_forced_close"
+            )
 
 
 class SpeakerPlugin:
@@ -545,6 +1201,7 @@ class SpeakerPlugin:
 
     def __init__(self, plugin_config: dict, namespace: str, executor, audio_client: AudioClient):
         self._node = _SpeakerNode(audio_client)
+        self._lifecycle_lock = self._node._lifecycle_lock
         executor.add_node(self._node)
 
     def get_tool(self) -> dict:
@@ -558,15 +1215,40 @@ class SpeakerPlugin:
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["start", "stop", "info"],
+                        "enum": ["start", "stop", "info", "wait_playback"],
                         "description": "Action to perform",
                     },
                     "input_topic": {
                         "type": "string",
                         "description": "ROS2 topic to subscribe for PCM audio (provided by canvas connection)",
                     },
+                    "playback_id": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Wait for this exact playback ID",
+                    },
+                    "after_playback_id": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Baseline from speaker info.last_playback_id; wait for the first newer playback",
+                    },
+                    "timeout_sec": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 120,
+                        "default": 30,
+                    },
                 },
                 "required": ["action"],
+                "x-action-params": {
+                    "start": {"params": ["input_topic"]},
+                    "stop": {"params": []},
+                    "info": {"params": []},
+                    "wait_playback": {
+                        "params": ["after_playback_id", "timeout_sec"],
+                        "description": "Call speaker info first, then wait until G1 firmware reports stable idle for the first PCM utterance after that last_playback_id",
+                    },
+                },
             },
             "topic_in": [{"format": "audio/pcm-16k"}],
         }
@@ -574,29 +1256,77 @@ class SpeakerPlugin:
     def start(self) -> None:
         pass  # startup sound is played on first dispatch(start) when project starts
 
-    def _play_startup_sound(self) -> None:
-        """Play startup PCM by directly calling PlayStream in small blocks with pacing."""
+    def _play_startup_sound(self) -> dict:
+        """Play startup audio and leave the global service stably idle."""
         import pathlib
         pcm_path = pathlib.Path(__file__).parent / 'resource' / 'startup_beep.pcm'
         try:
             pcm = pcm_path.read_bytes()
             block_size = 9600  # ~300ms per block
+            stream_id = f"{self._node._stream_prefix}-startup-{time.time_ns()}"
+            after_seq = self._node._playback_monitor.checkpoint()
+            final_submit_seq = after_seq
+            pcm_deadline = time.monotonic()
             for offset in range(0, len(pcm), block_size):
+                if self._node._startup_cancel.is_set():
+                    self._node._safe_play_stop()
+                    return {"state": "cancelled", "reason": "startup_cancelled"}
                 block = pcm[offset:offset + block_size]
-                code, _ = self._node._client.PlayStream(APP_NAME, "0", block)
+                submit_seq = self._node._playback_monitor.checkpoint()
+                sent = time.monotonic()
+                code, _ = self._node._client.PlayStream(
+                    APP_NAME, stream_id, block,
+                )
                 if code != 0:
+                    self._node._safe_play_stop()
                     self._node.get_logger().warn(f"[speaker] startup sound stopped at offset {offset}: code={code}")
-                    return
+                    return {
+                        "state": "error",
+                        "reason": f"startup_play_stream_failed:{code}",
+                    }
+                final_submit_seq = submit_seq
                 duration = len(block) / 32000
-                remaining = duration - 0.08
-                if remaining > 0:
-                    time.sleep(remaining)
-            self._node.get_logger().info(f"[speaker] startup sound OK ({len(pcm)} bytes)")
+                remaining = duration - (time.monotonic() - sent)
+                if (remaining > 0
+                        and self._node._startup_cancel.wait(remaining)):
+                    self._node._safe_play_stop()
+                    return {"state": "cancelled", "reason": "startup_cancelled"}
+                pcm_deadline = max(sent + duration, time.monotonic())
+            completion = self._node._playback_monitor.wait_for_stable_idle(
+                after_seq=after_seq,
+                idle_after_seq=final_submit_seq,
+                not_before=pcm_deadline,
+                timeout=self._node.NATURAL_IDLE_TIMEOUT,
+                cancelled=self._node._startup_cancel.is_set,
+            )
+            stop_code = None
+            if completion["state"] != "completed":
+                stop_code = self._node._safe_play_stop()
+                if stop_code == 0:
+                    completion = self._node._playback_monitor.wait_for_stable_idle(
+                        after_seq=after_seq,
+                        idle_after_seq=final_submit_seq,
+                        not_before=pcm_deadline,
+                        timeout=self._node.STOP_IDLE_TIMEOUT,
+                        cancelled=self._node._startup_cancel.is_set,
+                    )
+            self._node.get_logger().info(
+                f"[speaker] startup sound closed ({len(pcm)} bytes, "
+                f"state={completion['state']}, PlayStop={stop_code})"
+            )
+            return completion
         except Exception as e:
             self._node.get_logger().warn(f"[speaker] startup sound error: {e}")
+            self._node._safe_play_stop()
+            return {
+                "state": "error",
+                "reason": f"startup_exception:{type(e).__name__}:{e}",
+            }
 
     def stop(self) -> None:
-        self._node.stop_play()
+        self._node._startup_cancel.set()
+        with self._lifecycle_lock:
+            self._node.stop_play()
 
     def dispatch(self, action: str, args: dict) -> dict | None:
         if action != "info":
@@ -605,21 +1335,67 @@ class SpeakerPlugin:
             topic = args.get("input_topic", "")
             if not topic:
                 return {"error": "Missing input_topic"}
-            # Always stop first to ensure clean restart
-            self._node.stop_play()
-            # Play startup sound synchronously before starting subscription
-            self._play_startup_sound()
-            topic = self._node.start_play(topic)
-            return {"state": "ready", "topic": topic}
+            with self._lifecycle_lock:
+                # Clear only once, before internal cleanup.  Any concurrent
+                # stop request after this point sets the event permanently for
+                # this startup generation and cannot be overwritten.
+                self._node._startup_cancel.clear()
+                # Always stop first to ensure clean restart.
+                stopped = self._node.stop_play(cancel_startup=False)
+                if stopped["state"] == "error":
+                    return stopped
+                startup = self._play_startup_sound()
+                if startup["state"] != "completed":
+                    self._node.stop_play()
+                    return {
+                        "state": "error",
+                        "reason": "startup_audio_not_settled",
+                        "startup": startup,
+                    }
+                topic = self._node.start_play(topic)
+                return {"state": "ready", "topic": topic}
         elif action == "stop":
-            self._node.stop_play()
-            return {"state": "idle"}
+            self._node._startup_cancel.set()
+            with self._lifecycle_lock:
+                return self._node.stop_play()
         elif action == "info":
+            with self._node._playback_cv:
+                last_id = self._node._playback_sequence
+                latest = (
+                    self._node._playback_snapshot_locked(last_id)
+                    if last_id else None
+                )
+                fail_closed_reason = self._node._fail_closed_reason
             return {
                 "state": self._node.state,
                 "topic": self._node._topic,
                 "buffer_chunks": self._node._buf.qsize(),
+                "last_playback_id": last_id,
+                "latest_playback": latest,
+                "hardware_playback": self._node._playback_monitor.status(),
+                "completion_scope": "driver_serialized_pcm_speaker_session",
+                "native_tts_blocked": (
+                    _G1_PCM_COMPLETION_MODE_ENABLED.is_set()
+                ),
+                "recovery_required": (
+                    fail_closed_reason is not None
+                ),
+                "fail_closed_reason": fail_closed_reason,
             }
+        elif action == "wait_playback":
+            timeout = min(120.0, max(0.0, float(args.get("timeout_sec", 30))))
+            playback_id = args.get("playback_id")
+            after_playback_id = args.get("after_playback_id")
+            if playback_id is not None and after_playback_id is not None:
+                return {
+                    "state": "error",
+                    "reason": "choose_playback_id_or_after_playback_id",
+                }
+            return self._node.wait_for_playback(
+                playback_id=playback_id,
+                after_playback_id=after_playback_id,
+                timeout=timeout,
+            )
         return None
 
 

--- a/unitree/g1/playback_state.py
+++ b/unitree/g1/playback_state.py
@@ -1,0 +1,233 @@
+"""Observe the G1 body audio player's state over Unitree DDS.
+
+The public ``AudioClient`` can submit and stop audio, but it has no status
+method.  G1 firmware publishes the global player state on ``rt/audio_msg`` as
+JSON (``{"play_state": 1}`` while active and ``{"play_state": 0}`` while
+idle).  This module turns that event stream into a conservative stable-idle
+signal for the serialized speaker stream.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+import json
+import threading
+import time
+from typing import Callable
+
+
+class G1PlaybackStateMonitor:
+    """Track G1 audio-service transitions and wait for stable idle."""
+
+    def __init__(self, topic: str = "rt/audio_msg", *, available: bool = False,
+                 connect_error: str = "not_connected", monotonic=None,
+                 history_limit: int = 256, idle_settle_sec: float = 0.35):
+        self.topic = topic
+        self._monotonic = monotonic or time.monotonic
+        self._cv = threading.Condition(threading.RLock())
+        self._events = deque(maxlen=max(16, int(history_limit)))
+        self._event_seq = 0
+        self._current_state: int | None = None
+        self._last_event_ts: float | None = None
+        self._available = bool(available)
+        self._connect_error = "" if available else connect_error
+        self._idle_settle_sec = max(0.0, float(idle_settle_sec))
+        self._subscriber = None
+
+    @classmethod
+    def connect_dds(cls, topic: str = "rt/audio_msg", *, monotonic=None,
+                    idle_settle_sec: float = 0.35):
+        """Subscribe without making speaker startup fail if DDS is absent."""
+        monitor = cls(
+            topic,
+            monotonic=monotonic,
+            idle_settle_sec=idle_settle_sec,
+        )
+        try:
+            from unitree_sdk2py.core.channel import ChannelSubscriber
+            from unitree_sdk2py.idl.std_msgs.msg.dds_ import String_
+
+            subscriber = ChannelSubscriber(topic, String_)
+            # queueLen=0 dispatches directly from the DDS callback and avoids
+            # adding another ordering boundary between player state and RPC.
+            subscriber.Init(monitor.on_dds_message, 0)
+            monitor._subscriber = subscriber
+            with monitor._cv:
+                monitor._available = True
+                monitor._connect_error = ""
+        except Exception as exc:
+            with monitor._cv:
+                monitor._available = False
+                monitor._connect_error = (
+                    f"dds_subscribe_failed:{type(exc).__name__}:{exc}"
+                )
+        return monitor
+
+    @property
+    def available(self) -> bool:
+        with self._cv:
+            return self._available
+
+    def checkpoint(self) -> int:
+        """Return the latest event sequence before starting a new stream."""
+        with self._cv:
+            return self._event_seq
+
+    def on_dds_message(self, msg) -> None:
+        raw = getattr(msg, "data", None)
+        if raw is None:
+            raw = getattr(msg, "data_", None)
+        self.on_raw_message(raw)
+
+    def on_raw_message(self, raw) -> bool:
+        """Consume one DDS JSON payload; return whether it was play_state."""
+        if not isinstance(raw, str):
+            return False
+        try:
+            payload = json.loads(raw)
+        except (TypeError, json.JSONDecodeError):
+            return False
+        if not isinstance(payload, dict):
+            return False
+        state = payload.get("play_state")
+        if isinstance(state, bool) or state not in (0, 1):
+            return False
+
+        with self._cv:
+            self._event_seq += 1
+            timestamp = self._monotonic()
+            self._current_state = int(state)
+            self._last_event_ts = timestamp
+            self._events.append((self._event_seq, int(state), timestamp))
+            self._cv.notify_all()
+        return True
+
+    def _evaluate_locked(self, *, after_seq: int, idle_after_seq: int,
+                         not_before: float) -> dict:
+        playing = None
+        idle = None
+        for sequence, state, timestamp in self._events:
+            if sequence <= after_seq:
+                continue
+            if state == 1:
+                # G1 can briefly report 0→1→0 while draining its final PCM.
+                # A later playing event therefore invalidates an earlier idle.
+                playing = (sequence, timestamp)
+                idle = None
+            elif (playing is not None
+                  and sequence > playing[0]
+                  and sequence > idle_after_seq):
+                idle = (sequence, timestamp)
+
+        now = self._monotonic()
+        if idle is not None:
+            stable_since = max(idle[1], float(not_before))
+            settled_for = now - stable_since
+            if settled_for >= self._idle_settle_sec:
+                return {
+                    "state": "completed",
+                    "reason": "",
+                    "playing_seq": playing[0],
+                    "idle_seq": idle[0],
+                    "playing_ts": playing[1],
+                    "idle_ts": idle[1],
+                    "settled_for_sec": settled_for,
+                }
+            return {
+                "state": "waiting",
+                "reason": "idle_not_stable",
+                "playing_seq": playing[0],
+                "idle_seq": idle[0],
+                "settle_remaining_sec": max(
+                    0.0, self._idle_settle_sec - settled_for,
+                ),
+            }
+
+        return {
+            "state": "waiting",
+            "reason": "playing" if playing is not None else "start_not_seen",
+            "playing_seq": playing[0] if playing else None,
+            "idle_seq": None,
+        }
+
+    def wait_for_stable_idle(self, *, after_seq: int,
+                             idle_after_seq: int | None = None,
+                             not_before: float,
+                             timeout: float,
+                             cancelled: Callable[[], bool] | None = None,
+                             poll_interval: float = 0.05) -> dict:
+        """Wait for a post-checkpoint playing→stable-idle transition.
+
+        ``not_before`` is the local deadline of the final PCM block.  DDS and
+        AudioClient RPC replies are independent channels, so completion is not
+        gated on RPC acknowledgement ordering.  ``idle_after_seq`` is captured
+        immediately before sending the final block: it rejects an earlier
+        block's idle, while retaining a valid final idle that races ahead of
+        the final RPC reply.
+        """
+        if cancelled is None:
+            cancelled = lambda: False
+        with self._cv:
+            if not self._available:
+                return {
+                    "state": "error",
+                    "reason": self._connect_error or "play_state_unavailable",
+                }
+
+        deadline = self._monotonic() + max(0.0, float(timeout))
+        idle_gate = (
+            int(after_seq)
+            if idle_after_seq is None else int(idle_after_seq)
+        )
+        while True:
+            if cancelled():
+                return {"state": "interrupted", "reason": "interrupted"}
+            with self._cv:
+                result = self._evaluate_locked(
+                    after_seq=int(after_seq),
+                    idle_after_seq=idle_gate,
+                    not_before=float(not_before),
+                )
+                if result["state"] == "completed":
+                    return result
+                remaining = deadline - self._monotonic()
+                if remaining <= 0:
+                    return {
+                        "state": "timeout",
+                        "reason": (
+                            "play_state_idle_timeout"
+                            if result.get("playing_seq") is not None
+                            else "play_state_start_timeout"
+                        ),
+                        "playing_seq": result.get("playing_seq"),
+                        "idle_seq": result.get("idle_seq"),
+                    }
+                wait_for = min(max(0.001, poll_interval), remaining)
+                settle_remaining = result.get("settle_remaining_sec")
+                if settle_remaining is not None:
+                    wait_for = min(wait_for, max(0.001, settle_remaining))
+                self._cv.wait(timeout=wait_for)
+
+    def status(self) -> dict:
+        with self._cv:
+            return {
+                "available": self._available,
+                "topic": self.topic,
+                "current_state": self._current_state,
+                "event_seq": self._event_seq,
+                "last_event_ts": self._last_event_ts,
+                "idle_settle_sec": self._idle_settle_sec,
+                "connect_error": self._connect_error,
+            }
+
+    def close(self) -> None:
+        subscriber = self._subscriber
+        self._subscriber = None
+        if subscriber is not None:
+            try:
+                subscriber.Close()
+            except Exception:
+                pass
+        with self._cv:
+            self._available = False
+            self._cv.notify_all()

--- a/unitree/g1/tests/test_audio_client_stop.py
+++ b/unitree/g1/tests/test_audio_client_stop.py
@@ -1,0 +1,87 @@
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+G1_DIR = Path(__file__).resolve().parents[1]
+CLIENT_PATH = (
+    G1_DIR / "unitree_sdk2py" / "g1" / "audio" / "g1_audio_client.py"
+)
+
+
+class _Client:
+    def __init__(self, service_name, enable_lease):
+        self.service_name = service_name
+        self.enable_lease = enable_lease
+        self.calls = []
+        self.call_result = (0, "")
+
+    def _Call(self, api_id, parameter):
+        self.calls.append((api_id, parameter))
+        return self.call_result
+
+
+def _package(name):
+    module = types.ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+def _load_audio_client():
+    client_module = types.ModuleType("unitree_sdk2py.rpc.client")
+    client_module.Client = _Client
+    api_module = types.ModuleType(
+        "unitree_sdk2py.g1.audio.g1_audio_api",
+    )
+    constants = {
+        "AUDIO_SERVICE_NAME": "audio",
+        "AUDIO_API_VERSION": "1.0",
+        "ROBOT_API_ID_AUDIO_TTS": 1001,
+        "ROBOT_API_ID_AUDIO_ASR": 1002,
+        "ROBOT_API_ID_AUDIO_START_PLAY": 1003,
+        "ROBOT_API_ID_AUDIO_STOP_PLAY": 1004,
+        "ROBOT_API_ID_AUDIO_GET_VOLUME": 1005,
+        "ROBOT_API_ID_AUDIO_SET_VOLUME": 1006,
+        "ROBOT_API_ID_AUDIO_SET_RGB_LED": 1007,
+    }
+    for name, value in constants.items():
+        setattr(api_module, name, value)
+
+    stubs = {
+        "unitree_sdk2py": _package("unitree_sdk2py"),
+        "unitree_sdk2py.rpc": _package("unitree_sdk2py.rpc"),
+        "unitree_sdk2py.rpc.client": client_module,
+        "unitree_sdk2py.g1": _package("unitree_sdk2py.g1"),
+        "unitree_sdk2py.g1.audio": _package("unitree_sdk2py.g1.audio"),
+        "unitree_sdk2py.g1.audio.g1_audio_api": api_module,
+    }
+    name = "unitree_sdk2py.g1.audio.g1_audio_client"
+    spec = importlib.util.spec_from_file_location(name, CLIENT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(sys.modules, stubs):
+        spec.loader.exec_module(module)
+    return module
+
+
+class AudioClientStopTests(unittest.TestCase):
+    def test_play_stop_propagates_real_rpc_code(self):
+        module = _load_audio_client()
+        client = module.AudioClient()
+        client.call_result = (37, "failure")
+
+        result = client.PlayStop("g1_speaker")
+
+        self.assertEqual(result, 37)
+        self.assertEqual(client.calls[0][0], 1004)
+        self.assertEqual(
+            json.loads(client.calls[0][1]),
+            {"app_name": "g1_speaker"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_playback_state.py
+++ b/unitree/g1/tests/test_playback_state.py
@@ -1,0 +1,179 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+G1_DIR = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "g1_playback_state_under_test", G1_DIR / "playback_state.py",
+)
+PLAYBACK_STATE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PLAYBACK_STATE)
+
+
+class _Clock:
+    def __init__(self):
+        self.value = 10.0
+
+    def monotonic(self):
+        return self.value
+
+    def advance(self, seconds):
+        self.value += seconds
+
+
+class PlaybackStateMonitorTests(unittest.TestCase):
+    def setUp(self):
+        self.clock = _Clock()
+        self.monitor = PLAYBACK_STATE.G1PlaybackStateMonitor(
+            available=True,
+            monotonic=self.clock.monotonic,
+            idle_settle_sec=0.35,
+        )
+
+    def test_waits_for_playing_then_stable_idle_after_pcm_deadline(self):
+        checkpoint = self.monitor.checkpoint()
+        self.monitor.on_raw_message('{"play_state":1}')
+        self.clock.advance(0.5)
+        pcm_deadline = self.clock.monotonic()
+        self.monitor.on_raw_message('{"play_state":0}')
+
+        self.assertEqual(
+            self.monitor.wait_for_stable_idle(
+                after_seq=checkpoint,
+                not_before=pcm_deadline,
+                timeout=0,
+            )["state"],
+            "timeout",
+        )
+
+        self.clock.advance(0.36)
+        result = self.monitor.wait_for_stable_idle(
+            after_seq=checkpoint,
+            not_before=pcm_deadline,
+            timeout=0,
+        )
+        self.assertEqual(result["state"], "completed")
+        self.assertEqual(result["playing_seq"], 1)
+        self.assertEqual(result["idle_seq"], 2)
+
+    def test_final_zero_one_zero_bounce_uses_last_idle(self):
+        checkpoint = self.monitor.checkpoint()
+        self.monitor.on_raw_message('{"play_state":1}')
+        self.clock.advance(1.0)
+        pcm_deadline = self.clock.monotonic()
+        self.monitor.on_raw_message('{"play_state":0}')
+        self.clock.advance(0.08)
+        self.monitor.on_raw_message('{"play_state":1}')
+        self.clock.advance(0.18)
+        self.monitor.on_raw_message('{"play_state":0}')
+        self.clock.advance(0.36)
+
+        result = self.monitor.wait_for_stable_idle(
+            after_seq=checkpoint,
+            not_before=pcm_deadline,
+            timeout=0,
+        )
+
+        self.assertEqual(result["state"], "completed")
+        self.assertEqual(result["playing_seq"], 3)
+        self.assertEqual(result["idle_seq"], 4)
+
+    def test_does_not_gate_valid_idle_on_rpc_ack_order(self):
+        checkpoint = self.monitor.checkpoint()
+        self.monitor.on_raw_message('{"play_state":1}')
+        pcm_deadline = self.clock.monotonic()
+        # The final DDS idle can arrive before PlayStream returns.  There is no
+        # post-ACK gate here; stable firmware idle remains valid.
+        self.monitor.on_raw_message('{"play_state":0}')
+        self.clock.advance(0.36)
+
+        self.assertEqual(
+            self.monitor.wait_for_stable_idle(
+                after_seq=checkpoint,
+                not_before=pcm_deadline,
+                timeout=0,
+            )["state"],
+            "completed",
+        )
+
+    def test_idle_from_an_earlier_block_cannot_finish_final_block(self):
+        stream_start = self.monitor.checkpoint()
+        self.monitor.on_raw_message('{"play_state":1}')
+        self.monitor.on_raw_message('{"play_state":0}')
+        final_submit = self.monitor.checkpoint()
+        self.clock.advance(1.0)
+        pcm_deadline = self.clock.monotonic()
+        self.clock.advance(0.36)
+
+        result = self.monitor.wait_for_stable_idle(
+            after_seq=stream_start,
+            idle_after_seq=final_submit,
+            not_before=pcm_deadline,
+            timeout=0,
+        )
+        self.assertEqual(result["state"], "timeout")
+        self.assertEqual(result["reason"], "play_state_idle_timeout")
+
+        # A final idle after the pre-send checkpoint is valid even if the
+        # firmware does not repeat play_state=1 for a continuous stream.
+        self.monitor.on_raw_message('{"play_state":0}')
+        self.clock.advance(0.36)
+        self.assertEqual(
+            self.monitor.wait_for_stable_idle(
+                after_seq=stream_start,
+                idle_after_seq=final_submit,
+                not_before=pcm_deadline,
+                timeout=0,
+            )["state"],
+            "completed",
+        )
+
+    def test_requires_playing_after_checkpoint(self):
+        self.monitor.on_raw_message('{"play_state":1}')
+        checkpoint = self.monitor.checkpoint()
+        self.monitor.on_raw_message('{"play_state":0}')
+        self.clock.advance(1.0)
+
+        result = self.monitor.wait_for_stable_idle(
+            after_seq=checkpoint,
+            not_before=self.clock.monotonic(),
+            timeout=0,
+        )
+
+        self.assertEqual(result["state"], "timeout")
+        self.assertEqual(result["reason"], "play_state_start_timeout")
+
+    def test_rejects_invalid_messages(self):
+        for raw in (
+            None,
+            "",
+            "not-json",
+            "[]",
+            '{"play_state":true}',
+            '{"play_state":2}',
+            '{"text":"hello"}',
+        ):
+            self.assertFalse(self.monitor.on_raw_message(raw))
+        self.assertEqual(self.monitor.status()["event_seq"], 0)
+
+    def test_unavailable_monitor_fails_closed(self):
+        monitor = PLAYBACK_STATE.G1PlaybackStateMonitor(
+            connect_error="dds_subscribe_failed:RuntimeError",
+        )
+
+        self.assertEqual(
+            monitor.wait_for_stable_idle(
+                after_seq=0,
+                not_before=0,
+                timeout=0,
+            ),
+            {
+                "state": "error",
+                "reason": "dds_subscribe_failed:RuntimeError",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_speaker_completion.py
+++ b/unitree/g1/tests/test_speaker_completion.py
@@ -1,0 +1,949 @@
+import importlib.util
+import sys
+import threading
+import time
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+G1_DIR = Path(__file__).resolve().parents[1]
+
+
+class _Logger:
+    def info(self, *_args, **_kwargs):
+        pass
+
+    def warn(self, *_args, **_kwargs):
+        pass
+
+    def error(self, *_args, **_kwargs):
+        pass
+
+
+class _Timer:
+    def __init__(self, callback):
+        self.callback = callback
+
+    def cancel(self):
+        pass
+
+
+class _Node:
+    def __init__(self, name):
+        self.name = name
+        self.logger = _Logger()
+
+    def create_subscription(self, _msg_type, topic, callback, _qos):
+        return types.SimpleNamespace(topic=topic, callback=callback)
+
+    def destroy_subscription(self, _subscription):
+        pass
+
+    def create_publisher(self, *_args, **_kwargs):
+        return types.SimpleNamespace(publish=lambda _msg: None)
+
+    def create_timer(self, _period, callback):
+        return _Timer(callback)
+
+    def destroy_timer(self, _timer):
+        pass
+
+    def get_logger(self):
+        return self.logger
+
+
+class _Header:
+    def __init__(self):
+        self.frame_id = ""
+
+
+class _AudioChunk:
+    def __init__(self, data=b""):
+        self.header = _Header()
+        self.format = "audio/pcm-16k"
+        self.data = list(data)
+
+
+class _QoSProfile:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _package(name):
+    module = types.ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+def _load_device_module():
+    rclpy = _package("rclpy")
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_node.Node = _Node
+    rclpy_qos = types.ModuleType("rclpy.qos")
+    rclpy_qos.QoSProfile = _QoSProfile
+    rclpy_qos.ReliabilityPolicy = types.SimpleNamespace(
+        BEST_EFFORT="best_effort", RELIABLE="reliable",
+    )
+    rclpy_qos.HistoryPolicy = types.SimpleNamespace(KEEP_LAST="keep_last")
+    rclpy_qos.DurabilityPolicy = types.SimpleNamespace(
+        VOLATILE="volatile", TRANSIENT_LOCAL="transient_local",
+    )
+
+    std_msgs = _package("std_msgs")
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    std_msgs_msg.Header = _Header
+    std_msgs_msg.String = type("String", (), {})
+    audio_msgs = _package("audio_msgs")
+    audio_msgs_msg = types.ModuleType("audio_msgs.msg")
+    audio_msgs_msg.AudioChunk = _AudioChunk
+
+    sdk = _package("unitree_sdk2py")
+    sdk_g1 = _package("unitree_sdk2py.g1")
+    sdk_audio = _package("unitree_sdk2py.g1.audio")
+    sdk_client = types.ModuleType("unitree_sdk2py.g1.audio.g1_audio_client")
+    sdk_client.AudioClient = object
+    pointcloud = types.ModuleType("pointcloud_utils")
+    pointcloud.gravity_align_inplace = lambda *_args, **_kwargs: None
+    playback_state = types.ModuleType("playback_state")
+    playback_state.G1PlaybackStateMonitor = object
+
+    stubs = {
+        "rclpy": rclpy,
+        "rclpy.node": rclpy_node,
+        "rclpy.qos": rclpy_qos,
+        "std_msgs": std_msgs,
+        "std_msgs.msg": std_msgs_msg,
+        "audio_msgs": audio_msgs,
+        "audio_msgs.msg": audio_msgs_msg,
+        "unitree_sdk2py": sdk,
+        "unitree_sdk2py.g1": sdk_g1,
+        "unitree_sdk2py.g1.audio": sdk_audio,
+        "unitree_sdk2py.g1.audio.g1_audio_client": sdk_client,
+        "pointcloud_utils": pointcloud,
+        "playback_state": playback_state,
+        "numpy": types.ModuleType("numpy"),
+    }
+    spec = importlib.util.spec_from_file_location(
+        "g1_device_under_test", G1_DIR / "device.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(sys.modules, stubs):
+        spec.loader.exec_module(module)
+    return module
+
+
+DEVICE = _load_device_module()
+
+
+class _AudioClient:
+    def __init__(self):
+        self.stream_calls = []
+        self.stop_calls = []
+        self.stream_code = 0
+        self.stream_codes = []
+        self.stream_exceptions = []
+        self.stop_code = 0
+        self.block_stream = False
+        self.block_stream_call = None
+        self.stream_entered = threading.Event()
+        self.stream_release = threading.Event()
+        self.tts_calls = []
+
+    def PlayStream(self, app_name, stream_id, pcm):
+        self.stream_calls.append((app_name, stream_id, bytes(pcm)))
+        self.stream_entered.set()
+        if (self.block_stream
+                or self.block_stream_call == len(self.stream_calls)):
+            self.stream_release.wait(timeout=5)
+        if self.stream_exceptions:
+            exception = self.stream_exceptions.pop(0)
+            if exception is not None:
+                raise exception
+        code = (
+            self.stream_codes.pop(0)
+            if self.stream_codes else self.stream_code
+        )
+        return code, {}
+
+    def PlayStop(self, app_name):
+        self.stop_calls.append(app_name)
+        return self.stop_code
+
+    def TtsMaker(self, text, voice):
+        self.tts_calls.append((text, voice))
+        return 0
+
+
+class _Monitor:
+    def __init__(self, results=None):
+        self.results = list(results or ["completed"])
+        self.wait_calls = []
+
+    def checkpoint(self):
+        return 7
+
+    def wait_for_stable_idle(self, **kwargs):
+        self.wait_calls.append(kwargs)
+        state = self.results.pop(0) if self.results else "completed"
+        if state == "completed":
+            return {
+                "state": "completed",
+                "reason": "",
+                "playing_seq": 8,
+                "idle_seq": 9,
+                "playing_ts": 1.0,
+                "idle_ts": 2.0,
+            }
+        return {
+            "state": state,
+            "reason": "play_state_idle_timeout",
+            "playing_seq": 8,
+            "idle_seq": None,
+        }
+
+    def status(self):
+        return {"available": True, "current_state": 0, "event_seq": 9}
+
+
+class _ForcedCleanupMonitor(_Monitor):
+    def __init__(self):
+        super().__init__()
+        self.cleanup_entered = threading.Event()
+        self.call_count = 0
+
+    def wait_for_stable_idle(self, **kwargs):
+        self.wait_calls.append(kwargs)
+        self.call_count += 1
+        if self.call_count == 1:
+            return {
+                "state": "timeout",
+                "reason": "play_state_idle_timeout",
+                "playing_seq": 8,
+                "idle_seq": None,
+            }
+        self.cleanup_entered.set()
+        cancelled = kwargs.get("cancelled", lambda: False)
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            if cancelled():
+                return {"state": "interrupted", "reason": "interrupted"}
+            time.sleep(0.01)
+        return {"state": "timeout", "reason": "play_state_idle_timeout"}
+
+
+class _GatedNaturalTimeoutMonitor(_Monitor):
+    def __init__(self, cleanup_state="timeout"):
+        super().__init__()
+        self.cleanup_state = cleanup_state
+        self.natural_wait_entered = threading.Event()
+        self.natural_wait_release = threading.Event()
+        self.call_count = 0
+
+    def wait_for_stable_idle(self, **kwargs):
+        self.wait_calls.append(kwargs)
+        self.call_count += 1
+        if self.call_count == 1:
+            self.natural_wait_entered.set()
+            self.natural_wait_release.wait(timeout=2)
+            return {
+                "state": "timeout",
+                "reason": "play_state_idle_timeout",
+                "playing_seq": 8,
+                "idle_seq": None,
+            }
+        if self.cleanup_state == "completed":
+            return {
+                "state": "completed",
+                "reason": "",
+                "playing_seq": 8,
+                "idle_seq": 9,
+            }
+        return {
+            "state": self.cleanup_state,
+            "reason": "play_state_idle_timeout",
+            "playing_seq": 8,
+            "idle_seq": None,
+        }
+
+
+class _InterruptibleFailureCleanupMonitor(_Monitor):
+    def __init__(self):
+        super().__init__()
+        self.cleanup_entered = threading.Event()
+
+    def wait_for_stable_idle(self, **kwargs):
+        self.wait_calls.append(kwargs)
+        self.cleanup_entered.set()
+        cancelled = kwargs.get("cancelled", lambda: False)
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            if cancelled():
+                return {"state": "interrupted", "reason": "interrupted"}
+            time.sleep(0.005)
+        return {"state": "timeout", "reason": "play_state_idle_timeout"}
+
+
+class _BlockingBytes:
+    def __init__(self, payload):
+        self.payload = payload
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+    def __bytes__(self):
+        self.entered.set()
+        self.release.wait(timeout=2)
+        return self.payload
+
+
+class SpeakerCompletionTests(unittest.TestCase):
+    def _node(self, monitor=None):
+        client = _AudioClient()
+        node = DEVICE._SpeakerNode(client, playback_monitor=monitor or _Monitor())
+        node.start_play("/test/audio")
+        return node, client
+
+    def _publish_utterance(self, node, pcm=b"\x00\x00" * 1600):
+        node._on_chunk(_AudioChunk(pcm))
+        node._on_chunk(_AudioChunk(node.AUDIO_EOF_MAGIC))
+
+    def test_eof_waits_for_firmware_and_exposes_terminal_record(self):
+        monitor = _Monitor()
+        node, client = self._node(monitor)
+        started = time.monotonic()
+
+        self._publish_utterance(node)
+        result = node.wait_for_playback(after_playback_id=0, timeout=2)
+
+        self.assertEqual(result["state"], "completed")
+        self.assertEqual(result["completion_basis"], "g1_audio_service_stable_idle")
+        self.assertTrue(result["eof_received"])
+        self.assertEqual(result["audio_bytes"], 3200)
+        self.assertEqual(result["submitted_blocks"], 1)
+        self.assertGreaterEqual(time.monotonic() - started, 0.09)
+        self.assertEqual(len(client.stream_calls), 1)
+        self.assertNotEqual(client.stream_calls[0][1], "0")
+        self.assertGreaterEqual(
+            monitor.wait_calls[0]["not_before"], result["created_monotonic"],
+        )
+        node.stop_play()
+
+    def test_each_utterance_has_a_distinct_stream_id(self):
+        node, client = self._node(_Monitor(["completed", "completed"]))
+
+        self._publish_utterance(node)
+        first = node.wait_for_playback(after_playback_id=0, timeout=2)
+        self._publish_utterance(node)
+        second = node.wait_for_playback(
+            after_playback_id=first["playback_id"], timeout=2,
+        )
+
+        self.assertEqual(second["state"], "completed")
+        self.assertNotEqual(first["stream_id"], second["stream_id"])
+        self.assertEqual(
+            {call[1] for call in client.stream_calls},
+            {first["stream_id"], second["stream_id"]},
+        )
+        node.stop_play()
+
+    def test_timeout_closes_stream_but_never_claims_completion(self):
+        monitor = _Monitor(["timeout", "completed"])
+        node, client = self._node(monitor)
+
+        self._publish_utterance(node)
+        result = node.wait_for_playback(after_playback_id=0, timeout=2)
+
+        self.assertEqual(result["state"], "error")
+        self.assertEqual(
+            result["reason"],
+            "playback_not_complete_before_forced_close",
+        )
+        self.assertTrue(result["forced_stream_close"])
+        self.assertEqual(result["completion_basis"], "")
+        self.assertEqual(result["cleanup_state"], "completed")
+        # Initial stale-session cleanup + EOF stream close.
+        self.assertGreaterEqual(len(client.stop_calls), 2)
+        node.stop_play()
+
+    def test_wait_after_id_does_not_return_a_stale_completion(self):
+        node, _client = self._node()
+        self._publish_utterance(node)
+        first = node.wait_for_playback(after_playback_id=0, timeout=2)
+
+        result = node.wait_for_playback(
+            after_playback_id=first["playback_id"], timeout=0,
+        )
+
+        self.assertEqual(result["state"], "timeout")
+        self.assertEqual(result["reason"], "playback_not_started")
+        node.stop_play()
+
+    def test_wait_requires_an_explicit_exact_or_after_id(self):
+        node, _client = self._node()
+
+        self.assertEqual(
+            node.wait_for_playback(timeout=0),
+            {
+                "state": "error",
+                "reason": "playback_id_or_after_playback_id_required",
+            },
+        )
+        node.stop_play()
+
+    def test_idle_interrupt_does_not_mute_next_utterance(self):
+        node, _client = self._node()
+
+        result = node.interrupt()
+        self.assertEqual(result["state"], "ready")
+        self.assertFalse(node._muted)
+
+        self._publish_utterance(node)
+        completed = node.wait_for_playback(after_playback_id=0, timeout=2)
+        self.assertEqual(completed["state"], "completed")
+        node.stop_play()
+
+    def test_interrupt_before_eof_mutes_only_until_old_eof(self):
+        node, _client = self._node()
+        node._on_chunk(_AudioChunk(b"\x00\x00" * 1600))
+        first_id = node._playback_sequence
+
+        result = node.interrupt()
+        self.assertEqual(result["state"], "ready")
+        self.assertTrue(node._muted)
+        self.assertEqual(
+            node.wait_for_playback(playback_id=first_id, timeout=0)["state"],
+            "cancelled",
+        )
+
+        node._on_chunk(_AudioChunk(node.AUDIO_EOF_MAGIC))
+        self.assertFalse(node._muted)
+        self._publish_utterance(node)
+        completed = node.wait_for_playback(
+            after_playback_id=first_id, timeout=2,
+        )
+        self.assertEqual(completed["state"], "completed")
+        node.stop_play()
+
+    def test_interrupt_after_eof_does_not_mute_next_utterance(self):
+        node, _client = self._node(_Monitor(["completed", "completed"]))
+        node._on_chunk(_AudioChunk(b"\x00\x00" * 1600))
+        node._on_chunk(_AudioChunk(node.AUDIO_EOF_MAGIC))
+
+        node.interrupt()
+        self.assertFalse(node._muted)
+        first_id = node._playback_sequence
+        self._publish_utterance(node)
+        completed = node.wait_for_playback(
+            after_playback_id=first_id, timeout=2,
+        )
+        self.assertEqual(completed["state"], "completed")
+        node.stop_play()
+
+    def test_stop_cancels_open_playback(self):
+        node, _client = self._node()
+        node._on_chunk(_AudioChunk(b"\x00\x00" * 1600))
+        playback_id = node._playback_sequence
+
+        stopped = node.stop_play()
+
+        self.assertEqual(stopped["state"], "idle")
+        result = node.wait_for_playback(
+            playback_id=playback_id, timeout=0,
+        )
+        self.assertEqual(result["state"], "cancelled")
+        self.assertEqual(result["reason"], "speaker_stopped")
+
+    def test_missing_eof_never_reports_completed(self):
+        node, _client = self._node()
+        node._on_chunk(_AudioChunk(b"\x00\x00" * 1600))
+        playback_id = node._playback_sequence
+
+        node._check_flush()
+        result = node.wait_for_playback(
+            playback_id=playback_id, timeout=0.3,
+        )
+
+        self.assertEqual(result["state"], "timeout")
+        self.assertEqual(result["reason"], "playback_not_finished")
+        node.stop_play()
+
+    def test_two_utterances_can_queue_without_mixing_stream_ids(self):
+        node, client = self._node(_Monitor(["completed", "completed"]))
+
+        self._publish_utterance(node)
+        self._publish_utterance(node)
+        first = node.wait_for_playback(playback_id=1, timeout=2)
+        second = node.wait_for_playback(playback_id=2, timeout=2)
+
+        self.assertEqual(first["state"], "completed")
+        self.assertEqual(second["state"], "completed")
+        self.assertNotEqual(first["stream_id"], second["stream_id"])
+        self.assertEqual(len(client.stream_calls), 2)
+        node.stop_play()
+
+    def test_stuck_worker_blocks_reuse_until_it_really_exits(self):
+        node, client = self._node()
+        client.block_stream = True
+        for _ in range(3):
+            node._on_chunk(_AudioChunk(b"\x00\x00" * 1600))
+        self.assertTrue(client.stream_entered.wait(timeout=1))
+
+        interrupted = node.interrupt()
+
+        self.assertEqual(interrupted["state"], "error")
+        self.assertEqual(interrupted["reason"], "speaker_worker_stop_timeout")
+        self.assertTrue(node._interrupt_flag.is_set())
+        with self.assertRaisesRegex(RuntimeError, "still stopping"):
+            node.start_play("/test/new")
+
+        client.stream_release.set()
+        deadline = time.monotonic() + 2
+        while (node._drain_thread is not None
+               and node._drain_thread.is_alive()
+               and time.monotonic() < deadline):
+            time.sleep(0.01)
+        recovered = node.stop_play()
+        self.assertEqual(recovered["state"], "idle")
+
+    def test_mcp_contract_requires_a_correlation_id(self):
+        node, _client = self._node()
+        plugin = DEVICE.SpeakerPlugin.__new__(DEVICE.SpeakerPlugin)
+        plugin._node = node
+
+        schema = plugin.get_tool()["inputSchema"]
+        self.assertIn("wait_playback", schema["properties"]["action"]["enum"])
+        self.assertIn("playback_id", schema["properties"])
+        self.assertIn("after_playback_id", schema["properties"])
+        self.assertEqual(
+            plugin.dispatch("wait_playback", {"timeout_sec": 0})["reason"],
+            "playback_id_or_after_playback_id_required",
+        )
+        self.assertEqual(
+            plugin.dispatch(
+                "wait_playback",
+                {
+                    "playback_id": 1,
+                    "after_playback_id": 0,
+                    "timeout_sec": 0,
+                },
+            )["reason"],
+            "choose_playback_id_or_after_playback_id",
+        )
+        node.stop_play()
+
+    def test_native_tts_is_rejected_while_pcm_completion_mode_is_enabled(self):
+        node, client = self._node()
+        native = DEVICE.NativeTtsPlugin({}, "test", None, client)
+
+        blocked = native.dispatch("speak", {"text": "hello", "voice": 0})
+        self.assertEqual(blocked["state"], "error")
+        self.assertEqual(
+            blocked["reason"],
+            "native_tts_disabled_for_pcm_completion",
+        )
+        self.assertEqual(client.tts_calls, [])
+
+        node.stop_play()
+        still_blocked = native.dispatch(
+            "speak", {"text": "hello", "voice": 0},
+        )
+        self.assertEqual(still_blocked["state"], "error")
+        self.assertEqual(client.tts_calls, [])
+
+    def test_active_pause_is_rejected_without_stopping_audio(self):
+        node, client = self._node()
+        node._on_chunk(_AudioChunk(b"\x00\x00" * 1600))
+        stop_calls_before = len(client.stop_calls)
+
+        paused = node.pause()
+
+        self.assertEqual(paused["state"], "error")
+        self.assertEqual(paused["reason"], "active_pcm_pause_unsupported")
+        self.assertEqual(len(client.stop_calls), stop_calls_before)
+        node._on_chunk(_AudioChunk(node.AUDIO_EOF_MAGIC))
+        completed = node.wait_for_playback(
+            playback_id=node._playback_sequence, timeout=2,
+        )
+        self.assertEqual(completed["state"], "completed")
+        node.stop_play()
+
+    def test_play_stop_failure_blocks_reuse_and_never_reports_idle(self):
+        node, client = self._node()
+        client.stop_code = 37
+
+        failed = node.stop_play()
+
+        self.assertEqual(failed["state"], "error")
+        self.assertEqual(failed["reason"], "play_stop_failed:37")
+        self.assertTrue(node._interrupt_flag.is_set())
+        with self.assertRaisesRegex(RuntimeError, "still stopping"):
+            node.start_play("/test/reuse")
+
+        client.stop_code = 0
+        recovered = node.stop_play()
+        self.assertEqual(recovered["state"], "idle")
+
+    def test_interrupt_during_forced_cleanup_stays_cancelled(self):
+        monitor = _ForcedCleanupMonitor()
+        node, _client = self._node(monitor)
+        self._publish_utterance(node)
+        self.assertTrue(monitor.cleanup_entered.wait(timeout=2))
+        playback_id = node._playback_sequence
+
+        interrupted = node.interrupt()
+        result = node.wait_for_playback(
+            playback_id=playback_id, timeout=1,
+        )
+
+        self.assertEqual(interrupted["state"], "ready")
+        self.assertEqual(result["state"], "cancelled")
+        self.assertNotEqual(
+            result["reason"],
+            "playback_not_complete_before_forced_close",
+        )
+        node.stop_play()
+
+    def test_eof_interrupt_race_never_mutes_next_generation(self):
+        for _ in range(10):
+            node, _client = self._node(_Monitor(["completed", "completed"]))
+            node._on_chunk(_AudioChunk(b"\x00\x00" * 1600))
+            first_id = node._playback_sequence
+            barrier = threading.Barrier(3)
+
+            def send_eof():
+                barrier.wait()
+                node._on_chunk(_AudioChunk(node.AUDIO_EOF_MAGIC))
+
+            def interrupt():
+                barrier.wait()
+                node.interrupt()
+
+            eof_thread = threading.Thread(target=send_eof)
+            interrupt_thread = threading.Thread(target=interrupt)
+            eof_thread.start()
+            interrupt_thread.start()
+            barrier.wait()
+            eof_thread.join(timeout=2)
+            interrupt_thread.join(timeout=2)
+
+            self.assertFalse(node._muted)
+            self._publish_utterance(node)
+            result = node.wait_for_playback(
+                after_playback_id=first_id, timeout=2,
+            )
+            self.assertEqual(result["state"], "completed")
+            node.stop_play()
+
+    def test_late_callback_cannot_cross_stop_and_restart_generation(self):
+        node, _client = self._node()
+        old_callback = node._sub.callback
+        blocking_data = _BlockingBytes(b"\x00\x00" * 1600)
+        message = types.SimpleNamespace(data=blocking_data)
+        callback_error = []
+
+        def invoke_old_callback():
+            try:
+                old_callback(message)
+            except Exception as exc:  # pragma: no cover - asserted below
+                callback_error.append(exc)
+
+        callback_thread = threading.Thread(target=invoke_old_callback)
+        callback_thread.start()
+        self.assertTrue(blocking_data.entered.wait(timeout=1))
+
+        self.assertEqual(node.stop_play()["state"], "idle")
+        node.start_play("/test/restarted")
+        blocking_data.release.set()
+        callback_thread.join(timeout=1)
+
+        self.assertFalse(callback_thread.is_alive())
+        self.assertEqual(callback_error, [])
+        self.assertEqual(node._playback_sequence, 0)
+        self.assertIsNone(node._current_input_id)
+        self.assertTrue(node._buf.empty())
+        self.assertEqual(node.state, "ready")
+        node.stop_play()
+
+    def test_stop_and_smart_motion_interrupt_leave_no_false_ready_state(self):
+        for _ in range(50):
+            node, _client = self._node()
+            barrier = threading.Barrier(3)
+            results = []
+
+            def stop():
+                barrier.wait()
+                results.append(node.stop_play())
+
+            def interrupt():
+                barrier.wait()
+                results.append(node.interrupt())
+
+            stop_thread = threading.Thread(target=stop)
+            interrupt_thread = threading.Thread(target=interrupt)
+            stop_thread.start()
+            interrupt_thread.start()
+            barrier.wait()
+            stop_thread.join(timeout=1)
+            interrupt_thread.join(timeout=1)
+
+            self.assertFalse(stop_thread.is_alive())
+            self.assertFalse(interrupt_thread.is_alive())
+            self.assertEqual(len(results), 2)
+            self.assertEqual(node.state, "idle")
+            self.assertIsNone(node._sub)
+            self.assertIsNone(node._topic)
+            self.assertIsNone(node._active_subscription_generation)
+
+    def test_failed_forced_stop_cancels_queued_audio_and_blocks_reuse(self):
+        monitor = _GatedNaturalTimeoutMonitor()
+        node, client = self._node(monitor)
+        self._publish_utterance(node)
+        self.assertTrue(monitor.natural_wait_entered.wait(timeout=1))
+        self._publish_utterance(node)
+        client.stop_code = 37
+        monitor.natural_wait_release.set()
+
+        first = node.wait_for_playback(playback_id=1, timeout=1)
+        second = node.wait_for_playback(playback_id=2, timeout=1)
+
+        self.assertEqual(first["state"], "error")
+        self.assertEqual(first["reason"], "play_stop_failed:37")
+        self.assertEqual(second["state"], "cancelled")
+        self.assertEqual(second["reason"], "play_stop_failed:37")
+        self.assertEqual(len(client.stream_calls), 1)
+        self.assertEqual(node.state, "error")
+        self.assertTrue(node._interrupt_flag.is_set())
+        sequence = node._playback_sequence
+        self._publish_utterance(node)
+        self.assertEqual(node._playback_sequence, sequence)
+        with self.assertRaisesRegex(RuntimeError, "still stopping"):
+            node.start_play("/test/reuse")
+
+        client.stop_code = 0
+        self.assertEqual(node.stop_play()["state"], "idle")
+
+    def test_unconfirmed_idle_after_forced_stop_blocks_queued_audio(self):
+        monitor = _GatedNaturalTimeoutMonitor(cleanup_state="timeout")
+        node, client = self._node(monitor)
+        self._publish_utterance(node)
+        self.assertTrue(monitor.natural_wait_entered.wait(timeout=1))
+        self._publish_utterance(node)
+        monitor.natural_wait_release.set()
+
+        first = node.wait_for_playback(playback_id=1, timeout=1)
+        second = node.wait_for_playback(playback_id=2, timeout=1)
+
+        self.assertEqual(first["state"], "error")
+        self.assertEqual(
+            first["reason"],
+            "playback_not_complete_before_forced_close",
+        )
+        self.assertEqual(second["state"], "cancelled")
+        self.assertEqual(
+            second["reason"],
+            "hardware_idle_unconfirmed_after_forced_close",
+        )
+        self.assertEqual(len(client.stream_calls), 1)
+        self.assertEqual(node.state, "error")
+        self.assertTrue(node._interrupt_flag.is_set())
+        self.assertEqual(node.stop_play()["state"], "idle")
+
+    def test_midstream_rpc_failure_stops_and_blocks_later_audio(self):
+        node, client = self._node(_Monitor(["completed"]))
+        client.stream_codes = [0, 37]
+        client.block_stream_call = 2
+        block = b"\x00\x00" * 4800
+
+        # Three full merge blocks start the drain.  Hold the second RPC so an
+        # EOF and a later utterance are deterministically queued behind it.
+        for _ in range(3):
+            node._on_chunk(_AudioChunk(block))
+        deadline = time.monotonic() + 2
+        while (len(client.stream_calls) < 2
+               and time.monotonic() < deadline):
+            time.sleep(0.01)
+        self.assertEqual(len(client.stream_calls), 2)
+
+        node._on_chunk(_AudioChunk(node.AUDIO_EOF_MAGIC))
+        self._publish_utterance(node)
+        client.stream_release.set()
+
+        first = node.wait_for_playback(playback_id=1, timeout=2)
+        second = node.wait_for_playback(playback_id=2, timeout=2)
+
+        self.assertEqual(first["state"], "error")
+        self.assertEqual(first["reason"], "play_stream_failed")
+        self.assertEqual(first["stream_error"], "rpc_code:37")
+        self.assertEqual(first["play_stop_code"], 0)
+        self.assertEqual(second["state"], "cancelled")
+        self.assertEqual(second["reason"], "play_stream_failed")
+        self.assertEqual(len(client.stream_calls), 2)
+        self.assertEqual(node.state, "error")
+        self.assertTrue(node._interrupt_flag.is_set())
+
+        interrupted = node.interrupt()
+        self.assertEqual(interrupted["state"], "error")
+        self.assertEqual(interrupted["reason"], "speaker_stop_required")
+        self.assertEqual(
+            interrupted["fail_closed_reason"], "play_stream_failed",
+        )
+        self.assertTrue(node._interrupt_flag.is_set())
+        sequence = node._playback_sequence
+        self._publish_utterance(node)
+        self.assertEqual(node._playback_sequence, sequence)
+        self.assertEqual(len(client.stream_calls), 2)
+
+        self.assertEqual(node.stop_play()["state"], "idle")
+        node.start_play("/test/recovered")
+        self._publish_utterance(node)
+        recovered = node.wait_for_playback(
+            after_playback_id=sequence, timeout=2,
+        )
+        self.assertEqual(recovered["state"], "completed")
+        self.assertEqual(len(client.stream_calls), 3)
+        node.stop_play()
+
+    def test_stream_exception_is_fail_closed_and_cancels_later_audio(self):
+        node, client = self._node(_Monitor(["completed"]))
+        client.stream_exceptions = [OSError("ack lost")]
+        self.assertEqual(node.pause()["state"], "paused")
+        self._publish_utterance(node)
+        self._publish_utterance(node)
+
+        self.assertEqual(node.resume()["state"], "playing")
+        first = node.wait_for_playback(playback_id=1, timeout=2)
+        second = node.wait_for_playback(playback_id=2, timeout=2)
+
+        self.assertEqual(first["state"], "error")
+        self.assertEqual(first["reason"], "play_stream_failed")
+        self.assertEqual(first["stream_error"], "OSError:ack lost")
+        self.assertEqual(second["state"], "cancelled")
+        self.assertEqual(second["reason"], "play_stream_failed")
+        self.assertEqual(len(client.stream_calls), 1)
+        self.assertEqual(node.state, "error")
+        self.assertTrue(node._interrupt_flag.is_set())
+        self.assertEqual(node.stop_play()["state"], "idle")
+
+    def test_interrupt_during_failed_stream_cleanup_cannot_clear_latch(self):
+        monitor = _InterruptibleFailureCleanupMonitor()
+        node, client = self._node(monitor)
+        client.stream_code = 37
+        self._publish_utterance(node)
+        self.assertTrue(monitor.cleanup_entered.wait(timeout=1))
+
+        interrupted = node.interrupt()
+
+        self.assertEqual(interrupted["state"], "error")
+        self.assertEqual(interrupted["reason"], "speaker_stop_required")
+        self.assertEqual(
+            interrupted["fail_closed_reason"], "play_stream_failed",
+        )
+        self.assertEqual(node.state, "error")
+        self.assertEqual(node._fail_closed_reason, "play_stream_failed")
+        self.assertTrue(node._interrupt_flag.is_set())
+        sequence = node._playback_sequence
+        self._publish_utterance(node)
+        self.assertEqual(node._playback_sequence, sequence)
+        self.assertEqual(len(client.stream_calls), 1)
+
+        client.stop_code = 0
+        self.assertEqual(node.stop_play()["state"], "idle")
+        self.assertIsNone(node._fail_closed_reason)
+
+    def test_stop_cancels_startup_without_deadlock(self):
+        node, _client = self._node()
+        plugin = DEVICE.SpeakerPlugin.__new__(DEVICE.SpeakerPlugin)
+        plugin._node = node
+        plugin._lifecycle_lock = node._lifecycle_lock
+        startup_entered = threading.Event()
+
+        def cancellable_startup():
+            startup_entered.set()
+            node._startup_cancel.wait(timeout=2)
+            return {"state": "cancelled", "reason": "startup_cancelled"}
+
+        plugin._play_startup_sound = cancellable_startup
+        start_result = []
+
+        start_thread = threading.Thread(
+            target=lambda: start_result.append(
+                plugin.dispatch(
+                    "start", {"input_topic": "/test/after-startup"},
+                )
+            ),
+        )
+        start_thread.start()
+        self.assertTrue(startup_entered.wait(timeout=1))
+
+        stopped = plugin.dispatch("stop", {})
+        start_thread.join(timeout=2)
+
+        self.assertFalse(start_thread.is_alive())
+        self.assertEqual(stopped["state"], "idle")
+        self.assertEqual(start_result[0]["state"], "error")
+        self.assertEqual(
+            start_result[0]["reason"], "startup_audio_not_settled",
+        )
+        self.assertEqual(node.state, "idle")
+        self.assertIsNone(node._sub)
+
+    def test_stop_during_internal_start_cleanup_is_not_cleared(self):
+        node, client = self._node()
+        plugin = DEVICE.SpeakerPlugin.__new__(DEVICE.SpeakerPlugin)
+        plugin._node = node
+        plugin._lifecycle_lock = node._lifecycle_lock
+        original_stop_play = node.stop_play
+        cleanup_finished = threading.Event()
+        allow_cleanup_return = threading.Event()
+        startup_submissions = []
+
+        def gated_stop_play(*, cancel_startup=True):
+            result = original_stop_play(cancel_startup=cancel_startup)
+            if not cancel_startup:
+                cleanup_finished.set()
+                allow_cleanup_return.wait(timeout=2)
+            return result
+
+        def startup_probe():
+            if node._startup_cancel.is_set():
+                return {"state": "cancelled", "reason": "startup_cancelled"}
+            startup_submissions.append(True)
+            client.PlayStream("startup", "startup", b"\x00\x00")
+            return {"state": "completed"}
+
+        node.stop_play = gated_stop_play
+        plugin._play_startup_sound = startup_probe
+        start_result = []
+        stop_result = []
+        start_thread = threading.Thread(
+            target=lambda: start_result.append(
+                plugin.dispatch("start", {"input_topic": "/test/start-race"})
+            ),
+        )
+        start_thread.start()
+        self.assertTrue(cleanup_finished.wait(timeout=1))
+
+        stop_thread = threading.Thread(
+            target=lambda: stop_result.append(plugin.dispatch("stop", {})),
+        )
+        stop_thread.start()
+        deadline = time.monotonic() + 1
+        while (not node._startup_cancel.is_set()
+               and time.monotonic() < deadline):
+            time.sleep(0.005)
+        self.assertTrue(node._startup_cancel.is_set())
+        allow_cleanup_return.set()
+        start_thread.join(timeout=2)
+        stop_thread.join(timeout=2)
+
+        self.assertFalse(start_thread.is_alive())
+        self.assertFalse(stop_thread.is_alive())
+        self.assertEqual(startup_submissions, [])
+        self.assertEqual(start_result[0]["state"], "error")
+        self.assertEqual(stop_result[0]["state"], "idle")
+        self.assertEqual(node.state, "idle")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/unitree_sdk2py/g1/audio/g1_audio_client.py
+++ b/unitree/g1/unitree_sdk2py/g1/audio/g1_audio_client.py
@@ -67,5 +67,5 @@ class AudioClient(Client):
     
     def PlayStop(self, app_name: str):
         parameter = json.dumps({"app_name": app_name})
-        self._Call(ROBOT_API_ID_AUDIO_STOP_PLAY, parameter)
-        return 0
+        code, _ = self._Call(ROBOT_API_ID_AUDIO_STOP_PLAY, parameter)
+        return code


### PR DESCRIPTION
## 背景

> **方案定位：基于 G1 硬件播放状态的完成判定。** 最终的 `completed` 来自 G1 固件 DDS `play_state` 的真实 `播放中 → 稳定空闲`，不是根据本地队列清空、PCM 时长或固定定时器推算出的软件完成状态。PCM 时长在这里仅作为防止提前完成的安全门槛。

G1 的 `AudioClient.PlayStream` 返回值只表示本次 PCM 已提交，原先的本地队列清空也不等于机器人扬声器已经播完。因此上层无法可靠判断何时可以继续对话、导航或执行下一步。

实机确认 G1 固件会在 DDS 主题 `rt/audio_msg` 发布全局播放器状态：`play_state=1` 表示正在播放，`play_state=0` 表示空闲。本 PR 直接使用这个底层状态完成 G1 播放结束判定。

需要特别说明：`rt/audio_msg` 是全局状态，不能裸用某一次 `play_state=0` 直接判断当前这句话播完。本实现还会关联当前 PCM/EOF、最后一块提交检查点、真实音频截止时间和 350 ms 稳定空闲，并隔离其他音频来源。

## 变更

- 新增 G1 播放状态监控，解析 `rt/audio_msg`，等待 `播放中 → 稳定空闲`。
- 每句话使用独立的本地 `playback_id` 和固件 `stream_id`；EOF 作为句子边界。
- 按 PCM 真实时长提交，不再用“队列空了”推断播放结束。
- 最后一块 PCM 发送前记录状态序号，并在本地音频截止时间之后确认 350 ms 稳定空闲，可处理实机出现的 `0 → 1 → 0` 尾部抖动以及 RPC/DDS 乱序。
- `speaker` MCP 新增：
  - `info`：查看当前硬件播放状态、最近一条播放记录和 `last_playback_id`。
  - `wait_playback`：按 `playback_id`，或按 `after_playback_id` 等待下一条播放真正结束。
- `PlayStop` 现在透传真实 RPC 返回码；超时、提交失败、Stop 失败、硬件空闲未确认等情况都不会误报 `completed`。
- 异常后进入 fail-closed；SmartMotion 打断不能绕过，必须成功执行 `speaker stop`，再 `speaker start` 才能恢复。
- 增加停止、启动、EOF、回调迟到、RPC/DDS 乱序和多种并发竞态回归测试。

## 怎么使用

前提：Speaker 已通过正常画布连接启动，并持续接收 Perception TTS 输出的 PCM 和 EOF。

1. 播放前调用 `speaker info`，记下 `last_playback_id=N`。
2. 正常触发一次 Perception TTS。
3. 调用：

```json
{
  "action": "wait_playback",
  "after_playback_id": N,
  "timeout_sec": 30
}
```

返回满足下面条件时，表示这次 G1 PCM 播放已结束：

```json
{
  "state": "completed",
  "eof_received": true,
  "forced_stream_close": false,
  "completion_basis": "g1_audio_service_stable_idle",
  "hardware_playback": {
    "current_state": 0
  }
}
```

如果只想看当前播放器是否忙，直接调用 `speaker info`：`hardware_playback.current_state=1` 是播放中，`0` 是空闲。业务流程应使用 `wait_playback`，避免把一次旧的空闲状态误认为当前这句话已经结束。

## 评审人实机检查

1. 调用 `speaker start`，传入实际 PCM 输入主题。
2. 调用 `speaker info`，保存 `last_playback_id`。
3. 从正常 TTS 链路播放一句话，确保生产方发送 EOF。
4. 调用 `speaker wait_playback(after_playback_id=<上一步保存值>, timeout_sec=30)`。
5. 检查返回为 `state=completed`、`eof_received=true`、`forced_stream_close=false`，且最终 `hardware_playback.current_state=0`。
6. 连续播放两句话，确认两个 `playback_id`/`stream_id` 不同，第二次等待不会返回第一次的旧结果。

## 兼容性边界

- 完成状态覆盖 Driver 串行管理的 G1 PCM Speaker 会话，不代表麦克风听到的声学输出。
- `rt/audio_msg` 是全局状态，没有 app/stream ID。为避免原生 TTS 污染 PCM 的完成事件，只要 Speaker 插件启用，同一进程内的原生 `tts.speak` 会返回 `native_tts_disabled_for_pcm_completion`。应使用 Perception TTS → PCM Speaker 链路；若配置中完全禁用 Speaker，原生 TTS 行为保持不变。

## 验证

本地：

```bash
python3 -m unittest discover -s unitree/g1/tests -p 'test_*.py' -v
```

- 35 项测试全部通过。
- `git diff --check` 通过。
- Python 3.10 导入检查通过。

真实 G1：使用本提交源码只读挂载到现有 Driver 镜像，通过真实 MCP 完成 `tools/list → speaker start → PCM+EOF → wait_playback → info → speaker stop`：

- 5 秒、160000 字节 PCM 被拆为 17 个提交块。
- `wait_playback` 返回 `completed`。
- `forced_stream_close=false`。
- 最终固件状态为 `play_state=0`。
- `speaker stop` 返回真实 `PlayStop code=0`。

