### PR TITLE
fix(g1): harden velocity proposals and recover from transient stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ the first fresh, schema-valid, nonzero, nonterminal proposal. Invalid, expired,
 zero, terminal, or retired-nav proposals cannot claim that waiting lease. After
 an automatically bound task reaches a terminal state, the Driver retires its
 `nav_id` and returns to `waiting_for_nav_id` only after `StopMove` and fresh
-odometry confirm zero velocity. A concurrent watchdog fault takes precedence
+odometry confirm zero velocity. A schema-valid terminal proposal for the
+currently bound `nav_id` is always strict zero, so it may retire the lease even
+if ROS delivery exceeds the motion TTL; an expired nonzero proposal remains a
+TTL fault and can never execute. A concurrent watchdog fault takes precedence
 over terminal completion and blocks that automatic rearm, so its delayed
 physical stop cannot cross into the next lease. Explicit bindings, unconfirmed
 stops, and manual overrides remain disarmed until the control plane starts a

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ The Driver proposal envelope matches the `loco` motion contract: `x` and `y`
 accept `[-1, 1]` m/s, and yaw accepts `[-2, 2]` rad/s. Deploy-time
 configuration may tighten these bounds but cannot loosen them.
 
+The safety cloud uses best-effort `KEEP_LAST(1)` delivery and a ROS executor
+worker independent from proposal intake. A bounded `StopMove` or proposal RPC
+therefore cannot starve LiDAR freshness, while missing or invalid clouds still
+fail closed under the unchanged scan timeout.
+
 `loco start` supports two binding modes. Supplying `expected_nav_id` keeps the
 strict control-plane binding behavior. If it is omitted, the Driver subscribes
 in an unarmed `waiting_for_nav_id` state and atomically binds to the `nav_id` of

--- a/README.md
+++ b/README.md
@@ -95,6 +95,30 @@ last confirmed proposal stop. It also reports `binding_mode`,
 `last_set_velocity_duration_ms` value is measured RPC time, not the proposal
 TTL budget.
 
+### G1 Navigation Sensors
+
+The read-only `navigation_sensors` Driver plugin subscribes directly to the
+MID360 raw DDS streams instead of converting the body `/ubuntu/state/imu`
+JSON. It publishes the estimator inputs expected by the Perception FAST-LIVO2
+card:
+
+- `/ubuntu/navigation/lidar_fast_livo` — `sensor_msgs/msg/PointCloud2`,
+  RELIABLE + KEEP_LAST(2), with `x/y/z/intensity/tag/line/timestamp` fields;
+- `/ubuntu/navigation/imu` — `sensor_msgs/msg/Imu`, RELIABLE + KEEP_LAST(200);
+- `/ubuntu/navigation/sensor_diagnostics` — clock warm-up/reset and drop
+  counters as `std_msgs/msg/String` JSON.
+
+LiDAR and IMU retain their shared MID360 source clock and are normalized into
+one ROS system-time domain. Samples are dropped while clock offset estimation
+is not ready or after an invalid/reset observation; the Driver never invents a
+source timestamp. The fixed upside-down mounting rotation is applied equally
+to cloud and IMU. The existing `/ubuntu/lidar/cloud` legacy card remains
+enabled for Canvas and safety consumers.
+
+FAST-LIVO2 must connect to the two native topics above. The body IMU JSON is
+approximately 20 Hz, has no source timestamp, and is not a valid substitute
+for the MID360 built-in IMU.
+
 ## Writing a New Driver
 
 Want to add support for new hardware? See the **[Driver Development Guide](README_dev.md)** for the full specification, including:

--- a/README.md
+++ b/README.md
@@ -97,10 +97,12 @@ TTL budget.
 
 ### G1 Navigation Sensors
 
-The read-only `navigation_sensors` Driver plugin subscribes directly to the
-MID360 raw DDS streams instead of converting the body `/ubuntu/state/imu`
-JSON. It publishes the estimator inputs expected by the Perception FAST-LIVO2
-card:
+The read-only `navigation_sensors` Driver plugin launches an isolated worker
+process which subscribes directly to the MID360 raw DDS streams instead of
+converting the body `/ubuntu/state/imu` JSON. Keeping raw LiDAR conversion and
+IMU forwarding out of the full Driver process prevents the legacy LiDAR,
+camera, and MCP threads from starving the estimator input callbacks. The
+worker publishes the inputs expected by the Perception FAST-LIVO2 card:
 
 - `/ubuntu/navigation/lidar_fast_livo` — `sensor_msgs/msg/PointCloud2`,
   RELIABLE + KEEP_LAST(2), with `x/y/z/intensity/tag/line/timestamp` fields;
@@ -117,7 +119,9 @@ enabled for Canvas and safety consumers.
 
 FAST-LIVO2 must connect to the two native topics above. The body IMU JSON is
 approximately 20 Hz, has no source timestamp, and is not a valid substitute
-for the MID360 built-in IMU.
+for the MID360 built-in IMU. Before accepting a map, verify the isolated worker
+delivers approximately 10 Hz LiDAR and 200 Hz IMU; materially lower rates or
+repeated source-stamp gaps invalidate the mapping run.
 
 ## Writing a New Driver
 

--- a/README.md
+++ b/README.md
@@ -85,14 +85,16 @@ the first fresh, schema-valid, nonzero, nonterminal proposal. Invalid, expired,
 zero, terminal, or retired-nav proposals cannot claim that waiting lease. After
 an automatically bound task reaches a terminal state, the Driver retires its
 `nav_id` and returns to `waiting_for_nav_id` only after `StopMove` and fresh
-odometry confirm zero velocity. A schema-valid terminal proposal for the
-currently bound `nav_id` is always strict zero, so it may retire the lease even
-if ROS delivery exceeds the motion TTL; an expired nonzero proposal remains a
-TTL fault and can never execute. A concurrent watchdog fault takes precedence
-over terminal completion and blocks that automatic rearm, so its delayed
-physical stop cannot cross into the next lease. Explicit bindings, unconfirmed
-stops, and manual overrides remain disarmed until the control plane starts a
-new lease.
+odometry confirm zero velocity. Terminal confirmation waits at most five
+seconds and requires three consecutive fresh samples within `0.03 m/s` on both
+planar axes and `0.05 rad/s` on yaw; a single noisy zero sample cannot unlock
+the next task. A schema-valid terminal proposal for the currently bound
+`nav_id` is always strict zero, so it may retire the lease even if ROS delivery
+exceeds the motion TTL; an expired nonzero proposal remains a TTL fault and can
+never execute. A concurrent watchdog fault takes precedence over terminal
+completion and blocks that automatic rearm, so its delayed physical stop cannot
+cross into the next lease. Explicit bindings, unconfirmed stops, and manual
+overrides remain disarmed until the control plane starts a new lease.
 Every proposal still requires its own `nav_id`; omitting it from `loco start`
 does not disable identity checks.
 

--- a/README.md
+++ b/README.md
@@ -84,17 +84,14 @@ in an unarmed `waiting_for_nav_id` state and atomically binds to the `nav_id` of
 the first fresh, schema-valid, nonzero, nonterminal proposal. Invalid, expired,
 zero, terminal, or retired-nav proposals cannot claim that waiting lease. After
 an automatically bound task reaches a terminal state, the Driver retires its
-`nav_id` and returns to `waiting_for_nav_id` only after `StopMove` and fresh
-odometry confirm zero velocity. Terminal confirmation waits at most five
-seconds and requires three consecutive fresh samples within `0.03 m/s` on both
-planar axes and `0.05 rad/s` on yaw; a single noisy zero sample cannot unlock
-the next task. A schema-valid terminal proposal for the currently bound
+`nav_id`, attempts `StopMove`, records the SDK and odometry diagnostics, and
+immediately returns to `waiting_for_nav_id`. A missing `StopMove` receipt or
+odometry confirmation never latches the Canvas connection or blocks the next
+navigation task. A schema-valid terminal proposal for the currently bound
 `nav_id` is always strict zero, so it may retire the lease even if ROS delivery
 exceeds the motion TTL; an expired nonzero proposal remains a TTL fault and can
-never execute. A concurrent watchdog fault takes precedence over terminal
-completion and blocks that automatic rearm, so its delayed physical stop cannot
-cross into the next lease. Explicit bindings, unconfirmed stops, and manual
-overrides remain disarmed until the control plane starts a new lease.
+never execute. Non-terminal watchdog faults, explicit bindings, and manual
+overrides remain fail-closed until the control plane starts a new lease.
 Every proposal still requires its own `nav_id`; omitting it from `loco start`
 does not disable identity checks.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ python main.py
 4. Tools become available to the LLM agent and appear in the Web Dashboard
 5. The LLM agent can invoke tools via MCP `tools/call`
 
+### G1 Controlled Navigation Velocity
+
+The G1 `loco` actuator accepts a lease-bound
+`phanthy.navigation.velocity_proposal.v1` input. Valid proposals are executed
+through a capacity-one latest-only queue, so an older pending velocity is
+coalesced instead of backlogged. A proposal TTL lapse immediately triggers
+`StopMove`; only a successful post-call zero-odometry confirmation keeps the
+same navigation lease recoverable for the next fresh proposal. Hard safety,
+identity, sequence, RPC, and stop-confirmation faults still disarm the lease.
+
+`loco info` exposes proposal counters, the coalesced count, measured RPC and
+queue latency, rolling RPC p50/p95/p99/max values, rejection reasons, and the
+last confirmed proposal stop. The `last_set_velocity_duration_ms` value is
+measured RPC time, not the proposal TTL budget.
+
 ## Writing a New Driver
 
 Want to add support for new hardware? See the **[Driver Development Guide](README_dev.md)** for the full specification, including:

--- a/README.md
+++ b/README.md
@@ -69,11 +69,31 @@ coalesced instead of backlogged. A proposal TTL lapse immediately triggers
 `StopMove`; only a successful post-call zero-odometry confirmation keeps the
 same navigation lease recoverable for the next fresh proposal. Hard safety,
 identity, sequence, RPC, and stop-confirmation faults still disarm the lease.
+The Driver proposal envelope matches the `loco` motion contract: `x` and `y`
+accept `[-1, 1]` m/s, and yaw accepts `[-2, 2]` rad/s. Deploy-time
+configuration may tighten these bounds but cannot loosen them.
+
+`loco start` supports two binding modes. Supplying `expected_nav_id` keeps the
+strict control-plane binding behavior. If it is omitted, the Driver subscribes
+in an unarmed `waiting_for_nav_id` state and atomically binds to the `nav_id` of
+the first fresh, schema-valid, nonzero, nonterminal proposal. Invalid, expired,
+zero, terminal, or retired-nav proposals cannot claim that waiting lease. After
+an automatically bound task reaches a terminal state, the Driver retires its
+`nav_id` and returns to `waiting_for_nav_id` only after `StopMove` and fresh
+odometry confirm zero velocity. A concurrent watchdog fault takes precedence
+over terminal completion and blocks that automatic rearm, so its delayed
+physical stop cannot cross into the next lease. Explicit bindings, unconfirmed
+stops, and manual overrides remain disarmed until the control plane starts a
+new lease.
+Every proposal still requires its own `nav_id`; omitting it from `loco start`
+does not disable identity checks.
 
 `loco info` exposes proposal counters, the coalesced count, measured RPC and
 queue latency, rolling RPC p50/p95/p99/max values, rejection reasons, and the
-last confirmed proposal stop. The `last_set_velocity_duration_ms` value is
-measured RPC time, not the proposal TTL budget.
+last confirmed proposal stop. It also reports `binding_mode`,
+`waiting_for_nav_id`, and `auto_bound_nav_id`. The
+`last_set_velocity_duration_ms` value is measured RPC time, not the proposal
+TTL budget.
 
 ## Writing a New Driver
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -69,6 +69,10 @@ proposal TTL 失效会立即触发 `StopMove`；只有在返回后用新的 odom
 样本确认零速，同一导航 lease 才能保留并接受下一条新鲜 proposal。安全、
 身份、序列、RPC 和停车确认类硬故障仍会解除武装。
 
+安全点云使用 `BEST_EFFORT + KEEP_LAST(1)`，并在与 proposal 接收分离的
+ROS executor worker 上处理。有界 `StopMove` 或 proposal RPC 不会再阻塞
+LiDAR freshness；点云缺失或无效时仍按原 500 ms 门槛 fail closed。
+
 `loco info` 会返回 proposal 计数、合并数、实测 RPC/队列时延、滚动
 RPC p50/p95/p99/max、逐原因拒绝统计及最近一次已确认停车。
 `last_set_velocity_duration_ms` 表示实测 RPC 耗时，不是 proposal TTL 余量。

--- a/README_zh.md
+++ b/README_zh.md
@@ -60,6 +60,19 @@ python main.py
 4. 工具对 LLM Agent 可用，并显示在 Web Dashboard 中
 5. LLM Agent 通过 MCP `tools/call` 调用工具
 
+### G1 受控导航速度执行
+
+G1 `loco` actuator 接收由导航 lease 约束的
+`phanthy.navigation.velocity_proposal.v1` 输入。有效 proposal 通过容量为 1
+的 latest-only 队列执行：已等待的旧速度会被新速度合并替换，不会积压。
+proposal TTL 失效会立即触发 `StopMove`；只有在返回后用新的 odometry
+样本确认零速，同一导航 lease 才能保留并接受下一条新鲜 proposal。安全、
+身份、序列、RPC 和停车确认类硬故障仍会解除武装。
+
+`loco info` 会返回 proposal 计数、合并数、实测 RPC/队列时延、滚动
+RPC p50/p95/p99/max、逐原因拒绝统计及最近一次已确认停车。
+`last_set_velocity_duration_ms` 表示实测 RPC 耗时，不是 proposal TTL 余量。
+
 ## 开发新驱动
 
 想要为新硬件添加驱动？请参阅 **[驱动开发指南](README_dev.md)** 获取完整规范，包括：

--- a/unitree/g1/Dockerfile
+++ b/unitree/g1/Dockerfile
@@ -56,6 +56,7 @@ COPY controlled_spatial.py /work/controlled_spatial.py
 COPY controlled_spatial_map.py /work/controlled_spatial_map.py
 COPY pointcloud_utils.py /work/pointcloud_utils.py
 COPY navigation_sensor_bridge.py /work/navigation_sensor_bridge.py
+COPY navigation_sensor_bridge_main.py /work/navigation_sensor_bridge_main.py
 COPY navigation_pointcloud.py /work/navigation_pointcloud.py
 COPY navigation_time.py /work/navigation_time.py
 COPY test_slam_rpc.py /work/test_slam_rpc.py

--- a/unitree/g1/Dockerfile
+++ b/unitree/g1/Dockerfile
@@ -55,6 +55,9 @@ COPY scan_context.py /work/scan_context.py
 COPY controlled_spatial.py /work/controlled_spatial.py
 COPY controlled_spatial_map.py /work/controlled_spatial_map.py
 COPY pointcloud_utils.py /work/pointcloud_utils.py
+COPY navigation_sensor_bridge.py /work/navigation_sensor_bridge.py
+COPY navigation_pointcloud.py /work/navigation_pointcloud.py
+COPY navigation_time.py /work/navigation_time.py
 COPY test_slam_rpc.py /work/test_slam_rpc.py
 COPY config.yaml /work/config.yaml
 COPY deploy/     /deploy/

--- a/unitree/g1/Dockerfile
+++ b/unitree/g1/Dockerfile
@@ -50,6 +50,7 @@ COPY device.py /work/device.py
 COPY rpc_proxy.py /work/rpc_proxy.py
 COPY ext_devices.py /work/ext_devices.py
 COPY safety_harness.py /work/safety_harness.py
+COPY velocity_proposal.py /work/velocity_proposal.py
 COPY scan_context.py /work/scan_context.py
 COPY controlled_spatial.py /work/controlled_spatial.py
 COPY controlled_spatial_map.py /work/controlled_spatial_map.py

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -29,7 +29,7 @@ plugins:
     velocity_proposal_nav_status_timeout: 0.25
     velocity_proposal_watchdog_hz: 40
     velocity_proposal_rpc_timeout: 0.1
-    velocity_proposal_stop_rpc_timeout: 0.1
+    velocity_proposal_stop_rpc_timeout: 0.2
     velocity_proposal_fsm_rpc_timeout: 0.2
     velocity_proposal_stop_confirm_timeout: 0.5
     velocity_proposal_stop_linear_epsilon: 0.03

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -48,6 +48,29 @@ plugins:
     enabled: true
   lidar:
     enabled: true
+  # MID360 raw DDS -> native ROS 2 topics used by FAST-LIVO2. This bridge is
+  # read-only and coexists with the legacy lidar card used by Canvas/safety.
+  navigation_sensors:
+    enabled: true
+    raw_cloud_topic: rt/utlidar/cloud_livox_mid360
+    raw_imu_topic: rt/utlidar/imu_livox_mid360
+    publish_raw_cloud: false
+    publish_fast_livo_cloud: true
+    fast_livo_cloud_topic: /ubuntu/navigation/lidar_fast_livo
+    imu_topic: /ubuntu/navigation/imu
+    diagnostics_topic: /ubuntu/navigation/sensor_diagnostics
+    raw_lidar_frame: livox_raw_frame
+    lidar_frame: livox_frame
+    imu_frame: livox_frame
+    # The G1 MID360 is mounted upside down. Apply the same fixed rotation to
+    # both the cloud and its built-in IMU; FAST-LIVO2 keeps identity extrinsics.
+    sensor_rotation_matrix: [1.0, 0.0, 0.0,
+                             0.0, -1.0, 0.0,
+                             0.0, 0.0, -1.0]
+    clock_warmup_samples: 32
+    clock_window_samples: 400
+    clock_reset_threshold_ms: 1000
+    clock_reset_confirm_samples: 8
   slam:
     enabled: false
     map_dir: /opt/phanthy-motus/data/maps

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -34,9 +34,10 @@ plugins:
     velocity_proposal_rpc_timeout: 0.5
     velocity_proposal_stop_rpc_timeout: 0.1
     velocity_proposal_fsm_rpc_timeout: 0.2
-    # G1 StopMove is a one-second zero-velocity SetVelocity command; allow
-    # bounded gait settling while keeping the zero-odom thresholds unchanged.
-    velocity_proposal_stop_confirm_timeout: 2.0
+    # G1 StopMove is a one-second zero-velocity SetVelocity command. Allow up
+    # to five seconds for gait settling; the Driver still requires three
+    # consecutive fresh near-zero odometry samples before releasing the task.
+    velocity_proposal_stop_confirm_timeout: 5.0
     velocity_proposal_stop_linear_epsilon: 0.03
     velocity_proposal_stop_yaw_epsilon: 0.05
     velocity_proposal_allowed_fsm_ids: [500, 801]

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -28,10 +28,14 @@ plugins:
     velocity_proposal_fsm_timeout: 0.5
     velocity_proposal_nav_status_timeout: 0.25
     velocity_proposal_watchdog_hz: 40
-    velocity_proposal_rpc_timeout: 0.1
+    # Parent continuous-velocity RPC is asynchronous to ROS proposal intake;
+    # this bound is for collecting the hardware acknowledgement, not the TTL.
+    velocity_proposal_rpc_timeout: 0.5
     velocity_proposal_stop_rpc_timeout: 0.1
     velocity_proposal_fsm_rpc_timeout: 0.2
-    velocity_proposal_stop_confirm_timeout: 0.5
+    # G1 StopMove is a one-second zero-velocity SetVelocity command; allow
+    # bounded gait settling while keeping the zero-odom thresholds unchanged.
+    velocity_proposal_stop_confirm_timeout: 2.0
     velocity_proposal_stop_linear_epsilon: 0.03
     velocity_proposal_stop_yaw_epsilon: 0.05
     velocity_proposal_allowed_fsm_ids: [500, 801]

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -12,6 +12,29 @@ plugins:
     enabled: true
   loco:
     enabled: true
+    # N5 canvas input. Driver startup is disarmed until loco action=start binds
+    # the one authoritative proposal topic.
+    velocity_proposal_enabled: true
+    velocity_proposal_driver_authorized: true
+    velocity_proposal_max_ttl_ms: 250
+    velocity_proposal_min_x: -0.05
+    velocity_proposal_max_x: 0.15
+    velocity_proposal_max_abs_y: 0.12
+    velocity_proposal_max_abs_yaw: 0.35
+    velocity_proposal_max_planar_speed: 0.18
+    velocity_proposal_odom_timeout: 0.5
+    velocity_proposal_scan_timeout: 0.5
+    velocity_proposal_fsm_check_interval: 0.2
+    velocity_proposal_fsm_timeout: 0.5
+    velocity_proposal_nav_status_timeout: 0.25
+    velocity_proposal_watchdog_hz: 40
+    velocity_proposal_rpc_timeout: 0.1
+    velocity_proposal_stop_rpc_timeout: 0.1
+    velocity_proposal_fsm_rpc_timeout: 0.2
+    velocity_proposal_stop_confirm_timeout: 0.5
+    velocity_proposal_stop_linear_epsilon: 0.03
+    velocity_proposal_stop_yaw_epsilon: 0.05
+    velocity_proposal_allowed_fsm_ids: [500, 801]
   arm:
     enabled: true
   state:

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -29,7 +29,7 @@ plugins:
     velocity_proposal_nav_status_timeout: 0.25
     velocity_proposal_watchdog_hz: 40
     velocity_proposal_rpc_timeout: 0.1
-    velocity_proposal_stop_rpc_timeout: 0.2
+    velocity_proposal_stop_rpc_timeout: 0.1
     velocity_proposal_fsm_rpc_timeout: 0.2
     velocity_proposal_stop_confirm_timeout: 0.5
     velocity_proposal_stop_linear_epsilon: 0.03

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -17,11 +17,12 @@ plugins:
     velocity_proposal_enabled: true
     velocity_proposal_driver_authorized: true
     velocity_proposal_max_ttl_ms: 250
-    velocity_proposal_min_x: -0.05
-    velocity_proposal_max_x: 0.15
-    velocity_proposal_max_abs_y: 0.12
-    velocity_proposal_max_abs_yaw: 0.35
-    velocity_proposal_max_planar_speed: 0.18
+    velocity_proposal_min_x: -1.0
+    velocity_proposal_max_x: 1.0
+    velocity_proposal_max_abs_y: 1.0
+    velocity_proposal_max_abs_yaw: 2.0
+    # sqrt(2): preserve the declared [-1, 1] range on both x and y.
+    velocity_proposal_max_planar_speed: 1.4142135623730951
     velocity_proposal_odom_timeout: 0.5
     velocity_proposal_scan_timeout: 0.5
     velocity_proposal_fsm_check_interval: 0.2

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -1037,7 +1037,11 @@ class LocoPlugin:
     def _connect_velocity_proposal(self, args: dict) -> dict:
         try:
             topic = resolve_input_topic(args, self._velocity_proposal_topic)
-            expected_nav_id = resolve_expected_nav_id(args)
+            expected_nav_id = None
+            if args.get("expected_nav_id") is not None and args.get(
+                "expected_nav_id"
+            ) != "":
+                expected_nav_id = resolve_expected_nav_id(args)
         except ValueError as exc:
             self._client.StopMove()
             if self._smart_motion:
@@ -1046,6 +1050,7 @@ class LocoPlugin:
                 "state": "error",
                 "connected": False,
                 "error": str(exc),
+                "message": str(exc),
                 "topic_in": [self._velocity_proposal_port()],
             }
         if not self._smart_motion:
@@ -1057,9 +1062,14 @@ class LocoPlugin:
                 "topic_in": [self._velocity_proposal_port()],
             }
         result = self._smart_motion.bind_velocity_proposal(topic, expected_nav_id)
-        if result.get("error") or not (
-            result.get("connected") and result.get("armed")
-        ):
+        connected_for_execution = bool(
+            result.get("connected")
+            and (
+                result.get("armed")
+                or result.get("waiting_for_nav_id")
+            )
+        )
+        if result.get("error") or not connected_for_execution:
             result = dict(result)
             fallback_stop_ret = None
             fallback_stop_error = None
@@ -1069,13 +1079,14 @@ class LocoPlugin:
                 fallback_stop_error = str(exc)
             result["fallback_stop_ret"] = fallback_stop_ret
             result["fallback_stop_error"] = fallback_stop_error
-        return {
+        response = {
             **result,
-            "state": "ready" if (
-                result.get("connected") and result.get("armed")
-            ) else "error",
+            "state": "ready" if connected_for_execution else "error",
             "topic_in": [self._velocity_proposal_port()],
         }
+        if response.get("error") and not response.get("message"):
+            response["message"] = str(response["error"])
+        return response
 
     def _disconnect_velocity_proposal(self, reason: str) -> dict:
         # Main-process RPC is an independent first stop path.  It guarantees

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -38,6 +38,7 @@ from unitree_sdk2py.g1.audio.g1_audio_client import AudioClient
 from pointcloud_utils import gravity_align_inplace
 from velocity_proposal import (
     DEFAULT_VELOCITY_PROPOSAL_TOPIC,
+    resolve_expected_nav_id,
     resolve_input_topic,
     velocity_proposal_port,
 )
@@ -1036,6 +1037,7 @@ class LocoPlugin:
     def _connect_velocity_proposal(self, args: dict) -> dict:
         try:
             topic = resolve_input_topic(args, self._velocity_proposal_topic)
+            expected_nav_id = resolve_expected_nav_id(args)
         except ValueError as exc:
             self._client.StopMove()
             if self._smart_motion:
@@ -1054,15 +1056,17 @@ class LocoPlugin:
                 "error": "SmartMotion safety harness is required for velocity_proposal",
                 "topic_in": [self._velocity_proposal_port()],
             }
-        result = self._smart_motion.bind_velocity_proposal(topic)
+        result = self._smart_motion.bind_velocity_proposal(topic, expected_nav_id)
         if result.get("error") or not (
             result.get("connected") and result.get("armed")
         ):
             self._client.StopMove()
         return {
-            "state": "ready" if result.get("connected") else "error",
-            "topic_in": [self._velocity_proposal_port()],
             **result,
+            "state": "ready" if (
+                result.get("connected") and result.get("armed")
+            ) else "error",
+            "topic_in": [self._velocity_proposal_port()],
         }
 
     def _disconnect_velocity_proposal(self, reason: str) -> dict:

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -1060,7 +1060,15 @@ class LocoPlugin:
         if result.get("error") or not (
             result.get("connected") and result.get("armed")
         ):
-            self._client.StopMove()
+            result = dict(result)
+            fallback_stop_ret = None
+            fallback_stop_error = None
+            try:
+                fallback_stop_ret = self._client.StopMove()
+            except Exception as exc:
+                fallback_stop_error = str(exc)
+            result["fallback_stop_ret"] = fallback_stop_ret
+            result["fallback_stop_error"] = fallback_stop_error
         return {
             **result,
             "state": "ready" if (

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -18,6 +18,8 @@ drivers/unitree/g1/device.py — Unitree G1 设备插件（重构版）。
   StatePlugin        (sensor)    — DDS LowState → IMU/battery ROS2 topic
 """
 
+from __future__ import annotations
+
 import json
 import queue
 import socket
@@ -34,6 +36,11 @@ from audio_msgs.msg import AudioChunk
 
 from unitree_sdk2py.g1.audio.g1_audio_client import AudioClient
 from pointcloud_utils import gravity_align_inplace
+from velocity_proposal import (
+    DEFAULT_VELOCITY_PROPOSAL_TOPIC,
+    resolve_input_topic,
+    velocity_proposal_port,
+)
 
 # ── 常量 ──────────────────────────────────────────────────────────────────────
 
@@ -894,13 +901,18 @@ class LocoStatePlugin:
 
 class LocoPlugin:
     PREFIX = "loco"
+    # Stop locomotion before tearing down any other plugin during bundle
+    # shutdown.  This is an explicit lifecycle contract consumed by main.py.
+    STOP_PRIORITY = 0
 
     def __init__(self, plugin_config: dict, namespace: str, executor, loco_client, slam_client=None, smart_motion=None):
         self._client = loco_client
         self._slam_client = slam_client
         self._smart_motion = smart_motion
         self._namespace = namespace
+        self._control_lock = threading.RLock()
         self._move_timer: threading.Timer | None = None
+        self._velocity_proposal_topic = DEFAULT_VELOCITY_PROPOSAL_TOPIC
 
     def get_tools(self) -> list:
         tools = [self._loco_tool(), self._switch_mode_tool(), self._switch_mode_expert_tool()]
@@ -955,7 +967,11 @@ class LocoPlugin:
                     "shake_hand":       {"params": [],                                 "description": "Perform a handshake gesture"},
                 },
             },
+            "topic_in": [self._velocity_proposal_port()],
         }
+
+    def _velocity_proposal_port(self) -> dict:
+        return velocity_proposal_port(self._velocity_proposal_topic)
 
     # ── FSM state groups for safety checks ──────────────────────────────────────
     _GROUND_STATES = {0, 1}            # zero_torque, damp — lying on ground
@@ -1006,30 +1022,135 @@ class LocoPlugin:
         }
 
     def start(self) -> None:
+        # Driver startup remains disarmed.  Canvas action=start with the exact
+        # connected topic is the only path that arms proposal execution.
         pass
 
     def stop(self) -> None:
-        if self._move_timer:
-            self._move_timer.cancel()
-            self._move_timer = None
-        self._client.StopMove()
+        with self._control_lock:
+            if self._move_timer:
+                self._move_timer.cancel()
+                self._move_timer = None
+            self._disconnect_velocity_proposal("driver_stop")
+
+    def _connect_velocity_proposal(self, args: dict) -> dict:
+        try:
+            topic = resolve_input_topic(args, self._velocity_proposal_topic)
+        except ValueError as exc:
+            self._client.StopMove()
+            if self._smart_motion:
+                self._smart_motion.unbind_velocity_proposal("proposal_bind_rejected")
+            return {
+                "state": "error",
+                "connected": False,
+                "error": str(exc),
+                "topic_in": [self._velocity_proposal_port()],
+            }
+        if not self._smart_motion:
+            self._client.StopMove()
+            return {
+                "state": "error",
+                "connected": False,
+                "error": "SmartMotion safety harness is required for velocity_proposal",
+                "topic_in": [self._velocity_proposal_port()],
+            }
+        result = self._smart_motion.bind_velocity_proposal(topic)
+        if result.get("error") or not (
+            result.get("connected") and result.get("armed")
+        ):
+            self._client.StopMove()
+        return {
+            "state": "ready" if result.get("connected") else "error",
+            "topic_in": [self._velocity_proposal_port()],
+            **result,
+        }
+
+    def _disconnect_velocity_proposal(self, reason: str) -> dict:
+        # Main-process RPC is an independent first stop path.  It guarantees
+        # StopMove precedes subscriber teardown even if SmartMotion IPC hangs
+        # and the child has to be terminated fail-closed.
+        fallback_stop_ret = self._client.StopMove()
+        if self._smart_motion:
+            try:
+                result = self._smart_motion.unbind_velocity_proposal(reason)
+            except Exception as exc:
+                return {
+                    "state": "error",
+                    "connected": False,
+                    "stop_confirmed": False,
+                    "error": f"SmartMotion unbind failed: {exc}",
+                    "fallback_stop_ret": fallback_stop_ret,
+                    "topic_in": [self._velocity_proposal_port()],
+                }
+            stop_failed = (
+                result.get("error")
+                or result.get("stop_confirmed") is not True
+            )
+            if stop_failed:
+                result.setdefault("state", "error")
+                result.setdefault("error", "StopMove was not confirmed")
+                result["fallback_stop_ret"] = fallback_stop_ret
+            return {"topic_in": [self._velocity_proposal_port()], **result}
+        return {
+            "state": "idle" if fallback_stop_ret == 0 else "error",
+            "connected": False,
+            "stop_confirmed": fallback_stop_ret == 0,
+            "reason": reason,
+            "topic_in": [self._velocity_proposal_port()],
+            **({"error": f"StopMove failed: code={fallback_stop_ret}"} if fallback_stop_ret != 0 else {}),
+        }
 
     def _auto_stop(self):
         """Timer 回调：自动停止运动"""
-        self._move_timer = None
-        self._client.StopMove()
+        with self._control_lock:
+            self._move_timer = None
+            self._client.StopMove()
 
     def dispatch(self, action: str, args: dict) -> dict | None:
+        with self._control_lock:
+            try:
+                return self._dispatch_serialized(action, args)
+            except Exception as exc:
+                self._client.StopMove()
+                return {
+                    "state": "error",
+                    "connected": False,
+                    "error": f"loco safety fallback: {exc}",
+                    "topic_in": [self._velocity_proposal_port()],
+                }
+
+    def _dispatch_serialized(self, action: str, args: dict) -> dict | None:
+        tool_name = args.get("_tool_name", "loco")
         if action == "start":
-            return {"state": "ready"}
+            if tool_name == "loco":
+                return self._connect_velocity_proposal(args)
+            return {"state": "running" if tool_name == "motion_events" else "ready"}
         if action == "stop":
+            if tool_name == "loco":
+                return self._disconnect_velocity_proposal("canvas_stop")
             return {"state": "idle"}
         if action == "info":
-            tool_name = args.get("_tool_name", "motion_events")
             if tool_name == "motion_events" and self._smart_motion:
                 topic = f"/{self._namespace}/safety/motion_events"
                 return {"state": "running", "topic_out": [{"topic": topic, "format": "data/json"}]}
-            return None
+            if tool_name != "loco":
+                return {"state": "ready"}
+            if self._smart_motion:
+                result = self._smart_motion.get_velocity_proposal_status()
+                if result.get("error"):
+                    self._client.StopMove()
+            else:
+                result = {
+                    "enabled": False,
+                    "connected": False,
+                    "armed": False,
+                    "last_reason": "SmartMotion safety harness unavailable",
+                }
+            return {
+                "state": "running" if result.get("connected") else "ready",
+                "topic_in": [self._velocity_proposal_port()],
+                **result,
+            }
         if action == "move":
             vx   = float(args.get("vx",   0))
             vy   = float(args.get("vy",   0))
@@ -1038,7 +1159,10 @@ class LocoPlugin:
 
             # Route through SmartMotion safety harness
             if self._smart_motion:
-                return self._smart_motion.move(vx, vy, vyaw, duration)
+                result = self._smart_motion.move(vx, vy, vyaw, duration)
+                if result.get("error"):
+                    self._client.StopMove()
+                return result
 
             # Fallback: direct control (no safety harness)
             vx   = max(-1.0, min(1.0, vx))
@@ -1062,7 +1186,10 @@ class LocoPlugin:
         elif action == "stop_move":
             # Route through SmartMotion safety harness
             if self._smart_motion:
-                return self._smart_motion.stop()
+                result = self._smart_motion.stop()
+                if result.get("error"):
+                    self._client.StopMove()
+                return result
 
             # Fallback: direct control
             if self._move_timer:
@@ -1077,6 +1204,13 @@ class LocoPlugin:
             return {"ret": ret}
         elif action == "switch_mode":
             mode = args.get("mode", "")
+            if mode != "get_current_mode":
+                stopped = self._disconnect_velocity_proposal("mode_switch")
+                if mode != "emergency_stop" and (
+                    stopped.get("error")
+                    or stopped.get("stop_confirmed") is not True
+                ):
+                    return stopped
             code, current_fsm = self._client.GetFsmId()
 
             if code != 0:
@@ -1170,6 +1304,9 @@ class LocoPlugin:
                                  f"standup2squat, squat2standup, damp, zero_torque, "
                                  f"emergency_stop, get_current_mode"}
         elif action == "switch_mode_expert":
+            stopped = self._disconnect_velocity_proposal("expert_mode_switch")
+            if stopped.get("error") or stopped.get("stop_confirmed") is not True:
+                return stopped
             fid = int(args.get("fsm_id", 0))
             ret = self._client.SetFsmId(fid)
             return {"ret": ret, "fsm_id": fid}

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -410,7 +410,7 @@ def main():
             network_iface,
             proposal_config=proposal_cfg,
             fallback_stop=loco_client.StopMove,
-            parent_set_velocity=loco_client.SetVelocity,
+            parent_apply_velocity_proposal=loco_client.ApplyVelocityProposal,
             parent_get_fsm_id=loco_client.GetFsmId,
         )
         print("[bundle] SmartMotion safety harness active (subprocess)")

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -120,6 +120,15 @@ class G1DeviceBundle:
             self._plugins.append(LidarPlugin(plugins_cfg["lidar"], namespace, executor))
             print("[bundle] LidarPlugin loaded")
 
+        if plugins_cfg.get("navigation_sensors", {}).get("enabled", False):
+            from navigation_sensor_bridge import NavigationSensorPlugin
+            self._plugins.append(
+                NavigationSensorPlugin(
+                    plugins_cfg["navigation_sensors"], namespace, executor
+                )
+            )
+            print("[bundle] NavigationSensorPlugin loaded")
+
         if plugins_cfg.get("slam", {}).get("enabled", False):
             from device import SpatialPlugin
             self._plugins.append(SpatialPlugin(plugins_cfg["slam"], namespace, executor, slam_client, smart_motion=smart_motion))

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -411,6 +411,7 @@ def main():
             proposal_config=proposal_cfg,
             fallback_stop=loco_client.StopMove,
             parent_set_velocity=loco_client.SetVelocity,
+            parent_get_fsm_id=loco_client.GetFsmId,
         )
         print("[bundle] SmartMotion safety harness active (subprocess)")
 

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -182,8 +182,18 @@ class G1DeviceBundle:
         print(f"[bundle] All {len(self._plugins)} plugins started", flush=True)
 
     def stop_all(self) -> None:
-        for p in self._plugins:
-            p.stop()
+        ordered_plugins = sorted(
+            enumerate(self._plugins),
+            key=lambda item: getattr(item[1], "STOP_PRIORITY", 100),
+        )
+        for i, p in ordered_plugins:
+            try:
+                p.stop()
+            except Exception as exc:
+                print(
+                    f"[bundle] Plugin {i} ({type(p).__name__}) stop() FAILED: {exc}",
+                    flush=True,
+                )
         print("[bundle] All plugins stopped")
 
     def get_all_tools(self) -> list:
@@ -393,7 +403,14 @@ def main():
     harness_cfg = cfg.get("safety_harness", {})
     if harness_cfg.get("enabled", True):
         from safety_harness import SmartMotionProxy
-        smart_motion = SmartMotionProxy(namespace, harness_cfg, network_iface)
+        proposal_cfg = cfg.get("plugins", {}).get("loco", {})
+        smart_motion = SmartMotionProxy(
+            namespace,
+            harness_cfg,
+            network_iface,
+            proposal_config=proposal_cfg,
+            fallback_stop=loco_client.StopMove,
+        )
         print("[bundle] SmartMotion safety harness active (subprocess)")
 
     _bundle = G1DeviceBundle(cfg, namespace, executor, audio_client, loco_client, arm_client, slam_client, msc_client, smart_motion=smart_motion, network_iface=network_iface)
@@ -411,12 +428,29 @@ def main():
     server = ThreadingHTTPServer(("", mcp_port), make_handler())
     print(f"[bundle] MCP server → http://localhost:{mcp_port}")
 
+    shutdown_lock = threading.RLock()
+    shutdown_started = False
+
+    def _stop_runtime():
+        nonlocal shutdown_started
+        with shutdown_lock:
+            if shutdown_started:
+                return
+            shutdown_started = True
+            # LocoPlugin must StopMove/unbind while both motion subprocesses
+            # are still available; only then terminate those subprocesses.
+            try:
+                _bundle.stop_all()
+            finally:
+                try:
+                    if smart_motion:
+                        smart_motion.shutdown()
+                finally:
+                    loco_client.stop()
+
     def _shutdown(signum, frame):
         print(f"[bundle] signal {signum}, shutting down")
-        if smart_motion:
-            smart_motion.shutdown()
-        _bundle.stop_all()
-        loco_client.stop()
+        _stop_runtime()
         threading.Thread(target=server.shutdown, daemon=True).start()
 
     signal.signal(signal.SIGTERM, _shutdown)
@@ -425,7 +459,7 @@ def main():
     try:
         server.serve_forever()
     finally:
-        _bundle.stop_all()
+        _stop_runtime()
         executor.shutdown()
         rclpy.shutdown()
 

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -124,7 +124,10 @@ class G1DeviceBundle:
             from navigation_sensor_bridge import NavigationSensorPlugin
             self._plugins.append(
                 NavigationSensorPlugin(
-                    plugins_cfg["navigation_sensors"], namespace, executor
+                    plugins_cfg["navigation_sensors"],
+                    namespace,
+                    executor,
+                    network_iface,
                 )
             )
             print("[bundle] NavigationSensorPlugin loaded")

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -410,6 +410,7 @@ def main():
             network_iface,
             proposal_config=proposal_cfg,
             fallback_stop=loco_client.StopMove,
+            parent_set_velocity=loco_client.SetVelocity,
         )
         print("[bundle] SmartMotion safety harness active (subprocess)")
 

--- a/unitree/g1/navigation_pointcloud.py
+++ b/unitree/g1/navigation_pointcloud.py
@@ -1,0 +1,241 @@
+"""MID360 PointCloud2 layout conversion for the FAST-LIVO2 ROS2 MID360 port."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+# sensor_msgs/msg/PointField datatype constants
+UINT8 = 2
+UINT16 = 4
+FLOAT32 = 7
+FLOAT64 = 8
+
+
+@dataclass(frozen=True)
+class PointFieldSpec:
+    name: str
+    offset: int
+    datatype: int
+    count: int = 1
+
+
+# Match the PCL point layout used by the ROS2 MID360 FAST-LIVO2 port:
+# PCL_ADD_POINT4D, intensity, tag, line, alignment padding, timestamp.
+FAST_LIVO_FIELDS = (
+    PointFieldSpec("x", 0, FLOAT32),
+    PointFieldSpec("y", 4, FLOAT32),
+    PointFieldSpec("z", 8, FLOAT32),
+    PointFieldSpec("intensity", 16, FLOAT32),
+    PointFieldSpec("tag", 20, UINT8),
+    PointFieldSpec("line", 21, UINT8),
+    PointFieldSpec("timestamp", 24, FLOAT64),
+)
+FAST_LIVO_POINT_STEP = 32
+_FAST_LIVO_DTYPE = np.dtype(
+    {
+        "names": [field.name for field in FAST_LIVO_FIELDS],
+        "formats": ["<f4", "<f4", "<f4", "<f4", "u1", "u1", "<f8"],
+        "offsets": [field.offset for field in FAST_LIVO_FIELDS],
+        "itemsize": FAST_LIVO_POINT_STEP,
+    }
+)
+
+_EXPECTED_INPUT_TYPES = {
+    "x": FLOAT32,
+    "y": FLOAT32,
+    "z": FLOAT32,
+    "intensity": FLOAT32,
+    "ring": UINT16,
+    "time": FLOAT32,
+}
+_INPUT_DTYPES = {
+    "x": "<f4",
+    "y": "<f4",
+    "z": "<f4",
+    "intensity": "<f4",
+    "ring": "<u2",
+    "time": "<f4",
+}
+
+
+def validated_rotation_matrix(values: object | None) -> np.ndarray:
+    """Return a proper 3x3 rotation matrix from a row-major config value."""
+    if values is None:
+        return np.eye(3, dtype=np.float64)
+
+    rotation = np.asarray(values, dtype=np.float64)
+    if rotation.size != 9:
+        raise ValueError("sensor_rotation_matrix must contain 9 values")
+    rotation = rotation.reshape(3, 3)
+    if not np.isfinite(rotation).all():
+        raise ValueError("sensor_rotation_matrix contains non-finite values")
+    if not np.allclose(rotation @ rotation.T, np.eye(3), atol=1e-6):
+        raise ValueError("sensor_rotation_matrix must be orthonormal")
+    if not np.isclose(np.linalg.det(rotation), 1.0, atol=1e-6):
+        raise ValueError("sensor_rotation_matrix must be a proper rotation")
+    return rotation
+
+
+def rotate_vector3(values: object, rotation: np.ndarray) -> tuple[float, float, float]:
+    """Rotate one xyz vector from the raw MID360 frame into navigation frame."""
+    vector = np.asarray(values, dtype=np.float64)
+    if vector.size != 3:
+        raise ValueError("vector must contain 3 values")
+    rotated = rotation @ vector.reshape(3)
+    return tuple(float(value) for value in rotated)
+
+
+def rotate_covariance9(values: object, rotation: np.ndarray) -> list[float]:
+    """Rotate a row-major 3x3 covariance into the navigation frame."""
+    covariance = np.asarray(values, dtype=np.float64)
+    if covariance.size != 9:
+        raise ValueError("covariance must contain 9 values")
+    rotated = rotation @ covariance.reshape(3, 3) @ rotation.T
+    return [float(value) for value in rotated.reshape(9)]
+
+
+def rotate_orientation_xyzw(
+    values: object, rotation: np.ndarray
+) -> tuple[float, float, float, float]:
+    """Express a raw-frame orientation quaternion in the corrected frame.
+
+    ``rotation`` maps raw sensor vectors into the corrected navigation frame.
+    An IMU orientation describes the raw sensor frame in the world, so the
+    corrected-frame orientation is ``R_world_raw * rotation.T``.
+    """
+    quaternion = np.asarray(values, dtype=np.float64)
+    if quaternion.size != 4:
+        raise ValueError("quaternion must contain 4 values")
+    norm = float(np.linalg.norm(quaternion))
+    if not np.isfinite(norm) or norm < 1e-12:
+        raise ValueError("quaternion must be finite and non-zero")
+    x, y, z, w = quaternion / norm
+    raw_to_world = np.array(
+        [
+            [1.0 - 2.0 * (y * y + z * z), 2.0 * (x * y - z * w), 2.0 * (x * z + y * w)],
+            [2.0 * (x * y + z * w), 1.0 - 2.0 * (x * x + z * z), 2.0 * (y * z - x * w)],
+            [2.0 * (x * z - y * w), 2.0 * (y * z + x * w), 1.0 - 2.0 * (x * x + y * y)],
+        ],
+        dtype=np.float64,
+    )
+    corrected_to_world = raw_to_world @ rotation.T
+
+    trace = float(np.trace(corrected_to_world))
+    if trace > 0.0:
+        scale = 2.0 * np.sqrt(trace + 1.0)
+        qw = 0.25 * scale
+        qx = (corrected_to_world[2, 1] - corrected_to_world[1, 2]) / scale
+        qy = (corrected_to_world[0, 2] - corrected_to_world[2, 0]) / scale
+        qz = (corrected_to_world[1, 0] - corrected_to_world[0, 1]) / scale
+    else:
+        index = int(np.argmax(np.diag(corrected_to_world)))
+        if index == 0:
+            scale = 2.0 * np.sqrt(
+                1.0 + corrected_to_world[0, 0]
+                - corrected_to_world[1, 1]
+                - corrected_to_world[2, 2]
+            )
+            qw = (corrected_to_world[2, 1] - corrected_to_world[1, 2]) / scale
+            qx = 0.25 * scale
+            qy = (corrected_to_world[0, 1] + corrected_to_world[1, 0]) / scale
+            qz = (corrected_to_world[0, 2] + corrected_to_world[2, 0]) / scale
+        elif index == 1:
+            scale = 2.0 * np.sqrt(
+                1.0 + corrected_to_world[1, 1]
+                - corrected_to_world[0, 0]
+                - corrected_to_world[2, 2]
+            )
+            qw = (corrected_to_world[0, 2] - corrected_to_world[2, 0]) / scale
+            qx = (corrected_to_world[0, 1] + corrected_to_world[1, 0]) / scale
+            qy = 0.25 * scale
+            qz = (corrected_to_world[1, 2] + corrected_to_world[2, 1]) / scale
+        else:
+            scale = 2.0 * np.sqrt(
+                1.0 + corrected_to_world[2, 2]
+                - corrected_to_world[0, 0]
+                - corrected_to_world[1, 1]
+            )
+            qw = (corrected_to_world[1, 0] - corrected_to_world[0, 1]) / scale
+            qx = (corrected_to_world[0, 2] + corrected_to_world[2, 0]) / scale
+            qy = (corrected_to_world[1, 2] + corrected_to_world[2, 1]) / scale
+            qz = 0.25 * scale
+
+    corrected = np.array([qx, qy, qz, qw], dtype=np.float64)
+    corrected /= np.linalg.norm(corrected)
+    return tuple(float(value) for value in corrected)
+
+
+def unitree_mid360_to_fast_livo(
+    *,
+    data: bytes,
+    point_count: int,
+    point_step: int,
+    fields: list[tuple[str, int, int, int]],
+    header_stamp_ns: int,
+    rotation_matrix: np.ndarray | None = None,
+) -> bytes:
+    """Convert Unitree's packed MID360 points to the ROS2 port's PCL schema.
+
+    Unitree provides ``time`` as a per-point offset in nanoseconds.  The target
+    FAST-LIVO2 MID360 handler expects ``timestamp`` as an absolute nanosecond
+    value and subtracts the ROS header internally.
+    """
+    point_count = int(point_count)
+    point_step = int(point_step)
+    header_stamp_ns = int(header_stamp_ns)
+    if point_count < 1 or point_step < 1 or header_stamp_ns <= 0:
+        raise ValueError("point_count, point_step and header_stamp_ns must be positive")
+    if len(data) < point_count * point_step:
+        raise ValueError("point cloud data is shorter than point_count * point_step")
+
+    field_map = {name: (int(offset), int(datatype), int(count)) for name, offset, datatype, count in fields}
+    for name, expected_type in _EXPECTED_INPUT_TYPES.items():
+        if name not in field_map:
+            raise ValueError(f"missing MID360 field: {name}")
+        offset, datatype, count = field_map[name]
+        if datatype != expected_type or count != 1:
+            raise ValueError(
+                f"unexpected MID360 field {name}: datatype={datatype}, count={count}"
+            )
+        if offset < 0 or offset + np.dtype(_INPUT_DTYPES[name]).itemsize > point_step:
+            raise ValueError(f"MID360 field {name} exceeds point_step")
+
+    def view(name: str) -> np.ndarray:
+        offset = field_map[name][0]
+        return np.ndarray(
+            shape=(point_count,),
+            dtype=_INPUT_DTYPES[name],
+            buffer=data,
+            offset=offset,
+            strides=(point_step,),
+        )
+
+    ring = view("ring")
+    if int(ring.max(initial=0)) > 255:
+        raise ValueError("MID360 ring value exceeds uint8 line range")
+
+    relative_time_ns = view("time")
+    if not np.isfinite(relative_time_ns).all() or float(relative_time_ns.min()) < 0:
+        raise ValueError("MID360 time contains negative or non-finite values")
+
+    rotation = validated_rotation_matrix(rotation_matrix)
+    xyz = np.column_stack((view("x"), view("y"), view("z"))).astype(
+        np.float32, copy=False
+    )
+    if not np.array_equal(rotation, np.eye(3)):
+        xyz = xyz @ rotation.astype(np.float32).T
+
+    converted = np.zeros(point_count, dtype=_FAST_LIVO_DTYPE)
+    converted["x"] = xyz[:, 0]
+    converted["y"] = xyz[:, 1]
+    converted["z"] = xyz[:, 2]
+    converted["intensity"] = view("intensity")
+    converted["tag"] = 0x10
+    converted["line"] = ring.astype(np.uint8, copy=False)
+    converted["timestamp"] = np.float64(header_stamp_ns) + relative_time_ns.astype(
+        np.float64, copy=False
+    )
+    return converted.tobytes(order="C")

--- a/unitree/g1/navigation_sensor_bridge.py
+++ b/unitree/g1/navigation_sensor_bridge.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 from array import array
 import json
+import os
+from pathlib import Path
 import queue
+import subprocess
+import sys
 import threading
 import time
 
@@ -412,7 +416,8 @@ class _NavigationSensorNode(Node):
         if now - self._last_diagnostics_time < 1.0:
             return
         self._last_diagnostics_time = now
-        clock = self._clock_offset.snapshot().to_dict()
+        status = self.status()
+        clock = status["clock"]
         if clock["offset_ns"] is not None:
             clock["offset_sec"] = round(clock["offset_ns"] / 1_000_000_000, 6)
         if clock["residual_ns"] is not None:
@@ -420,8 +425,7 @@ class _NavigationSensorNode(Node):
         out = String()
         out.data = json.dumps(
             {
-                "clock": clock,
-                "counters": dict(self._counters),
+                **status,
                 "raw_topics": {
                     "cloud": self._raw_cloud_topic,
                     "imu": self._raw_imu_topic,
@@ -491,34 +495,108 @@ class _NavigationSensorNode(Node):
         self._imu_worker.join(timeout=2.0)
 
 
+class _NavigationSensorStatusNode(Node):
+    """Lightweight main-process monitor for the isolated bridge worker."""
+
+    def __init__(self, config: dict, namespace: str):
+        super().__init__("g1_navigation_sensor_status")
+        prefix = f"/{namespace}/navigation"
+        self.cloud_topic = _absolute_topic(config.get("cloud_topic"), f"{prefix}/lidar")
+        self.fast_livo_cloud_topic = _absolute_topic(
+            config.get("fast_livo_cloud_topic"), f"{prefix}/lidar_fast_livo"
+        )
+        self.imu_topic = _absolute_topic(config.get("imu_topic"), f"{prefix}/imu")
+        self.diagnostics_topic = _absolute_topic(
+            config.get("diagnostics_topic"), f"{prefix}/sensor_diagnostics"
+        )
+        self._publish_raw_cloud = bool(config.get("publish_raw_cloud", True))
+        self._publish_fast_livo_cloud = bool(
+            config.get("publish_fast_livo_cloud", True)
+        )
+        self._lock = threading.RLock()
+        self._last_diagnostics = None
+        self._last_diagnostics_monotonic = 0.0
+        self._diagnostics_sub = self.create_subscription(
+            String, self.diagnostics_topic, self._on_diagnostics, 10
+        )
+
+    def _on_diagnostics(self, msg) -> None:
+        try:
+            payload = json.loads(msg.data)
+        except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+            return
+        if not isinstance(payload, dict):
+            return
+        with self._lock:
+            self._last_diagnostics = payload
+            self._last_diagnostics_monotonic = time.monotonic()
+
+    def status(self, worker_running: bool) -> dict:
+        with self._lock:
+            payload = dict(self._last_diagnostics or {})
+            received_at = self._last_diagnostics_monotonic
+
+        diagnostics_age_ms = (
+            round((time.monotonic() - received_at) * 1000.0, 1)
+            if received_at > 0.0
+            else None
+        )
+        blockers = list(payload.get("blockers") or [])
+        if not worker_running:
+            blockers.append("worker_not_running")
+        if diagnostics_age_ms is None:
+            blockers.append("diagnostics_not_received")
+        elif diagnostics_age_ms > 2000.0:
+            blockers.append("diagnostics_stale")
+
+        blockers = list(dict.fromkeys(blockers))
+        return {
+            **payload,
+            "ready": not blockers,
+            "blockers": blockers,
+            "worker_running": bool(worker_running),
+            "diagnostics_age_ms": diagnostics_age_ms,
+        }
+
+
 class NavigationSensorPlugin:
     PREFIX = "navigation_sensors"
 
-    def __init__(self, plugin_config: dict, namespace: str, executor):
+    def __init__(
+        self,
+        plugin_config: dict,
+        namespace: str,
+        executor,
+        network_iface: str = "eth0",
+    ):
         self._executor = executor
-        self._node = _NavigationSensorNode(plugin_config, namespace)
-        executor.add_node(self._node)
+        self._namespace = namespace
+        self._network_iface = network_iface
+        self._status_node = _NavigationSensorStatusNode(plugin_config, namespace)
+        executor.add_node(self._status_node)
+        self._worker_path = Path(__file__).with_name("navigation_sensor_bridge_main.py")
+        self._proc = None
 
     def get_tools(self) -> list[dict]:
         tools = []
-        if self._node._publish_fast_livo_cloud:
+        if self._status_node._publish_fast_livo_cloud:
             tools.append(
                 self._tool(
                     "navigation_lidar_fast_livo",
                     "MID360 PointCloud2 adapted for the pinned FAST-LIVO2 ROS2 port",
-                    self._node.fast_livo_cloud_topic,
+                    self._status_node.fast_livo_cloud_topic,
                     "sensor/pointcloud",
                     "sensor_msgs/msg/PointCloud2",
                     "RELIABLE + KEEP_LAST(depth=2) + VOLATILE",
                     "livox_frame",
                 )
             )
-        if self._node._publish_raw_cloud:
+        if self._status_node._publish_raw_cloud:
             tools.append(
                 self._tool(
                     "navigation_lidar",
                     "Standard PointCloud2 with raw MID360 fields and per-point time preserved",
-                    self._node.cloud_topic,
+                    self._status_node.cloud_topic,
                     "sensor/pointcloud",
                     "sensor_msgs/msg/PointCloud2",
                     "BEST_EFFORT + KEEP_LAST(depth=2) + VOLATILE",
@@ -530,7 +608,7 @@ class NavigationSensorPlugin:
                 self._tool(
                     "navigation_imu",
                     "Standard IMU for FAST-LIVO2 in the same normalized clock domain as LiDAR",
-                    self._node.imu_topic,
+                    self._status_node.imu_topic,
                     "sensor/imu",
                     "sensor_msgs/msg/Imu",
                     "RELIABLE + KEEP_LAST(depth=200) + VOLATILE",
@@ -539,7 +617,7 @@ class NavigationSensorPlugin:
                 self._tool(
                     "navigation_sensor_diagnostics",
                     "Navigation sensor clock and drop diagnostics",
-                    self._node.diagnostics_topic,
+                    self._status_node.diagnostics_topic,
                     "data/json",
                     "std_msgs/msg/String",
                     "RELIABLE + KEEP_LAST(depth=10) + VOLATILE",
@@ -578,25 +656,53 @@ class NavigationSensorPlugin:
         }
 
     def start(self) -> None:
-        pass
+        if self._worker_running():
+            return
+        if not self._worker_path.is_file():
+            raise FileNotFoundError(f"navigation sensor worker missing: {self._worker_path}")
+        env = os.environ.copy()
+        env["ROS_NAMESPACE"] = self._namespace
+        self._proc = subprocess.Popen(
+            [sys.executable, str(self._worker_path), self._network_iface],
+            cwd=str(self._worker_path.parent),
+            env=env,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+        print(
+            f"[navigation-sensors] isolated worker started pid={self._proc.pid}",
+            flush=True,
+        )
+
+    def _worker_running(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
 
     def stop(self) -> None:
-        self._node.close()
+        if self._worker_running():
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                self._proc.wait(timeout=2.0)
         try:
-            self._executor.remove_node(self._node)
-            self._node.destroy_node()
+            self._executor.remove_node(self._status_node)
+            self._status_node.destroy_node()
         except Exception:
             pass
 
     def dispatch(self, action: str, args: dict) -> dict | None:
         if action in {"start", "info"}:
+            if action == "start" and not self._worker_running():
+                self.start()
             tool_name = args.get("_tool_name", "")
             tools = {tool["name"]: tool for tool in self.get_tools()}
             selected = tools.get(tool_name, tools["navigation_sensor_diagnostics"])
-            status = self._node.status()
+            status = self._status_node.status(self._worker_running())
             return {
                 "state": "ready" if status["ready"] else "not_ready",
                 "topic_out": selected["topic_out"],
+                "worker_pid": self._proc.pid if self._worker_running() else None,
                 **status,
             }
         if action == "stop":

--- a/unitree/g1/navigation_sensor_bridge.py
+++ b/unitree/g1/navigation_sensor_bridge.py
@@ -1,0 +1,604 @@
+"""Raw MID360 DDS to standard ROS2 sensor topics for traditional navigation.
+
+The bridge is intentionally independent from the dashboard-oriented LidarPlugin.
+It preserves raw PointCloud2 fields, normalizes LiDAR/IMU timestamps into the
+Jetson ROS clock domain, and applies one fixed mounting rotation to both the
+estimator point cloud and IMU.  It never applies dynamic gravity alignment.
+"""
+
+from __future__ import annotations
+
+from array import array
+import json
+import queue
+import threading
+import time
+
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import Imu, PointCloud2, PointField
+from std_msgs.msg import String
+
+from navigation_pointcloud import (
+    FAST_LIVO_FIELDS,
+    FAST_LIVO_POINT_STEP,
+    rotate_covariance9,
+    rotate_orientation_xyzw,
+    rotate_vector3,
+    unitree_mid360_to_fast_livo,
+    validated_rotation_matrix,
+)
+from navigation_time import ClockOffsetEstimator, split_ns, stamp_to_ns
+from unitree_sdk2py.core.channel import ChannelSubscriber
+from unitree_sdk2py.idl.sensor_msgs.msg.dds_ import Imu_, PointCloud2_
+
+
+_RAW_CLOUD_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=2,
+    durability=DurabilityPolicy.VOLATILE,
+)
+_FAST_LIVO_CLOUD_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=2,
+    durability=DurabilityPolicy.VOLATILE,
+)
+_IMU_QOS = QoSProfile(
+    # The pinned FAST-LIVO2 port uses the ROS default reliable subscription.
+    # A reliable publisher remains compatible with best-effort diagnostics,
+    # while the inverse pairing silently disconnects the estimator input.
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=200,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+
+def _absolute_topic(value: str | None, fallback: str) -> str:
+    topic = (value or fallback).strip()
+    return topic if topic.startswith("/") else f"/{topic}"
+
+
+class _NavigationSensorNode(Node):
+    def __init__(self, config: dict, namespace: str):
+        super().__init__("g1_navigation_sensor_bridge")
+
+        prefix = f"/{namespace}/navigation"
+        self.cloud_topic = _absolute_topic(config.get("cloud_topic"), f"{prefix}/lidar")
+        self.fast_livo_cloud_topic = _absolute_topic(
+            config.get("fast_livo_cloud_topic"), f"{prefix}/lidar_fast_livo"
+        )
+        self._publish_raw_cloud = bool(config.get("publish_raw_cloud", True))
+        self._publish_fast_livo_cloud = bool(
+            config.get("publish_fast_livo_cloud", True)
+        )
+        self.imu_topic = _absolute_topic(config.get("imu_topic"), f"{prefix}/imu")
+        self.diagnostics_topic = _absolute_topic(
+            config.get("diagnostics_topic"), f"{prefix}/sensor_diagnostics"
+        )
+        self._raw_cloud_topic = config.get(
+            "raw_cloud_topic", "rt/utlidar/cloud_livox_mid360"
+        )
+        self._raw_imu_topic = config.get(
+            "raw_imu_topic", "rt/utlidar/imu_livox_mid360"
+        )
+        self._raw_lidar_frame = config.get("raw_lidar_frame", "livox_raw_frame")
+        self._lidar_frame = config.get("lidar_frame", "livox_frame")
+        self._imu_frame = config.get("imu_frame", self._lidar_frame)
+        self._sensor_rotation = validated_rotation_matrix(
+            config.get("sensor_rotation_matrix")
+        )
+
+        # Do not use ``self._clock``: rclpy.node.Node owns that attribute and
+        # get_clock() returns it internally.
+        self._clock_offset = ClockOffsetEstimator(
+            warmup_samples=int(config.get("clock_warmup_samples", 32)),
+            window_samples=int(config.get("clock_window_samples", 400)),
+            reset_threshold_ns=int(
+                float(config.get("clock_reset_threshold_ms", 1000.0)) * 1_000_000
+            ),
+            reset_confirm_samples=int(config.get("clock_reset_confirm_samples", 8)),
+        )
+
+        self._cloud_pub = (
+            self.create_publisher(PointCloud2, self.cloud_topic, _RAW_CLOUD_QOS)
+            if self._publish_raw_cloud
+            else None
+        )
+        self._fast_livo_cloud_pub = (
+            self.create_publisher(
+                PointCloud2,
+                self.fast_livo_cloud_topic,
+                _FAST_LIVO_CLOUD_QOS,
+            )
+            if self._publish_fast_livo_cloud
+            else None
+        )
+        self._imu_pub = self.create_publisher(Imu, self.imu_topic, _IMU_QOS)
+        self._diagnostics_pub = self.create_publisher(String, self.diagnostics_topic, 10)
+
+        self._cloud_queue: queue.Queue = queue.Queue(maxsize=2)
+        self._imu_queue: queue.Queue = queue.Queue(maxsize=4)
+        self._stop = threading.Event()
+        self._cloud_worker = threading.Thread(
+            target=self._cloud_loop, name="navigation_cloud", daemon=True
+        )
+        self._imu_worker = threading.Thread(
+            target=self._imu_loop, name="navigation_imu", daemon=True
+        )
+        self._cloud_worker.start()
+        self._imu_worker.start()
+
+        self._last_stamp_ns = {"cloud": 0, "imu": 0}
+        self._last_diagnostics_time = 0.0
+        self._counters = {
+            "cloud_received": 0,
+            "cloud_published": 0,
+            "cloud_dropped": 0,
+            "fast_livo_cloud_published": 0,
+            "fast_livo_cloud_dropped": 0,
+            "imu_received": 0,
+            "imu_published": 0,
+            "imu_dropped": 0,
+            "stamp_clamped": 0,
+        }
+        self._last_receive_monotonic = {"cloud": 0.0, "imu": 0.0}
+
+        self._cloud_sub = ChannelSubscriber(self._raw_cloud_topic, PointCloud2_)
+        self._cloud_sub.Init(self._on_cloud, 1)
+        self._imu_sub = ChannelSubscriber(self._raw_imu_topic, Imu_)
+        # Direct callback avoids the SDK BQueue dropping new samples when its
+        # single slot is occupied.  This callback only timestamps and enqueues.
+        self._imu_sub.Init(self._on_imu)
+        cloud_outputs = []
+        if self._publish_fast_livo_cloud:
+            cloud_outputs.append(self.fast_livo_cloud_topic)
+        if self._publish_raw_cloud:
+            cloud_outputs.append(self.cloud_topic)
+        self.get_logger().info(
+            f"Navigation sensors: {self._raw_cloud_topic} -> "
+            f"{','.join(cloud_outputs) or '(disabled)'}; "
+            f"{self._raw_imu_topic} -> {self.imu_topic}; "
+            f"raw_frame={self._raw_lidar_frame}, corrected_frame={self._lidar_frame}, "
+            f"sensor_rotation={self._sensor_rotation.reshape(9).tolist()}"
+        )
+
+    def _correct_stamp(self, source_stamp, stream: str) -> int | None:
+        try:
+            source_ns = stamp_to_ns(source_stamp.sec, source_stamp.nanosec)
+            host_ns = self.get_clock().now().nanoseconds
+            corrected_ns = self._clock_offset.correct_observation(source_ns, host_ns)
+        except (AttributeError, TypeError, ValueError) as exc:
+            self.get_logger().warning(f"invalid {stream} timestamp: {exc}")
+            return None
+
+        if corrected_ns is None:
+            return None
+        if corrected_ns <= self._last_stamp_ns[stream]:
+            corrected_ns = self._last_stamp_ns[stream] + 1
+            self._counters["stamp_clamped"] += 1
+        self._last_stamp_ns[stream] = corrected_ns
+        return corrected_ns
+
+    @staticmethod
+    def _set_stamp(header, timestamp_ns: int, frame_id: str) -> None:
+        sec, nanosec = split_ns(timestamp_ns)
+        header.stamp.sec = sec
+        header.stamp.nanosec = nanosec
+        header.frame_id = frame_id
+
+    def _on_cloud(self, msg) -> None:
+        self._counters["cloud_received"] += 1
+        self._last_receive_monotonic["cloud"] = time.monotonic()
+        corrected_ns = self._correct_stamp(msg.header.stamp, "cloud")
+        if corrected_ns is None:
+            self._counters["cloud_dropped"] += 1
+            self._maybe_publish_diagnostics()
+            return
+
+        fields = [
+            (str(field.name), int(field.offset), int(field.datatype), int(field.count))
+            for field in msg.fields
+        ]
+        item = (
+            corrected_ns,
+            int(msg.height),
+            int(msg.width),
+            fields,
+            bool(msg.is_bigendian),
+            int(msg.point_step),
+            int(msg.row_step),
+            bytes(msg.data),
+            bool(msg.is_dense),
+        )
+        try:
+            self._cloud_queue.put_nowait(item)
+        except queue.Full:
+            try:
+                self._cloud_queue.get_nowait()
+            except queue.Empty:
+                pass
+            self._counters["cloud_dropped"] += 1
+            self._cloud_queue.put_nowait(item)
+        self._maybe_publish_diagnostics()
+
+    def _cloud_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                item = self._cloud_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if item is None:
+                break
+
+            (
+                corrected_ns,
+                height,
+                width,
+                fields,
+                is_bigendian,
+                point_step,
+                row_step,
+                data,
+                is_dense,
+            ) = item
+            expected_size = row_step * height
+            if point_step <= 0 or height <= 0 or width <= 0 or len(data) < expected_size:
+                self._counters["cloud_dropped"] += 1
+                continue
+
+            # The estimator input is the priority path.  Publishing the raw and
+            # adapted 0.4/0.6 MB clouds together can saturate Python ROS2
+            # serialization on the live Jetson, so the raw diagnostic output is
+            # independently switchable.
+            if self._fast_livo_cloud_pub is not None:
+                try:
+                    converted = unitree_mid360_to_fast_livo(
+                        data=data,
+                        point_count=height * width,
+                        point_step=point_step,
+                        fields=fields,
+                        header_stamp_ns=corrected_ns,
+                        rotation_matrix=self._sensor_rotation,
+                    )
+                    fast_livo = PointCloud2()
+                    self._set_stamp(
+                        fast_livo.header, corrected_ns, self._lidar_frame
+                    )
+                    fast_livo.height = 1
+                    fast_livo.width = height * width
+                    fast_livo.fields = [
+                        PointField(
+                            name=field.name,
+                            offset=field.offset,
+                            datatype=field.datatype,
+                            count=field.count,
+                        )
+                        for field in FAST_LIVO_FIELDS
+                    ]
+                    fast_livo.is_bigendian = False
+                    fast_livo.point_step = FAST_LIVO_POINT_STEP
+                    fast_livo.row_step = FAST_LIVO_POINT_STEP * fast_livo.width
+                    # Humble's generated setter validates a bytes object one
+                    # element at a time in debug mode.  array('B') takes its
+                    # constant-time fast path for large PointCloud2 payloads.
+                    fast_livo.data = array("B", converted)
+                    fast_livo.is_dense = is_dense
+                    self._fast_livo_cloud_pub.publish(fast_livo)
+                    self._counters["fast_livo_cloud_published"] += 1
+                except (TypeError, ValueError) as exc:
+                    self._counters["fast_livo_cloud_dropped"] += 1
+                    if self._counters["fast_livo_cloud_dropped"] <= 3:
+                        self.get_logger().warning(
+                            f"FAST-LIVO cloud conversion failed: {exc}"
+                        )
+
+            if self._cloud_pub is not None:
+                out = PointCloud2()
+                self._set_stamp(out.header, corrected_ns, self._raw_lidar_frame)
+                out.height = height
+                out.width = width
+                out.fields = [
+                    PointField(
+                        name=name,
+                        offset=offset,
+                        datatype=datatype,
+                        count=count,
+                    )
+                    for name, offset, datatype, count in fields
+                ]
+                out.is_bigendian = is_bigendian
+                out.point_step = point_step
+                out.row_step = row_step
+                out.data = array("B", data)
+                out.is_dense = is_dense
+                self._cloud_pub.publish(out)
+                self._counters["cloud_published"] += 1
+
+    def _on_imu(self, msg) -> None:
+        self._counters["imu_received"] += 1
+        self._last_receive_monotonic["imu"] = time.monotonic()
+        corrected_ns = self._correct_stamp(msg.header.stamp, "imu")
+        if corrected_ns is None:
+            self._counters["imu_dropped"] += 1
+            self._maybe_publish_diagnostics()
+            return
+
+        try:
+            self._imu_queue.put_nowait((corrected_ns, msg))
+        except queue.Full:
+            # Prefer fresh inertial data over completing a stale backlog.
+            try:
+                self._imu_queue.get_nowait()
+            except queue.Empty:
+                pass
+            self._counters["imu_dropped"] += 1
+            self._imu_queue.put_nowait((corrected_ns, msg))
+        self._maybe_publish_diagnostics()
+
+    def _imu_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                item = self._imu_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if item is None:
+                break
+            corrected_ns, msg = item
+
+            out = Imu()
+            self._set_stamp(out.header, corrected_ns, self._imu_frame)
+
+            q = msg.orientation
+            q_norm_sq = (
+                float(q.x) ** 2
+                + float(q.y) ** 2
+                + float(q.z) ** 2
+                + float(q.w) ** 2
+            )
+            if q_norm_sq > 0.25:
+                qx, qy, qz, qw = rotate_orientation_xyzw(
+                    (float(q.x), float(q.y), float(q.z), float(q.w)),
+                    self._sensor_rotation,
+                )
+                out.orientation.x = qx
+                out.orientation.y = qy
+                out.orientation.z = qz
+                out.orientation.w = qw
+                out.orientation_covariance = rotate_covariance9(
+                    msg.orientation_covariance, self._sensor_rotation
+                )
+            else:
+                # The live MID360 stream reports an all-zero quaternion.  Publish
+                # identity and mark orientation unavailable per REP-145.
+                out.orientation.w = 1.0
+                out.orientation_covariance[0] = -1.0
+
+            wx, wy, wz = rotate_vector3(
+                (
+                    float(msg.angular_velocity.x),
+                    float(msg.angular_velocity.y),
+                    float(msg.angular_velocity.z),
+                ),
+                self._sensor_rotation,
+            )
+            out.angular_velocity.x = wx
+            out.angular_velocity.y = wy
+            out.angular_velocity.z = wz
+            out.angular_velocity_covariance = rotate_covariance9(
+                msg.angular_velocity_covariance, self._sensor_rotation
+            )
+            ax, ay, az = rotate_vector3(
+                (
+                    float(msg.linear_acceleration.x),
+                    float(msg.linear_acceleration.y),
+                    float(msg.linear_acceleration.z),
+                ),
+                self._sensor_rotation,
+            )
+            out.linear_acceleration.x = ax
+            out.linear_acceleration.y = ay
+            out.linear_acceleration.z = az
+            out.linear_acceleration_covariance = rotate_covariance9(
+                msg.linear_acceleration_covariance, self._sensor_rotation
+            )
+            self._imu_pub.publish(out)
+            self._counters["imu_published"] += 1
+
+    def _maybe_publish_diagnostics(self) -> None:
+        now = time.monotonic()
+        if now - self._last_diagnostics_time < 1.0:
+            return
+        self._last_diagnostics_time = now
+        clock = self._clock_offset.snapshot().to_dict()
+        if clock["offset_ns"] is not None:
+            clock["offset_sec"] = round(clock["offset_ns"] / 1_000_000_000, 6)
+        if clock["residual_ns"] is not None:
+            clock["residual_ms"] = round(clock["residual_ns"] / 1_000_000, 3)
+        out = String()
+        out.data = json.dumps(
+            {
+                "clock": clock,
+                "counters": dict(self._counters),
+                "raw_topics": {
+                    "cloud": self._raw_cloud_topic,
+                    "imu": self._raw_imu_topic,
+                },
+                "frames": {
+                    "raw_lidar": self._raw_lidar_frame,
+                    "lidar": self._lidar_frame,
+                    "imu": self._imu_frame,
+                },
+                "sensor_rotation_matrix": [
+                    float(value) for value in self._sensor_rotation.reshape(9)
+                ],
+            },
+            separators=(",", ":"),
+        )
+        self._diagnostics_pub.publish(out)
+
+    def status(self) -> dict:
+        now = time.monotonic()
+        ages = {
+            stream: (
+                round((now - received_at) * 1000.0, 1)
+                if received_at > 0.0
+                else None
+            )
+            for stream, received_at in self._last_receive_monotonic.items()
+        }
+        clock = self._clock_offset.snapshot().to_dict()
+        blockers = []
+        if not clock["ready"]:
+            blockers.append("clock_not_ready")
+        if ages["cloud"] is None or ages["cloud"] > 500.0:
+            blockers.append("cloud_stale")
+        if ages["imu"] is None or ages["imu"] > 100.0:
+            blockers.append("imu_stale")
+        if self._publish_fast_livo_cloud and not self._counters[
+            "fast_livo_cloud_published"
+        ]:
+            blockers.append("fast_livo_cloud_not_published")
+        if not self._counters["imu_published"]:
+            blockers.append("imu_not_published")
+        return {
+            "ready": not blockers,
+            "blockers": blockers,
+            "receive_age_ms": ages,
+            "clock": clock,
+            "counters": dict(self._counters),
+        }
+
+    def close(self) -> None:
+        for subscriber in (self._cloud_sub, self._imu_sub):
+            try:
+                subscriber.Close()
+            except Exception:
+                pass
+        self._stop.set()
+        for work_queue in (self._cloud_queue, self._imu_queue):
+            try:
+                work_queue.put_nowait(None)
+            except queue.Full:
+                try:
+                    work_queue.get_nowait()
+                except queue.Empty:
+                    pass
+                work_queue.put_nowait(None)
+        self._cloud_worker.join(timeout=2.0)
+        self._imu_worker.join(timeout=2.0)
+
+
+class NavigationSensorPlugin:
+    PREFIX = "navigation_sensors"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor):
+        self._executor = executor
+        self._node = _NavigationSensorNode(plugin_config, namespace)
+        executor.add_node(self._node)
+
+    def get_tools(self) -> list[dict]:
+        tools = []
+        if self._node._publish_fast_livo_cloud:
+            tools.append(
+                self._tool(
+                    "navigation_lidar_fast_livo",
+                    "MID360 PointCloud2 adapted for the pinned FAST-LIVO2 ROS2 port",
+                    self._node.fast_livo_cloud_topic,
+                    "sensor/pointcloud",
+                    "sensor_msgs/msg/PointCloud2",
+                    "RELIABLE + KEEP_LAST(depth=2) + VOLATILE",
+                    "livox_frame",
+                )
+            )
+        if self._node._publish_raw_cloud:
+            tools.append(
+                self._tool(
+                    "navigation_lidar",
+                    "Standard PointCloud2 with raw MID360 fields and per-point time preserved",
+                    self._node.cloud_topic,
+                    "sensor/pointcloud",
+                    "sensor_msgs/msg/PointCloud2",
+                    "BEST_EFFORT + KEEP_LAST(depth=2) + VOLATILE",
+                    "livox_raw_frame",
+                )
+            )
+        tools.extend(
+            [
+                self._tool(
+                    "navigation_imu",
+                    "Standard IMU for FAST-LIVO2 in the same normalized clock domain as LiDAR",
+                    self._node.imu_topic,
+                    "sensor/imu",
+                    "sensor_msgs/msg/Imu",
+                    "RELIABLE + KEEP_LAST(depth=200) + VOLATILE",
+                    "livox_frame",
+                ),
+                self._tool(
+                    "navigation_sensor_diagnostics",
+                    "Navigation sensor clock and drop diagnostics",
+                    self._node.diagnostics_topic,
+                    "data/json",
+                    "std_msgs/msg/String",
+                    "RELIABLE + KEEP_LAST(depth=10) + VOLATILE",
+                    "",
+                ),
+            ]
+        )
+        return tools
+
+    @staticmethod
+    def _tool(
+        name: str,
+        description: str,
+        topic: str,
+        message_format: str,
+        ros_type: str,
+        qos: str,
+        frame_id: str,
+    ) -> dict:
+        descriptor = {
+            "topic": topic,
+            "format": message_format,
+            "ros_type": ros_type,
+            "qos": qos,
+            "timestamp": "MID360 source clock normalized to ROS system time",
+        }
+        if frame_id:
+            descriptor["frame_id"] = frame_id
+        return {
+            "name": name,
+            "type": "sensor",
+            "multiInstance": False,
+            "description": f"{description}. Publishes to {topic}",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [descriptor],
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        self._node.close()
+        try:
+            self._executor.remove_node(self._node)
+            self._node.destroy_node()
+        except Exception:
+            pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action in {"start", "info"}:
+            tool_name = args.get("_tool_name", "")
+            tools = {tool["name"]: tool for tool in self.get_tools()}
+            selected = tools.get(tool_name, tools["navigation_sensor_diagnostics"])
+            status = self._node.status()
+            return {
+                "state": "ready" if status["ready"] else "not_ready",
+                "topic_out": selected["topic_out"],
+                **status,
+            }
+        if action == "stop":
+            return {"state": "idle"}
+        return None

--- a/unitree/g1/navigation_sensor_bridge_main.py
+++ b/unitree/g1/navigation_sensor_bridge_main.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Isolated MID360 bridge worker for the G1 Driver navigation sensor card."""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import socket
+import sys
+import threading
+from pathlib import Path
+
+import rclpy
+from rclpy.executors import MultiThreadedExecutor
+import yaml
+
+from navigation_sensor_bridge import _NavigationSensorNode
+from unitree_sdk2py.core.channel import ChannelFactoryInitialize
+
+
+def _load_config() -> dict:
+    path = Path(os.environ.get("CONFIG_PATH", Path(__file__).with_name("config.yaml")))
+    with path.open() as stream:
+        config = yaml.safe_load(stream)
+    if not isinstance(config, dict):
+        raise ValueError(f"navigation bridge config must be a mapping: {path}")
+    return config
+
+
+def _resolve_namespace(config: dict) -> str:
+    value = os.environ.get("ROS_NAMESPACE", "").strip()
+    if not value:
+        value = str(config.get("ros_namespace", "")).strip()
+    if not value:
+        value = socket.gethostname()
+    value = re.sub(r"[^a-zA-Z0-9_]", "_", value.strip("/"))
+    if not value:
+        raise ValueError("ROS namespace resolves to an empty value")
+    return value
+
+
+def main() -> int:
+    network_interface = (
+        sys.argv[1] if len(sys.argv) > 1 else os.environ.get("NETWORK_INTERFACE", "eth0")
+    )
+    config = _load_config()
+    plugin_config = config.get("plugins", {}).get("navigation_sensors", {})
+    if not plugin_config.get("enabled", False):
+        raise RuntimeError("plugins.navigation_sensors.enabled must be true")
+
+    namespace = _resolve_namespace(config)
+    ChannelFactoryInitialize(0, network_interface)
+    print(
+        f"[navigation-sensors-worker] DDS initialized on {network_interface}; "
+        f"ROS namespace={namespace}",
+        flush=True,
+    )
+
+    rclpy.init()
+    executor = MultiThreadedExecutor(num_threads=3)
+    node = _NavigationSensorNode(plugin_config, namespace)
+    executor.add_node(node)
+    stop = threading.Event()
+
+    def _request_stop(signum, _frame):
+        print(
+            f"[navigation-sensors-worker] signal {signum}, shutting down",
+            flush=True,
+        )
+        stop.set()
+
+    signal.signal(signal.SIGTERM, _request_stop)
+    signal.signal(signal.SIGINT, _request_stop)
+
+    try:
+        while rclpy.ok() and not stop.is_set():
+            executor.spin_once(timeout_sec=0.2)
+    finally:
+        node.close()
+        executor.remove_node(node)
+        node.destroy_node()
+        executor.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unitree/g1/navigation_time.py
+++ b/unitree/g1/navigation_time.py
@@ -1,0 +1,150 @@
+"""Clock-domain normalization helpers for the G1 navigation sensor bridge.
+
+Unitree's MID360 publishes LiDAR and IMU headers in a shared sensor clock that
+is not guaranteed to match the Jetson system clock.  Estimators and planners
+must still receive ROS timestamps in one coherent clock domain.  This module is
+kept free of ROS dependencies so the correction policy can be unit tested on a
+development machine.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import asdict, dataclass
+import threading
+
+
+NSEC_PER_SEC = 1_000_000_000
+
+
+def stamp_to_ns(sec: int, nanosec: int) -> int:
+    """Convert a ROS-style ``sec``/``nanosec`` pair to integer nanoseconds."""
+    if not 0 <= int(nanosec) < NSEC_PER_SEC:
+        raise ValueError(f"nanosec out of range: {nanosec}")
+    return int(sec) * NSEC_PER_SEC + int(nanosec)
+
+
+def split_ns(timestamp_ns: int) -> tuple[int, int]:
+    """Split integer nanoseconds into a normalized ROS timestamp pair."""
+    sec, nanosec = divmod(int(timestamp_ns), NSEC_PER_SEC)
+    return sec, nanosec
+
+
+@dataclass(frozen=True)
+class ClockSnapshot:
+    ready: bool
+    samples: int
+    offset_ns: int | None
+    residual_ns: int | None
+    resets: int
+    rejected: int
+    pending_reset_samples: int
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class ClockOffsetEstimator:
+    """Estimate ``host_time - sensor_time`` from callback arrival times.
+
+    Transport and scheduling latency is non-negative, so the minimum candidate
+    in a rolling window is a better offset estimate than an average.  A single
+    late callback is rejected instead of shifting every subsequent timestamp.
+    Persistent jumps are treated as a source-clock reset and require a new
+    warm-up period.
+    """
+
+    def __init__(
+        self,
+        *,
+        warmup_samples: int = 32,
+        window_samples: int = 400,
+        reset_threshold_ns: int = NSEC_PER_SEC,
+        reset_confirm_samples: int = 8,
+    ) -> None:
+        if warmup_samples < 1:
+            raise ValueError("warmup_samples must be positive")
+        if window_samples < warmup_samples:
+            raise ValueError("window_samples must be >= warmup_samples")
+        if reset_threshold_ns < 1:
+            raise ValueError("reset_threshold_ns must be positive")
+        if reset_confirm_samples < 2:
+            raise ValueError("reset_confirm_samples must be >= 2")
+
+        self._warmup_samples = warmup_samples
+        self._reset_threshold_ns = reset_threshold_ns
+        self._reset_confirm_samples = reset_confirm_samples
+        self._candidates: deque[int] = deque(maxlen=window_samples)
+        self._pending_reset: list[int] = []
+        self._offset_ns: int | None = None
+        self._residual_ns: int | None = None
+        self._ready = False
+        self._resets = 0
+        self._rejected = 0
+        self._lock = threading.Lock()
+
+    def correct_observation(self, source_ns: int, host_arrival_ns: int) -> int | None:
+        """Observe one sample and return its corrected host timestamp when ready.
+
+        ``None`` means the sample must not be published: either the initial
+        offset is still warming up or the observation looks like a clock jump.
+        """
+        source_ns = int(source_ns)
+        host_arrival_ns = int(host_arrival_ns)
+        if source_ns <= 0 or host_arrival_ns <= 0:
+            raise ValueError("timestamps must be positive")
+
+        candidate = host_arrival_ns - source_ns
+        with self._lock:
+            if self._offset_ns is None:
+                self._accept_locked(candidate)
+            else:
+                delta = candidate - self._offset_ns
+                if delta < -self._reset_threshold_ns:
+                    # The source clock jumped forward.  Re-baseline immediately;
+                    # normal callback latency cannot make this candidate smaller.
+                    self._reset_locked(candidate)
+                elif delta > self._reset_threshold_ns:
+                    # This may be one delayed callback or a source clock that
+                    # jumped backwards.  Require consecutive evidence so a large
+                    # point-cloud callback cannot reset the IMU clock domain.
+                    self._pending_reset.append(candidate)
+                    self._rejected += 1
+                    self._residual_ns = delta
+                    if len(self._pending_reset) >= self._reset_confirm_samples:
+                        self._reset_locked(min(self._pending_reset))
+                    return None
+                else:
+                    self._pending_reset.clear()
+                    self._accept_locked(candidate)
+
+            if not self._ready:
+                return None
+            return source_ns + int(self._offset_ns)
+
+    def snapshot(self) -> ClockSnapshot:
+        with self._lock:
+            return ClockSnapshot(
+                ready=self._ready,
+                samples=len(self._candidates),
+                offset_ns=self._offset_ns,
+                residual_ns=self._residual_ns,
+                resets=self._resets,
+                rejected=self._rejected,
+                pending_reset_samples=len(self._pending_reset),
+            )
+
+    def _accept_locked(self, candidate: int) -> None:
+        self._candidates.append(candidate)
+        self._offset_ns = min(self._candidates)
+        self._residual_ns = candidate - self._offset_ns
+        self._ready = len(self._candidates) >= self._warmup_samples
+
+    def _reset_locked(self, candidate: int) -> None:
+        self._candidates.clear()
+        self._pending_reset.clear()
+        self._offset_ns = None
+        self._residual_ns = None
+        self._ready = False
+        self._resets += 1
+        self._accept_locked(candidate)

--- a/unitree/g1/rpc_proxy.py
+++ b/unitree/g1/rpc_proxy.py
@@ -8,9 +8,166 @@ responses arrive late or timeout. Running LocoClient in a subprocess avoids this
 Modeled after R1's rpc_proxy.py with G1-specific adaptations.
 """
 
+import math
 import multiprocessing
+import queue
 import threading
 import time
+
+
+PROPOSAL_CONTINUOUS_DURATION_SECONDS = 864000.0
+
+
+class ProposalRpcExecutor:
+    """Own one fail-closed velocity-proposal lease inside the RPC worker.
+
+    G1 firmware does not reliably execute sub-second ``duration`` values.  A
+    proposal therefore uses the same continuous velocity command as the known
+    working ``Move(..., True)`` path, while this worker owns the short deadline
+    and sends ``StopMove`` when it expires.
+    """
+
+    def __init__(self, loco, monotonic=time.monotonic, wall_time=time.time):
+        self._loco = loco
+        self._monotonic = monotonic
+        self._wall_time = wall_time
+        self.active = False
+        self.deadline_monotonic = 0.0
+        self.nav_id = None
+        self.sequence = None
+
+    def _clear(self) -> None:
+        self.active = False
+        self.deadline_monotonic = 0.0
+        self.nav_id = None
+        self.sequence = None
+
+    def seconds_until_deadline(self):
+        if not self.active:
+            return None
+        return max(0.0, self.deadline_monotonic - self._monotonic())
+
+    def stop(self, reason: str, force: bool = False) -> dict:
+        """Stop and retire the current lease; ``force`` also stops when idle."""
+        if not self.active and not force:
+            return {
+                "ret": 0,
+                "error": None,
+                "reason": reason,
+                "stop_issued": False,
+            }
+        started = self._monotonic()
+        ret = None
+        error = None
+        try:
+            ret = self._loco.StopMove()
+        except Exception as exc:
+            error = str(exc)
+        completed = self._monotonic()
+        self._clear()
+        return {
+            "ret": ret,
+            "error": error,
+            "reason": reason,
+            "stop_issued": True,
+            "started_monotonic": started,
+            "completed_monotonic": completed,
+            "completed_unix_ms": round(self._wall_time() * 1000),
+            "duration_ms": max(0, round((completed - started) * 1000)),
+        }
+
+    def expire_if_due(self) -> dict | None:
+        if not self.active or self._monotonic() < self.deadline_monotonic:
+            return None
+        return self.stop("proposal_ttl_expired")
+
+    def apply(
+        self,
+        vx: float,
+        vy: float,
+        vyaw: float,
+        deadline_monotonic: float,
+        nav_id: str,
+        sequence: int,
+        request_id: int | None = None,
+    ) -> dict:
+        """Apply a continuous velocity only while the Driver deadline is live."""
+        started = self._monotonic()
+        deadline = float(deadline_monotonic)
+        request = {
+            "vx": float(vx),
+            "vy": float(vy),
+            "vyaw": float(vyaw),
+            "deadline_monotonic": deadline,
+            "nav_id": nav_id,
+            "sequence": int(sequence),
+        }
+        base = {
+            "request_id": request_id,
+            "rpc_method": "SetVelocity(continuous)",
+            "request": request,
+            "ret": None,
+            "error": None,
+            "applied": False,
+            "started_monotonic": started,
+        }
+        if not math.isfinite(deadline) or deadline <= started:
+            stopped = self.stop("proposal_ttl_expired_before_rpc", force=True)
+            return {
+                **base,
+                "error": "proposal_ttl_expired_before_rpc",
+                "stop_ret": stopped.get("ret"),
+                "stop_error": stopped.get("error"),
+                "completed_monotonic": self._monotonic(),
+                "completed_unix_ms": round(self._wall_time() * 1000),
+            }
+
+        ret = None
+        error = None
+        try:
+            # LocoClient.Move(..., True) maps to this exact long-duration RPC,
+            # but its Python wrapper does not return the SetVelocity code.
+            ret = self._loco.SetVelocity(
+                float(vx),
+                float(vy),
+                float(vyaw),
+                PROPOSAL_CONTINUOUS_DURATION_SECONDS,
+            )
+        except Exception as exc:
+            error = str(exc)
+        completed = self._monotonic()
+        result = {
+            **base,
+            "ret": ret,
+            "error": error,
+            "completed_monotonic": completed,
+            "completed_unix_ms": round(self._wall_time() * 1000),
+            "duration_ms": max(0, round((completed - started) * 1000)),
+        }
+
+        if error is not None or ret != 0:
+            stopped = self.stop("proposal_velocity_rpc_failed", force=True)
+            result.update({
+                "stop_ret": stopped.get("ret"),
+                "stop_error": stopped.get("error"),
+            })
+            return result
+
+        if completed >= deadline:
+            stopped = self.stop("proposal_ttl_expired_after_rpc", force=True)
+            result.update({
+                "error": "proposal_ttl_expired_after_rpc",
+                "stop_ret": stopped.get("ret"),
+                "stop_error": stopped.get("error"),
+            })
+            return result
+
+        self.active = True
+        self.deadline_monotonic = deadline
+        self.nav_id = nav_id
+        self.sequence = int(sequence)
+        result["applied"] = True
+        return result
 
 
 def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.Queue,
@@ -25,22 +182,63 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
     loco.SetTimeout(10.0)
     loco.Init()
 
+    proposal_executor = ProposalRpcExecutor(loco)
+
     time.sleep(0.5)
     print("[G1 RpcWorker] ready", flush=True)
 
+    read_only_methods = {
+        "GetFsmId",
+        "GetFsmMode",
+        "GetBalanceMode",
+        "GetSwingHeight",
+        "GetStandHeight",
+        "GetPhase",
+    }
+
     while True:
+        proposal_executor.expire_if_due()
         try:
-            cmd = cmd_queue.get()
+            wait_timeout = proposal_executor.seconds_until_deadline()
+            if wait_timeout is None:
+                cmd = cmd_queue.get()
+            else:
+                cmd = cmd_queue.get(timeout=wait_timeout)
+        except queue.Empty:
+            proposal_executor.expire_if_due()
+            continue
         except Exception:
             break
         if cmd is None:
+            proposal_executor.stop("rpc_worker_shutdown")
             break
 
         method = cmd.get("method")
         args = cmd.get("args", [])
         kwargs = cmd.get("kwargs", {})
+        rpc_request_id = cmd.get("request_id")
 
         try:
+            if method == "__apply_velocity_proposal":
+                result_queue.put({
+                    "request_id": rpc_request_id,
+                    "result": proposal_executor.apply(*args, **kwargs),
+                })
+                continue
+
+            if method == "StopMove":
+                stopped = proposal_executor.stop("explicit_stop_move", force=True)
+                result_queue.put({
+                    "request_id": rpc_request_id,
+                    "result": stopped.get("ret"),
+                })
+                continue
+
+            # Read-only state queries may run while a proposal is active.  Any
+            # other Loco operation first retires the proposal authority.
+            if proposal_executor.active and method not in read_only_methods:
+                proposal_executor.stop("parent_rpc_override", force=True)
+
             # Special: FSM sequence execution (runs entirely in subprocess, no GIL)
             if method == "__run_fsm_sequence":
                 steps_spec, interval, step_timeout, settle_delay = args
@@ -49,7 +247,7 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                     fn = getattr(loco, method_name)
                     ret = fn()
                     if ret != 0:
-                        result_queue.put({"result": {
+                        result_queue.put({"request_id": rpc_request_id, "result": {
                             "error": f"Step '{step_name}' failed: code={ret}",
                             "step": step_name, "completed": completed}})
                         break  # abort sequence on failure
@@ -65,7 +263,7 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                             break
                     if not ok:
                         _, current = loco.GetFsmId()
-                        result_queue.put({"result": {
+                        result_queue.put({"request_id": rpc_request_id, "result": {
                             "error": f"Timeout '{step_name}' (expected={target_fsm}, got={current})",
                             "step": step_name, "fsm_id": current, "completed": completed}})
                         break  # abort sequence on timeout
@@ -74,15 +272,23 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                     time.sleep(settle_delay)
                 else:
                     # Only reached if loop completed without break (all steps succeeded)
-                    result_queue.put({"result": {"ret": 0, "steps": completed,
-                                                 "fsm_id": steps_spec[-1][1]}})
+                    result_queue.put({
+                        "request_id": rpc_request_id,
+                        "result": {
+                            "ret": 0,
+                            "steps": completed,
+                            "fsm_id": steps_spec[-1][1],
+                        },
+                    })
                 continue  # next cmd
 
             fn = getattr(loco, method)
             result = fn(*args, **kwargs)
-            result_queue.put({"result": result})
+            result_queue.put({"request_id": rpc_request_id, "result": result})
         except Exception as e:
-            result_queue.put({"error": str(e)})
+            result_queue.put({"request_id": rpc_request_id, "error": str(e)})
+        finally:
+            proposal_executor.expire_if_due()
 
 
 class RpcProxy:
@@ -99,18 +305,36 @@ class RpcProxy:
         )
         self._proc.start()
         self._lock = threading.Lock()
+        self._request_id = 0
 
     def _call(self, method: str, *args, timeout: float = 15.0, **kwargs):
         with self._lock:
-            self._cmd_q.put({"method": method, "args": args, "kwargs": kwargs})
-            try:
-                r = self._result_q.get(timeout=timeout)
-            except Exception:
-                return None
-            if "error" in r:
-                print(f"[G1 RpcProxy] {method} error: {r['error']}", flush=True)
-                return None
-            return r["result"]
+            self._request_id += 1
+            request_id = self._request_id
+            self._cmd_q.put({
+                "request_id": request_id,
+                "method": method,
+                "args": args,
+                "kwargs": kwargs,
+            })
+            deadline = time.monotonic() + timeout
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0.0:
+                    return None
+                try:
+                    response = self._result_q.get(timeout=remaining)
+                except Exception:
+                    return None
+                if response.get("request_id") != request_id:
+                    continue
+                if "error" in response:
+                    print(
+                        f"[G1 RpcProxy] {method} error: {response['error']}",
+                        flush=True,
+                    )
+                    return None
+                return response["result"]
 
     def _call_code(self, method: str, *args, **kwargs) -> int:
         """For methods that return a single int code."""
@@ -174,6 +398,47 @@ class RpcProxy:
 
     def SetVelocity(self, vx: float, vy: float, omega: float, duration: float = 1.0):
         return self._call_code("SetVelocity", vx, vy, omega, duration)
+
+    def ApplyVelocityProposal(
+        self,
+        vx: float,
+        vy: float,
+        vyaw: float,
+        deadline_monotonic: float,
+        nav_id: str,
+        sequence: int,
+        request_id: int | None = None,
+    ) -> dict:
+        result = self._call(
+            "__apply_velocity_proposal",
+            vx,
+            vy,
+            vyaw,
+            deadline_monotonic,
+            nav_id,
+            sequence,
+            request_id,
+            timeout=1.0,
+        )
+        if isinstance(result, dict):
+            return result
+        return {
+            "request_id": request_id,
+            "rpc_method": "SetVelocity(continuous)",
+            "request": {
+                "vx": vx,
+                "vy": vy,
+                "vyaw": vyaw,
+                "deadline_monotonic": deadline_monotonic,
+                "nav_id": nav_id,
+                "sequence": sequence,
+            },
+            "ret": None,
+            "error": "parent_proposal_rpc_unavailable",
+            "applied": False,
+            "completed_monotonic": time.monotonic(),
+            "completed_unix_ms": round(time.time() * 1000),
+        }
 
     def SetTaskId(self, task_id: float):
         return self._call_code("SetTaskId", task_id)

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -75,6 +75,193 @@ class SpeedLimits:
     vyaw_decel: float = 0.2
 
 
+@dataclass(frozen=True)
+class StopConfirmationStart:
+    monotonic: float
+    unix_ms: int
+    odometry_callback_count: int
+
+
+class OdomStopMonitor:
+    """Wait for measured zero velocity without blocking the odom callback."""
+
+    def __init__(self):
+        self._condition = threading.Condition()
+        self._last_time = 0.0
+        self._last_velocity = (float("inf"), float("inf"), float("inf"))
+        self._callback_count = 0
+
+    def record(self, velocity, received_monotonic=None):
+        received = (
+            time.monotonic()
+            if received_monotonic is None
+            else float(received_monotonic)
+        )
+        motion = tuple(float(value) for value in velocity)
+        if len(motion) != 3:
+            raise ValueError("odometry velocity must contain x, y, and yaw")
+        with self._condition:
+            self._last_time = received
+            self._last_velocity = motion
+            self._callback_count += 1
+            self._condition.notify_all()
+
+    def begin_confirmation(self):
+        with self._condition:
+            return StopConfirmationStart(
+                monotonic=time.monotonic(),
+                unix_ms=round(time.time() * 1000),
+                odometry_callback_count=self._callback_count,
+            )
+
+    def latest(self, now=None):
+        observed_at = time.monotonic() if now is None else float(now)
+        with self._condition:
+            age = (
+                observed_at - self._last_time
+                if self._last_time
+                else float("inf")
+            )
+            return {
+                "time": self._last_time,
+                "age": age,
+                "velocity": self._last_velocity,
+                "callback_count": self._callback_count,
+            }
+
+    def wait_for_stopped(
+        self,
+        start,
+        timeout,
+        max_age,
+        linear_epsilon,
+        yaw_epsilon,
+        stop_move_ret,
+        stop_move_error=None,
+        stop_move_completed_monotonic=None,
+        callbacks_at_stop_move_completion=None,
+    ):
+        deadline = start.monotonic + timeout
+        confirmed = False
+        timed_out = False
+        with self._condition:
+            while stop_move_ret == 0:
+                now = time.monotonic()
+                vx, vy, yaw = self._last_velocity
+                is_new = (
+                    self._callback_count > start.odometry_callback_count
+                    and self._last_time >= start.monotonic
+                    and self._last_time <= deadline
+                )
+                is_fresh = self._last_time and now - self._last_time <= max_age
+                is_zero = (
+                    abs(vx) <= linear_epsilon
+                    and abs(vy) <= linear_epsilon
+                    and abs(yaw) <= yaw_epsilon
+                )
+                if is_new and is_fresh and is_zero:
+                    confirmed = True
+                    break
+                remaining = deadline - now
+                if remaining <= 0.0:
+                    timed_out = True
+                    break
+                # Condition.wait releases the monitor lock, so the dedicated
+                # Unitree ch_reader thread can record and signal the next odom.
+                self._condition.wait(timeout=remaining)
+
+            now = time.monotonic()
+            age = now - self._last_time if self._last_time else float("inf")
+            vx, vy, yaw = self._last_velocity
+            diagnostics = {
+                "stop_move_ret": stop_move_ret,
+                "stop_move_error": stop_move_error,
+                "confirmation_started_monotonic": start.monotonic,
+                "confirmation_started_unix_ms": start.unix_ms,
+                "stop_move_completed_monotonic": stop_move_completed_monotonic,
+                "stop_move_duration_ms": (
+                    round(
+                        (stop_move_completed_monotonic - start.monotonic) * 1000
+                    )
+                    if stop_move_completed_monotonic is not None
+                    else None
+                ),
+                "last_odometry_monotonic": self._last_time or None,
+                "last_odometry_age_ms": (
+                    round(age * 1000) if math.isfinite(age) else None
+                ),
+                "last_odometry_velocity": {
+                    "x": vx if math.isfinite(vx) else None,
+                    "y": vy if math.isfinite(vy) else None,
+                    "yaw": yaw if math.isfinite(yaw) else None,
+                },
+                "odometry_callback_count": self._callback_count,
+                "odometry_callbacks_since_confirmation": max(
+                    0,
+                    self._callback_count - start.odometry_callback_count,
+                ),
+                "odometry_callbacks_during_stop_move": max(
+                    0,
+                    (
+                        callbacks_at_stop_move_completion
+                        if callbacks_at_stop_move_completion is not None
+                        else start.odometry_callback_count
+                    ) - start.odometry_callback_count,
+                ),
+                "confirmation_timed_out": timed_out,
+            }
+        return confirmed, diagnostics
+
+
+def issue_stop_and_confirm(
+    stop_move,
+    monitor,
+    timeout,
+    max_age,
+    linear_epsilon,
+    yaw_epsilon,
+    after_stop_attempt=None,
+):
+    """Issue a bounded StopMove and require a subsequent measured zero frame."""
+    start = monitor.begin_confirmation()
+    stop_move_ret = None
+    stop_move_error = None
+    try:
+        stop_move_ret = stop_move()
+    except Exception as exc:
+        stop_move_error = str(exc)
+    finally:
+        stop_move_completed_monotonic = time.monotonic()
+        callbacks_at_stop_move_completion = monitor.latest(
+            stop_move_completed_monotonic
+        )["callback_count"]
+        if after_stop_attempt is not None:
+            after_stop_attempt()
+
+    stop_confirmed, diagnostics = monitor.wait_for_stopped(
+        start=start,
+        timeout=timeout,
+        max_age=max_age,
+        linear_epsilon=linear_epsilon,
+        yaw_epsilon=yaw_epsilon,
+        stop_move_ret=stop_move_ret,
+        stop_move_error=stop_move_error,
+        stop_move_completed_monotonic=stop_move_completed_monotonic,
+        callbacks_at_stop_move_completion=callbacks_at_stop_move_completion,
+    )
+    result = {
+        "ret": stop_move_ret,
+        "stop_confirmed": stop_confirmed,
+        "stop_issued_monotonic": start.monotonic,
+        "stop_confirmation": diagnostics,
+    }
+    if stop_move_error:
+        result["error"] = f"StopMove failed: {stop_move_error}"
+    elif stop_move_ret != 0:
+        result["error"] = f"StopMove failed, ret={stop_move_ret}"
+    return result
+
+
 # ── SmartMotionProxy (main process) ─────────────────────────────────────────
 
 class SmartMotionProxy:
@@ -400,12 +587,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     speed_zone = SpeedZone.NORMAL
     move_timer = None   # threading.Timer
     last_cloud_time = 0.0
-    last_odom_time = 0.0
     last_fsm_check = 0.0
     last_fsm_id = None
     main_control_ready = False
     last_nav_status_time = 0.0
-    last_odom_motion = (float("inf"), float("inf"), float("inf"))
+    odom_stop_monitor = OdomStopMonitor()
     safety_lock = threading.Lock()
     motion_command_lock = threading.RLock()
     proposal_execution_lock = threading.Lock()
@@ -485,7 +671,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         return stop_loco_client.StopMove()
 
     @motion_synchronized
-    def do_stop(reason_str):
+    def do_stop(reason_str, confirm_physical_stop=False):
         nonlocal state, current_cmd, speed_zone, move_timer, stop_repeat_count
         was_proposal_motion = bool(
             current_cmd and current_cmd.get("source") == "velocity_proposal"
@@ -494,20 +680,40 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             move_timer.cancel()
             move_timer = None
         clear_proposal_execution()
-        stop_ret = None
-        stop_error = None
-        try:
-            stop_ret = issue_stop_move()
-        except Exception as exc:
-            stop_error = str(exc)
-        # A physical-stop confirmation must use odometry newer than the
-        # completed StopMove RPC attempt.
-        stop_issued_monotonic = time.monotonic()
         was_moving = state == MotionState.MOVING
-        state = MotionState.IDLE
-        current_cmd = None
-        speed_zone = SpeedZone.NORMAL
-        stop_repeat_count = 3  # repeat StopMove to ensure controller stops
+
+        def complete_logical_stop():
+            nonlocal state, current_cmd, speed_zone, stop_repeat_count
+            state = MotionState.IDLE
+            current_cmd = None
+            speed_zone = SpeedZone.NORMAL
+            stop_repeat_count = 3  # repeat StopMove to ensure controller stops
+
+        if confirm_physical_stop:
+            result = issue_stop_and_confirm(
+                issue_stop_move,
+                odom_stop_monitor,
+                proposal_stop_confirm_timeout,
+                proposal_odom_timeout,
+                proposal_stop_linear_epsilon,
+                proposal_stop_yaw_epsilon,
+                after_stop_attempt=complete_logical_stop,
+            )
+        else:
+            stop_ret = None
+            stop_error = None
+            try:
+                stop_ret = issue_stop_move()
+            except Exception as exc:
+                stop_error = str(exc)
+            complete_logical_stop()
+            result = {
+                "ret": stop_ret,
+                "stop_confirmed": stop_ret == 0,
+                "stop_issued_monotonic": time.monotonic(),
+            }
+            if stop_error:
+                result["error"] = f"StopMove failed: {stop_error}"
         if was_proposal_motion and reason_str == "obstacle":
             proposal_gate.disarm("obstacle_stop_latched")
         if was_moving:
@@ -517,15 +723,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     event_data["obstacle_distance"] = round(obstacle_dist, 2)
                     event_data["obstacle_angle_deg"] = round(math.degrees(obstacle_angle), 1)
             publish_event("motion_stop", event_data)
-        result = {
-            "ret": stop_ret,
-            "state": "idle",
-            "reason": reason_str,
-            "stop_confirmed": stop_ret == 0,
-            "stop_issued_monotonic": stop_issued_monotonic,
-        }
-        if stop_error:
-            result["error"] = f"StopMove failed: {stop_error}"
+        result.update({"state": "idle", "reason": reason_str})
         return result
 
     @motion_synchronized
@@ -746,7 +944,6 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     # ── OdomState DDS Subscription (foot force) ──
     def on_odom(msg):
         nonlocal foot_airborne_start, foot_force_seen_nonzero
-        nonlocal last_odom_time, last_odom_motion
 
         velocity = list(msg.velocity)
         motion = (
@@ -754,9 +951,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             float(velocity[1]) if len(velocity) > 1 else float("inf"),
             float(msg.yaw_speed),
         )
-        with safety_lock:
-            last_odom_time = time.monotonic()
-            last_odom_motion = motion
+        odom_stop_monitor.record(motion)
 
         if state != MotionState.MOVING:
             foot_airborne_start = 0.0
@@ -869,9 +1064,9 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         if force_fsm_check:
             refresh_fsm_state()
         now = time.monotonic()
+        odom = odom_stop_monitor.latest(now)
         with safety_lock:
             lowstate_age = now - last_lowstate_time if last_lowstate_time else float("inf")
-            odom_age = now - last_odom_time if last_odom_time else float("inf")
             scan_age = now - last_cloud_time if last_cloud_time else float("inf")
             nav_status_age = (
                 now - last_nav_status_time if last_nav_status_time else float("inf")
@@ -881,6 +1076,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             fsm_id = last_fsm_id
             control_ready = main_control_ready
             tilted = tilt_triggered
+        odom_age = odom["age"]
 
         reason = ""
         if not proposal_driver_authorized:
@@ -911,31 +1107,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             "emergency_stop_clear": control_ready and fsm_age <= proposal_fsm_timeout,
             "lowstate_age_ms": None if not math.isfinite(lowstate_age) else round(lowstate_age * 1000),
             "odometry_age_ms": None if not math.isfinite(odom_age) else round(odom_age * 1000),
+            "odometry_callback_count": odom["callback_count"],
             "scan_age_ms": None if not math.isfinite(scan_age) else round(scan_age * 1000),
             "nav2_status_age_ms": None if not math.isfinite(nav_status_age) else round(nav_status_age * 1000),
             "fsm_age_ms": None if not math.isfinite(fsm_age) else round(fsm_age * 1000),
         }
-
-    def confirm_robot_stopped(timeout, not_before):
-        """Confirm StopMove using a fresh near-zero measured odometry sample."""
-        deadline = time.monotonic() + timeout
-        while True:
-            now = time.monotonic()
-            with safety_lock:
-                odom_time = last_odom_time
-                vx, vy, yaw = last_odom_motion
-            if (
-                odom_time
-                and odom_time >= not_before
-                and now - odom_time <= proposal_odom_timeout
-                and abs(vx) <= proposal_stop_linear_epsilon
-                and abs(vy) <= proposal_stop_linear_epsilon
-                and abs(yaw) <= proposal_stop_yaw_epsilon
-            ):
-                return True
-            if now >= deadline:
-                return False
-            time.sleep(min(0.02, deadline - now))
 
     # ── Command handlers ──
     @motion_synchronized
@@ -1218,21 +1394,21 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     "error": "StopMove was not confirmed before proposal rebind",
                     "connected": False,
                     "stop_confirmed": False,
+                    "stop_move_ret": stopped.get("stop_move_ret"),
+                    "stop_move_error": stopped.get("stop_move_error"),
+                    "stop_confirmation": stopped.get("stop_confirmation"),
                 }
         else:
-            stopped = do_stop("proposal_bind")
-            physically_stopped = (
-                stopped.get("stop_confirmed")
-                and confirm_robot_stopped(
-                    proposal_stop_confirm_timeout,
-                    stopped["stop_issued_monotonic"],
-                )
-            )
-            if not physically_stopped:
+            stopped = do_stop("proposal_bind", confirm_physical_stop=True)
+            if not stopped.get("stop_confirmed"):
+                diagnostics = stopped.get("stop_confirmation") or {}
                 return {
                     "error": "StopMove/odometry stop was not confirmed before proposal bind",
                     "connected": False,
                     "stop_confirmed": False,
+                    "stop_move_ret": diagnostics.get("stop_move_ret"),
+                    "stop_move_error": diagnostics.get("stop_move_error"),
+                    "stop_confirmation": diagnostics,
                 }
         if not proposal_enabled:
             return {"error": "velocity_proposal_execution_disabled", "connected": False}
@@ -1260,6 +1436,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             return {"error": f"velocity_proposal_subscribe_failed: {exc}", "connected": False}
         result = handle_get_velocity_proposal_status()
         result["state"] = "connected"
+        result["stop_confirmed"] = True
+        result["stop_move_ret"] = stopped.get("stop_move_ret", stopped.get("ret"))
+        result["stop_move_error"] = stopped.get("stop_move_error")
+        result["stop_confirmation"] = stopped.get("stop_confirmation")
         return result
 
     @motion_synchronized
@@ -1268,29 +1448,25 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         # only proposal subscription.
         if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
             do_stop_nav()
-        stopped = do_stop(reason)
+        stopped = do_stop(reason, confirm_physical_stop=True)
         for _ in range(2):
-            if stopped.get("stop_confirmed"):
+            # Preserve the original retry contract: retry rejected/failed RPC
+            # attempts, but do not mask a measured nonzero or odom timeout by
+            # issuing more StopMove calls.
+            if stopped.get("ret") == 0:
                 break
-            try:
-                stop_ret = issue_stop_move()
-            except Exception as exc:
-                stopped["error"] = f"StopMove failed: {exc}"
-            else:
-                stopped["ret"] = stop_ret
-                stopped["stop_confirmed"] = stop_ret == 0
-            finally:
-                stopped["stop_issued_monotonic"] = time.monotonic()
-        stopped["stop_confirmed"] = bool(
-            stopped.get("stop_confirmed")
-            and confirm_robot_stopped(
+            stopped = issue_stop_and_confirm(
+                issue_stop_move,
+                odom_stop_monitor,
                 proposal_stop_confirm_timeout,
-                stopped["stop_issued_monotonic"],
+                proposal_odom_timeout,
+                proposal_stop_linear_epsilon,
+                proposal_stop_yaw_epsilon,
             )
-        )
         if not stopped["stop_confirmed"]:
             proposal_gate.disarm("stop_unconfirmed")
             proposal_connected.clear()
+            diagnostics = stopped.get("stop_confirmation") or {}
             return {
                 "state": "error",
                 "connected": bool(proposal_node.topic),
@@ -1299,6 +1475,9 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 "subscriber_retained": bool(proposal_node.topic),
                 "reason": reason,
                 "error": stopped.get("error") or "fresh zero-odometry stop was not confirmed",
+                "stop_move_ret": diagnostics.get("stop_move_ret"),
+                "stop_move_error": diagnostics.get("stop_move_error"),
+                "stop_confirmation": diagnostics,
             }
         proposal_gate.unbind(reason)
         proposal_connected.clear()
@@ -1308,6 +1487,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             "connected": False,
             "stop_confirmed": True,
             "reason": reason,
+            "stop_move_ret": stopped.get("ret"),
+            "stop_move_error": (
+                (stopped.get("stop_confirmation") or {}).get("stop_move_error")
+            ),
+            "stop_confirmation": stopped.get("stop_confirmation"),
             **({"error": stopped["error"]} if stopped.get("error") else {}),
         }
 
@@ -1744,12 +1928,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     if move_timer:
         move_timer.cancel()
     with motion_command_lock:
-        stopped = do_stop("process_exit")
-        if stopped.get("stop_confirmed"):
-            stopped["stop_confirmed"] = confirm_robot_stopped(
-                proposal_stop_confirm_timeout,
-                stopped["stop_issued_monotonic"],
-            )
+        do_stop("process_exit", confirm_physical_stop=True)
         proposal_gate.unbind("process_exit")
         proposal_node.unbind()
     executor.shutdown()

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -38,6 +38,28 @@ from velocity_proposal import (
 )
 
 
+UNITREE_STOP_MOVE_DURATION_SECONDS = 1.0
+DEFAULT_STOP_CONFIRM_TIMEOUT_SECONDS = 2.0
+MAX_STOP_CONFIRM_TIMEOUT_SECONDS = 3.0
+
+
+def resolve_stop_confirmation_timeout(configured_timeout):
+    """Bound zero-odom confirmation around the G1 StopMove command.
+
+    unitree_sdk2py implements StopMove as SetVelocity(0, 0, 0) with the
+    default one-second duration.  The physical confirmation window must not
+    expire before that command can finish, while remaining fail-closed and
+    bounded against missing odometry.
+    """
+    return min(
+        MAX_STOP_CONFIRM_TIMEOUT_SECONDS,
+        max(
+            UNITREE_STOP_MOVE_DURATION_SECONDS,
+            float(configured_timeout),
+        ),
+    )
+
+
 # ── Enums & Data Classes (shared between processes) ──────────────────────────
 
 class MotionState(enum.Enum):
@@ -301,30 +323,237 @@ def issue_stop_and_confirm(
     )
 
 
+def aggregate_stop_attempts(attempts):
+    """Return the final stop result without discarding earlier evidence."""
+    if not attempts:
+        raise ValueError("at least one stop attempt is required")
+    result = dict(attempts[-1])
+    result["stop_attempt_count"] = len(attempts)
+    result["stop_attempts"] = [dict(attempt) for attempt in attempts]
+    return result
+
+
+class ProposalExecutionLease:
+    """Thread-safe deadline ownership for an applied velocity proposal.
+
+    A newly validated proposal may renew an already applied velocity while the
+    serialized parent RPC is still in flight.  It must not, however, activate
+    execution before the first SetVelocity call starts or revive a lease after
+    the watchdog has tripped.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._generation = 0
+        self._active = False
+        self._deadline = 0.0
+        self._fault = None
+
+    def arm(self, deadline: float) -> Optional[int]:
+        candidate = float(deadline)
+        with self._lock:
+            if self._fault is not None:
+                return None
+            self._generation += 1
+            if self._active:
+                self._deadline = max(self._deadline, candidate)
+            else:
+                self._deadline = candidate
+            self._active = True
+            return self._generation
+
+    def renew_if_active(self, deadline: float) -> bool:
+        """Renew an active lease; return false if a fault already won."""
+        candidate = float(deadline)
+        with self._lock:
+            if self._fault is not None:
+                return False
+            if self._active:
+                self._deadline = max(self._deadline, candidate)
+            return True
+
+    def clear(self) -> None:
+        with self._lock:
+            self._generation += 1
+            self._active = False
+            self._deadline = 0.0
+            self._fault = None
+
+    def fault_for_generation(self, generation: int) -> str:
+        with self._lock:
+            if self._fault and self._fault[0] == generation:
+                return self._fault[1]
+            return ""
+
+    def current_fault(self):
+        with self._lock:
+            return self._fault
+
+    def watchdog_snapshot(self):
+        with self._lock:
+            if not self._active:
+                return None
+            return self._generation, self._deadline
+
+    def trip(self, generation: int, reason: str, now: float) -> bool:
+        """Atomically trip only if the observed lease is still due/faulted."""
+        with self._lock:
+            if not self._active or generation != self._generation:
+                return False
+            if reason == "proposal_ttl_expired" and now < self._deadline:
+                return False
+            self._active = False
+            self._fault = (generation, reason)
+            return True
+
+
+def velocity_commands_differ(current, target, abs_tol: float = 1e-9) -> bool:
+    """Return whether a safety update changes the effective velocity."""
+    return any(
+        not math.isclose(
+            float(before),
+            float(after),
+            rel_tol=0.0,
+            abs_tol=abs_tol,
+        )
+        for before, after in zip(current, target)
+    )
+
+
 @dataclass
 class ProposalApplyDiagnostics:
-    """Process-lifetime proposal receive/apply evidence for ``loco info``."""
+    """Current or most recent nav-lease execution evidence for ``loco info``."""
 
+    session_nav_id: Optional[str] = None
     received: int = 0
     accepted: int = 0
     rejected: int = 0
     applied: int = 0
+    first_received_monotonic: Optional[float] = None
+    last_received_monotonic: Optional[float] = None
+    last_receive_gap_ms: Optional[int] = None
+    max_receive_gap_ms: Optional[int] = None
+    last_proposal_age_ms: Optional[int] = None
+    max_proposal_age_ms: Optional[int] = None
+    expired_on_arrival: int = 0
+    watchdog_faults_by_reason: dict = field(default_factory=dict)
+    first_rejection_reason: Optional[str] = None
     last_rejection_reason: Optional[str] = None
+    rejections_by_reason: dict = field(default_factory=dict)
+    last_set_velocity_rpc_method: Optional[str] = None
+    last_set_velocity_request: Optional[dict] = None
     last_set_velocity_ret: Optional[int] = None
     last_set_velocity_error: Optional[str] = None
+    last_set_velocity_applied: Optional[bool] = None
     last_set_velocity_request_id: Optional[int] = None
     last_set_velocity_duration_ms: Optional[int] = None
     last_set_velocity_completed_monotonic: Optional[float] = None
     last_set_velocity_completed_unix_ms: Optional[int] = None
+    last_set_velocity_stop_ret: Optional[int] = None
+    last_set_velocity_stop_error: Optional[str] = None
     _lock: threading.Lock = field(
         default_factory=threading.Lock,
         init=False,
         repr=False,
     )
+    _applied_identities: set = field(
+        default_factory=set,
+        init=False,
+        repr=False,
+    )
 
-    def record_received(self) -> None:
+    def begin_session(self, nav_id: str) -> None:
+        """Reset per-lease counters while retaining them after later cleanup."""
+        with self._lock:
+            self.session_nav_id = nav_id
+            self.received = 0
+            self.accepted = 0
+            self.rejected = 0
+            self.applied = 0
+            self.first_received_monotonic = None
+            self.last_received_monotonic = None
+            self.last_receive_gap_ms = None
+            self.max_receive_gap_ms = None
+            self.last_proposal_age_ms = None
+            self.max_proposal_age_ms = None
+            self.expired_on_arrival = 0
+            self.watchdog_faults_by_reason = {}
+            self.first_rejection_reason = None
+            self.last_rejection_reason = None
+            self.rejections_by_reason = {}
+            self.last_set_velocity_rpc_method = None
+            self.last_set_velocity_request = None
+            self.last_set_velocity_ret = None
+            self.last_set_velocity_error = None
+            self.last_set_velocity_applied = None
+            self.last_set_velocity_request_id = None
+            self.last_set_velocity_duration_ms = None
+            self.last_set_velocity_completed_monotonic = None
+            self.last_set_velocity_completed_unix_ms = None
+            self.last_set_velocity_stop_ret = None
+            self.last_set_velocity_stop_error = None
+            self._applied_identities = set()
+
+    def record_received(self, received_monotonic: Optional[float] = None) -> None:
+        received = (
+            time.monotonic()
+            if received_monotonic is None
+            else float(received_monotonic)
+        )
         with self._lock:
             self.received += 1
+            if self.first_received_monotonic is None:
+                self.first_received_monotonic = received
+            if self.last_received_monotonic is not None:
+                gap_ms = max(
+                    0,
+                    round((received - self.last_received_monotonic) * 1000),
+                )
+                self.last_receive_gap_ms = gap_ms
+                if (
+                    self.max_receive_gap_ms is None
+                    or gap_ms > self.max_receive_gap_ms
+                ):
+                    self.max_receive_gap_ms = gap_ms
+            self.last_received_monotonic = received
+
+    def record_proposal_arrival(
+        self,
+        payload,
+        received_unix_ms: float,
+    ) -> None:
+        """Record source-to-callback age without participating in validation."""
+        if not isinstance(payload, dict):
+            return
+        issued_at = payload.get("issued_at_unix_ms")
+        ttl_ms = payload.get("ttl_ms")
+        if (
+            isinstance(issued_at, bool)
+            or not isinstance(issued_at, (int, float))
+            or not math.isfinite(float(issued_at))
+        ):
+            return
+        age_ms = round(float(received_unix_ms) - float(issued_at))
+        with self._lock:
+            self.last_proposal_age_ms = age_ms
+            if (
+                self.max_proposal_age_ms is None
+                or age_ms > self.max_proposal_age_ms
+            ):
+                self.max_proposal_age_ms = age_ms
+            if (
+                not isinstance(ttl_ms, bool)
+                and isinstance(ttl_ms, int)
+                and ttl_ms > 0
+                and age_ms >= ttl_ms
+            ):
+                self.expired_on_arrival += 1
+
+    def record_watchdog_fault(self, reason: str) -> None:
+        with self._lock:
+            self.watchdog_faults_by_reason[reason] = (
+                self.watchdog_faults_by_reason.get(reason, 0) + 1
+            )
 
     def record_accepted(self) -> None:
         with self._lock:
@@ -333,14 +562,25 @@ class ProposalApplyDiagnostics:
     def record_rejected(self, reason: str) -> None:
         with self._lock:
             self.rejected += 1
+            if self.first_rejection_reason is None:
+                self.first_rejection_reason = reason
             self.last_rejection_reason = reason
+            self.rejections_by_reason[reason] = (
+                self.rejections_by_reason.get(reason, 0) + 1
+            )
 
     def record_set_velocity(self, result: dict, duration: float) -> None:
         completed_monotonic = result.get("completed_monotonic")
         completed_unix_ms = result.get("completed_unix_ms")
         with self._lock:
+            self.last_set_velocity_rpc_method = result.get("rpc_method")
+            request = result.get("request")
+            self.last_set_velocity_request = (
+                dict(request) if isinstance(request, dict) else None
+            )
             self.last_set_velocity_ret = result.get("ret")
             self.last_set_velocity_error = result.get("error")
+            self.last_set_velocity_applied = bool(result.get("applied"))
             self.last_set_velocity_request_id = result.get("request_id")
             self.last_set_velocity_duration_ms = max(
                 0,
@@ -356,21 +596,54 @@ class ProposalApplyDiagnostics:
                 if completed_unix_ms is not None
                 else None
             )
+            self.last_set_velocity_stop_ret = result.get("stop_ret")
+            self.last_set_velocity_stop_error = result.get("stop_error")
 
-    def record_applied(self) -> None:
+    def record_applied(
+        self,
+        nav_id: Optional[str] = None,
+        sequence: Optional[int] = None,
+    ) -> None:
         with self._lock:
+            if nav_id is not None and sequence is not None:
+                identity = (str(nav_id), int(sequence))
+                if identity in self._applied_identities:
+                    return
+                self._applied_identities.add(identity)
             self.applied += 1
 
     def snapshot(self) -> dict:
         with self._lock:
             return {
+                "session_nav_id": self.session_nav_id,
                 "received": self.received,
                 "accepted": self.accepted,
                 "rejected": self.rejected,
                 "applied": self.applied,
+                "first_received_monotonic": self.first_received_monotonic,
+                "last_received_monotonic": self.last_received_monotonic,
+                "last_receive_gap_ms": self.last_receive_gap_ms,
+                "max_receive_gap_ms": self.max_receive_gap_ms,
+                "last_proposal_age_ms": self.last_proposal_age_ms,
+                "max_proposal_age_ms": self.max_proposal_age_ms,
+                "expired_on_arrival": self.expired_on_arrival,
+                "watchdog_faults_by_reason": dict(
+                    self.watchdog_faults_by_reason
+                ),
+                "first_rejection_reason": self.first_rejection_reason,
                 "last_rejection_reason": self.last_rejection_reason,
+                "rejections_by_reason": dict(self.rejections_by_reason),
+                "last_set_velocity_rpc_method": (
+                    self.last_set_velocity_rpc_method
+                ),
+                "last_set_velocity_request": (
+                    dict(self.last_set_velocity_request)
+                    if self.last_set_velocity_request is not None
+                    else None
+                ),
                 "last_set_velocity_ret": self.last_set_velocity_ret,
                 "last_set_velocity_error": self.last_set_velocity_error,
+                "last_set_velocity_applied": self.last_set_velocity_applied,
                 "last_set_velocity_request_id": (
                     self.last_set_velocity_request_id
                 ),
@@ -382,6 +655,10 @@ class ProposalApplyDiagnostics:
                 ),
                 "last_set_velocity_completed_unix_ms": (
                     self.last_set_velocity_completed_unix_ms
+                ),
+                "last_set_velocity_stop_ret": self.last_set_velocity_stop_ret,
+                "last_set_velocity_stop_error": (
+                    self.last_set_velocity_stop_error
                 ),
             }
 
@@ -433,31 +710,62 @@ def _request_parent_loco_rpc(
             return result
 
 
-def request_parent_set_velocity(
+def request_parent_apply_velocity_proposal(
     request_queue,
     result_queue,
     request_id: int,
     vx: float,
     vy: float,
     vyaw: float,
-    duration: float,
+    deadline_monotonic: float,
+    nav_id: str,
+    sequence: int,
     timeout: float,
 ) -> dict:
-    """Request one finite SetVelocity from the parent and wait boundedly."""
+    """Request one Driver-deadline-controlled velocity from the parent."""
+    request = {
+        "vx": vx,
+        "vy": vy,
+        "vyaw": vyaw,
+        "deadline_monotonic": deadline_monotonic,
+        "nav_id": nav_id,
+        "sequence": sequence,
+    }
+    result = _request_parent_loco_rpc(
+        request_queue,
+        result_queue,
+        request={
+            "method": "apply_velocity_proposal",
+            "request_id": request_id,
+            **request,
+        },
+        timeout=timeout,
+        timeout_error="parent_velocity_proposal_timeout",
+        ipc_error_prefix="parent_velocity_proposal_ipc_error",
+    )
+    result.setdefault("rpc_method", "SetVelocity(continuous)")
+    result.setdefault("request", request)
+    result.setdefault("applied", False)
+    return result
+
+
+def request_parent_stop_velocity_proposal(
+    request_queue,
+    result_queue,
+    request_id: int,
+    timeout: float,
+) -> dict:
+    """Order StopMove after every earlier parent proposal RPC."""
     return _request_parent_loco_rpc(
         request_queue,
         result_queue,
         request={
-            "method": "set_velocity",
+            "method": "stop_velocity_proposal",
             "request_id": request_id,
-            "vx": vx,
-            "vy": vy,
-            "vyaw": vyaw,
-            "duration": duration,
         },
         timeout=timeout,
-        timeout_error="parent_set_velocity_timeout",
-        ipc_error_prefix="parent_set_velocity_ipc_error",
+        timeout_error="parent_velocity_stop_timeout",
+        ipc_error_prefix="parent_velocity_stop_ipc_error",
     )
 
 
@@ -488,7 +796,7 @@ class SmartMotionProxy:
 
     def __init__(self, namespace: str, config: dict, network_iface: str,
                  proposal_config: Optional[dict] = None,
-                 fallback_stop=None, parent_set_velocity=None,
+                 fallback_stop=None, parent_apply_velocity_proposal=None,
                  parent_get_fsm_id=None):
         ctx = mp.get_context("spawn")
         self._cmd_queue = ctx.Queue()
@@ -498,7 +806,7 @@ class SmartMotionProxy:
         self._call_lock = threading.RLock()
         self._request_id = 0
         self._fallback_stop = fallback_stop
-        self._parent_set_velocity = parent_set_velocity
+        self._parent_apply_velocity_proposal = parent_apply_velocity_proposal
         self._parent_get_fsm_id = parent_get_fsm_id
         self._parent_velocity_shutdown = threading.Event()
         self._proc = ctx.Process(
@@ -531,22 +839,33 @@ class SmartMotionProxy:
             if request is None:
                 return
             request_id = request.get("request_id")
-            method = request.get("method", "set_velocity")
+            method = request.get("method", "apply_velocity_proposal")
             ret = None
             fsm_id = None
             error = None
+            response = {}
             try:
-                if method == "set_velocity":
-                    if self._parent_set_velocity is None:
+                if method == "apply_velocity_proposal":
+                    if self._parent_apply_velocity_proposal is None:
                         raise RuntimeError(
-                            "parent SetVelocity RPC is unavailable"
+                            "parent proposal RPC is unavailable"
                         )
-                    ret = self._parent_set_velocity(
+                    result = self._parent_apply_velocity_proposal(
                         request["vx"],
                         request["vy"],
                         request["vyaw"],
-                        request["duration"],
+                        request["deadline_monotonic"],
+                        request["nav_id"],
+                        request["sequence"],
+                        request_id,
                     )
+                    if not isinstance(result, dict):
+                        raise RuntimeError(
+                            "parent proposal RPC returned an invalid result"
+                        )
+                    response.update(result)
+                    ret = result.get("ret")
+                    error = result.get("error")
                 elif method == "get_fsm_id":
                     if self._parent_get_fsm_id is None:
                         raise RuntimeError(
@@ -558,21 +877,28 @@ class SmartMotionProxy:
                             "parent GetFsmId returned an invalid result"
                         )
                     ret, fsm_id = result
+                elif method == "stop_velocity_proposal":
+                    if self._fallback_stop is None:
+                        raise RuntimeError(
+                            "parent StopMove RPC is unavailable"
+                        )
+                    ret = self._fallback_stop()
                 else:
                     raise RuntimeError(
                         f"unsupported parent Loco RPC method: {method}"
                     )
             except Exception as exc:
                 error = str(exc)
-            self._parent_velocity_result_queue.put({
+            response.update({
                 "method": method,
                 "request_id": request_id,
                 "ret": ret,
                 "fsm_id": fsm_id,
                 "error": error,
-                "completed_monotonic": time.monotonic(),
-                "completed_unix_ms": round(time.time() * 1000),
             })
+            response.setdefault("completed_monotonic", time.monotonic())
+            response.setdefault("completed_unix_ms", round(time.time() * 1000))
+            self._parent_velocity_result_queue.put(response)
 
     def _signal_parent_velocity_shutdown(self) -> None:
         shutdown = getattr(self, "_parent_velocity_shutdown", None)
@@ -792,7 +1118,13 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     # independent child clients so a delayed parent RPC cannot block the
     # fail-closed stop paths.
     proposal_rpc_timeout = min(
-        0.2, max(0.02, float(proposal_config.get("velocity_proposal_rpc_timeout", 0.1)))
+        1.0,
+        max(
+            0.1,
+            float(
+                proposal_config.get("velocity_proposal_rpc_timeout", 0.5)
+            ),
+        ),
     )
     stop_rpc_timeout = min(
         0.2,
@@ -907,17 +1239,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     proposal_watchdog_hz = max(
         20.0, float(proposal_config.get("velocity_proposal_watchdog_hz", 40.0))
     )
-    proposal_stop_confirm_timeout = min(
-        1.0,
-        max(
-            0.1,
-            float(
-                proposal_config.get(
-                    "velocity_proposal_stop_confirm_timeout",
-                    0.5,
-                )
-            ),
-        ),
+    proposal_stop_confirm_timeout = resolve_stop_confirmation_timeout(
+        proposal_config.get(
+            "velocity_proposal_stop_confirm_timeout",
+            DEFAULT_STOP_CONFIRM_TIMEOUT_SECONDS,
+        )
     )
     proposal_stop_linear_epsilon = max(
         0.0, float(proposal_config.get("velocity_proposal_stop_linear_epsilon", 0.03))
@@ -946,17 +1272,21 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     odom_stop_monitor = OdomStopMonitor()
     safety_lock = threading.Lock()
     motion_command_lock = threading.RLock()
-    proposal_execution_lock = threading.Lock()
+    proposal_execution_lease = ProposalExecutionLease()
     proposal_connected = threading.Event()
     proposal_stop_transition = threading.Event()
     safety_threads_shutdown = threading.Event()
-    proposal_execution_generation = 0
-    proposal_execution_active = False
-    proposal_execution_deadline = 0.0
-    proposal_watchdog_fault = None
+    proposal_callback_ready = threading.Event()
+    proposal_callback_failed = threading.Event()
+    proposal_callback_error_lock = threading.Lock()
+    proposal_callback_error = None
+    proposal_ros_thread = None
     parent_loco_request_id = 0
     parent_loco_rpc_lock = threading.Lock()
     proposal_apply_diagnostics = ProposalApplyDiagnostics()
+    proposal_apply_queue = queue.Queue(maxsize=1)
+    last_stop_result = None
+    last_proposal_stop_result = None
 
     def motion_synchronized(func):
         def locked(*args, **kwargs):
@@ -964,53 +1294,88 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 return func(*args, **kwargs)
         return locked
 
+    def proposal_callback_status():
+        with proposal_callback_error_lock:
+            error = proposal_callback_error
+        return {
+            "ready": proposal_callback_ready.is_set(),
+            "alive": bool(
+                proposal_ros_thread is not None
+                and proposal_ros_thread.is_alive()
+            ),
+            "failed": proposal_callback_failed.is_set(),
+            "error": error,
+        }
+
     def arm_proposal_execution(deadline):
-        nonlocal proposal_execution_generation, proposal_execution_active
-        nonlocal proposal_execution_deadline, proposal_watchdog_fault
-        with proposal_execution_lock:
-            proposal_execution_generation += 1
-            proposal_execution_active = True
-            proposal_execution_deadline = deadline
-            proposal_watchdog_fault = None
-            return proposal_execution_generation
+        return proposal_execution_lease.arm(deadline)
+
+    def refresh_proposal_execution_deadline(deadline):
+        return proposal_execution_lease.renew_if_active(deadline)
 
     def clear_proposal_execution():
-        nonlocal proposal_execution_generation, proposal_execution_active
-        nonlocal proposal_execution_deadline, proposal_watchdog_fault
-        with proposal_execution_lock:
-            proposal_execution_generation += 1
-            proposal_execution_active = False
-            proposal_execution_deadline = 0.0
-            proposal_watchdog_fault = None
+        proposal_execution_lease.clear()
 
     def proposal_fault_for_generation(generation):
-        with proposal_execution_lock:
-            if proposal_watchdog_fault and proposal_watchdog_fault[0] == generation:
-                return proposal_watchdog_fault[1]
-            return ""
+        return proposal_execution_lease.fault_for_generation(generation)
 
     def current_proposal_watchdog_fault():
-        with proposal_execution_lock:
-            return proposal_watchdog_fault
+        return proposal_execution_lease.current_fault()
 
-    def apply_parent_set_velocity(vx, vy, vyaw, duration):
+    def apply_parent_velocity_proposal(command):
         nonlocal parent_loco_request_id
         # The FSM monitor and proposal callback share one request/result pair.
         # Serialize them so one waiter cannot consume the other's reply.
         with parent_loco_rpc_lock:
             parent_loco_request_id += 1
-            result = request_parent_set_velocity(
+            result = request_parent_apply_velocity_proposal(
                 request_queue=parent_velocity_queue,
                 result_queue=parent_velocity_result_queue,
                 request_id=parent_loco_request_id,
-                vx=vx,
-                vy=vy,
-                vyaw=vyaw,
-                duration=duration,
+                vx=command["vx"],
+                vy=command["vy"],
+                vyaw=command["vyaw"],
+                deadline_monotonic=command["deadline_monotonic"],
+                nav_id=command["nav_id"],
+                sequence=command["sequence"],
                 timeout=proposal_rpc_timeout,
             )
-        proposal_apply_diagnostics.record_set_velocity(result, duration)
+        proposal_apply_diagnostics.record_set_velocity(
+            result,
+            max(0.0, command["deadline_monotonic"] - command["queued_monotonic"]),
+        )
         return result
+
+    def stop_parent_velocity_proposal():
+        """Serialize StopMove behind any in-flight parent proposal apply."""
+        nonlocal parent_loco_request_id
+        with parent_loco_rpc_lock:
+            parent_loco_request_id += 1
+            return request_parent_stop_velocity_proposal(
+                request_queue=parent_velocity_queue,
+                result_queue=parent_velocity_result_queue,
+                request_id=parent_loco_request_id,
+                timeout=proposal_rpc_timeout,
+            )
+
+    def clear_proposal_apply_queue():
+        while True:
+            try:
+                proposal_apply_queue.get_nowait()
+            except queue.Empty:
+                return
+
+    def enqueue_proposal_apply(command):
+        """Keep only the newest validated command while the parent RPC is busy."""
+        while True:
+            try:
+                proposal_apply_queue.put_nowait(command)
+                return
+            except queue.Full:
+                try:
+                    proposal_apply_queue.get_nowait()
+                except queue.Empty:
+                    pass
 
     def query_parent_fsm_id():
         nonlocal parent_loco_request_id
@@ -1063,14 +1428,42 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         external_stop_attempt=None,
     ):
         nonlocal state, current_cmd, speed_zone, move_timer, stop_repeat_count
+        nonlocal last_stop_result, last_proposal_stop_result
         was_proposal_motion = bool(
             current_cmd and current_cmd.get("source") == "velocity_proposal"
         )
+        retry_proposal_stop = was_proposal_motion and not confirm_physical_stop
         if move_timer:
             move_timer.cancel()
             move_timer = None
+        clear_proposal_apply_queue()
         clear_proposal_execution()
         was_moving = state == MotionState.MOVING
+
+        if was_proposal_motion and not confirm_physical_stop:
+            # The independent client brakes immediately.  The ordered parent
+            # StopMove then runs after any in-flight continuous SetVelocity,
+            # preventing a late successful apply from restarting motion.
+            start = odom_stop_monitor.begin_confirmation()
+            try:
+                watchdog_loco_client.StopMove()
+            except Exception:
+                pass
+            parent_stop = stop_parent_velocity_proposal()
+            external_stop_attempt = {
+                "confirmation_start": {
+                    "monotonic": start.monotonic,
+                    "unix_ms": start.unix_ms,
+                    "odometry_callback_count": start.odometry_callback_count,
+                },
+                "stop_move_ret": parent_stop.get("ret"),
+                "stop_move_error": parent_stop.get("error"),
+                "stop_move_completed_monotonic": parent_stop.get(
+                    "completed_monotonic",
+                    time.monotonic(),
+                ),
+            }
+            confirm_physical_stop = True
 
         def complete_logical_stop():
             nonlocal state, current_cmd, speed_zone, stop_repeat_count
@@ -1100,7 +1493,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                             "stop_move_completed_monotonic"
                         ]
                     ),
-                    timeout=proposal_stop_confirm_timeout,
+                    timeout=(
+                        min(0.15, proposal_stop_confirm_timeout)
+                        if retry_proposal_stop
+                        else proposal_stop_confirm_timeout
+                    ),
                     max_age=proposal_odom_timeout,
                     linear_epsilon=proposal_stop_linear_epsilon,
                     yaw_epsilon=proposal_stop_yaw_epsilon,
@@ -1116,6 +1513,33 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     proposal_stop_yaw_epsilon,
                     after_stop_attempt=complete_logical_stop,
                 )
+            stop_attempts = [result]
+            if retry_proposal_stop and not result.get("stop_confirmed"):
+                # A continuous G1 velocity command can acknowledge one
+                # StopMove while measured gait velocity remains nonzero.  Use
+                # one bounded, ordered retry and retain both confirmations.
+                retry_start = odom_stop_monitor.begin_confirmation()
+                try:
+                    watchdog_loco_client.StopMove()
+                except Exception:
+                    pass
+                retry_parent_stop = stop_parent_velocity_proposal()
+                result = finish_stop_confirmation(
+                    monitor=odom_stop_monitor,
+                    start=retry_start,
+                    stop_move_ret=retry_parent_stop.get("ret"),
+                    stop_move_error=retry_parent_stop.get("error"),
+                    stop_move_completed_monotonic=retry_parent_stop.get(
+                        "completed_monotonic",
+                        time.monotonic(),
+                    ),
+                    timeout=proposal_stop_confirm_timeout,
+                    max_age=proposal_odom_timeout,
+                    linear_epsilon=proposal_stop_linear_epsilon,
+                    yaw_epsilon=proposal_stop_yaw_epsilon,
+                )
+                stop_attempts.append(result)
+            result = aggregate_stop_attempts(stop_attempts)
         else:
             stop_ret = None
             stop_error = None
@@ -1141,6 +1565,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     event_data["obstacle_angle_deg"] = round(math.degrees(obstacle_angle), 1)
             publish_event("motion_stop", event_data)
         result.update({"state": "idle", "reason": reason_str})
+        if confirm_physical_stop:
+            last_stop_result = dict(result)
+            if retry_proposal_stop:
+                last_proposal_stop_result = dict(result)
         return result
 
     @motion_synchronized
@@ -1278,12 +1706,17 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     def emergency_stop(reason_str, extra=None):
         """Emergency stop with optional damp mode for tilt."""
         nonlocal state, current_cmd, speed_zone, move_timer, stop_repeat_count
-        if current_cmd and current_cmd.get("source") == "velocity_proposal":
-            proposal_gate.disarm(f"{reason_str}_latched")
-        if move_timer:
-            move_timer.cancel()
-            move_timer = None
-        clear_proposal_execution()
+        was_proposal_motion = bool(
+            current_cmd and current_cmd.get("source") == "velocity_proposal"
+        )
+        was_active = state in (
+            MotionState.MOVING,
+            MotionState.NAVIGATING,
+            MotionState.NAV_PAUSED,
+        )
+        # Preserve the emergency path's immediate physical brake.  Proposal
+        # motion additionally performs an ordered parent stop below so a late
+        # continuous-velocity reply cannot restart the robot.
         try:
             stop_loco_client.StopMove()
         except Exception:
@@ -1293,7 +1726,14 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 loco_client.SetFsmId(1)  # damp mode
             except Exception:
                 pass
-        was_active = state in (MotionState.MOVING, MotionState.NAVIGATING, MotionState.NAV_PAUSED)
+        if was_proposal_motion:
+            proposal_gate.disarm(f"{reason_str}_latched")
+            do_stop(reason_str)
+        else:
+            if move_timer:
+                move_timer.cancel()
+                move_timer = None
+            clear_proposal_execution()
         if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
             try:
                 slam_client.PauseNav()
@@ -1551,7 +1991,16 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
 
     # ── Command handlers ──
     @motion_synchronized
-    def handle_move(vx, vy, vyaw, duration, finite_rpc=False, source="mcp"):
+    def handle_move(
+        vx,
+        vy,
+        vyaw,
+        duration,
+        finite_rpc=False,
+        source="mcp",
+        proposal=None,
+        deadline_monotonic=None,
+    ):
         nonlocal state, current_cmd, speed_zone, move_timer
 
         if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
@@ -1577,38 +2026,37 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             "duration": duration, "start_time": now,
             "end_time": (now + duration) if duration > 0 else None,
             "source": source,
+            "effective_velocity": (
+                clamped_vx,
+                clamped_vy,
+                clamped_vyaw,
+            ),
         }
+        if proposal is not None:
+            current_cmd.update({
+                "nav_id": proposal.nav_id,
+                "sequence": proposal.sequence,
+                "deadline_monotonic": deadline_monotonic,
+            })
         state = MotionState.MOVING
         speed_zone = SpeedZone.NORMAL
 
-        proposal_generation = None
-        set_velocity_error = None
         if finite_rpc:
-            proposal_generation = arm_proposal_execution(
-                time.monotonic() + duration
-            )
-            apply_result = apply_parent_set_velocity(
-                clamped_vx, clamped_vy, clamped_vyaw, duration
-            )
-            ret = apply_result.get("ret")
-            set_velocity_error = apply_result.get("error")
+            if proposal is None or deadline_monotonic is None:
+                raise ValueError("proposal identity and deadline are required")
+            enqueue_proposal_apply({
+                "vx": clamped_vx,
+                "vy": clamped_vy,
+                "vyaw": clamped_vyaw,
+                "deadline_monotonic": float(deadline_monotonic),
+                "queued_monotonic": time.monotonic(),
+                "nav_id": proposal.nav_id,
+                "sequence": proposal.sequence,
+            })
+            ret = None
         else:
             clear_proposal_execution()
             ret = loco_client.Move(clamped_vx, clamped_vy, clamped_vyaw, True)
-
-        watchdog_reason = (
-            proposal_fault_for_generation(proposal_generation)
-            if proposal_generation is not None
-            else ""
-        )
-        if watchdog_reason:
-            return {
-                "ret": ret,
-                "duration": duration,
-                "state": state.value,
-                "watchdog_reason": watchdog_reason,
-                "set_velocity_error": set_velocity_error,
-            }
 
         if duration > 0 and not finite_rpc:
             move_timer = threading.Timer(duration, duration_expired)
@@ -1645,7 +2093,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             "vyaw": clamped_vyaw,
             "duration": duration,
             "state": state.value,
-            "set_velocity_error": set_velocity_error,
+            "queued": finite_rpc,
         }
 
     @motion_synchronized
@@ -1763,12 +2211,12 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                         "error": f"No movement for {stall_timeout}s, navigation cancelled",
                         "pose": pose}
 
-            # Run safety checks and ROS2 spin during wait
+            # Run safety checks during wait.  ROS callbacks are serviced by
+            # the dedicated proposal/event executor thread.
             process_safety_checks()
             if stop_repeat_count > 0 and state == MotionState.IDLE:
                 loco_client.StopMove()
                 stop_repeat_count -= 1
-            executor.spin_once(timeout_sec=0)
 
             time.sleep(poll_interval)
 
@@ -1821,14 +2269,23 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             do_stop_nav()
         proposal_stop_transition.set()
         proposal_connected.clear()
+        clear_proposal_apply_queue()
         clear_proposal_execution()
         start = odom_stop_monitor.begin_confirmation()
+        fail_safe_stop_ret = None
+        fail_safe_stop_error = None
+        try:
+            fail_safe_stop_ret = watchdog_loco_client.StopMove()
+        except Exception as exc:
+            fail_safe_stop_error = str(exc)
         return {
             "confirmation_start": {
                 "monotonic": start.monotonic,
                 "unix_ms": start.unix_ms,
                 "odometry_callback_count": start.odometry_callback_count,
-            }
+            },
+            "fail_safe_stop_ret": fail_safe_stop_ret,
+            "fail_safe_stop_error": fail_safe_stop_error,
         }
 
     @motion_synchronized
@@ -1837,6 +2294,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         expected_nav_id,
         external_stop_attempt=None,
     ):
+        nonlocal last_proposal_stop_result
         try:
             expected_nav_id = resolve_expected_nav_id(
                 {"expected_nav_id": expected_nav_id}
@@ -1929,8 +2387,22 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 "expected_topic": expected_proposal_topic,
                 "connected": False,
             }
+        callback_status = proposal_callback_status()
+        if (
+            callback_status["failed"]
+            or not callback_status["ready"]
+            or not callback_status["alive"]
+        ):
+            proposal_gate.disarm("proposal_callback_unavailable")
+            return {
+                "error": "velocity_proposal_callback_unavailable",
+                "connected": False,
+                "proposal_callback": callback_status,
+            }
         try:
+            last_proposal_stop_result = None
             proposal_gate.bind(topic, expected_nav_id)
+            proposal_apply_diagnostics.begin_session(expected_nav_id)
             proposal_node.bind(topic, on_velocity_proposal)
             proposal_connected.set()
             refresh_fsm_state()
@@ -1957,6 +2429,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         reason="canvas_stop",
         external_stop_attempt=None,
     ):
+        nonlocal last_stop_result
         # N5 ordering: command and observe physical stop before destroying the
         # only proposal subscription.
         if (
@@ -1983,6 +2456,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 proposal_stop_linear_epsilon,
                 proposal_stop_yaw_epsilon,
             )
+        last_stop_result = dict(stopped)
         if not stopped["stop_confirmed"]:
             proposal_gate.disarm("stop_unconfirmed")
             proposal_connected.clear()
@@ -2018,9 +2492,12 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     @motion_synchronized
     def handle_get_velocity_proposal_status():
         result = proposal_gate.snapshot(time.monotonic())
+        latest_stop = last_stop_result or {}
+        latest_proposal_stop = last_proposal_stop_result or {}
         result.update({
             "enabled": proposal_enabled,
             "canvas_running": proposal_connected.is_set(),
+            "stop_transition_active": proposal_stop_transition.is_set(),
             "driver_authorized": bool(
                 proposal_driver_authorized
                 and not proposal_stop_transition.is_set()
@@ -2029,41 +2506,72 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             ),
             "expected_topic": expected_proposal_topic,
             "schema": proposal_limits.schema,
+            "proposal_callback": proposal_callback_status(),
             "safety": proposal_runtime_status(force_fsm_check=False),
             "proposal_execution": proposal_apply_diagnostics.snapshot(),
+            "last_stop_confirmed": latest_stop.get("stop_confirmed"),
+            "last_stop_move_ret": latest_stop.get("ret"),
+            "last_stop_move_error": (
+                (latest_stop.get("stop_confirmation") or {}).get(
+                    "stop_move_error"
+                )
+            ),
+            "last_stop_confirmation": latest_stop.get("stop_confirmation"),
+            "last_proposal_stop": (
+                dict(latest_proposal_stop)
+                if latest_proposal_stop
+                else None
+            ),
         })
         return result
 
     @motion_synchronized
     def on_velocity_proposal(msg):
         nonlocal last_nav_status_time
-        proposal_apply_diagnostics.record_received()
+        now = time.monotonic()
+        received_unix_ms = time.time() * 1000
+        proposal_apply_diagnostics.record_received(now)
         if proposal_stop_transition.is_set():
             proposal_apply_diagnostics.record_rejected("stop_transition")
             return
-        now = time.monotonic()
         pending_fault = current_proposal_watchdog_fault()
-        if pending_fault:
-            _, reason = pending_fault
-            proposal_apply_diagnostics.record_rejected(reason)
-            if reason == "proposal_ttl_expired":
-                proposal_gate.watchdog(now)
-                do_stop(reason)
-            else:
-                proposal_gate.disarm(reason)
-                do_stop(reason)
-            return
         try:
             payload = json.loads(msg.data)
         except (json.JSONDecodeError, TypeError, AttributeError):
+            if pending_fault:
+                _, reason = pending_fault
+                proposal_apply_diagnostics.record_rejected(reason)
+                if reason == "proposal_ttl_expired":
+                    proposal_gate.watchdog(now)
+                else:
+                    proposal_gate.disarm(reason)
+                do_stop(reason)
+                return
             proposal_apply_diagnostics.record_rejected("invalid_json")
             if proposal_gate.armed:
                 proposal_gate.disarm("invalid_json")
                 do_stop("invalid_json")
             return
+        proposal_apply_diagnostics.record_proposal_arrival(
+            payload,
+            received_unix_ms,
+        )
+        if pending_fault:
+            _, reason = pending_fault
+            proposal_apply_diagnostics.record_rejected(reason)
+            if reason == "proposal_ttl_expired":
+                proposal_gate.watchdog(now)
+            else:
+                proposal_gate.disarm(reason)
+            do_stop(reason)
+            return
 
         was_armed = proposal_gate.armed
-        decision = proposal_gate.accept(payload, now)
+        decision = proposal_gate.accept(
+            payload,
+            now,
+            now_unix_ms=received_unix_ms,
+        )
         if decision.stop:
             if decision.reason != "proposal_zero":
                 proposal_apply_diagnostics.record_rejected(decision.reason)
@@ -2083,9 +2591,9 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         with safety_lock:
             last_nav_status_time = now
 
-        # Refresh the Unitree controller state immediately before every
-        # physical command; do not authorize from a cached FSM sample.
-        runtime = proposal_runtime_status(force_fsm_check=True)
+        # The independent FSM monitor keeps this sample fresh.  Avoid a
+        # synchronous per-frame query that would block ROS proposal callbacks.
+        runtime = proposal_runtime_status(force_fsm_check=False)
         if not runtime["ready"]:
             reason = runtime["reason"] or "driver_safety_not_ready"
             proposal_apply_diagnostics.record_rejected(reason)
@@ -2102,59 +2610,69 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             proposal_gate.watchdog(time.monotonic())
             do_stop("proposal_ttl_expired")
             return
+        if not refresh_proposal_execution_deadline(
+            proposal_gate.deadline_monotonic
+        ):
+            fault = current_proposal_watchdog_fault()
+            reason = fault[1] if fault else "proposal_execution_fault"
+            proposal_apply_diagnostics.record_rejected(reason)
+            if reason == "proposal_ttl_expired":
+                proposal_gate.watchdog(time.monotonic())
+            else:
+                proposal_gate.disarm(reason)
+            do_stop(reason)
+            return
         proposal_apply_diagnostics.record_accepted()
-        result = handle_move(
+        handle_move(
             proposal.x,
             proposal.y,
             proposal.yaw,
             remaining,
             finite_rpc=True,
             source="velocity_proposal",
+            proposal=proposal,
+            deadline_monotonic=proposal_gate.deadline_monotonic,
         )
-        watchdog_reason = result.get("watchdog_reason")
-        if watchdog_reason:
-            proposal_apply_diagnostics.record_rejected(watchdog_reason)
-            if watchdog_reason != "proposal_ttl_expired":
-                proposal_gate.disarm(watchdog_reason)
-            else:
-                proposal_gate.watchdog(time.monotonic())
-            do_stop(watchdog_reason)
-            return
-        ret = result.get("ret")
-        set_velocity_error = result.get("set_velocity_error")
-        if set_velocity_error or ret != 0:
-            reason = (
-                "parent_set_velocity_timeout"
-                if set_velocity_error == "parent_set_velocity_timeout"
-                else "set_velocity_failed"
-            )
-            proposal_apply_diagnostics.record_rejected(reason)
-            proposal_gate.disarm(reason)
-            do_stop(reason)
-            return
-        proposal_apply_diagnostics.record_applied()
 
     @motion_synchronized
     def apply_safety_velocity(cmd, vx, vy, vyaw):
-        """Preserve a proposal's finite firmware lease during deceleration."""
+        """Queue a bounded parent-side proposal update during deceleration."""
         if cmd and cmd.get("source") == "velocity_proposal":
             remaining = proposal_gate.deadline_monotonic - time.monotonic()
             if remaining <= 0.0:
                 proposal_gate.watchdog(time.monotonic())
                 do_stop("proposal_ttl_expired")
                 return
-            result = apply_parent_set_velocity(vx, vy, vyaw, remaining)
-            if result.get("error") or result.get("ret") != 0:
-                reason = (
-                    "parent_set_velocity_timeout"
-                    if result.get("error") == "parent_set_velocity_timeout"
-                    else "set_velocity_failed"
+            if not cmd.get("nav_id") or cmd.get("sequence") is None:
+                proposal_apply_diagnostics.record_rejected(
+                    "proposal_identity_missing"
                 )
-                proposal_apply_diagnostics.record_rejected(reason)
-                proposal_gate.disarm(reason)
-                do_stop(reason)
-            return
+                proposal_gate.disarm("proposal_identity_missing")
+                do_stop("proposal_identity_missing")
+                return
+            target_velocity = (float(vx), float(vy), float(vyaw))
+            effective_velocity = cmd.get("effective_velocity")
+            if (
+                effective_velocity is not None
+                and not velocity_commands_differ(
+                    effective_velocity,
+                    target_velocity,
+                )
+            ):
+                return False
+            cmd["effective_velocity"] = target_velocity
+            enqueue_proposal_apply({
+                "vx": vx,
+                "vy": vy,
+                "vyaw": vyaw,
+                "deadline_monotonic": proposal_gate.deadline_monotonic,
+                "queued_monotonic": time.monotonic(),
+                "nav_id": cmd["nav_id"],
+                "sequence": cmd["sequence"],
+            })
+            return True
         loco_client.Move(vx, vy, vyaw, True)
+        return True
 
     # ── Safety checks (inline in main loop) ──
     @motion_synchronized
@@ -2252,17 +2770,97 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             if safety_threads_shutdown.wait(proposal_fsm_check_interval):
                 break
 
+    def proposal_apply_loop():
+        """Apply only the newest validated proposal without blocking ROS spin."""
+        while not safety_threads_shutdown.is_set():
+            try:
+                command = proposal_apply_queue.get(timeout=0.05)
+            except queue.Empty:
+                continue
+
+            with motion_command_lock:
+                if (
+                    proposal_stop_transition.is_set()
+                    or not proposal_connected.is_set()
+                    or not proposal_gate.armed
+                    or command["nav_id"] != proposal_gate.expected_nav_id
+                    or command["sequence"] != proposal_gate.last_sequence
+                ):
+                    continue
+                now = time.monotonic()
+                if now >= command["deadline_monotonic"]:
+                    proposal_apply_diagnostics.record_rejected(
+                        "proposal_ttl_expired"
+                    )
+                    proposal_gate.watchdog(now)
+                    do_stop("proposal_ttl_expired")
+                    continue
+                runtime = proposal_runtime_status(force_fsm_check=False)
+                if not runtime["ready"]:
+                    reason = runtime["reason"] or "driver_safety_not_ready"
+                    proposal_apply_diagnostics.record_rejected(reason)
+                    proposal_gate.disarm(reason)
+                    do_stop(reason)
+                    continue
+                generation = arm_proposal_execution(
+                    command["deadline_monotonic"]
+                )
+                if generation is None:
+                    fault = current_proposal_watchdog_fault()
+                    reason = fault[1] if fault else "proposal_execution_fault"
+                    proposal_apply_diagnostics.record_rejected(reason)
+                    if reason == "proposal_ttl_expired":
+                        proposal_gate.watchdog(time.monotonic())
+                    else:
+                        proposal_gate.disarm(reason)
+                    do_stop(reason)
+                    continue
+
+            result = apply_parent_velocity_proposal(command)
+
+            with motion_command_lock:
+                watchdog_reason = proposal_fault_for_generation(generation)
+                if watchdog_reason:
+                    proposal_apply_diagnostics.record_rejected(
+                        watchdog_reason
+                    )
+                    if watchdog_reason == "proposal_ttl_expired":
+                        proposal_gate.watchdog(time.monotonic())
+                    else:
+                        proposal_gate.disarm(watchdog_reason)
+                    do_stop(watchdog_reason)
+                    continue
+
+                error = result.get("error")
+                ret = result.get("ret")
+                if error or ret != 0 or not result.get("applied"):
+                    if error in {
+                        "proposal_ttl_expired_before_rpc",
+                        "proposal_ttl_expired_after_rpc",
+                    }:
+                        reason = "proposal_ttl_expired"
+                    elif error == "parent_velocity_proposal_timeout":
+                        reason = "parent_velocity_proposal_timeout"
+                    else:
+                        reason = "set_velocity_failed"
+                    proposal_apply_diagnostics.record_rejected(reason)
+                    proposal_gate.disarm(reason)
+                    do_stop(reason)
+                    continue
+                proposal_apply_diagnostics.record_applied(
+                    command["nav_id"],
+                    command["sequence"],
+                )
+
     def proposal_watchdog_loop():
         """At >=20 Hz, physically stop an active proposal on TTL or fault."""
-        nonlocal proposal_execution_active, proposal_watchdog_fault
         period = 1.0 / proposal_watchdog_hz
         while not safety_threads_shutdown.wait(period):
             now = time.monotonic()
-            with proposal_execution_lock:
-                if not proposal_execution_active:
-                    continue
-                generation = proposal_execution_generation
-                deadline = proposal_execution_deadline
+            lease = proposal_execution_lease.watchdog_snapshot()
+            if lease is None:
+                continue
+            generation, deadline = lease
             reason = "proposal_ttl_expired" if now >= deadline else ""
             if not reason:
                 runtime = proposal_runtime_status(force_fsm_check=False)
@@ -2270,34 +2868,56 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     reason = runtime["reason"] or "driver_safety_not_ready"
             if not reason:
                 continue
-            with proposal_execution_lock:
-                if (
-                    not proposal_execution_active
-                    or generation != proposal_execution_generation
-                ):
-                    continue
-                proposal_execution_active = False
-                proposal_watchdog_fault = (generation, reason)
+            if not proposal_execution_lease.trip(generation, reason, now):
+                continue
+            proposal_apply_diagnostics.record_watchdog_fault(reason)
             try:
                 watchdog_loco_client.StopMove()
             except Exception:
                 pass
 
     def consume_proposal_watchdog_fault():
-        with proposal_execution_lock:
-            fault = proposal_watchdog_fault
+        fault = current_proposal_watchdog_fault()
         if not fault:
             return
-        generation, reason = fault
-        with proposal_execution_lock:
-            if generation != proposal_execution_generation:
-                return
+        _, reason = fault
         with motion_command_lock:
+            if current_proposal_watchdog_fault() != fault:
+                return
             if reason == "proposal_ttl_expired":
                 proposal_gate.watchdog(time.monotonic())
             else:
                 proposal_gate.disarm(reason)
             do_stop(reason)
+
+    def proposal_ros_spin_loop():
+        """Service proposal/event callbacks independently of the busy loop."""
+        nonlocal proposal_callback_error
+        try:
+            # Complete one non-blocking executor cycle before advertising that
+            # binds can safely create the proposal subscription.
+            executor.spin_once(timeout_sec=0)
+            proposal_callback_ready.set()
+            while not safety_threads_shutdown.is_set():
+                executor.spin_once(timeout_sec=0.02)
+        except Exception as exc:
+            with proposal_callback_error_lock:
+                proposal_callback_error = str(exc)
+            proposal_callback_failed.set()
+            proposal_callback_ready.clear()
+            with motion_command_lock:
+                if proposal_gate.connected_topic or proposal_gate.armed:
+                    proposal_apply_diagnostics.record_rejected(
+                        "proposal_callback_error"
+                    )
+                proposal_gate.disarm("proposal_callback_error")
+                do_stop("proposal_callback_error")
+            print(
+                f"[SmartMotion] proposal ROS callback failed closed: {exc}",
+                flush=True,
+            )
+        finally:
+            proposal_callback_ready.clear()
 
     # ── Main loop ──
     fsm_monitor_thread = threading.Thread(
@@ -2310,8 +2930,25 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         daemon=True,
         name="g1_loco_velocity_watchdog",
     )
+    proposal_apply_thread = threading.Thread(
+        target=proposal_apply_loop,
+        daemon=True,
+        name="g1_loco_velocity_apply",
+    )
+    proposal_ros_thread = threading.Thread(
+        target=proposal_ros_spin_loop,
+        daemon=True,
+        name="g1_loco_proposal_ros",
+    )
+    proposal_ros_thread.start()
+    if not proposal_callback_ready.wait(timeout=1.0):
+        with proposal_callback_error_lock:
+            if proposal_callback_error is None:
+                proposal_callback_error = "proposal_callback_start_timeout"
+        proposal_callback_failed.set()
     fsm_monitor_thread.start()
     proposal_watchdog_thread.start()
+    proposal_apply_thread.start()
     print(f"[SmartMotion:pid={os.getpid()}] entering main loop")
     running = True
     last_obstacle_check = 0.0
@@ -2480,20 +3117,17 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             print(f"[SmartMotion] health: slam_info msgs={slam_info_msg_count} "
                   f"pos_info={slam_info_pos_count} state={state.value}", flush=True)
 
-        # Spin ROS2 (non-blocking)
-        try:
-            executor.spin_once(timeout_sec=0)
-        except Exception as exc:
-            with motion_command_lock:
-                proposal_gate.disarm("proposal_callback_error")
-                do_stop("proposal_callback_error")
-            print(f"[SmartMotion] ROS callback failed: {exc}", flush=True)
-
     # Cleanup
     safety_threads_shutdown.set()
     proposal_connected.clear()
+    try:
+        executor.wake()
+    except Exception:
+        pass
+    proposal_ros_thread.join(timeout=0.5)
     proposal_watchdog_thread.join(timeout=0.5)
     fsm_monitor_thread.join(timeout=0.75)
+    proposal_apply_thread.join(timeout=proposal_rpc_timeout + 0.25)
     if move_timer:
         move_timer.cancel()
     with motion_command_lock:

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -14,6 +14,8 @@ drivers/unitree/g1/safety_harness.py — SmartMotion 独立进程安全层。
 此模块不是 MCP plugin，由驱动生命周期管理，默认自动启动。
 """
 
+from __future__ import annotations
+
 import enum
 import json
 import math
@@ -25,6 +27,12 @@ import threading
 import time
 from dataclasses import dataclass, field
 from typing import Optional
+
+from velocity_proposal import (
+    DEFAULT_VELOCITY_PROPOSAL_TOPIC,
+    ProposalLimits,
+    VelocityProposalGate,
+)
 
 
 # ── Enums & Data Classes (shared between processes) ──────────────────────────
@@ -71,26 +79,79 @@ class SpeedLimits:
 class SmartMotionProxy:
     """Main-process proxy that communicates with the SmartMotion subprocess."""
 
-    def __init__(self, namespace: str, config: dict, network_iface: str):
+    def __init__(self, namespace: str, config: dict, network_iface: str,
+                 proposal_config: Optional[dict] = None,
+                 fallback_stop=None):
         ctx = mp.get_context("spawn")
         self._cmd_queue = ctx.Queue()
         self._result_queue = ctx.Queue()
+        self._call_lock = threading.Lock()
+        self._request_id = 0
         self._proc = ctx.Process(
             target=_run_smart_motion_process,
-            args=(namespace, config, network_iface, self._cmd_queue, self._result_queue),
+            args=(namespace, config, proposal_config or {}, network_iface,
+                  self._cmd_queue, self._result_queue),
             name="smart_motion", daemon=True,
         )
         self._proc.start()
+        self._fallback_stop = fallback_stop
+        self._exit_monitor = threading.Thread(
+            target=self._monitor_process_exit,
+            daemon=True,
+            name="smart_motion_exit_monitor",
+        )
+        self._exit_monitor.start()
         print(f"[SmartMotionProxy] subprocess started → pid={self._proc.pid}")
 
-    def _call(self, method: str, timeout: float = 15.0, **kwargs) -> dict:
-        """Send command to subprocess and wait for result."""
-        self._cmd_queue.put({"method": method, **kwargs})
+    def _monitor_process_exit(self) -> None:
+        """Issue an independent parent-side stop on every child exit.
+
+        The child normally stops itself in its cleanup path.  This second path
+        covers unhandled exceptions, SIGKILL/SIGTERM, and forced termination
+        after an IPC timeout, where Python cleanup cannot be relied upon.
+        """
+        self._proc.join()
+        if self._fallback_stop is None:
+            return
         try:
-            result = self._result_queue.get(timeout=timeout)
-            return result
-        except queue.Empty:
-            return {"error": f"SmartMotion subprocess timeout ({method})"}
+            self._fallback_stop()
+        except Exception as exc:
+            print(
+                f"[SmartMotionProxy] child-exit StopMove failed: {exc}",
+                flush=True,
+            )
+
+    def _call(self, method: str, timeout: float = 15.0, **kwargs) -> dict:
+        """Serialize calls and correlate replies across HTTP/ROS threads."""
+        with self._call_lock:
+            if not self._proc.is_alive():
+                return {"error": "SmartMotion subprocess is not running"}
+            self._request_id += 1
+            request_id = self._request_id
+            self._cmd_queue.put({
+                "method": method,
+                "request_id": request_id,
+                **kwargs,
+            })
+            deadline = time.monotonic() + timeout
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0.0:
+                    self._terminate_unresponsive_process()
+                    return {"error": f"SmartMotion subprocess timeout ({method})"}
+                try:
+                    envelope = self._result_queue.get(timeout=remaining)
+                except queue.Empty:
+                    self._terminate_unresponsive_process()
+                    return {"error": f"SmartMotion subprocess timeout ({method})"}
+                if envelope.get("request_id") == request_id:
+                    return envelope.get("result") or {}
+
+    def _terminate_unresponsive_process(self) -> None:
+        """Fail closed: an IPC-hung motion owner may not keep executing."""
+        if self._proc.is_alive():
+            self._proc.terminate()
+            self._proc.join(timeout=1.0)
 
     def move(self, vx: float, vy: float, vyaw: float, duration: float = -1.0) -> dict:
         return self._call("move", vx=vx, vy=vy, vyaw=vyaw, duration=duration)
@@ -119,6 +180,15 @@ class SmartMotionProxy:
     def get_state(self) -> dict:
         return self._call("get_state")
 
+    def bind_velocity_proposal(self, topic: str) -> dict:
+        return self._call("bind_velocity_proposal", topic=topic)
+
+    def unbind_velocity_proposal(self, reason: str = "canvas_stop") -> dict:
+        return self._call("unbind_velocity_proposal", reason=reason)
+
+    def get_velocity_proposal_status(self) -> dict:
+        return self._call("get_velocity_proposal_status")
+
     # ── SLAM RPC passthrough (single SlamClient owns all SLAM operations) ──
 
     def start_mapping(self) -> dict:
@@ -134,20 +204,24 @@ class SmartMotionProxy:
 
     def shutdown(self) -> None:
         try:
-            self._cmd_queue.put({"method": "shutdown"})
+            self._call("shutdown", timeout=3.0)
             self._proc.join(timeout=3.0)
         except Exception:
             pass
         if self._proc.is_alive():
             self._proc.terminate()
             self._proc.join(timeout=2.0)
+        # Ensure the parent-side child-exit StopMove completes before the
+        # caller tears down the independent RpcProxy used by that callback.
+        self._exit_monitor.join(timeout=2.0)
         print("[SmartMotionProxy] subprocess stopped")
 
 
 # ── SmartMotion subprocess entry ─────────────────────────────────────────────
 
-def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
-                              cmd_queue: mp.Queue, result_queue: mp.Queue):
+def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dict,
+                              network_iface: str, cmd_queue: mp.Queue,
+                              result_queue: mp.Queue):
     """Entry point for the SmartMotion subprocess.
 
     Initializes its own DDS channel, RPC clients, ROS2 node, and LiDAR subscription.
@@ -170,6 +244,12 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         depth=200,
         durability=DurabilityPolicy.VOLATILE,
     )
+    _PROPOSAL_QOS = QoSProfile(
+        reliability=ReliabilityPolicy.RELIABLE,
+        history=HistoryPolicy.KEEP_LAST,
+        depth=10,
+        durability=DurabilityPolicy.VOLATILE,
+    )
 
     # ── Initialize DDS ──
     ChannelFactoryInitialize(0, network_iface)
@@ -179,6 +259,30 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     loco_client = LocoClient()
     loco_client.Init()
     loco_client.SetTimeout(10.0)
+
+    # Proposal execution, stopping, watchdog stopping and FSM polling use
+    # independent RPC clients so a delayed call cannot block physical stop.
+    proposal_rpc_timeout = min(
+        0.2, max(0.02, float(proposal_config.get("velocity_proposal_rpc_timeout", 0.1)))
+    )
+    stop_rpc_timeout = min(
+        0.2, max(0.02, float(proposal_config.get("velocity_proposal_stop_rpc_timeout", 0.1)))
+    )
+    fsm_rpc_timeout = min(
+        0.5, max(0.05, float(proposal_config.get("velocity_proposal_fsm_rpc_timeout", 0.2)))
+    )
+    proposal_loco_client = LocoClient()
+    proposal_loco_client.Init()
+    proposal_loco_client.SetTimeout(proposal_rpc_timeout)
+    stop_loco_client = LocoClient()
+    stop_loco_client.Init()
+    stop_loco_client.SetTimeout(stop_rpc_timeout)
+    watchdog_loco_client = LocoClient()
+    watchdog_loco_client.Init()
+    watchdog_loco_client.SetTimeout(stop_rpc_timeout)
+    fsm_loco_client = LocoClient()
+    fsm_loco_client.Init()
+    fsm_loco_client.SetTimeout(fsm_rpc_timeout)
 
     slam_client = SlamClient()
     slam_client.Init()
@@ -206,6 +310,30 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     executor.add_node(event_node)
     print(f"[SmartMotion:pid={os.getpid()}] ROS2 event node ready → /{namespace}/safety/motion_events")
 
+    class _VelocityProposalNode(Node):
+        """Own the one dynamically connected N5 proposal subscription."""
+
+        def __init__(self):
+            super().__init__("g1_loco_velocity_proposal")
+            self._subscription = None
+            self.topic = ""
+
+        def bind(self, topic: str, callback) -> None:
+            self.unbind()
+            self._subscription = self.create_subscription(
+                String, topic, callback, _PROPOSAL_QOS
+            )
+            self.topic = topic
+
+        def unbind(self) -> None:
+            if self._subscription is not None:
+                self.destroy_subscription(self._subscription)
+                self._subscription = None
+            self.topic = ""
+
+    proposal_node = _VelocityProposalNode()
+    executor.add_node(proposal_node)
+
     # ── Config ──
     decel_threshold = config.get("decel_threshold", 2.0)
     stop_threshold = config.get("stop_threshold", 0.8)
@@ -213,6 +341,52 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     z_min = config.get("z_min", 0.1)
     z_max = config.get("z_max", 1.8)
     limits = SpeedLimits()
+    proposal_enabled = bool(proposal_config.get("velocity_proposal_enabled", True))
+    proposal_driver_authorized = bool(
+        proposal_config.get("velocity_proposal_driver_authorized", False)
+    )
+    expected_proposal_topic = DEFAULT_VELOCITY_PROPOSAL_TOPIC
+    # Deployment configuration may tighten, but never loosen, N5 limits.
+    proposal_limits = ProposalLimits(
+        frame="base_link",
+        max_ttl_ms=min(250, int(proposal_config.get("velocity_proposal_max_ttl_ms", 250))),
+        min_x=max(-0.05, float(proposal_config.get("velocity_proposal_min_x", -0.05))),
+        max_x=min(0.15, float(proposal_config.get("velocity_proposal_max_x", 0.15))),
+        max_abs_y=min(0.12, float(proposal_config.get("velocity_proposal_max_abs_y", 0.12))),
+        max_abs_yaw=min(0.35, float(proposal_config.get("velocity_proposal_max_abs_yaw", 0.35))),
+        max_planar_speed=min(0.18, float(proposal_config.get("velocity_proposal_max_planar_speed", 0.18))),
+    )
+    proposal_gate = VelocityProposalGate(proposal_limits)
+    proposal_odom_timeout = float(proposal_config.get("velocity_proposal_odom_timeout", 0.5))
+    proposal_scan_timeout = float(proposal_config.get("velocity_proposal_scan_timeout", 0.5))
+    proposal_fsm_check_interval = float(
+        proposal_config.get("velocity_proposal_fsm_check_interval", 0.2)
+    )
+    proposal_fsm_timeout = max(
+        proposal_fsm_check_interval,
+        float(proposal_config.get("velocity_proposal_fsm_timeout", 0.5)),
+    )
+    proposal_nav_status_timeout = min(
+        proposal_limits.max_ttl_ms / 1000.0,
+        float(proposal_config.get("velocity_proposal_nav_status_timeout", 0.25)),
+    )
+    proposal_watchdog_hz = max(
+        20.0, float(proposal_config.get("velocity_proposal_watchdog_hz", 40.0))
+    )
+    proposal_stop_confirm_timeout = min(
+        1.0,
+        max(0.1, float(proposal_config.get("velocity_proposal_stop_confirm_timeout", 0.5))),
+    )
+    proposal_stop_linear_epsilon = max(
+        0.0, float(proposal_config.get("velocity_proposal_stop_linear_epsilon", 0.03))
+    )
+    proposal_stop_yaw_epsilon = max(
+        0.0, float(proposal_config.get("velocity_proposal_stop_yaw_epsilon", 0.05))
+    )
+    proposal_allowed_fsm_ids = {
+        int(value)
+        for value in proposal_config.get("velocity_proposal_allowed_fsm_ids", [500, 801])
+    }
 
     # ── State ──
     state = MotionState.IDLE
@@ -220,6 +394,57 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     nav_cmd = None      # dict: {target_name, target_pose, start_time}
     speed_zone = SpeedZone.NORMAL
     move_timer = None   # threading.Timer
+    last_cloud_time = 0.0
+    last_odom_time = 0.0
+    last_fsm_check = 0.0
+    last_fsm_id = None
+    main_control_ready = False
+    last_nav_status_time = 0.0
+    last_odom_motion = (float("inf"), float("inf"), float("inf"))
+    safety_lock = threading.Lock()
+    motion_command_lock = threading.RLock()
+    proposal_execution_lock = threading.Lock()
+    proposal_connected = threading.Event()
+    safety_threads_shutdown = threading.Event()
+    proposal_execution_generation = 0
+    proposal_execution_active = False
+    proposal_execution_deadline = 0.0
+    proposal_watchdog_fault = None
+
+    def motion_synchronized(func):
+        def locked(*args, **kwargs):
+            with motion_command_lock:
+                return func(*args, **kwargs)
+        return locked
+
+    def arm_proposal_execution(deadline):
+        nonlocal proposal_execution_generation, proposal_execution_active
+        nonlocal proposal_execution_deadline, proposal_watchdog_fault
+        with proposal_execution_lock:
+            proposal_execution_generation += 1
+            proposal_execution_active = True
+            proposal_execution_deadline = deadline
+            proposal_watchdog_fault = None
+            return proposal_execution_generation
+
+    def clear_proposal_execution():
+        nonlocal proposal_execution_generation, proposal_execution_active
+        nonlocal proposal_execution_deadline, proposal_watchdog_fault
+        with proposal_execution_lock:
+            proposal_execution_generation += 1
+            proposal_execution_active = False
+            proposal_execution_deadline = 0.0
+            proposal_watchdog_fault = None
+
+    def proposal_fault_for_generation(generation):
+        with proposal_execution_lock:
+            if proposal_watchdog_fault and proposal_watchdog_fault[0] == generation:
+                return proposal_watchdog_fault[1]
+            return ""
+
+    def current_proposal_watchdog_fault():
+        with proposal_execution_lock:
+            return proposal_watchdog_fault
 
     # Obstacle state (written by LiDAR callback, read by main loop)
     obstacle_lock = threading.Lock()
@@ -250,17 +475,36 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         event_node.publish(event)
         print(f"[SmartMotion] event: {event_type} | {json.dumps(data)}", flush=True)
 
+    def issue_stop_move():
+        """Call StopMove and return the Unitree RPC acknowledgement code."""
+        return stop_loco_client.StopMove()
+
+    @motion_synchronized
     def do_stop(reason_str):
         nonlocal state, current_cmd, speed_zone, move_timer, stop_repeat_count
+        was_proposal_motion = bool(
+            current_cmd and current_cmd.get("source") == "velocity_proposal"
+        )
         if move_timer:
             move_timer.cancel()
             move_timer = None
-        loco_client.StopMove()
+        clear_proposal_execution()
+        stop_ret = None
+        stop_error = None
+        try:
+            stop_ret = issue_stop_move()
+        except Exception as exc:
+            stop_error = str(exc)
+        # A physical-stop confirmation must use odometry newer than the
+        # completed StopMove RPC attempt.
+        stop_issued_monotonic = time.monotonic()
         was_moving = state == MotionState.MOVING
         state = MotionState.IDLE
         current_cmd = None
         speed_zone = SpeedZone.NORMAL
         stop_repeat_count = 3  # repeat StopMove to ensure controller stops
+        if was_proposal_motion and reason_str == "obstacle":
+            proposal_gate.disarm("obstacle_stop_latched")
         if was_moving:
             event_data = {"reason": reason_str}
             if reason_str == "obstacle":
@@ -268,8 +512,18 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     event_data["obstacle_distance"] = round(obstacle_dist, 2)
                     event_data["obstacle_angle_deg"] = round(math.degrees(obstacle_angle), 1)
             publish_event("motion_stop", event_data)
-        return {"ret": 0, "state": "idle", "reason": reason_str}
+        result = {
+            "ret": stop_ret,
+            "state": "idle",
+            "reason": reason_str,
+            "stop_confirmed": stop_ret == 0,
+            "stop_issued_monotonic": stop_issued_monotonic,
+        }
+        if stop_error:
+            result["error"] = f"StopMove failed: {stop_error}"
+        return result
 
+    @motion_synchronized
     def do_stop_nav():
         nonlocal state, nav_cmd, speed_zone
         try:
@@ -284,6 +538,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             publish_event("nav_stopped", {"reason": "command"})
         return {"status": "stopped"}
 
+    @motion_synchronized
     def duration_expired():
         nonlocal state, current_cmd, speed_zone, move_timer
         move_timer = None
@@ -292,7 +547,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
 
     # ── LiDAR DDS Subscription ──
     def on_cloud(msg):
-        nonlocal obstacle_dist, obstacle_angle, lateral_obstacle
+        nonlocal obstacle_dist, obstacle_angle, lateral_obstacle, last_cloud_time
 
         # Get heading
         if state == MotionState.MOVING and current_cmd:
@@ -314,6 +569,8 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         n_valid = min(total_points, len(data) // point_step)
         if n_valid == 0:
             return
+        with safety_lock:
+            last_cloud_time = time.monotonic()
 
         # Numpy batch extraction (xyz at offsets 0, 4, 8 — already gravity-aligned)
         buf = np.frombuffer(data, dtype=np.uint8, count=n_valid * point_step).reshape(n_valid, point_step)
@@ -389,8 +646,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     motor_temp_stop = config.get("motor_temp_stop", 85)
 
     # Safety state
-    safety_lock = threading.Lock()
-    last_lowstate_time = time.monotonic()
+    last_lowstate_time = 0.0
     tilt_triggered = False
     foot_airborne_start = 0.0
     foot_force_seen_nonzero = False  # only enable airborne detection after seeing real force
@@ -398,13 +654,20 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     last_temp_check = 0.0
     stop_repeat_count = 0  # counter for repeated StopMove after emergency
 
+    @motion_synchronized
     def emergency_stop(reason_str, extra=None):
         """Emergency stop with optional damp mode for tilt."""
         nonlocal state, current_cmd, speed_zone, move_timer, stop_repeat_count
+        if current_cmd and current_cmd.get("source") == "velocity_proposal":
+            proposal_gate.disarm(f"{reason_str}_latched")
         if move_timer:
             move_timer.cancel()
             move_timer = None
-        loco_client.StopMove()
+        clear_proposal_execution()
+        try:
+            stop_loco_client.StopMove()
+        except Exception:
+            pass
         if reason_str == "tilt":
             try:
                 loco_client.SetFsmId(1)  # damp mode
@@ -432,23 +695,29 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         nonlocal last_lowstate_time, tilt_triggered, max_motor_temp, last_temp_check
 
         now = time.monotonic()
-        with safety_lock:
-            last_lowstate_time = now
-
         # Tilt detection (20Hz, every callback)
         imu = msg.imu_state
         roll = abs(float(imu.rpy[0]))
         pitch = abs(float(imu.rpy[1]))
+        is_tilted = roll > tilt_threshold or pitch > tilt_threshold
+        with safety_lock:
+            last_lowstate_time = now
+            was_tilted = tilt_triggered
+            tilt_triggered = is_tilted
 
-        if (roll > tilt_threshold or pitch > tilt_threshold):
-            if not tilt_triggered and state in (MotionState.MOVING, MotionState.NAVIGATING, MotionState.NAV_PAUSED):
-                tilt_triggered = True
-                emergency_stop("tilt", {
-                    "roll_deg": round(math.degrees(roll), 1),
-                    "pitch_deg": round(math.degrees(pitch), 1),
-                })
-        else:
-            tilt_triggered = False
+        if (
+            is_tilted
+            and not was_tilted
+            and state in (
+                MotionState.MOVING,
+                MotionState.NAVIGATING,
+                MotionState.NAV_PAUSED,
+            )
+        ):
+            emergency_stop("tilt", {
+                "roll_deg": round(math.degrees(roll), 1),
+                "pitch_deg": round(math.degrees(pitch), 1),
+            })
 
         # Joint temperature (1Hz check)
         if now - last_temp_check >= 1.0:
@@ -472,6 +741,17 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     # ── OdomState DDS Subscription (foot force) ──
     def on_odom(msg):
         nonlocal foot_airborne_start, foot_force_seen_nonzero
+        nonlocal last_odom_time, last_odom_motion
+
+        velocity = list(msg.velocity)
+        motion = (
+            float(velocity[0]) if len(velocity) > 0 else float("inf"),
+            float(velocity[1]) if len(velocity) > 1 else float("inf"),
+            float(msg.yaw_speed),
+        )
+        with safety_lock:
+            last_odom_time = time.monotonic()
+            last_odom_motion = motion
 
         if state != MotionState.MOVING:
             foot_airborne_start = 0.0
@@ -566,8 +846,95 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     except Exception as e:
         print(f"[SmartMotion:pid={os.getpid()}] WARNING: rt/slam_info subscribe failed: {e}")
 
+    def refresh_fsm_state():
+        nonlocal last_fsm_check, last_fsm_id, main_control_ready
+        try:
+            code, fsm_id = fsm_loco_client.GetFsmId()
+            ready = code == 0 and int(fsm_id) in proposal_allowed_fsm_ids
+        except Exception:
+            fsm_id = None
+            ready = False
+        with safety_lock:
+            last_fsm_check = time.monotonic()
+            last_fsm_id = fsm_id
+            main_control_ready = ready
+
+    def proposal_runtime_status(force_fsm_check=False):
+        """Return current Driver-owned readiness for proposal execution."""
+        if force_fsm_check:
+            refresh_fsm_state()
+        now = time.monotonic()
+        with safety_lock:
+            lowstate_age = now - last_lowstate_time if last_lowstate_time else float("inf")
+            odom_age = now - last_odom_time if last_odom_time else float("inf")
+            scan_age = now - last_cloud_time if last_cloud_time else float("inf")
+            nav_status_age = (
+                now - last_nav_status_time if last_nav_status_time else float("inf")
+            )
+            fsm_age = now - last_fsm_check if last_fsm_check else float("inf")
+            temperature = max_motor_temp
+            fsm_id = last_fsm_id
+            control_ready = main_control_ready
+            tilted = tilt_triggered
+
+        reason = ""
+        if not proposal_driver_authorized:
+            reason = "driver_execution_not_authorized"
+        elif lowstate_age > comm_timeout:
+            reason = "main_control_state_stale"
+        elif odom_age > proposal_odom_timeout:
+            reason = "odometry_stale"
+        elif scan_age > proposal_scan_timeout:
+            reason = "scan_stale"
+        elif tilted:
+            reason = "tilt_latched"
+        elif temperature > motor_temp_stop:
+            reason = "joint_overheat_latched"
+        elif nav_status_age > proposal_nav_status_timeout:
+            reason = "nav2_status_stale"
+        elif fsm_age > proposal_fsm_timeout:
+            reason = "main_control_status_stale"
+        elif not control_ready:
+            reason = "main_control_not_ready"
+
+        return {
+            "ready": not reason,
+            "reason": reason or None,
+            "fsm_id": fsm_id,
+            # In this G1 API, a fresh allowed locomotion FSM is the native
+            # fail-closed proxy for main-control/e-stop execution permission.
+            "emergency_stop_clear": control_ready and fsm_age <= proposal_fsm_timeout,
+            "lowstate_age_ms": None if not math.isfinite(lowstate_age) else round(lowstate_age * 1000),
+            "odometry_age_ms": None if not math.isfinite(odom_age) else round(odom_age * 1000),
+            "scan_age_ms": None if not math.isfinite(scan_age) else round(scan_age * 1000),
+            "nav2_status_age_ms": None if not math.isfinite(nav_status_age) else round(nav_status_age * 1000),
+            "fsm_age_ms": None if not math.isfinite(fsm_age) else round(fsm_age * 1000),
+        }
+
+    def confirm_robot_stopped(timeout, not_before):
+        """Confirm StopMove using a fresh near-zero measured odometry sample."""
+        deadline = time.monotonic() + timeout
+        while True:
+            now = time.monotonic()
+            with safety_lock:
+                odom_time = last_odom_time
+                vx, vy, yaw = last_odom_motion
+            if (
+                odom_time
+                and odom_time >= not_before
+                and now - odom_time <= proposal_odom_timeout
+                and abs(vx) <= proposal_stop_linear_epsilon
+                and abs(vy) <= proposal_stop_linear_epsilon
+                and abs(yaw) <= proposal_stop_yaw_epsilon
+            ):
+                return True
+            if now >= deadline:
+                return False
+            time.sleep(min(0.02, deadline - now))
+
     # ── Command handlers ──
-    def handle_move(vx, vy, vyaw, duration):
+    @motion_synchronized
+    def handle_move(vx, vy, vyaw, duration, finite_rpc=False, source="mcp"):
         nonlocal state, current_cmd, speed_zone, move_timer
 
         if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
@@ -578,7 +945,12 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
 
         previous = None
         if state == MotionState.MOVING and current_cmd:
-            previous = {"vx": current_cmd["vx"], "vy": current_cmd["vy"], "vyaw": current_cmd["vyaw"]}
+            previous = {
+                "vx": current_cmd["vx"],
+                "vy": current_cmd["vy"],
+                "vyaw": current_cmd["vyaw"],
+                "source": current_cmd.get("source", "mcp"),
+            }
 
         clamped_vx, clamped_vy, clamped_vyaw = clamp(vx, vy, vyaw, SpeedZone.NORMAL)
 
@@ -587,29 +959,68 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             "vx": vx, "vy": vy, "vyaw": vyaw,
             "duration": duration, "start_time": now,
             "end_time": (now + duration) if duration > 0 else None,
+            "source": source,
         }
         state = MotionState.MOVING
         speed_zone = SpeedZone.NORMAL
 
-        ret = loco_client.Move(clamped_vx, clamped_vy, clamped_vyaw, True)
+        proposal_generation = None
+        if finite_rpc:
+            proposal_generation = arm_proposal_execution(
+                time.monotonic() + duration
+            )
+            ret = proposal_loco_client.SetVelocity(
+                clamped_vx, clamped_vy, clamped_vyaw, duration
+            )
+        else:
+            clear_proposal_execution()
+            ret = loco_client.Move(clamped_vx, clamped_vy, clamped_vyaw, True)
 
-        if duration > 0:
+        watchdog_reason = (
+            proposal_fault_for_generation(proposal_generation)
+            if proposal_generation is not None
+            else ""
+        )
+        if watchdog_reason:
+            return {
+                "ret": ret,
+                "duration": duration,
+                "state": state.value,
+                "watchdog_reason": watchdog_reason,
+            }
+
+        if duration > 0 and not finite_rpc:
             move_timer = threading.Timer(duration, duration_expired)
             move_timer.start()
 
-        if previous:
+        if previous and not (
+            source == "velocity_proposal"
+            and previous.get("source") == "velocity_proposal"
+        ):
             publish_event("new_command", {
                 "previous": previous,
-                "new": {"vx": clamped_vx, "vy": clamped_vy, "vyaw": clamped_vyaw},
+                "new": {
+                    "vx": clamped_vx,
+                    "vy": clamped_vy,
+                    "vyaw": clamped_vyaw,
+                    "source": source,
+                },
             })
-        else:
+        elif not previous:
             publish_event("motion_start", {
-                "params": {"vx": clamped_vx, "vy": clamped_vy, "vyaw": clamped_vyaw, "duration": duration},
+                "params": {
+                    "vx": clamped_vx,
+                    "vy": clamped_vy,
+                    "vyaw": clamped_vyaw,
+                    "duration": duration,
+                    "source": source,
+                },
             })
 
         return {"ret": ret, "vx": clamped_vx, "vy": clamped_vy, "vyaw": clamped_vyaw,
                 "duration": duration, "state": state.value}
 
+    @motion_synchronized
     def handle_navigate_to(x, y, yaw, target_name, speed=0.5, mode=1, stall_timeout=60):
         nonlocal state, nav_cmd, speed_zone, nav_arrived_flag, nav_arrived_error
 
@@ -737,6 +1148,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         print(f"[SmartMotion] wait_nav_done: state changed to {state.value}", flush=True)
         return {"status": "stopped", "state": state.value}
 
+    @motion_synchronized
     def handle_pause_nav(reason_str):
         nonlocal state
         if state != MotionState.NAVIGATING:
@@ -750,6 +1162,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         publish_event("nav_paused", event_data)
         return {"status": "paused"} if code == 0 else {"error": f"PauseNav failed, code={code}"}
 
+    @motion_synchronized
     def handle_resume_nav():
         nonlocal state
         if state != MotionState.NAV_PAUSED:
@@ -759,6 +1172,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         publish_event("nav_resumed", {})
         return {"status": "resumed"} if code == 0 else {"error": f"ResumeNav failed, code={code}"}
 
+    @motion_synchronized
     def handle_get_state():
         result = {"state": state.value, "speed_zone": speed_zone.value}
         if current_cmd and state == MotionState.MOVING:
@@ -770,7 +1184,221 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             result["lateral_obstacle"] = lateral_obstacle
         return result
 
+    @motion_synchronized
+    def handle_bind_velocity_proposal(topic):
+        # A proposal stream and Unitree native navigation may never own motion
+        # at the same time.
+        if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
+            do_stop_nav()
+        if proposal_gate.connected_topic or proposal_node.topic:
+            stopped = handle_unbind_velocity_proposal("proposal_rebind")
+            if not stopped.get("stop_confirmed"):
+                return {
+                    "error": "StopMove was not confirmed before proposal rebind",
+                    "connected": False,
+                    "stop_confirmed": False,
+                }
+        else:
+            stopped = do_stop("proposal_bind")
+            physically_stopped = (
+                stopped.get("stop_confirmed")
+                and confirm_robot_stopped(
+                    proposal_stop_confirm_timeout,
+                    stopped["stop_issued_monotonic"],
+                )
+            )
+            if not physically_stopped:
+                return {
+                    "error": "StopMove/odometry stop was not confirmed before proposal bind",
+                    "connected": False,
+                    "stop_confirmed": False,
+                }
+        if not proposal_enabled:
+            return {"error": "velocity_proposal_execution_disabled", "connected": False}
+        if not proposal_driver_authorized:
+            return {"error": "driver_execution_not_authorized", "connected": False}
+        if topic != expected_proposal_topic:
+            return {
+                "error": "unexpected_velocity_proposal_topic",
+                "expected_topic": expected_proposal_topic,
+                "connected": False,
+            }
+        try:
+            proposal_node.bind(topic, on_velocity_proposal)
+            proposal_gate.bind(topic)
+            proposal_connected.set()
+            refresh_fsm_state()
+        except Exception as exc:
+            proposal_gate.unbind("subscription_create_failed")
+            proposal_connected.clear()
+            proposal_node.unbind()
+            try:
+                stop_loco_client.StopMove()
+            except Exception:
+                pass
+            return {"error": f"velocity_proposal_subscribe_failed: {exc}", "connected": False}
+        result = handle_get_velocity_proposal_status()
+        result["state"] = "connected"
+        return result
+
+    @motion_synchronized
+    def handle_unbind_velocity_proposal(reason="canvas_stop"):
+        # N5 ordering: command and observe physical stop before destroying the
+        # only proposal subscription.
+        if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
+            do_stop_nav()
+        stopped = do_stop(reason)
+        for _ in range(2):
+            if stopped.get("stop_confirmed"):
+                break
+            try:
+                stop_ret = issue_stop_move()
+            except Exception as exc:
+                stopped["error"] = f"StopMove failed: {exc}"
+            else:
+                stopped["ret"] = stop_ret
+                stopped["stop_confirmed"] = stop_ret == 0
+            finally:
+                stopped["stop_issued_monotonic"] = time.monotonic()
+        stopped["stop_confirmed"] = bool(
+            stopped.get("stop_confirmed")
+            and confirm_robot_stopped(
+                proposal_stop_confirm_timeout,
+                stopped["stop_issued_monotonic"],
+            )
+        )
+        if not stopped["stop_confirmed"]:
+            proposal_gate.disarm("stop_unconfirmed")
+            proposal_connected.clear()
+            return {
+                "state": "error",
+                "connected": bool(proposal_node.topic),
+                "armed": False,
+                "stop_confirmed": False,
+                "subscriber_retained": bool(proposal_node.topic),
+                "reason": reason,
+                "error": stopped.get("error") or "fresh zero-odometry stop was not confirmed",
+            }
+        proposal_gate.unbind(reason)
+        proposal_connected.clear()
+        proposal_node.unbind()
+        return {
+            "state": "idle",
+            "connected": False,
+            "stop_confirmed": True,
+            "reason": reason,
+            **({"error": stopped["error"]} if stopped.get("error") else {}),
+        }
+
+    @motion_synchronized
+    def handle_get_velocity_proposal_status():
+        result = proposal_gate.snapshot(time.monotonic())
+        result.update({
+            "enabled": proposal_enabled,
+            "canvas_running": proposal_connected.is_set(),
+            "driver_authorized": bool(
+                proposal_driver_authorized
+                and proposal_gate.connected_topic
+                and proposal_gate.armed
+            ),
+            "expected_topic": expected_proposal_topic,
+            "schema": proposal_limits.schema,
+            "safety": proposal_runtime_status(force_fsm_check=False),
+        })
+        return result
+
+    @motion_synchronized
+    def on_velocity_proposal(msg):
+        nonlocal last_nav_status_time
+        now = time.monotonic()
+        pending_fault = current_proposal_watchdog_fault()
+        if pending_fault:
+            _, reason = pending_fault
+            if reason == "proposal_ttl_expired":
+                proposal_gate.watchdog(now)
+                do_stop(reason)
+            else:
+                proposal_gate.disarm(reason)
+                do_stop(reason)
+                return
+        try:
+            payload = json.loads(msg.data)
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            if proposal_gate.armed:
+                proposal_gate.disarm("invalid_json")
+                do_stop("invalid_json")
+            return
+
+        was_armed = proposal_gate.armed
+        decision = proposal_gate.accept(payload, now)
+        if decision.stop:
+            is_proposal_motion = bool(
+                current_cmd and current_cmd.get("source") == "velocity_proposal"
+            )
+            newly_disarmed = was_armed and not proposal_gate.armed
+            if decision.proposal is not None or is_proposal_motion or newly_disarmed:
+                do_stop(decision.reason)
+            return
+        if not decision.execute or decision.proposal is None:
+            return
+
+        with safety_lock:
+            last_nav_status_time = now
+
+        # Refresh the Unitree controller state immediately before every
+        # physical command; do not authorize from a cached FSM sample.
+        runtime = proposal_runtime_status(force_fsm_check=True)
+        if not runtime["ready"]:
+            reason = runtime["reason"] or "driver_safety_not_ready"
+            proposal_gate.disarm(reason)
+            do_stop(reason)
+            return
+
+        proposal = decision.proposal
+        remaining = proposal_gate.deadline_monotonic - time.monotonic()
+        if remaining <= 0.0:
+            proposal_gate.watchdog(time.monotonic())
+            do_stop("proposal_ttl_expired")
+            return
+        result = handle_move(
+            proposal.x,
+            proposal.y,
+            proposal.yaw,
+            remaining,
+            finite_rpc=True,
+            source="velocity_proposal",
+        )
+        watchdog_reason = result.get("watchdog_reason")
+        if watchdog_reason:
+            if watchdog_reason != "proposal_ttl_expired":
+                proposal_gate.disarm(watchdog_reason)
+            else:
+                proposal_gate.watchdog(time.monotonic())
+            do_stop(watchdog_reason)
+            return
+        ret = result.get("ret")
+        if ret not in (None, 0):
+            proposal_gate.disarm("set_velocity_failed")
+            do_stop("set_velocity_failed")
+
+    @motion_synchronized
+    def apply_safety_velocity(cmd, vx, vy, vyaw):
+        """Preserve a proposal's finite firmware lease during deceleration."""
+        if cmd and cmd.get("source") == "velocity_proposal":
+            remaining = proposal_gate.deadline_monotonic - time.monotonic()
+            if remaining <= 0.0:
+                proposal_gate.watchdog(time.monotonic())
+                do_stop("proposal_ttl_expired")
+                return
+            ret = proposal_loco_client.SetVelocity(vx, vy, vyaw, remaining)
+            if ret != 0:
+                proposal_gate.disarm("set_velocity_failed")
+                do_stop("set_velocity_failed")
+            return
+        loco_client.Move(vx, vy, vyaw, True)
+
     # ── Safety checks (inline in main loop) ──
+    @motion_synchronized
     def process_safety_checks():
         nonlocal state, speed_zone
 
@@ -793,7 +1421,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     speed_zone = SpeedZone.DECELERATED
                     if current_cmd:
                         dvx, dvy, dvyaw = clamp(current_cmd["vx"], current_cmd["vy"], current_cmd["vyaw"], SpeedZone.DECELERATED)
-                        loco_client.Move(dvx, dvy, dvyaw, True)
+                        apply_safety_velocity(current_cmd, dvx, dvy, dvyaw)
                         publish_event("joint_overheat", {
                             "max_temp": round(temp, 1),
                             "action": "decelerate",
@@ -819,7 +1447,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     print(f"[SmartMotion:obstacle] DECEL — dist={dist:.2f}m angle={math.degrees(obstacle_angle):.1f}° lateral={lateral}", flush=True)
                     if cmd:
                         dvx, dvy, dvyaw = clamp(cmd["vx"], cmd["vy"], cmd["vyaw"], SpeedZone.DECELERATED)
-                        loco_client.Move(dvx, dvy, dvyaw, True)
+                        apply_safety_velocity(cmd, dvx, dvy, dvyaw)
                         with obstacle_lock:
                             od = obstacle_dist
                             oa = obstacle_angle
@@ -834,7 +1462,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     speed_zone = SpeedZone.NORMAL
                     if cmd:
                         cvx, cvy, cvyaw = clamp(cmd["vx"], cmd["vy"], cmd["vyaw"], SpeedZone.NORMAL)
-                        loco_client.Move(cvx, cvy, cvyaw, True)
+                        apply_safety_velocity(cmd, cvx, cvy, cvyaw)
                         publish_event("motion_resume", {"speed": {"vx": cvx, "vy": cvy, "vyaw": cvyaw}})
 
         elif state == MotionState.NAVIGATING:
@@ -856,39 +1484,147 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                 print(f"[SmartMotion:nav_obstacle] RESUME NAV — "
                       f"dist={dist:.2f}m, obstacle cleared", flush=True)
 
+    def fsm_monitor_loop():
+        """Poll main-control authorization independently of proposal callbacks."""
+        while not safety_threads_shutdown.is_set():
+            if not proposal_connected.wait(timeout=0.05):
+                continue
+            refresh_fsm_state()
+            if safety_threads_shutdown.wait(proposal_fsm_check_interval):
+                break
+
+    def proposal_watchdog_loop():
+        """At >=20 Hz, physically stop an active proposal on TTL or fault."""
+        nonlocal proposal_execution_active, proposal_watchdog_fault
+        period = 1.0 / proposal_watchdog_hz
+        while not safety_threads_shutdown.wait(period):
+            now = time.monotonic()
+            with proposal_execution_lock:
+                if not proposal_execution_active:
+                    continue
+                generation = proposal_execution_generation
+                deadline = proposal_execution_deadline
+            reason = "proposal_ttl_expired" if now >= deadline else ""
+            if not reason:
+                runtime = proposal_runtime_status(force_fsm_check=False)
+                if not runtime["ready"]:
+                    reason = runtime["reason"] or "driver_safety_not_ready"
+            if not reason:
+                continue
+            with proposal_execution_lock:
+                if (
+                    not proposal_execution_active
+                    or generation != proposal_execution_generation
+                ):
+                    continue
+                proposal_execution_active = False
+                proposal_watchdog_fault = (generation, reason)
+            try:
+                watchdog_loco_client.StopMove()
+            except Exception:
+                pass
+
+    def consume_proposal_watchdog_fault():
+        with proposal_execution_lock:
+            fault = proposal_watchdog_fault
+        if not fault:
+            return
+        generation, reason = fault
+        with proposal_execution_lock:
+            if generation != proposal_execution_generation:
+                return
+        with motion_command_lock:
+            if reason == "proposal_ttl_expired":
+                proposal_gate.watchdog(time.monotonic())
+            else:
+                proposal_gate.disarm(reason)
+            do_stop(reason)
+
     # ── Main loop ──
+    fsm_monitor_thread = threading.Thread(
+        target=fsm_monitor_loop,
+        daemon=True,
+        name="g1_loco_fsm_monitor",
+    )
+    proposal_watchdog_thread = threading.Thread(
+        target=proposal_watchdog_loop,
+        daemon=True,
+        name="g1_loco_velocity_watchdog",
+    )
+    fsm_monitor_thread.start()
+    proposal_watchdog_thread.start()
     print(f"[SmartMotion:pid={os.getpid()}] entering main loop")
     running = True
     last_obstacle_check = 0.0
     last_slam_info_log = 0.0
 
     while running:
+        try:
+            consume_proposal_watchdog_fault()
+        except Exception as exc:
+            with motion_command_lock:
+                proposal_gate.disarm("watchdog_fault_handler_error")
+                try:
+                    stop_loco_client.StopMove()
+                except Exception:
+                    pass
+            print(
+                f"[SmartMotion] watchdog fault handling failed closed: {exc}",
+                flush=True,
+            )
         # Process commands (non-blocking)
+        cmd = None
         try:
             cmd = cmd_queue.get(timeout=0.05)
             method = cmd.get("method")
             result = None
 
             if method == "move":
-                result = handle_move(cmd["vx"], cmd["vy"], cmd["vyaw"], cmd["duration"])
+                with motion_command_lock:
+                    proposal_gate.disarm("manual_override")
+                    result = handle_move(
+                        cmd["vx"], cmd["vy"], cmd["vyaw"], cmd["duration"],
+                        source="mcp",
+                    )
             elif method == "stop":
-                result = do_stop(cmd.get("reason", "command"))
+                with motion_command_lock:
+                    proposal_gate.disarm("manual_stop")
+                    if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
+                        do_stop_nav()
+                    result = do_stop(cmd.get("reason", "command"))
             elif method == "navigate_to":
-                result = handle_navigate_to(cmd["x"], cmd["y"], cmd["yaw"],
-                                            cmd.get("target_name", ""),
-                                            speed=cmd.get("speed", 0.5),
-                                            mode=cmd.get("mode", 1),
-                                            stall_timeout=cmd.get("stall_timeout", 60))
+                with motion_command_lock:
+                    proposal_gate.disarm("native_navigation_override")
+                    result = handle_navigate_to(
+                        cmd["x"], cmd["y"], cmd["yaw"],
+                        cmd.get("target_name", ""),
+                        speed=cmd.get("speed", 0.5),
+                        mode=cmd.get("mode", 1),
+                        stall_timeout=cmd.get("stall_timeout", 60),
+                    )
             elif method == "pause_nav":
                 result = handle_pause_nav(cmd.get("reason", "command"))
             elif method == "resume_nav":
                 result = handle_resume_nav()
             elif method == "stop_nav":
-                result = do_stop_nav()
+                with motion_command_lock:
+                    proposal_gate.disarm("native_stop_nav")
+                    if state == MotionState.MOVING:
+                        result = do_stop("native_stop_nav")
+                    else:
+                        result = do_stop_nav()
             elif method == "wait_nav_done":
                 result = handle_wait_nav_done(cmd.get("stall_timeout", 60))
             elif method == "get_state":
                 result = handle_get_state()
+            elif method == "bind_velocity_proposal":
+                result = handle_bind_velocity_proposal(cmd.get("topic", ""))
+            elif method == "unbind_velocity_proposal":
+                result = handle_unbind_velocity_proposal(
+                    cmd.get("reason", "canvas_stop")
+                )
+            elif method == "get_velocity_proposal_status":
+                result = handle_get_velocity_proposal_status()
             elif method == "start_mapping":
                 code, resp = slam_client.StartMapping()
                 result = {"code": code, "response": resp}
@@ -909,30 +1645,56 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                 )
                 result = {"code": code, "response": resp}
             elif method == "shutdown":
-                if state == MotionState.MOVING:
-                    loco_client.StopMove()
-                elif state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
-                    try:
-                        slam_client.PauseNav()
-                    except Exception:
-                        pass
+                handle_unbind_velocity_proposal("process_shutdown")
                 running = False
                 result = {"status": "shutdown"}
+            else:
+                result = {"error": f"unknown SmartMotion method: {method}"}
 
             if result is not None:
-                result_queue.put(result)
+                result_queue.put({
+                    "request_id": cmd.get("request_id"),
+                    "result": result,
+                })
         except queue.Empty:
             pass
+        except Exception as exc:
+            with motion_command_lock:
+                proposal_gate.disarm("smart_motion_command_error")
+                try:
+                    stop_loco_client.StopMove()
+                except Exception:
+                    pass
+            if cmd is not None:
+                result_queue.put({
+                    "request_id": cmd.get("request_id"),
+                    "result": {"error": f"SmartMotion command failed: {exc}"},
+                })
 
         # Safety checks at 10Hz
         now = time.monotonic()
         if now - last_obstacle_check >= 0.1:
             last_obstacle_check = now
-            process_safety_checks()
+            try:
+                process_safety_checks()
+            except Exception as exc:
+                with motion_command_lock:
+                    proposal_gate.disarm("safety_check_error")
+                    try:
+                        stop_loco_client.StopMove()
+                    except Exception:
+                        pass
+                print(
+                    f"[SmartMotion] safety check failed closed: {exc}",
+                    flush=True,
+                )
 
             # Repeat StopMove after emergency_stop to ensure controller receives it
             if stop_repeat_count > 0 and state == MotionState.IDLE:
-                loco_client.StopMove()
+                try:
+                    stop_loco_client.StopMove()
+                except Exception:
+                    pass
                 stop_repeat_count -= 1
 
         # Periodic health log: verify slam_info subscription is working
@@ -942,11 +1704,30 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                   f"pos_info={slam_info_pos_count} state={state.value}", flush=True)
 
         # Spin ROS2 (non-blocking)
-        executor.spin_once(timeout_sec=0)
+        try:
+            executor.spin_once(timeout_sec=0)
+        except Exception as exc:
+            with motion_command_lock:
+                proposal_gate.disarm("proposal_callback_error")
+                do_stop("proposal_callback_error")
+            print(f"[SmartMotion] ROS callback failed: {exc}", flush=True)
 
     # Cleanup
+    safety_threads_shutdown.set()
+    proposal_connected.clear()
+    proposal_watchdog_thread.join(timeout=0.5)
+    fsm_monitor_thread.join(timeout=0.75)
     if move_timer:
         move_timer.cancel()
+    with motion_command_lock:
+        stopped = do_stop("process_exit")
+        if stopped.get("stop_confirmed"):
+            stopped["stop_confirmed"] = confirm_robot_stopped(
+                proposal_stop_confirm_timeout,
+                stopped["stop_issued_monotonic"],
+            )
+        proposal_gate.unbind("process_exit")
+        proposal_node.unbind()
     executor.shutdown()
     rclpy.shutdown()
     print(f"[SmartMotion:pid={os.getpid()}] shutdown complete")

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -1348,7 +1348,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     import rclpy
     from rclpy.node import Node
     from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
-    from rclpy.executors import SingleThreadedExecutor
+    from rclpy.executors import MultiThreadedExecutor
     from std_msgs.msg import String, UInt8MultiArray
 
     from unitree_sdk2py.core.channel import ChannelFactoryInitialize, ChannelSubscriber
@@ -1365,6 +1365,12 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         reliability=ReliabilityPolicy.RELIABLE,
         history=HistoryPolicy.KEEP_LAST,
         depth=10,
+        durability=DurabilityPolicy.VOLATILE,
+    )
+    _CLOUD_QOS = QoSProfile(
+        reliability=ReliabilityPolicy.BEST_EFFORT,
+        history=HistoryPolicy.KEEP_LAST,
+        depth=1,
         durability=DurabilityPolicy.VOLATILE,
     )
 
@@ -1422,7 +1428,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
 
     # ── Initialize ROS2 ──
     rclpy.init()
-    executor = SingleThreadedExecutor()
+    # LiDAR freshness and proposal intake live on separate nodes.  Two executor
+    # workers prevent a fail-closed StopMove in the proposal callback from
+    # starving the 10 Hz cloud callback and recursively creating scan_stale.
+    executor = MultiThreadedExecutor(num_threads=2)
 
     class _EventNode(Node):
         def __init__(self):
@@ -1969,7 +1978,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
 
     try:
         event_node.create_subscription(
-            UInt8MultiArray, f"/{namespace}/lidar/cloud", on_cloud, _QOS)
+            UInt8MultiArray, f"/{namespace}/lidar/cloud", on_cloud, _CLOUD_QOS)
         print(f"[SmartMotion:pid={os.getpid()}] LiDAR subscribed (ROS2 /{namespace}/lidar/cloud)")
     except Exception as e:
         print(f"[SmartMotion:pid={os.getpid()}] WARNING: LiDAR subscribe failed: {e}")

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -262,6 +262,31 @@ def issue_stop_and_confirm(
     return result
 
 
+def resolve_proposal_stop_timeouts(proposal_config):
+    """Keep StopMove acknowledgement bounded within the odometry budget."""
+    confirmation_timeout = min(
+        1.0,
+        max(
+            0.1,
+            float(
+                proposal_config.get(
+                    "velocity_proposal_stop_confirm_timeout",
+                    0.5,
+                )
+            ),
+        ),
+    )
+    requested_rpc_timeout = float(
+        proposal_config.get("velocity_proposal_stop_rpc_timeout", 0.2)
+    )
+    # G1 cfb8efe hardware returned StopMove in about 111 ms.  A 100 ms
+    # client timeout therefore produced SDK code 3104 even while fresh zero
+    # odometry continued to arrive.  Preserve a bounded margin without ever
+    # extending beyond the physical-stop confirmation budget.
+    rpc_timeout = min(confirmation_timeout, max(0.2, requested_rpc_timeout))
+    return rpc_timeout, confirmation_timeout
+
+
 # ── SmartMotionProxy (main process) ─────────────────────────────────────────
 
 class SmartMotionProxy:
@@ -457,8 +482,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     proposal_rpc_timeout = min(
         0.2, max(0.02, float(proposal_config.get("velocity_proposal_rpc_timeout", 0.1)))
     )
-    stop_rpc_timeout = min(
-        0.2, max(0.02, float(proposal_config.get("velocity_proposal_stop_rpc_timeout", 0.1)))
+    stop_rpc_timeout, proposal_stop_confirm_timeout = (
+        resolve_proposal_stop_timeouts(proposal_config)
     )
     fsm_rpc_timeout = min(
         0.5, max(0.05, float(proposal_config.get("velocity_proposal_fsm_rpc_timeout", 0.2)))
@@ -564,10 +589,6 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     )
     proposal_watchdog_hz = max(
         20.0, float(proposal_config.get("velocity_proposal_watchdog_hz", 40.0))
-    )
-    proposal_stop_confirm_timeout = min(
-        1.0,
-        max(0.1, float(proposal_config.get("velocity_proposal_stop_confirm_timeout", 0.5))),
     )
     proposal_stop_linear_epsilon = max(
         0.0, float(proposal_config.get("velocity_proposal_stop_linear_epsilon", 0.03))

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -2915,21 +2915,15 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 decision.proposal and decision.proposal.is_terminal
             )
             if terminal_proposal:
-                stopped = do_stop(
+                do_stop(
                     decision.reason,
                     confirm_physical_stop=terminal_proposal,
                 )
-                terminal_stop_clean = bool(
-                    stopped.get("reason") == decision.reason
-                )
-                resumed_waiting = proposal_gate.resume_waiting_after_terminal_stop(
-                    bool(stopped.get("stop_confirmed"))
-                    and terminal_stop_clean
-                )
+                resumed_waiting = proposal_gate.resume_waiting_after_terminal()
                 if resumed_waiting:
-                    # The confirmed terminal stop already completed the
-                    # physical brake.  Do not let its deferred StopMove
-                    # repeats cross the lease boundary into the next task.
+                    # The terminal stop attempt has completed.  Keep its
+                    # deferred StopMove repeats out of the next task even when
+                    # the SDK receipt or odometry confirmation timed out.
                     stop_repeat_count = 0
                 return
             is_proposal_motion = bool(

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -32,9 +32,9 @@ from typing import Optional
 
 from velocity_proposal import (
     DEFAULT_VELOCITY_PROPOSAL_TOPIC,
-    ProposalLimits,
     VelocityProposalGate,
     resolve_expected_nav_id,
+    resolve_proposal_limits,
 )
 
 
@@ -426,18 +426,33 @@ class ProposalExecutionLease:
                 self._deadline = max(self._deadline, candidate)
             return True
 
-    def clear(self) -> None:
+    def clear_and_observe_fault(self):
+        """Clear the lease and atomically return any fault that won first."""
         with self._lock:
+            fault = self._fault
             self._generation += 1
             self._active = False
             self._deadline = 0.0
             self._fault = None
+            return fault
+
+    def clear(self) -> None:
+        self.clear_and_observe_fault()
 
     def fault_for_generation(self, generation: int) -> str:
         with self._lock:
             if self._fault and self._fault[0] == generation:
                 return self._fault[1]
             return ""
+
+    def is_current_generation(self, generation: int) -> bool:
+        """Return whether an asynchronous apply still owns the active lease."""
+        with self._lock:
+            return bool(
+                self._active
+                and self._fault is None
+                and generation == self._generation
+            )
 
     def current_fault(self):
         with self._lock:
@@ -459,6 +474,48 @@ class ProposalExecutionLease:
             self._active = False
             self._fault = (generation, reason)
             return True
+
+
+class ProposalWatchdogTransition:
+    """Serialize watchdog trip/stop dispatch against execution cleanup."""
+
+    def __init__(self, lease: ProposalExecutionLease):
+        self._lease = lease
+        self._lock = threading.Lock()
+
+    def clear_and_observe_fault(self):
+        """Wait for an already-tripped stop dispatch before clearing."""
+        with self._lock:
+            return self._lease.clear_and_observe_fault()
+
+    def trip_and_dispatch_stop(
+        self,
+        generation: int,
+        reason: str,
+        now: float,
+        dispatch_stop,
+    ) -> bool:
+        """Dispatch the physical stop before cleanup may cross generations."""
+        with self._lock:
+            if not self._lease.trip(generation, reason, now):
+                return False
+            dispatch_stop()
+            return True
+
+
+def proposal_apply_result_is_current(
+    command,
+    proposal_gate,
+    proposal_execution_lease,
+    generation,
+) -> bool:
+    """Reject an RPC completion superseded by stop, task, or sequence change."""
+    return bool(
+        proposal_execution_lease.is_current_generation(generation)
+        and proposal_gate.armed
+        and command.get("nav_id") == proposal_gate.expected_nav_id
+        and command.get("sequence") == proposal_gate.last_sequence
+    )
 
 
 def velocity_commands_differ(current, target, abs_tol: float = 1e-9) -> bool:
@@ -537,8 +594,8 @@ class ProposalApplyDiagnostics:
     last_set_velocity_completed_unix_ms: Optional[int] = None
     last_set_velocity_stop_ret: Optional[int] = None
     last_set_velocity_stop_error: Optional[str] = None
-    _lock: threading.Lock = field(
-        default_factory=threading.Lock,
+    _lock: threading.RLock = field(
+        default_factory=threading.RLock,
         init=False,
         repr=False,
     )
@@ -553,7 +610,7 @@ class ProposalApplyDiagnostics:
         repr=False,
     )
 
-    def begin_session(self, nav_id: str) -> None:
+    def begin_session(self, nav_id: Optional[str]) -> None:
         """Reset per-lease counters while retaining them after later cleanup."""
         with self._lock:
             self.session_nav_id = nav_id
@@ -588,6 +645,39 @@ class ProposalApplyDiagnostics:
             self.last_set_velocity_stop_error = None
             self._applied_identities = set()
             self._set_velocity_rpc_durations_ms = deque(maxlen=512)
+
+    def bind_session_nav_id(self, nav_id: str) -> None:
+        """Attach a first-proposal lease without resetting arrival evidence."""
+        with self._lock:
+            if self.session_nav_id is None:
+                self.session_nav_id = str(nav_id)
+
+    def bind_claimed_session(
+        self,
+        nav_id: str,
+        received_monotonic: float,
+        payload,
+        received_unix_ms: float,
+    ) -> bool:
+        """Bind an auto-claimed lease and roll counters on later tasks.
+
+        The first claim preserves invalid/expired packets observed while the
+        Canvas connection was initially waiting.  A later claim starts a new
+        per-lease diagnostic session and restores the claiming packet as its
+        first arrival evidence.
+        """
+        resolved = str(nav_id)
+        with self._lock:
+            if self.session_nav_id is None:
+                self.session_nav_id = resolved
+                return False
+            if self.session_nav_id == resolved:
+                return False
+            # Keep rollover atomic against async apply/watchdog diagnostics.
+            self.begin_session(resolved)
+            self.record_received(received_monotonic)
+            self.record_proposal_arrival(payload, received_unix_ms)
+            return True
 
     def record_received(self, received_monotonic: Optional[float] = None) -> None:
         received = (
@@ -1192,7 +1282,11 @@ class SmartMotionProxy:
     def get_state(self) -> dict:
         return self._call("get_state")
 
-    def bind_velocity_proposal(self, topic: str, expected_nav_id: str) -> dict:
+    def bind_velocity_proposal(
+        self,
+        topic: str,
+        expected_nav_id: Optional[str] = None,
+    ) -> dict:
         return self._call_with_parent_stop(
             "bind_velocity_proposal",
             topic=topic,
@@ -1382,16 +1476,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         proposal_config.get("velocity_proposal_driver_authorized", False)
     )
     expected_proposal_topic = DEFAULT_VELOCITY_PROPOSAL_TOPIC
-    # Deployment configuration may tighten, but never loosen, N5 limits.
-    proposal_limits = ProposalLimits(
-        frame="base_link",
-        max_ttl_ms=min(250, int(proposal_config.get("velocity_proposal_max_ttl_ms", 250))),
-        min_x=max(-0.05, float(proposal_config.get("velocity_proposal_min_x", -0.05))),
-        max_x=min(0.15, float(proposal_config.get("velocity_proposal_max_x", 0.15))),
-        max_abs_y=min(0.12, float(proposal_config.get("velocity_proposal_max_abs_y", 0.12))),
-        max_abs_yaw=min(0.35, float(proposal_config.get("velocity_proposal_max_abs_yaw", 0.35))),
-        max_planar_speed=min(0.18, float(proposal_config.get("velocity_proposal_max_planar_speed", 0.18))),
-    )
+    # Deployment configuration may tighten, but never loosen, Driver limits.
+    proposal_limits = resolve_proposal_limits(proposal_config)
     proposal_gate = VelocityProposalGate(proposal_limits)
     proposal_odom_timeout = float(proposal_config.get("velocity_proposal_odom_timeout", 0.5))
     proposal_scan_timeout = float(proposal_config.get("velocity_proposal_scan_timeout", 0.5))
@@ -1443,6 +1529,9 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     safety_lock = threading.Lock()
     motion_command_lock = threading.RLock()
     proposal_execution_lease = ProposalExecutionLease()
+    proposal_watchdog_transition = ProposalWatchdogTransition(
+        proposal_execution_lease
+    )
     proposal_connected = threading.Event()
     proposal_stop_transition = threading.Event()
     safety_threads_shutdown = threading.Event()
@@ -1484,7 +1573,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         return proposal_execution_lease.renew_if_active(deadline)
 
     def clear_proposal_execution():
-        proposal_execution_lease.clear()
+        return proposal_watchdog_transition.clear_and_observe_fault()
 
     def proposal_fault_for_generation(generation):
         return proposal_execution_lease.fault_for_generation(generation)
@@ -1510,10 +1599,6 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 sequence=command["sequence"],
                 timeout=proposal_rpc_timeout,
             )
-        proposal_apply_diagnostics.record_set_velocity(
-            result,
-            queued_monotonic=command["queued_monotonic"],
-        )
         return result
 
     def stop_parent_velocity_proposal():
@@ -1596,16 +1681,22 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         was_proposal_motion = bool(
             current_cmd and current_cmd.get("source") == "velocity_proposal"
         )
-        watchdog_fault = (
-            current_proposal_watchdog_fault()
-            if was_proposal_motion
-            else None
-        )
+        if move_timer:
+            move_timer.cancel()
+            move_timer = None
+        clear_proposal_apply_queue()
+        # Linearize terminal/local stop against the independent watchdog.  If
+        # clear wins, a stale generation can no longer trip.  If trip wins,
+        # preserve that fault so this stop cannot authorize a new lease while
+        # the watchdog's physical StopMove may still be in flight.
+        watchdog_fault = clear_proposal_execution()
         reason_str = authoritative_proposal_stop_reason(
             reason_str,
             watchdog_fault,
         )
-        if watchdog_fault and reason_str != "proposal_ttl_expired":
+        if watchdog_fault and (
+            reason_str != "proposal_ttl_expired" or not proposal_gate.armed
+        ):
             proposal_gate.disarm(reason_str)
         recoverable_stop_requested = bool(
             proposal_gate.armed
@@ -1616,16 +1707,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             was_proposal_motion or recoverable_stop_requested
         )
         retry_proposal_stop = (
-            proposal_stop_context and not confirm_physical_stop
+            proposal_stop_context and external_stop_attempt is None
         )
-        if move_timer:
-            move_timer.cancel()
-            move_timer = None
-        clear_proposal_apply_queue()
-        clear_proposal_execution()
         was_moving = state == MotionState.MOVING
 
-        if proposal_stop_context and not confirm_physical_stop:
+        if proposal_stop_context and external_stop_attempt is None:
             # The independent client brakes immediately.  The ordered parent
             # StopMove then runs after any in-flight continuous SetVelocity,
             # preventing a late successful apply from restarting motion.
@@ -2494,32 +2580,40 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     @motion_synchronized
     def handle_bind_velocity_proposal(
         topic,
-        expected_nav_id,
+        expected_nav_id=None,
         external_stop_attempt=None,
     ):
         nonlocal last_proposal_stop_result
-        try:
-            expected_nav_id = resolve_expected_nav_id(
-                {"expected_nav_id": expected_nav_id}
-            )
-        except ValueError as exc:
-            stopped = do_stop(
-                str(exc),
-                confirm_physical_stop=True,
-                external_stop_attempt=external_stop_attempt,
-            )
-            proposal_gate.disarm(str(exc))
-            diagnostics = stopped.get("stop_confirmation") or {}
-            return {
-                "error": str(exc),
-                "connected": bool(proposal_node.topic),
-                "armed": False,
-                "stop_confirmed": stopped.get("stop_confirmed", False),
-                "stop_move_ret": diagnostics.get("stop_move_ret"),
-                "stop_move_error": diagnostics.get("stop_move_error"),
-                "stop_confirmation": diagnostics,
-            }
-        if proposal_gate.is_bound_to(topic, expected_nav_id):
+        if expected_nav_id is not None and expected_nav_id != "":
+            try:
+                expected_nav_id = resolve_expected_nav_id(
+                    {"expected_nav_id": expected_nav_id}
+                )
+            except ValueError as exc:
+                stopped = do_stop(
+                    str(exc),
+                    confirm_physical_stop=True,
+                    external_stop_attempt=external_stop_attempt,
+                )
+                proposal_gate.disarm(str(exc))
+                diagnostics = stopped.get("stop_confirmation") or {}
+                return {
+                    "error": str(exc),
+                    "connected": bool(proposal_node.topic),
+                    "armed": False,
+                    "stop_confirmed": stopped.get("stop_confirmed", False),
+                    "stop_move_ret": diagnostics.get("stop_move_ret"),
+                    "stop_move_error": diagnostics.get("stop_move_error"),
+                    "stop_confirmation": diagnostics,
+                }
+        else:
+            expected_nav_id = None
+        already_bound = (
+            proposal_gate.is_bound_to(topic, expected_nav_id)
+            if expected_nav_id is not None
+            else proposal_gate.is_waiting_on(topic)
+        )
+        if already_bound:
             stopped = do_stop(
                 "proposal_bind_existing",
                 confirm_physical_stop=True,
@@ -2730,7 +2824,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
 
     @motion_synchronized
     def on_velocity_proposal(msg):
-        nonlocal last_nav_status_time
+        nonlocal last_nav_status_time, stop_repeat_count
         now = time.monotonic()
         received_unix_ms = time.time() * 1000
         proposal_apply_diagnostics.record_received(now)
@@ -2770,14 +2864,43 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             return
 
         was_armed = proposal_gate.armed
+        was_waiting_for_nav_id = proposal_gate.waiting_for_nav_id
         decision = proposal_gate.accept(
             payload,
             now,
             now_unix_ms=received_unix_ms,
         )
+        if was_waiting_for_nav_id and proposal_gate.expected_nav_id:
+            proposal_apply_diagnostics.bind_claimed_session(
+                proposal_gate.expected_nav_id,
+                received_monotonic=now,
+                payload=payload,
+                received_unix_ms=received_unix_ms,
+            )
         if decision.stop:
             if decision.reason != "proposal_zero":
                 proposal_apply_diagnostics.record_rejected(decision.reason)
+            terminal_proposal = bool(
+                decision.proposal and decision.proposal.is_terminal
+            )
+            if terminal_proposal:
+                stopped = do_stop(
+                    decision.reason,
+                    confirm_physical_stop=terminal_proposal,
+                )
+                terminal_stop_clean = bool(
+                    stopped.get("reason") == decision.reason
+                )
+                resumed_waiting = proposal_gate.resume_waiting_after_terminal_stop(
+                    bool(stopped.get("stop_confirmed"))
+                    and terminal_stop_clean
+                )
+                if resumed_waiting:
+                    # The confirmed terminal stop already completed the
+                    # physical brake.  Do not let its deferred StopMove
+                    # repeats cross the lease boundary into the next task.
+                    stop_repeat_count = 0
+                return
             is_proposal_motion = bool(
                 current_cmd and current_cmd.get("source") == "velocity_proposal"
             )
@@ -3048,6 +3171,23 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     do_stop(watchdog_reason)
                     continue
 
+                if not proposal_apply_result_is_current(
+                    command,
+                    proposal_gate,
+                    proposal_execution_lease,
+                    generation,
+                ):
+                    # Stop/terminal/manual override cleared the generation, or
+                    # a newer task/sequence superseded this result while the
+                    # parent RPC was in flight.  It must not disarm or pollute
+                    # diagnostics for the current lease.
+                    continue
+
+                proposal_apply_diagnostics.record_set_velocity(
+                    result,
+                    queued_monotonic=command["queued_monotonic"],
+                )
+
                 error = result.get("error")
                 ret = result.get("ret")
                 if error or ret != 0 or not result.get("applied"):
@@ -3088,13 +3228,20 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     reason = runtime["reason"] or "driver_safety_not_ready"
             if not reason:
                 continue
-            if not proposal_execution_lease.trip(generation, reason, now):
+            def dispatch_watchdog_stop():
+                proposal_apply_diagnostics.record_watchdog_fault(reason)
+                try:
+                    watchdog_loco_client.StopMove()
+                except Exception:
+                    pass
+
+            if not proposal_watchdog_transition.trip_and_dispatch_stop(
+                generation,
+                reason,
+                now,
+                dispatch_watchdog_stop,
+            ):
                 continue
-            proposal_apply_diagnostics.record_watchdog_fault(reason)
-            try:
-                watchdog_loco_client.StopMove()
-            except Exception:
-                pass
 
     def consume_proposal_watchdog_fault():
         fault = current_proposal_watchdog_fault()
@@ -3239,7 +3386,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 try:
                     result = handle_bind_velocity_proposal(
                         cmd.get("topic", ""),
-                        cmd.get("expected_nav_id", ""),
+                        cmd.get("expected_nav_id"),
                         external_stop_attempt=cmd.get(
                             "external_stop_attempt"
                         ),
@@ -3324,12 +3471,13 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 )
 
             # Repeat StopMove after emergency_stop to ensure controller receives it
-            if stop_repeat_count > 0 and state == MotionState.IDLE:
-                try:
-                    stop_loco_client.StopMove()
-                except Exception:
-                    pass
-                stop_repeat_count -= 1
+            with motion_command_lock:
+                if stop_repeat_count > 0 and state == MotionState.IDLE:
+                    try:
+                        stop_loco_client.StopMove()
+                    except Exception:
+                        pass
+                    stop_repeat_count -= 1
 
         # Periodic health log: verify slam_info subscription is working
         if now - last_slam_info_log >= 10.0:

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -25,6 +25,7 @@ import queue
 import struct
 import threading
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -90,6 +91,7 @@ class OdomStopMonitor:
         self._last_time = 0.0
         self._last_velocity = (float("inf"), float("inf"), float("inf"))
         self._callback_count = 0
+        self._callback_history = deque(maxlen=4096)
 
     def record(self, velocity, received_monotonic=None):
         received = (
@@ -104,6 +106,7 @@ class OdomStopMonitor:
             self._last_time = received
             self._last_velocity = motion
             self._callback_count += 1
+            self._callback_history.append((received, self._callback_count))
             self._condition.notify_all()
 
     def begin_confirmation(self):
@@ -128,6 +131,15 @@ class OdomStopMonitor:
                 "velocity": self._last_velocity,
                 "callback_count": self._callback_count,
             }
+
+    def callback_count_at(self, observed_monotonic):
+        """Return the last callback count observed at or before a timestamp."""
+        boundary = float(observed_monotonic)
+        with self._condition:
+            for received, callback_count in reversed(self._callback_history):
+                if received <= boundary:
+                    return callback_count
+            return 0
 
     def wait_for_stopped(
         self,
@@ -213,30 +225,24 @@ class OdomStopMonitor:
         return confirmed, diagnostics
 
 
-def issue_stop_and_confirm(
-    stop_move,
+def finish_stop_confirmation(
     monitor,
+    start,
+    stop_move_ret,
+    stop_move_error,
+    stop_move_completed_monotonic,
     timeout,
     max_age,
     linear_epsilon,
     yaw_epsilon,
     after_stop_attempt=None,
 ):
-    """Issue a bounded StopMove and require a subsequent measured zero frame."""
-    start = monitor.begin_confirmation()
-    stop_move_ret = None
-    stop_move_error = None
-    try:
-        stop_move_ret = stop_move()
-    except Exception as exc:
-        stop_move_error = str(exc)
-    finally:
-        stop_move_completed_monotonic = time.monotonic()
-        callbacks_at_stop_move_completion = monitor.latest(
-            stop_move_completed_monotonic
-        )["callback_count"]
-        if after_stop_attempt is not None:
-            after_stop_attempt()
+    """Confirm an acknowledged StopMove against post-boundary odometry."""
+    callbacks_at_stop_move_completion = monitor.callback_count_at(
+        stop_move_completed_monotonic
+    )
+    if after_stop_attempt is not None:
+        after_stop_attempt()
 
     stop_confirmed, diagnostics = monitor.wait_for_stopped(
         start=start,
@@ -262,29 +268,36 @@ def issue_stop_and_confirm(
     return result
 
 
-def resolve_proposal_stop_timeouts(proposal_config):
-    """Keep StopMove acknowledgement bounded within the odometry budget."""
-    confirmation_timeout = min(
-        1.0,
-        max(
-            0.1,
-            float(
-                proposal_config.get(
-                    "velocity_proposal_stop_confirm_timeout",
-                    0.5,
-                )
-            ),
-        ),
+def issue_stop_and_confirm(
+    stop_move,
+    monitor,
+    timeout,
+    max_age,
+    linear_epsilon,
+    yaw_epsilon,
+    after_stop_attempt=None,
+):
+    """Issue a bounded StopMove and require a subsequent measured zero frame."""
+    start = monitor.begin_confirmation()
+    stop_move_ret = None
+    stop_move_error = None
+    try:
+        stop_move_ret = stop_move()
+    except Exception as exc:
+        stop_move_error = str(exc)
+    stop_move_completed_monotonic = time.monotonic()
+    return finish_stop_confirmation(
+        monitor=monitor,
+        start=start,
+        stop_move_ret=stop_move_ret,
+        stop_move_error=stop_move_error,
+        stop_move_completed_monotonic=stop_move_completed_monotonic,
+        timeout=timeout,
+        max_age=max_age,
+        linear_epsilon=linear_epsilon,
+        yaw_epsilon=yaw_epsilon,
+        after_stop_attempt=after_stop_attempt,
     )
-    requested_rpc_timeout = float(
-        proposal_config.get("velocity_proposal_stop_rpc_timeout", 0.2)
-    )
-    # G1 cfb8efe hardware returned StopMove in about 111 ms.  A 100 ms
-    # client timeout therefore produced SDK code 3104 even while fresh zero
-    # odometry continued to arrive.  Preserve a bounded margin without ever
-    # extending beyond the physical-stop confirmation budget.
-    rpc_timeout = min(confirmation_timeout, max(0.2, requested_rpc_timeout))
-    return rpc_timeout, confirmation_timeout
 
 
 # ── SmartMotionProxy (main process) ─────────────────────────────────────────
@@ -298,7 +311,7 @@ class SmartMotionProxy:
         ctx = mp.get_context("spawn")
         self._cmd_queue = ctx.Queue()
         self._result_queue = ctx.Queue()
-        self._call_lock = threading.Lock()
+        self._call_lock = threading.RLock()
         self._request_id = 0
         self._proc = ctx.Process(
             target=_run_smart_motion_process,
@@ -366,6 +379,42 @@ class SmartMotionProxy:
             self._proc.terminate()
             self._proc.join(timeout=1.0)
 
+    def _call_with_parent_stop(self, method: str, **kwargs) -> dict:
+        """Bracket a parent-side StopMove with child odometry confirmation."""
+        with self._call_lock:
+            prepared = self._call("begin_velocity_proposal_stop_confirmation")
+            confirmation_start = prepared.get("confirmation_start")
+            stop_move_ret = None
+            stop_move_error = None
+            try:
+                if self._fallback_stop is None:
+                    raise RuntimeError("parent StopMove RPC is unavailable")
+                stop_move_ret = self._fallback_stop()
+            except Exception as exc:
+                stop_move_error = str(exc)
+            stop_move_completed_monotonic = time.monotonic()
+
+            if not confirmation_start:
+                return {
+                    "error": prepared.get("error")
+                    or "SmartMotion stop confirmation did not start",
+                    "stop_confirmed": False,
+                    "stop_move_ret": stop_move_ret,
+                    "stop_move_error": stop_move_error,
+                }
+            return self._call(
+                method,
+                external_stop_attempt={
+                    "confirmation_start": confirmation_start,
+                    "stop_move_ret": stop_move_ret,
+                    "stop_move_error": stop_move_error,
+                    "stop_move_completed_monotonic": (
+                        stop_move_completed_monotonic
+                    ),
+                },
+                **kwargs,
+            )
+
     def move(self, vx: float, vy: float, vyaw: float, duration: float = -1.0) -> dict:
         return self._call("move", vx=vx, vy=vy, vyaw=vyaw, duration=duration)
 
@@ -394,14 +443,17 @@ class SmartMotionProxy:
         return self._call("get_state")
 
     def bind_velocity_proposal(self, topic: str, expected_nav_id: str) -> dict:
-        return self._call(
+        return self._call_with_parent_stop(
             "bind_velocity_proposal",
             topic=topic,
             expected_nav_id=expected_nav_id,
         )
 
     def unbind_velocity_proposal(self, reason: str = "canvas_stop") -> dict:
-        return self._call("unbind_velocity_proposal", reason=reason)
+        return self._call_with_parent_stop(
+            "unbind_velocity_proposal",
+            reason=reason,
+        )
 
     def get_velocity_proposal_status(self) -> dict:
         return self._call("get_velocity_proposal_status")
@@ -482,8 +534,17 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     proposal_rpc_timeout = min(
         0.2, max(0.02, float(proposal_config.get("velocity_proposal_rpc_timeout", 0.1)))
     )
-    stop_rpc_timeout, proposal_stop_confirm_timeout = (
-        resolve_proposal_stop_timeouts(proposal_config)
+    stop_rpc_timeout = min(
+        0.2,
+        max(
+            0.02,
+            float(
+                proposal_config.get(
+                    "velocity_proposal_stop_rpc_timeout",
+                    0.1,
+                )
+            ),
+        ),
     )
     fsm_rpc_timeout = min(
         0.5, max(0.05, float(proposal_config.get("velocity_proposal_fsm_rpc_timeout", 0.2)))
@@ -590,6 +651,18 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     proposal_watchdog_hz = max(
         20.0, float(proposal_config.get("velocity_proposal_watchdog_hz", 40.0))
     )
+    proposal_stop_confirm_timeout = min(
+        1.0,
+        max(
+            0.1,
+            float(
+                proposal_config.get(
+                    "velocity_proposal_stop_confirm_timeout",
+                    0.5,
+                )
+            ),
+        ),
+    )
     proposal_stop_linear_epsilon = max(
         0.0, float(proposal_config.get("velocity_proposal_stop_linear_epsilon", 0.03))
     )
@@ -617,6 +690,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     motion_command_lock = threading.RLock()
     proposal_execution_lock = threading.Lock()
     proposal_connected = threading.Event()
+    proposal_stop_transition = threading.Event()
     safety_threads_shutdown = threading.Event()
     proposal_execution_generation = 0
     proposal_execution_active = False
@@ -692,7 +766,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         return stop_loco_client.StopMove()
 
     @motion_synchronized
-    def do_stop(reason_str, confirm_physical_stop=False):
+    def do_stop(
+        reason_str,
+        confirm_physical_stop=False,
+        external_stop_attempt=None,
+    ):
         nonlocal state, current_cmd, speed_zone, move_timer, stop_repeat_count
         was_proposal_motion = bool(
             current_cmd and current_cmd.get("source") == "velocity_proposal"
@@ -711,15 +789,42 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             stop_repeat_count = 3  # repeat StopMove to ensure controller stops
 
         if confirm_physical_stop:
-            result = issue_stop_and_confirm(
-                issue_stop_move,
-                odom_stop_monitor,
-                proposal_stop_confirm_timeout,
-                proposal_odom_timeout,
-                proposal_stop_linear_epsilon,
-                proposal_stop_yaw_epsilon,
-                after_stop_attempt=complete_logical_stop,
-            )
+            if external_stop_attempt is not None:
+                start_data = external_stop_attempt["confirmation_start"]
+                result = finish_stop_confirmation(
+                    monitor=odom_stop_monitor,
+                    start=StopConfirmationStart(
+                        monotonic=float(start_data["monotonic"]),
+                        unix_ms=int(start_data["unix_ms"]),
+                        odometry_callback_count=int(
+                            start_data["odometry_callback_count"]
+                        ),
+                    ),
+                    stop_move_ret=external_stop_attempt.get("stop_move_ret"),
+                    stop_move_error=external_stop_attempt.get(
+                        "stop_move_error"
+                    ),
+                    stop_move_completed_monotonic=float(
+                        external_stop_attempt[
+                            "stop_move_completed_monotonic"
+                        ]
+                    ),
+                    timeout=proposal_stop_confirm_timeout,
+                    max_age=proposal_odom_timeout,
+                    linear_epsilon=proposal_stop_linear_epsilon,
+                    yaw_epsilon=proposal_stop_yaw_epsilon,
+                    after_stop_attempt=complete_logical_stop,
+                )
+            else:
+                result = issue_stop_and_confirm(
+                    issue_stop_move,
+                    odom_stop_monitor,
+                    proposal_stop_confirm_timeout,
+                    proposal_odom_timeout,
+                    proposal_stop_linear_epsilon,
+                    proposal_stop_yaw_epsilon,
+                    after_stop_attempt=complete_logical_stop,
+                )
         else:
             stop_ret = None
             stop_error = None
@@ -1387,29 +1492,87 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         return result
 
     @motion_synchronized
-    def handle_bind_velocity_proposal(topic, expected_nav_id):
+    def handle_begin_velocity_proposal_stop_confirmation():
+        # Freeze proposal execution before the responsive parent RpcProxy
+        # issues StopMove.  Keep the subscription until zero odometry is
+        # confirmed so teardown remains fail-closed.
+        if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
+            do_stop_nav()
+        proposal_stop_transition.set()
+        proposal_connected.clear()
+        clear_proposal_execution()
+        start = odom_stop_monitor.begin_confirmation()
+        return {
+            "confirmation_start": {
+                "monotonic": start.monotonic,
+                "unix_ms": start.unix_ms,
+                "odometry_callback_count": start.odometry_callback_count,
+            }
+        }
+
+    @motion_synchronized
+    def handle_bind_velocity_proposal(
+        topic,
+        expected_nav_id,
+        external_stop_attempt=None,
+    ):
         try:
             expected_nav_id = resolve_expected_nav_id(
                 {"expected_nav_id": expected_nav_id}
             )
         except ValueError as exc:
+            stopped = do_stop(
+                str(exc),
+                confirm_physical_stop=True,
+                external_stop_attempt=external_stop_attempt,
+            )
             proposal_gate.disarm(str(exc))
-            do_stop(str(exc))
+            diagnostics = stopped.get("stop_confirmation") or {}
             return {
                 "error": str(exc),
                 "connected": bool(proposal_node.topic),
                 "armed": False,
+                "stop_confirmed": stopped.get("stop_confirmed", False),
+                "stop_move_ret": diagnostics.get("stop_move_ret"),
+                "stop_move_error": diagnostics.get("stop_move_error"),
+                "stop_confirmation": diagnostics,
             }
         if proposal_gate.is_bound_to(topic, expected_nav_id):
+            stopped = do_stop(
+                "proposal_bind_existing",
+                confirm_physical_stop=True,
+                external_stop_attempt=external_stop_attempt,
+            )
+            if not stopped.get("stop_confirmed"):
+                proposal_gate.disarm("stop_unconfirmed")
+                diagnostics = stopped.get("stop_confirmation") or {}
+                return {
+                    "error": "StopMove/odometry stop was not confirmed before proposal bind",
+                    "connected": bool(proposal_node.topic),
+                    "armed": False,
+                    "stop_confirmed": False,
+                    "stop_move_ret": diagnostics.get("stop_move_ret"),
+                    "stop_move_error": diagnostics.get("stop_move_error"),
+                    "stop_confirmation": diagnostics,
+                }
+            proposal_connected.set()
+            proposal_stop_transition.clear()
             result = handle_get_velocity_proposal_status()
             result["state"] = "connected"
+            result["stop_confirmed"] = True
+            result["stop_move_ret"] = stopped.get("ret")
+            result["stop_move_error"] = (
+                (stopped.get("stop_confirmation") or {}).get(
+                    "stop_move_error"
+                )
+            )
+            result["stop_confirmation"] = stopped.get("stop_confirmation")
             return result
-        # A proposal stream and Unitree native navigation may never own motion
-        # at the same time.
-        if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
-            do_stop_nav()
         if proposal_gate.connected_topic or proposal_node.topic:
-            stopped = handle_unbind_velocity_proposal("proposal_rebind")
+            stopped = handle_unbind_velocity_proposal(
+                "proposal_rebind",
+                external_stop_attempt=external_stop_attempt,
+            )
             if not stopped.get("stop_confirmed"):
                 return {
                     "error": "StopMove was not confirmed before proposal rebind",
@@ -1420,7 +1583,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     "stop_confirmation": stopped.get("stop_confirmation"),
                 }
         else:
-            stopped = do_stop("proposal_bind", confirm_physical_stop=True)
+            stopped = do_stop(
+                "proposal_bind",
+                confirm_physical_stop=True,
+                external_stop_attempt=external_stop_attempt,
+            )
             if not stopped.get("stop_confirmed"):
                 diagnostics = stopped.get("stop_confirmation") or {}
                 return {
@@ -1455,6 +1622,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             except Exception:
                 pass
             return {"error": f"velocity_proposal_subscribe_failed: {exc}", "connected": False}
+        proposal_stop_transition.clear()
         result = handle_get_velocity_proposal_status()
         result["state"] = "connected"
         result["stop_confirmed"] = True
@@ -1464,13 +1632,23 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         return result
 
     @motion_synchronized
-    def handle_unbind_velocity_proposal(reason="canvas_stop"):
+    def handle_unbind_velocity_proposal(
+        reason="canvas_stop",
+        external_stop_attempt=None,
+    ):
         # N5 ordering: command and observe physical stop before destroying the
         # only proposal subscription.
-        if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
+        if (
+            external_stop_attempt is None
+            and state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED)
+        ):
             do_stop_nav()
-        stopped = do_stop(reason, confirm_physical_stop=True)
-        for _ in range(2):
+        stopped = do_stop(
+            reason,
+            confirm_physical_stop=True,
+            external_stop_attempt=external_stop_attempt,
+        )
+        for _ in range(2 if external_stop_attempt is None else 0):
             # Preserve the original retry contract: retry rejected/failed RPC
             # attempts, but do not mask a measured nonzero or odom timeout by
             # issuing more StopMove calls.
@@ -1524,6 +1702,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             "canvas_running": proposal_connected.is_set(),
             "driver_authorized": bool(
                 proposal_driver_authorized
+                and not proposal_stop_transition.is_set()
                 and proposal_gate.connected_topic
                 and proposal_gate.armed
             ),
@@ -1536,6 +1715,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     @motion_synchronized
     def on_velocity_proposal(msg):
         nonlocal last_nav_status_time
+        if proposal_stop_transition.is_set():
+            return
         now = time.monotonic()
         pending_fault = current_proposal_watchdog_fault()
         if pending_fault:
@@ -1843,15 +2024,29 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 result = handle_wait_nav_done(cmd.get("stall_timeout", 60))
             elif method == "get_state":
                 result = handle_get_state()
+            elif method == "begin_velocity_proposal_stop_confirmation":
+                result = handle_begin_velocity_proposal_stop_confirmation()
             elif method == "bind_velocity_proposal":
-                result = handle_bind_velocity_proposal(
-                    cmd.get("topic", ""),
-                    cmd.get("expected_nav_id", ""),
-                )
+                try:
+                    result = handle_bind_velocity_proposal(
+                        cmd.get("topic", ""),
+                        cmd.get("expected_nav_id", ""),
+                        external_stop_attempt=cmd.get(
+                            "external_stop_attempt"
+                        ),
+                    )
+                finally:
+                    proposal_stop_transition.clear()
             elif method == "unbind_velocity_proposal":
-                result = handle_unbind_velocity_proposal(
-                    cmd.get("reason", "canvas_stop")
-                )
+                try:
+                    result = handle_unbind_velocity_proposal(
+                        cmd.get("reason", "canvas_stop"),
+                        external_stop_attempt=cmd.get(
+                            "external_stop_attempt"
+                        ),
+                    )
+                finally:
+                    proposal_stop_transition.clear()
             elif method == "get_velocity_proposal_status":
                 result = handle_get_velocity_proposal_status()
             elif method == "start_mapping":
@@ -1890,6 +2085,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         except Exception as exc:
             with motion_command_lock:
                 proposal_gate.disarm("smart_motion_command_error")
+                proposal_stop_transition.clear()
                 try:
                     stop_loco_client.StopMove()
                 except Exception:

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -5,8 +5,8 @@ drivers/unitree/g1/safety_harness.py — SmartMotion 独立进程安全层。
 架构：
   - SmartMotionProcess: 独立子进程，拥有自己的 DDS 通道和 ROS2 节点
     - 订阅 LiDAR 点云，10Hz 全量 numpy 处理
-    - 在本地执行停止、FSM 和 SlamClient RPC
-    - 将安全判定通过的 proposal SetVelocity 有界交给主进程 Driver RPC
+    - 在本地执行停止和 SlamClient RPC
+    - 将 proposal SetVelocity 和 FSM GetFsmId 有界交给主进程 Driver RPC
     - 发布运动事件到 ROS2 topic
   - SmartMotionProxy: 主进程中的轻量代理，通过 multiprocessing Queue 通信
     - 对外暴露与原 SmartMotion 相同的 API
@@ -386,31 +386,24 @@ class ProposalApplyDiagnostics:
             }
 
 
-def request_parent_set_velocity(
+def _request_parent_loco_rpc(
     request_queue,
     result_queue,
-    request_id: int,
-    vx: float,
-    vy: float,
-    vyaw: float,
-    duration: float,
+    request: dict,
     timeout: float,
+    timeout_error: str,
+    ipc_error_prefix: str,
 ) -> dict:
-    """Request one finite SetVelocity from the parent and wait boundedly."""
+    """Send one correlated parent Loco RPC request and wait boundedly."""
     started = time.monotonic()
+    request_id = request["request_id"]
     try:
-        request_queue.put({
-            "request_id": request_id,
-            "vx": vx,
-            "vy": vy,
-            "vyaw": vyaw,
-            "duration": duration,
-        })
+        request_queue.put(request)
     except Exception as exc:
         return {
             "request_id": request_id,
             "ret": None,
-            "error": f"parent_set_velocity_ipc_error: {exc}",
+            "error": f"{ipc_error_prefix}: {exc}",
             "completed_monotonic": time.monotonic(),
             "completed_unix_ms": round(time.time() * 1000),
         }
@@ -422,7 +415,7 @@ def request_parent_set_velocity(
             return {
                 "request_id": request_id,
                 "ret": None,
-                "error": "parent_set_velocity_timeout",
+                "error": timeout_error,
                 "completed_monotonic": time.monotonic(),
                 "completed_unix_ms": round(time.time() * 1000),
             }
@@ -432,12 +425,60 @@ def request_parent_set_velocity(
             return {
                 "request_id": request_id,
                 "ret": None,
-                "error": "parent_set_velocity_timeout",
+                "error": timeout_error,
                 "completed_monotonic": time.monotonic(),
                 "completed_unix_ms": round(time.time() * 1000),
             }
         if result.get("request_id") == request_id:
             return result
+
+
+def request_parent_set_velocity(
+    request_queue,
+    result_queue,
+    request_id: int,
+    vx: float,
+    vy: float,
+    vyaw: float,
+    duration: float,
+    timeout: float,
+) -> dict:
+    """Request one finite SetVelocity from the parent and wait boundedly."""
+    return _request_parent_loco_rpc(
+        request_queue,
+        result_queue,
+        request={
+            "method": "set_velocity",
+            "request_id": request_id,
+            "vx": vx,
+            "vy": vy,
+            "vyaw": vyaw,
+            "duration": duration,
+        },
+        timeout=timeout,
+        timeout_error="parent_set_velocity_timeout",
+        ipc_error_prefix="parent_set_velocity_ipc_error",
+    )
+
+
+def request_parent_get_fsm_id(
+    request_queue,
+    result_queue,
+    request_id: int,
+    timeout: float,
+) -> dict:
+    """Request one fail-closed GetFsmId sample from the parent RpcProxy."""
+    return _request_parent_loco_rpc(
+        request_queue,
+        result_queue,
+        request={
+            "method": "get_fsm_id",
+            "request_id": request_id,
+        },
+        timeout=timeout,
+        timeout_error="parent_get_fsm_id_timeout",
+        ipc_error_prefix="parent_get_fsm_id_ipc_error",
+    )
 
 
 # ── SmartMotionProxy (main process) ─────────────────────────────────────────
@@ -447,7 +488,8 @@ class SmartMotionProxy:
 
     def __init__(self, namespace: str, config: dict, network_iface: str,
                  proposal_config: Optional[dict] = None,
-                 fallback_stop=None, parent_set_velocity=None):
+                 fallback_stop=None, parent_set_velocity=None,
+                 parent_get_fsm_id=None):
         ctx = mp.get_context("spawn")
         self._cmd_queue = ctx.Queue()
         self._result_queue = ctx.Queue()
@@ -457,6 +499,7 @@ class SmartMotionProxy:
         self._request_id = 0
         self._fallback_stop = fallback_stop
         self._parent_set_velocity = parent_set_velocity
+        self._parent_get_fsm_id = parent_get_fsm_id
         self._parent_velocity_shutdown = threading.Event()
         self._proc = ctx.Process(
             target=_run_smart_motion_process,
@@ -482,28 +525,50 @@ class SmartMotionProxy:
         print(f"[SmartMotionProxy] subprocess started → pid={self._proc.pid}")
 
     def _serve_parent_velocity_requests(self) -> None:
-        """Execute child-approved SetVelocity calls on the parent RpcProxy."""
+        """Execute child-approved Loco calls on the parent RpcProxy."""
         while True:
             request = self._parent_velocity_queue.get()
             if request is None:
                 return
             request_id = request.get("request_id")
+            method = request.get("method", "set_velocity")
             ret = None
+            fsm_id = None
             error = None
             try:
-                if self._parent_set_velocity is None:
-                    raise RuntimeError("parent SetVelocity RPC is unavailable")
-                ret = self._parent_set_velocity(
-                    request["vx"],
-                    request["vy"],
-                    request["vyaw"],
-                    request["duration"],
-                )
+                if method == "set_velocity":
+                    if self._parent_set_velocity is None:
+                        raise RuntimeError(
+                            "parent SetVelocity RPC is unavailable"
+                        )
+                    ret = self._parent_set_velocity(
+                        request["vx"],
+                        request["vy"],
+                        request["vyaw"],
+                        request["duration"],
+                    )
+                elif method == "get_fsm_id":
+                    if self._parent_get_fsm_id is None:
+                        raise RuntimeError(
+                            "parent GetFsmId RPC is unavailable"
+                        )
+                    result = self._parent_get_fsm_id()
+                    if not isinstance(result, (list, tuple)) or len(result) != 2:
+                        raise RuntimeError(
+                            "parent GetFsmId returned an invalid result"
+                        )
+                    ret, fsm_id = result
+                else:
+                    raise RuntimeError(
+                        f"unsupported parent Loco RPC method: {method}"
+                    )
             except Exception as exc:
                 error = str(exc)
             self._parent_velocity_result_queue.put({
+                "method": method,
                 "request_id": request_id,
                 "ret": ret,
+                "fsm_id": fsm_id,
                 "error": error,
                 "completed_monotonic": time.monotonic(),
                 "completed_unix_ms": round(time.time() * 1000),
@@ -722,10 +787,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     loco_client.Init()
     loco_client.SetTimeout(10.0)
 
-    # Proposal execution is deliberately routed back through the parent
-    # Driver RpcProxy.  Stopping, watchdog stopping and FSM polling retain
-    # independent child clients so a delayed apply cannot block fail-closed
-    # stop paths.
+    # Proposal execution and its FSM authorization are deliberately routed
+    # through the parent Driver RpcProxy. Stopping and watchdog stopping keep
+    # independent child clients so a delayed parent RPC cannot block the
+    # fail-closed stop paths.
     proposal_rpc_timeout = min(
         0.2, max(0.02, float(proposal_config.get("velocity_proposal_rpc_timeout", 0.1)))
     )
@@ -750,17 +815,13 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     watchdog_loco_client = LocoClient()
     watchdog_loco_client.Init()
     watchdog_loco_client.SetTimeout(stop_rpc_timeout)
-    fsm_loco_client = LocoClient()
-    fsm_loco_client.Init()
-    fsm_loco_client.SetTimeout(fsm_rpc_timeout)
-
     slam_client = SlamClient()
     slam_client.Init()
     slam_client.SetTimeout(10.0)  # must be AFTER Init() — Init() resets timeout to 5.0
 
     print(
-        f"[SmartMotion:pid={os.getpid()}] stop/FSM LocoClient + "
-        "parent proposal RPC + SlamClient ready"
+        f"[SmartMotion:pid={os.getpid()}] stop LocoClient + "
+        "parent proposal/FSM RPC + SlamClient ready"
     )
 
     # ── Initialize ROS2 ──
@@ -878,6 +939,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     last_cloud_time = 0.0
     last_fsm_check = 0.0
     last_fsm_id = None
+    last_fsm_ret = None
+    last_fsm_error = None
     main_control_ready = False
     last_nav_status_time = 0.0
     odom_stop_monitor = OdomStopMonitor()
@@ -891,7 +954,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     proposal_execution_active = False
     proposal_execution_deadline = 0.0
     proposal_watchdog_fault = None
-    proposal_apply_request_id = 0
+    parent_loco_request_id = 0
+    parent_loco_rpc_lock = threading.Lock()
     proposal_apply_diagnostics = ProposalApplyDiagnostics()
 
     def motion_synchronized(func):
@@ -930,20 +994,34 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             return proposal_watchdog_fault
 
     def apply_parent_set_velocity(vx, vy, vyaw, duration):
-        nonlocal proposal_apply_request_id
-        proposal_apply_request_id += 1
-        result = request_parent_set_velocity(
-            request_queue=parent_velocity_queue,
-            result_queue=parent_velocity_result_queue,
-            request_id=proposal_apply_request_id,
-            vx=vx,
-            vy=vy,
-            vyaw=vyaw,
-            duration=duration,
-            timeout=proposal_rpc_timeout,
-        )
+        nonlocal parent_loco_request_id
+        # The FSM monitor and proposal callback share one request/result pair.
+        # Serialize them so one waiter cannot consume the other's reply.
+        with parent_loco_rpc_lock:
+            parent_loco_request_id += 1
+            result = request_parent_set_velocity(
+                request_queue=parent_velocity_queue,
+                result_queue=parent_velocity_result_queue,
+                request_id=parent_loco_request_id,
+                vx=vx,
+                vy=vy,
+                vyaw=vyaw,
+                duration=duration,
+                timeout=proposal_rpc_timeout,
+            )
         proposal_apply_diagnostics.record_set_velocity(result, duration)
         return result
+
+    def query_parent_fsm_id():
+        nonlocal parent_loco_request_id
+        with parent_loco_rpc_lock:
+            parent_loco_request_id += 1
+            return request_parent_get_fsm_id(
+                request_queue=parent_velocity_queue,
+                result_queue=parent_velocity_result_queue,
+                request_id=parent_loco_request_id,
+                timeout=fsm_rpc_timeout,
+            )
 
     # Obstacle state (written by LiDAR callback, read by main loop)
     obstacle_lock = threading.Lock()
@@ -1386,16 +1464,29 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         print(f"[SmartMotion:pid={os.getpid()}] WARNING: rt/slam_info subscribe failed: {e}")
 
     def refresh_fsm_state():
-        nonlocal last_fsm_check, last_fsm_id, main_control_ready
+        nonlocal last_fsm_check, last_fsm_id, last_fsm_ret
+        nonlocal last_fsm_error, main_control_ready
+        fsm_id = None
+        ret = None
+        error = None
         try:
-            code, fsm_id = fsm_loco_client.GetFsmId()
-            ready = code == 0 and int(fsm_id) in proposal_allowed_fsm_ids
-        except Exception:
-            fsm_id = None
+            result = query_parent_fsm_id()
+            ret = result.get("ret")
+            fsm_id = result.get("fsm_id")
+            error = result.get("error")
+            ready = (
+                error is None
+                and ret == 0
+                and int(fsm_id) in proposal_allowed_fsm_ids
+            )
+        except Exception as exc:
+            error = str(exc)
             ready = False
         with safety_lock:
             last_fsm_check = time.monotonic()
             last_fsm_id = fsm_id
+            last_fsm_ret = ret
+            last_fsm_error = error
             main_control_ready = ready
 
     def proposal_runtime_status(force_fsm_check=False):
@@ -1413,6 +1504,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             fsm_age = now - last_fsm_check if last_fsm_check else float("inf")
             temperature = max_motor_temp
             fsm_id = last_fsm_id
+            fsm_ret = last_fsm_ret
+            fsm_error = last_fsm_error
             control_ready = main_control_ready
             tilted = tilt_triggered
         odom_age = odom["age"]
@@ -1432,6 +1525,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             reason = "joint_overheat_latched"
         elif nav_status_age > proposal_nav_status_timeout:
             reason = "nav2_status_stale"
+        elif fsm_error is not None or (fsm_ret is not None and fsm_ret != 0):
+            reason = "main_control_rpc_failed"
         elif fsm_age > proposal_fsm_timeout:
             reason = "main_control_status_stale"
         elif not control_ready:
@@ -1441,6 +1536,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             "ready": not reason,
             "reason": reason or None,
             "fsm_id": fsm_id,
+            "fsm_ret": fsm_ret,
+            "fsm_error": fsm_error,
             # In this G1 API, a fresh allowed locomotion FSM is the native
             # fail-closed proxy for main-control/e-stop execution permission.
             "emergency_stop_clear": control_ready and fsm_age <= proposal_fsm_timeout,

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -41,6 +41,7 @@ from velocity_proposal import (
 UNITREE_STOP_MOVE_DURATION_SECONDS = 1.0
 DEFAULT_STOP_CONFIRM_TIMEOUT_SECONDS = 2.0
 MAX_STOP_CONFIRM_TIMEOUT_SECONDS = 3.0
+TRANSLATION_OBSTACLE_EPSILON = 0.01
 
 
 def resolve_stop_confirmation_timeout(configured_timeout):
@@ -84,6 +85,59 @@ class SpeedZone(enum.Enum):
     NORMAL = "normal"
     DECELERATED = "decelerated"
     STOPPED = "stopped"
+
+
+def translation_obstacle_heading(command, epsilon=TRANSLATION_OBSTACLE_EPSILON):
+    """Return the translation heading, or ``None`` for an in-place command."""
+    if not command:
+        return None
+    vx = float(command.get("vx", 0.0))
+    vy = float(command.get("vy", 0.0))
+    if math.hypot(vx, vy) <= float(epsilon):
+        return None
+    return math.atan2(vy, vx)
+
+
+def obstacle_observation_applies(
+    command,
+    observation_heading,
+    heading_tolerance,
+):
+    """Reject stale cones and never treat pure rotation as translation."""
+    command_heading = translation_obstacle_heading(command)
+    if command_heading is None or observation_heading is None:
+        return False
+    delta = abs(
+        (command_heading - float(observation_heading) + math.pi)
+        % (2 * math.pi)
+        - math.pi
+    )
+    return delta <= max(0.0, float(heading_tolerance))
+
+
+def authoritative_proposal_stop_reason(requested_reason, watchdog_fault):
+    """Preserve an execution fault that won before a concurrent local stop."""
+    if watchdog_fault:
+        return str(watchdog_fault[1])
+    return str(requested_reason)
+
+
+def proposal_decision_requires_physical_stop(
+    reason,
+    has_proposal,
+    proposal_motion_active,
+    newly_disarmed,
+    recoverable_stop_active,
+):
+    """Let confirmed obstacle holds drain stale ROS samples without RPCs."""
+    if (
+        recoverable_stop_active
+        and reason == "proposal_ttl_expired"
+        and not proposal_motion_active
+        and not newly_disarmed
+    ):
+        return False
+    return bool(has_proposal or proposal_motion_active or newly_disarmed)
 
 
 @dataclass
@@ -1393,6 +1447,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     obstacle_dist = float("inf")
     obstacle_angle = 0.0
     lateral_obstacle = False
+    obstacle_scan_heading = None
 
     # Nav arrival state (updated by rt/slam_info DDS callback in this subprocess)
     slam_info_lock = threading.Lock()
@@ -1432,6 +1487,17 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         was_proposal_motion = bool(
             current_cmd and current_cmd.get("source") == "velocity_proposal"
         )
+        watchdog_fault = (
+            current_proposal_watchdog_fault()
+            if was_proposal_motion
+            else None
+        )
+        reason_str = authoritative_proposal_stop_reason(
+            reason_str,
+            watchdog_fault,
+        )
+        if watchdog_fault:
+            proposal_gate.disarm(reason_str)
         retry_proposal_stop = was_proposal_motion and not confirm_physical_stop
         if move_timer:
             move_timer.cancel()
@@ -1556,7 +1622,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             if stop_error:
                 result["error"] = f"StopMove failed: {stop_error}"
         if was_proposal_motion and reason_str == "obstacle":
-            proposal_gate.disarm("obstacle_stop_latched")
+            if result.get("stop_confirmed"):
+                proposal_gate.hold_for_obstacle()
+            else:
+                proposal_gate.disarm("obstacle_stop_unconfirmed")
         if was_moving:
             event_data = {"reason": reason_str}
             if reason_str == "obstacle":
@@ -1595,13 +1664,12 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
 
     # ── LiDAR DDS Subscription ──
     def on_cloud(msg):
-        nonlocal obstacle_dist, obstacle_angle, lateral_obstacle, last_cloud_time
+        nonlocal obstacle_dist, obstacle_angle, lateral_obstacle
+        nonlocal obstacle_scan_heading, last_cloud_time
 
         # Get heading
         if state == MotionState.MOVING and current_cmd:
-            vx_cmd = current_cmd.get("vx", 0)
-            vy_cmd = current_cmd.get("vy", 0)
-            heading = math.atan2(vy_cmd, vx_cmd) if (abs(vx_cmd) > 0.01 or abs(vy_cmd) > 0.01) else 0.0
+            heading = translation_obstacle_heading(current_cmd)
         else:
             # NAVIGATING/IDLE: LiDAR is in body frame, heading=0 = robot forward
             heading = 0.0
@@ -1619,6 +1687,15 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             return
         with safety_lock:
             last_cloud_time = time.monotonic()
+        if heading is None:
+            # In-place rotation has no translation corridor.  Keep scan
+            # freshness, but do not apply a synthetic forward obstacle cone.
+            with obstacle_lock:
+                obstacle_dist = float("inf")
+                obstacle_angle = 0.0
+                lateral_obstacle = False
+                obstacle_scan_heading = None
+            return
 
         # Numpy batch extraction (xyz at offsets 0, 4, 8 — already gravity-aligned)
         buf = np.frombuffer(data, dtype=np.uint8, count=n_valid * point_step).reshape(n_valid, point_step)
@@ -1637,6 +1714,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 obstacle_dist = float("inf")
                 obstacle_angle = 0.0
                 lateral_obstacle = False
+                obstacle_scan_heading = heading
             return
 
         vx_pts = px[valid]
@@ -1677,6 +1755,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             obstacle_dist = min_fwd_dist
             obstacle_angle = min_fwd_angle
             lateral_obstacle = lat_detected
+            obstacle_scan_heading = heading
 
     try:
         event_node.create_subscription(
@@ -2579,7 +2658,13 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 current_cmd and current_cmd.get("source") == "velocity_proposal"
             )
             newly_disarmed = was_armed and not proposal_gate.armed
-            if decision.proposal is not None or is_proposal_motion or newly_disarmed:
+            if proposal_decision_requires_physical_stop(
+                decision.reason,
+                decision.proposal is not None,
+                is_proposal_motion,
+                newly_disarmed,
+                proposal_gate.recoverable_stop_active,
+            ):
                 do_stop(decision.reason)
             return
         if not decision.execute or decision.proposal is None:
@@ -2710,18 +2795,26 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         with obstacle_lock:
             dist = obstacle_dist
             lateral = lateral_obstacle
+            angle = obstacle_angle
+            scan_heading = obstacle_scan_heading
 
         if state == MotionState.MOVING:
             cmd = current_cmd  # snapshot to avoid race condition
+            if not obstacle_observation_applies(
+                cmd,
+                scan_heading,
+                cone_half_angle,
+            ):
+                return
             if dist <= stop_threshold:
                 if speed_zone != SpeedZone.STOPPED:
                     speed_zone = SpeedZone.STOPPED
-                    print(f"[SmartMotion:obstacle] STOP — dist={dist:.2f}m angle={math.degrees(obstacle_angle):.1f}° lateral={lateral}", flush=True)
+                    print(f"[SmartMotion:obstacle] STOP — dist={dist:.2f}m angle={math.degrees(angle):.1f}° lateral={lateral}", flush=True)
                     do_stop("obstacle")
             elif dist <= decel_threshold or lateral:
                 if speed_zone != SpeedZone.DECELERATED:
                     speed_zone = SpeedZone.DECELERATED
-                    print(f"[SmartMotion:obstacle] DECEL — dist={dist:.2f}m angle={math.degrees(obstacle_angle):.1f}° lateral={lateral}", flush=True)
+                    print(f"[SmartMotion:obstacle] DECEL — dist={dist:.2f}m angle={math.degrees(angle):.1f}° lateral={lateral}", flush=True)
                     if cmd:
                         dvx, dvy, dvyaw = clamp(cmd["vx"], cmd["vy"], cmd["vyaw"], SpeedZone.DECELERATED)
                         apply_safety_velocity(cmd, dvx, dvy, dvyaw)

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -39,8 +39,9 @@ from velocity_proposal import (
 
 
 UNITREE_STOP_MOVE_DURATION_SECONDS = 1.0
-DEFAULT_STOP_CONFIRM_TIMEOUT_SECONDS = 2.0
-MAX_STOP_CONFIRM_TIMEOUT_SECONDS = 3.0
+DEFAULT_STOP_CONFIRM_TIMEOUT_SECONDS = 5.0
+MAX_STOP_CONFIRM_TIMEOUT_SECONDS = 5.0
+STOP_CONFIRM_REQUIRED_ZERO_SAMPLES = 3
 TRANSLATION_OBSTACLE_EPSILON = 0.01
 
 
@@ -183,7 +184,9 @@ class OdomStopMonitor:
             self._last_time = received
             self._last_velocity = motion
             self._callback_count += 1
-            self._callback_history.append((received, self._callback_count))
+            self._callback_history.append(
+                (received, self._callback_count, motion)
+            )
             self._condition.notify_all()
 
     def begin_confirmation(self):
@@ -213,7 +216,9 @@ class OdomStopMonitor:
         """Return the last callback count observed at or before a timestamp."""
         boundary = float(observed_monotonic)
         with self._condition:
-            for received, callback_count in reversed(self._callback_history):
+            for received, callback_count, _motion in reversed(
+                self._callback_history
+            ):
                 if received <= boundary:
                     return callback_count
             return 0
@@ -229,27 +234,38 @@ class OdomStopMonitor:
         stop_move_error=None,
         stop_move_completed_monotonic=None,
         callbacks_at_stop_move_completion=None,
+        required_zero_samples=STOP_CONFIRM_REQUIRED_ZERO_SAMPLES,
     ):
         deadline = start.monotonic + timeout
         confirmed = False
         timed_out = False
+        required_zero_samples = max(1, int(required_zero_samples))
+        consecutive_zero_samples = 0
+        last_processed_callback_count = start.odometry_callback_count
         with self._condition:
             while stop_move_ret == 0:
                 now = time.monotonic()
-                vx, vy, yaw = self._last_velocity
-                is_new = (
-                    self._callback_count > start.odometry_callback_count
-                    and self._last_time >= start.monotonic
-                    and self._last_time <= deadline
-                )
-                is_fresh = self._last_time and now - self._last_time <= max_age
-                is_zero = (
-                    abs(vx) <= linear_epsilon
-                    and abs(vy) <= linear_epsilon
-                    and abs(yaw) <= yaw_epsilon
-                )
-                if is_new and is_fresh and is_zero:
-                    confirmed = True
+                for received, callback_count, motion in self._callback_history:
+                    if callback_count <= last_processed_callback_count:
+                        continue
+                    last_processed_callback_count = callback_count
+                    if received < start.monotonic or received > deadline:
+                        continue
+                    vx, vy, yaw = motion
+                    is_fresh = now - received <= max_age
+                    is_zero = (
+                        abs(vx) <= linear_epsilon
+                        and abs(vy) <= linear_epsilon
+                        and abs(yaw) <= yaw_epsilon
+                    )
+                    if is_fresh and is_zero:
+                        consecutive_zero_samples += 1
+                    else:
+                        consecutive_zero_samples = 0
+                    if consecutive_zero_samples >= required_zero_samples:
+                        confirmed = True
+                        break
+                if confirmed:
                     break
                 remaining = deadline - now
                 if remaining <= 0.0:
@@ -297,6 +313,8 @@ class OdomStopMonitor:
                         else start.odometry_callback_count
                     ) - start.odometry_callback_count,
                 ),
+                "required_consecutive_zero_samples": required_zero_samples,
+                "consecutive_zero_samples": consecutive_zero_samples,
                 "confirmation_timed_out": timed_out,
             }
         return confirmed, diagnostics
@@ -313,6 +331,7 @@ def finish_stop_confirmation(
     linear_epsilon,
     yaw_epsilon,
     after_stop_attempt=None,
+    required_zero_samples=STOP_CONFIRM_REQUIRED_ZERO_SAMPLES,
 ):
     """Confirm an acknowledged StopMove against post-boundary odometry."""
     callbacks_at_stop_move_completion = monitor.callback_count_at(
@@ -331,6 +350,7 @@ def finish_stop_confirmation(
         stop_move_error=stop_move_error,
         stop_move_completed_monotonic=stop_move_completed_monotonic,
         callbacks_at_stop_move_completion=callbacks_at_stop_move_completion,
+        required_zero_samples=required_zero_samples,
     )
     result = {
         "ret": stop_move_ret,
@@ -353,6 +373,7 @@ def issue_stop_and_confirm(
     linear_epsilon,
     yaw_epsilon,
     after_stop_attempt=None,
+    required_zero_samples=STOP_CONFIRM_REQUIRED_ZERO_SAMPLES,
 ):
     """Issue a bounded StopMove and require a subsequent measured zero frame."""
     start = monitor.begin_confirmation()
@@ -374,6 +395,7 @@ def issue_stop_and_confirm(
         linear_epsilon=linear_epsilon,
         yaw_epsilon=yaw_epsilon,
         after_stop_attempt=after_stop_attempt,
+        required_zero_samples=required_zero_samples,
     )
 
 

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -32,6 +32,7 @@ from velocity_proposal import (
     DEFAULT_VELOCITY_PROPOSAL_TOPIC,
     ProposalLimits,
     VelocityProposalGate,
+    resolve_expected_nav_id,
 )
 
 
@@ -180,8 +181,12 @@ class SmartMotionProxy:
     def get_state(self) -> dict:
         return self._call("get_state")
 
-    def bind_velocity_proposal(self, topic: str) -> dict:
-        return self._call("bind_velocity_proposal", topic=topic)
+    def bind_velocity_proposal(self, topic: str, expected_nav_id: str) -> dict:
+        return self._call(
+            "bind_velocity_proposal",
+            topic=topic,
+            expected_nav_id=expected_nav_id,
+        )
 
     def unbind_velocity_proposal(self, reason: str = "canvas_stop") -> dict:
         return self._call("unbind_velocity_proposal", reason=reason)
@@ -1185,7 +1190,23 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         return result
 
     @motion_synchronized
-    def handle_bind_velocity_proposal(topic):
+    def handle_bind_velocity_proposal(topic, expected_nav_id):
+        try:
+            expected_nav_id = resolve_expected_nav_id(
+                {"expected_nav_id": expected_nav_id}
+            )
+        except ValueError as exc:
+            proposal_gate.disarm(str(exc))
+            do_stop(str(exc))
+            return {
+                "error": str(exc),
+                "connected": bool(proposal_node.topic),
+                "armed": False,
+            }
+        if proposal_gate.is_bound_to(topic, expected_nav_id):
+            result = handle_get_velocity_proposal_status()
+            result["state"] = "connected"
+            return result
         # A proposal stream and Unitree native navigation may never own motion
         # at the same time.
         if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
@@ -1224,8 +1245,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 "connected": False,
             }
         try:
+            proposal_gate.bind(topic, expected_nav_id)
             proposal_node.bind(topic, on_velocity_proposal)
-            proposal_gate.bind(topic)
             proposal_connected.set()
             refresh_fsm_state()
         except Exception as exc:
@@ -1618,7 +1639,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             elif method == "get_state":
                 result = handle_get_state()
             elif method == "bind_velocity_proposal":
-                result = handle_bind_velocity_proposal(cmd.get("topic", ""))
+                result = handle_bind_velocity_proposal(
+                    cmd.get("topic", ""),
+                    cmd.get("expected_nav_id", ""),
+                )
             elif method == "unbind_velocity_proposal":
                 result = handle_unbind_velocity_proposal(
                     cmd.get("reason", "canvas_stop")

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -5,7 +5,8 @@ drivers/unitree/g1/safety_harness.py — SmartMotion 独立进程安全层。
 架构：
   - SmartMotionProcess: 独立子进程，拥有自己的 DDS 通道和 ROS2 节点
     - 订阅 LiDAR 点云，10Hz 全量 numpy 处理
-    - 执行 LocoClient / SlamClient RPC 调用
+    - 在本地执行停止、FSM 和 SlamClient RPC
+    - 将安全判定通过的 proposal SetVelocity 有界交给主进程 Driver RPC
     - 发布运动事件到 ROS2 topic
   - SmartMotionProxy: 主进程中的轻量代理，通过 multiprocessing Queue 通信
     - 对外暴露与原 SmartMotion 相同的 API
@@ -300,6 +301,145 @@ def issue_stop_and_confirm(
     )
 
 
+@dataclass
+class ProposalApplyDiagnostics:
+    """Process-lifetime proposal receive/apply evidence for ``loco info``."""
+
+    received: int = 0
+    accepted: int = 0
+    rejected: int = 0
+    applied: int = 0
+    last_rejection_reason: Optional[str] = None
+    last_set_velocity_ret: Optional[int] = None
+    last_set_velocity_error: Optional[str] = None
+    last_set_velocity_request_id: Optional[int] = None
+    last_set_velocity_duration_ms: Optional[int] = None
+    last_set_velocity_completed_monotonic: Optional[float] = None
+    last_set_velocity_completed_unix_ms: Optional[int] = None
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock,
+        init=False,
+        repr=False,
+    )
+
+    def record_received(self) -> None:
+        with self._lock:
+            self.received += 1
+
+    def record_accepted(self) -> None:
+        with self._lock:
+            self.accepted += 1
+
+    def record_rejected(self, reason: str) -> None:
+        with self._lock:
+            self.rejected += 1
+            self.last_rejection_reason = reason
+
+    def record_set_velocity(self, result: dict, duration: float) -> None:
+        completed_monotonic = result.get("completed_monotonic")
+        completed_unix_ms = result.get("completed_unix_ms")
+        with self._lock:
+            self.last_set_velocity_ret = result.get("ret")
+            self.last_set_velocity_error = result.get("error")
+            self.last_set_velocity_request_id = result.get("request_id")
+            self.last_set_velocity_duration_ms = max(
+                0,
+                round(float(duration) * 1000),
+            )
+            self.last_set_velocity_completed_monotonic = (
+                float(completed_monotonic)
+                if completed_monotonic is not None
+                else None
+            )
+            self.last_set_velocity_completed_unix_ms = (
+                int(completed_unix_ms)
+                if completed_unix_ms is not None
+                else None
+            )
+
+    def record_applied(self) -> None:
+        with self._lock:
+            self.applied += 1
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            return {
+                "received": self.received,
+                "accepted": self.accepted,
+                "rejected": self.rejected,
+                "applied": self.applied,
+                "last_rejection_reason": self.last_rejection_reason,
+                "last_set_velocity_ret": self.last_set_velocity_ret,
+                "last_set_velocity_error": self.last_set_velocity_error,
+                "last_set_velocity_request_id": (
+                    self.last_set_velocity_request_id
+                ),
+                "last_set_velocity_duration_ms": (
+                    self.last_set_velocity_duration_ms
+                ),
+                "last_set_velocity_completed_monotonic": (
+                    self.last_set_velocity_completed_monotonic
+                ),
+                "last_set_velocity_completed_unix_ms": (
+                    self.last_set_velocity_completed_unix_ms
+                ),
+            }
+
+
+def request_parent_set_velocity(
+    request_queue,
+    result_queue,
+    request_id: int,
+    vx: float,
+    vy: float,
+    vyaw: float,
+    duration: float,
+    timeout: float,
+) -> dict:
+    """Request one finite SetVelocity from the parent and wait boundedly."""
+    started = time.monotonic()
+    try:
+        request_queue.put({
+            "request_id": request_id,
+            "vx": vx,
+            "vy": vy,
+            "vyaw": vyaw,
+            "duration": duration,
+        })
+    except Exception as exc:
+        return {
+            "request_id": request_id,
+            "ret": None,
+            "error": f"parent_set_velocity_ipc_error: {exc}",
+            "completed_monotonic": time.monotonic(),
+            "completed_unix_ms": round(time.time() * 1000),
+        }
+
+    deadline = started + max(0.0, float(timeout))
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0.0:
+            return {
+                "request_id": request_id,
+                "ret": None,
+                "error": "parent_set_velocity_timeout",
+                "completed_monotonic": time.monotonic(),
+                "completed_unix_ms": round(time.time() * 1000),
+            }
+        try:
+            result = result_queue.get(timeout=remaining)
+        except queue.Empty:
+            return {
+                "request_id": request_id,
+                "ret": None,
+                "error": "parent_set_velocity_timeout",
+                "completed_monotonic": time.monotonic(),
+                "completed_unix_ms": round(time.time() * 1000),
+            }
+        if result.get("request_id") == request_id:
+            return result
+
+
 # ── SmartMotionProxy (main process) ─────────────────────────────────────────
 
 class SmartMotionProxy:
@@ -307,20 +447,32 @@ class SmartMotionProxy:
 
     def __init__(self, namespace: str, config: dict, network_iface: str,
                  proposal_config: Optional[dict] = None,
-                 fallback_stop=None):
+                 fallback_stop=None, parent_set_velocity=None):
         ctx = mp.get_context("spawn")
         self._cmd_queue = ctx.Queue()
         self._result_queue = ctx.Queue()
+        self._parent_velocity_queue = ctx.Queue()
+        self._parent_velocity_result_queue = ctx.Queue()
         self._call_lock = threading.RLock()
         self._request_id = 0
+        self._fallback_stop = fallback_stop
+        self._parent_set_velocity = parent_set_velocity
+        self._parent_velocity_shutdown = threading.Event()
         self._proc = ctx.Process(
             target=_run_smart_motion_process,
             args=(namespace, config, proposal_config or {}, network_iface,
-                  self._cmd_queue, self._result_queue),
+                  self._cmd_queue, self._result_queue,
+                  self._parent_velocity_queue,
+                  self._parent_velocity_result_queue),
             name="smart_motion", daemon=True,
         )
         self._proc.start()
-        self._fallback_stop = fallback_stop
+        self._parent_velocity_thread = threading.Thread(
+            target=self._serve_parent_velocity_requests,
+            daemon=True,
+            name="smart_motion_parent_velocity",
+        )
+        self._parent_velocity_thread.start()
         self._exit_monitor = threading.Thread(
             target=self._monitor_process_exit,
             daemon=True,
@@ -328,6 +480,42 @@ class SmartMotionProxy:
         )
         self._exit_monitor.start()
         print(f"[SmartMotionProxy] subprocess started → pid={self._proc.pid}")
+
+    def _serve_parent_velocity_requests(self) -> None:
+        """Execute child-approved SetVelocity calls on the parent RpcProxy."""
+        while True:
+            request = self._parent_velocity_queue.get()
+            if request is None:
+                return
+            request_id = request.get("request_id")
+            ret = None
+            error = None
+            try:
+                if self._parent_set_velocity is None:
+                    raise RuntimeError("parent SetVelocity RPC is unavailable")
+                ret = self._parent_set_velocity(
+                    request["vx"],
+                    request["vy"],
+                    request["vyaw"],
+                    request["duration"],
+                )
+            except Exception as exc:
+                error = str(exc)
+            self._parent_velocity_result_queue.put({
+                "request_id": request_id,
+                "ret": ret,
+                "error": error,
+                "completed_monotonic": time.monotonic(),
+                "completed_unix_ms": round(time.time() * 1000),
+            })
+
+    def _signal_parent_velocity_shutdown(self) -> None:
+        shutdown = getattr(self, "_parent_velocity_shutdown", None)
+        request_queue = getattr(self, "_parent_velocity_queue", None)
+        if shutdown is None or request_queue is None or shutdown.is_set():
+            return
+        shutdown.set()
+        request_queue.put(None)
 
     def _monitor_process_exit(self) -> None:
         """Issue an independent parent-side stop on every child exit.
@@ -337,15 +525,16 @@ class SmartMotionProxy:
         after an IPC timeout, where Python cleanup cannot be relied upon.
         """
         self._proc.join()
-        if self._fallback_stop is None:
-            return
         try:
-            self._fallback_stop()
+            if self._fallback_stop is not None:
+                self._fallback_stop()
         except Exception as exc:
             print(
                 f"[SmartMotionProxy] child-exit StopMove failed: {exc}",
                 flush=True,
             )
+        finally:
+            self._signal_parent_velocity_shutdown()
 
     def _call(self, method: str, timeout: float = 15.0, **kwargs) -> dict:
         """Serialize calls and correlate replies across HTTP/ROS threads."""
@@ -483,6 +672,8 @@ class SmartMotionProxy:
         # Ensure the parent-side child-exit StopMove completes before the
         # caller tears down the independent RpcProxy used by that callback.
         self._exit_monitor.join(timeout=2.0)
+        self._signal_parent_velocity_shutdown()
+        self._parent_velocity_thread.join(timeout=2.0)
         print("[SmartMotionProxy] subprocess stopped")
 
 
@@ -490,7 +681,9 @@ class SmartMotionProxy:
 
 def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dict,
                               network_iface: str, cmd_queue: mp.Queue,
-                              result_queue: mp.Queue):
+                              result_queue: mp.Queue,
+                              parent_velocity_queue: mp.Queue,
+                              parent_velocity_result_queue: mp.Queue):
     """Entry point for the SmartMotion subprocess.
 
     Initializes its own DDS channel, RPC clients, ROS2 node, and LiDAR subscription.
@@ -529,8 +722,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     loco_client.Init()
     loco_client.SetTimeout(10.0)
 
-    # Proposal execution, stopping, watchdog stopping and FSM polling use
-    # independent RPC clients so a delayed call cannot block physical stop.
+    # Proposal execution is deliberately routed back through the parent
+    # Driver RpcProxy.  Stopping, watchdog stopping and FSM polling retain
+    # independent child clients so a delayed apply cannot block fail-closed
+    # stop paths.
     proposal_rpc_timeout = min(
         0.2, max(0.02, float(proposal_config.get("velocity_proposal_rpc_timeout", 0.1)))
     )
@@ -549,9 +744,6 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     fsm_rpc_timeout = min(
         0.5, max(0.05, float(proposal_config.get("velocity_proposal_fsm_rpc_timeout", 0.2)))
     )
-    proposal_loco_client = LocoClient()
-    proposal_loco_client.Init()
-    proposal_loco_client.SetTimeout(proposal_rpc_timeout)
     stop_loco_client = LocoClient()
     stop_loco_client.Init()
     stop_loco_client.SetTimeout(stop_rpc_timeout)
@@ -566,7 +758,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     slam_client.Init()
     slam_client.SetTimeout(10.0)  # must be AFTER Init() — Init() resets timeout to 5.0
 
-    print(f"[SmartMotion:pid={os.getpid()}] LocoClient + SlamClient ready")
+    print(
+        f"[SmartMotion:pid={os.getpid()}] stop/FSM LocoClient + "
+        "parent proposal RPC + SlamClient ready"
+    )
 
     # ── Initialize ROS2 ──
     rclpy.init()
@@ -696,6 +891,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     proposal_execution_active = False
     proposal_execution_deadline = 0.0
     proposal_watchdog_fault = None
+    proposal_apply_request_id = 0
+    proposal_apply_diagnostics = ProposalApplyDiagnostics()
 
     def motion_synchronized(func):
         def locked(*args, **kwargs):
@@ -731,6 +928,22 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     def current_proposal_watchdog_fault():
         with proposal_execution_lock:
             return proposal_watchdog_fault
+
+    def apply_parent_set_velocity(vx, vy, vyaw, duration):
+        nonlocal proposal_apply_request_id
+        proposal_apply_request_id += 1
+        result = request_parent_set_velocity(
+            request_queue=parent_velocity_queue,
+            result_queue=parent_velocity_result_queue,
+            request_id=proposal_apply_request_id,
+            vx=vx,
+            vy=vy,
+            vyaw=vyaw,
+            duration=duration,
+            timeout=proposal_rpc_timeout,
+        )
+        proposal_apply_diagnostics.record_set_velocity(result, duration)
+        return result
 
     # Obstacle state (written by LiDAR callback, read by main loop)
     obstacle_lock = threading.Lock()
@@ -1272,13 +1485,16 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         speed_zone = SpeedZone.NORMAL
 
         proposal_generation = None
+        set_velocity_error = None
         if finite_rpc:
             proposal_generation = arm_proposal_execution(
                 time.monotonic() + duration
             )
-            ret = proposal_loco_client.SetVelocity(
+            apply_result = apply_parent_set_velocity(
                 clamped_vx, clamped_vy, clamped_vyaw, duration
             )
+            ret = apply_result.get("ret")
+            set_velocity_error = apply_result.get("error")
         else:
             clear_proposal_execution()
             ret = loco_client.Move(clamped_vx, clamped_vy, clamped_vyaw, True)
@@ -1294,6 +1510,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 "duration": duration,
                 "state": state.value,
                 "watchdog_reason": watchdog_reason,
+                "set_velocity_error": set_velocity_error,
             }
 
         if duration > 0 and not finite_rpc:
@@ -1324,8 +1541,15 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 },
             })
 
-        return {"ret": ret, "vx": clamped_vx, "vy": clamped_vy, "vyaw": clamped_vyaw,
-                "duration": duration, "state": state.value}
+        return {
+            "ret": ret,
+            "vx": clamped_vx,
+            "vy": clamped_vy,
+            "vyaw": clamped_vyaw,
+            "duration": duration,
+            "state": state.value,
+            "set_velocity_error": set_velocity_error,
+        }
 
     @motion_synchronized
     def handle_navigate_to(x, y, yaw, target_name, speed=0.5, mode=1, stall_timeout=60):
@@ -1709,28 +1933,33 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             "expected_topic": expected_proposal_topic,
             "schema": proposal_limits.schema,
             "safety": proposal_runtime_status(force_fsm_check=False),
+            "proposal_execution": proposal_apply_diagnostics.snapshot(),
         })
         return result
 
     @motion_synchronized
     def on_velocity_proposal(msg):
         nonlocal last_nav_status_time
+        proposal_apply_diagnostics.record_received()
         if proposal_stop_transition.is_set():
+            proposal_apply_diagnostics.record_rejected("stop_transition")
             return
         now = time.monotonic()
         pending_fault = current_proposal_watchdog_fault()
         if pending_fault:
             _, reason = pending_fault
+            proposal_apply_diagnostics.record_rejected(reason)
             if reason == "proposal_ttl_expired":
                 proposal_gate.watchdog(now)
                 do_stop(reason)
             else:
                 proposal_gate.disarm(reason)
                 do_stop(reason)
-                return
+            return
         try:
             payload = json.loads(msg.data)
         except (json.JSONDecodeError, TypeError, AttributeError):
+            proposal_apply_diagnostics.record_rejected("invalid_json")
             if proposal_gate.armed:
                 proposal_gate.disarm("invalid_json")
                 do_stop("invalid_json")
@@ -1739,6 +1968,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         was_armed = proposal_gate.armed
         decision = proposal_gate.accept(payload, now)
         if decision.stop:
+            if decision.reason != "proposal_zero":
+                proposal_apply_diagnostics.record_rejected(decision.reason)
             is_proposal_motion = bool(
                 current_cmd and current_cmd.get("source") == "velocity_proposal"
             )
@@ -1747,6 +1978,9 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 do_stop(decision.reason)
             return
         if not decision.execute or decision.proposal is None:
+            proposal_apply_diagnostics.record_rejected(
+                decision.reason or "proposal_not_executable"
+            )
             return
 
         with safety_lock:
@@ -1757,6 +1991,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         runtime = proposal_runtime_status(force_fsm_check=True)
         if not runtime["ready"]:
             reason = runtime["reason"] or "driver_safety_not_ready"
+            proposal_apply_diagnostics.record_rejected(reason)
             proposal_gate.disarm(reason)
             do_stop(reason)
             return
@@ -1764,9 +1999,13 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         proposal = decision.proposal
         remaining = proposal_gate.deadline_monotonic - time.monotonic()
         if remaining <= 0.0:
+            proposal_apply_diagnostics.record_rejected(
+                "proposal_ttl_expired"
+            )
             proposal_gate.watchdog(time.monotonic())
             do_stop("proposal_ttl_expired")
             return
+        proposal_apply_diagnostics.record_accepted()
         result = handle_move(
             proposal.x,
             proposal.y,
@@ -1777,6 +2016,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         )
         watchdog_reason = result.get("watchdog_reason")
         if watchdog_reason:
+            proposal_apply_diagnostics.record_rejected(watchdog_reason)
             if watchdog_reason != "proposal_ttl_expired":
                 proposal_gate.disarm(watchdog_reason)
             else:
@@ -1784,9 +2024,18 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             do_stop(watchdog_reason)
             return
         ret = result.get("ret")
-        if ret not in (None, 0):
-            proposal_gate.disarm("set_velocity_failed")
-            do_stop("set_velocity_failed")
+        set_velocity_error = result.get("set_velocity_error")
+        if set_velocity_error or ret != 0:
+            reason = (
+                "parent_set_velocity_timeout"
+                if set_velocity_error == "parent_set_velocity_timeout"
+                else "set_velocity_failed"
+            )
+            proposal_apply_diagnostics.record_rejected(reason)
+            proposal_gate.disarm(reason)
+            do_stop(reason)
+            return
+        proposal_apply_diagnostics.record_applied()
 
     @motion_synchronized
     def apply_safety_velocity(cmd, vx, vy, vyaw):
@@ -1797,10 +2046,16 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 proposal_gate.watchdog(time.monotonic())
                 do_stop("proposal_ttl_expired")
                 return
-            ret = proposal_loco_client.SetVelocity(vx, vy, vyaw, remaining)
-            if ret != 0:
-                proposal_gate.disarm("set_velocity_failed")
-                do_stop("set_velocity_failed")
+            result = apply_parent_set_velocity(vx, vy, vyaw, remaining)
+            if result.get("error") or result.get("ret") != 0:
+                reason = (
+                    "parent_set_velocity_timeout"
+                    if result.get("error") == "parent_set_velocity_timeout"
+                    else "set_velocity_failed"
+                )
+                proposal_apply_diagnostics.record_rejected(reason)
+                proposal_gate.disarm(reason)
+                do_stop(reason)
             return
         loco_client.Move(vx, vy, vyaw, True)
 

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -474,6 +474,35 @@ def velocity_commands_differ(current, target, abs_tol: float = 1e-9) -> bool:
     )
 
 
+def put_latest(command_queue, command) -> bool:
+    """Insert one command and replace, rather than backlog, an older one.
+
+    Returns true when a queued command was coalesced away.  The consumer may
+    race with replacement, but a capacity-one queue can never retain more than
+    the newest command available at the replacement boundary.
+    """
+    coalesced = False
+    while True:
+        try:
+            command_queue.put_nowait(command)
+            return coalesced
+        except queue.Full:
+            try:
+                command_queue.get_nowait()
+                coalesced = True
+            except queue.Empty:
+                pass
+
+
+def percentile_ms(samples, percentile):
+    """Return a nearest-rank latency percentile for diagnostics."""
+    if not samples:
+        return None
+    ordered = sorted(int(value) for value in samples)
+    rank = max(1, math.ceil(float(percentile) * len(ordered)))
+    return ordered[min(len(ordered) - 1, rank - 1)]
+
+
 @dataclass
 class ProposalApplyDiagnostics:
     """Current or most recent nav-lease execution evidence for ``loco info``."""
@@ -483,6 +512,7 @@ class ProposalApplyDiagnostics:
     accepted: int = 0
     rejected: int = 0
     applied: int = 0
+    coalesced: int = 0
     first_received_monotonic: Optional[float] = None
     last_received_monotonic: Optional[float] = None
     last_receive_gap_ms: Optional[int] = None
@@ -501,6 +531,8 @@ class ProposalApplyDiagnostics:
     last_set_velocity_applied: Optional[bool] = None
     last_set_velocity_request_id: Optional[int] = None
     last_set_velocity_duration_ms: Optional[int] = None
+    last_set_velocity_queue_delay_ms: Optional[int] = None
+    last_set_velocity_end_to_end_ms: Optional[int] = None
     last_set_velocity_completed_monotonic: Optional[float] = None
     last_set_velocity_completed_unix_ms: Optional[int] = None
     last_set_velocity_stop_ret: Optional[int] = None
@@ -515,6 +547,11 @@ class ProposalApplyDiagnostics:
         init=False,
         repr=False,
     )
+    _set_velocity_rpc_durations_ms: deque = field(
+        default_factory=lambda: deque(maxlen=512),
+        init=False,
+        repr=False,
+    )
 
     def begin_session(self, nav_id: str) -> None:
         """Reset per-lease counters while retaining them after later cleanup."""
@@ -524,6 +561,7 @@ class ProposalApplyDiagnostics:
             self.accepted = 0
             self.rejected = 0
             self.applied = 0
+            self.coalesced = 0
             self.first_received_monotonic = None
             self.last_received_monotonic = None
             self.last_receive_gap_ms = None
@@ -542,11 +580,14 @@ class ProposalApplyDiagnostics:
             self.last_set_velocity_applied = None
             self.last_set_velocity_request_id = None
             self.last_set_velocity_duration_ms = None
+            self.last_set_velocity_queue_delay_ms = None
+            self.last_set_velocity_end_to_end_ms = None
             self.last_set_velocity_completed_monotonic = None
             self.last_set_velocity_completed_unix_ms = None
             self.last_set_velocity_stop_ret = None
             self.last_set_velocity_stop_error = None
             self._applied_identities = set()
+            self._set_velocity_rpc_durations_ms = deque(maxlen=512)
 
     def record_received(self, received_monotonic: Optional[float] = None) -> None:
         received = (
@@ -613,6 +654,10 @@ class ProposalApplyDiagnostics:
         with self._lock:
             self.accepted += 1
 
+    def record_coalesced(self) -> None:
+        with self._lock:
+            self.coalesced += 1
+
     def record_rejected(self, reason: str) -> None:
         with self._lock:
             self.rejected += 1
@@ -623,9 +668,46 @@ class ProposalApplyDiagnostics:
                 self.rejections_by_reason.get(reason, 0) + 1
             )
 
-    def record_set_velocity(self, result: dict, duration: float) -> None:
+    def record_set_velocity(
+        self,
+        result: dict,
+        queued_monotonic: Optional[float] = None,
+    ) -> None:
+        """Record measured RPC timing, never the proposal TTL budget."""
+        started_monotonic = result.get("started_monotonic")
         completed_monotonic = result.get("completed_monotonic")
         completed_unix_ms = result.get("completed_unix_ms")
+        duration_ms = result.get("duration_ms")
+        if (
+            duration_ms is None
+            and started_monotonic is not None
+            and completed_monotonic is not None
+        ):
+            duration_ms = max(
+                0,
+                round(
+                    (float(completed_monotonic) - float(started_monotonic))
+                    * 1000
+                ),
+            )
+        queue_delay_ms = None
+        end_to_end_ms = None
+        if queued_monotonic is not None and started_monotonic is not None:
+            queue_delay_ms = max(
+                0,
+                round(
+                    (float(started_monotonic) - float(queued_monotonic))
+                    * 1000
+                ),
+            )
+        if queued_monotonic is not None and completed_monotonic is not None:
+            end_to_end_ms = max(
+                0,
+                round(
+                    (float(completed_monotonic) - float(queued_monotonic))
+                    * 1000
+                ),
+            )
         with self._lock:
             self.last_set_velocity_rpc_method = result.get("rpc_method")
             request = result.get("request")
@@ -636,10 +718,17 @@ class ProposalApplyDiagnostics:
             self.last_set_velocity_error = result.get("error")
             self.last_set_velocity_applied = bool(result.get("applied"))
             self.last_set_velocity_request_id = result.get("request_id")
-            self.last_set_velocity_duration_ms = max(
-                0,
-                round(float(duration) * 1000),
+            self.last_set_velocity_duration_ms = (
+                max(0, int(duration_ms))
+                if duration_ms is not None
+                else None
             )
+            self.last_set_velocity_queue_delay_ms = queue_delay_ms
+            self.last_set_velocity_end_to_end_ms = end_to_end_ms
+            if duration_ms is not None:
+                self._set_velocity_rpc_durations_ms.append(
+                    max(0, int(duration_ms))
+                )
             self.last_set_velocity_completed_monotonic = (
                 float(completed_monotonic)
                 if completed_monotonic is not None
@@ -674,6 +763,7 @@ class ProposalApplyDiagnostics:
                 "accepted": self.accepted,
                 "rejected": self.rejected,
                 "applied": self.applied,
+                "coalesced": self.coalesced,
                 "first_received_monotonic": self.first_received_monotonic,
                 "last_received_monotonic": self.last_received_monotonic,
                 "last_receive_gap_ms": self.last_receive_gap_ms,
@@ -703,6 +793,32 @@ class ProposalApplyDiagnostics:
                 ),
                 "last_set_velocity_duration_ms": (
                     self.last_set_velocity_duration_ms
+                ),
+                "last_set_velocity_queue_delay_ms": (
+                    self.last_set_velocity_queue_delay_ms
+                ),
+                "last_set_velocity_end_to_end_ms": (
+                    self.last_set_velocity_end_to_end_ms
+                ),
+                "set_velocity_rpc_samples": len(
+                    self._set_velocity_rpc_durations_ms
+                ),
+                "set_velocity_rpc_p50_ms": percentile_ms(
+                    self._set_velocity_rpc_durations_ms,
+                    0.50,
+                ),
+                "set_velocity_rpc_p95_ms": percentile_ms(
+                    self._set_velocity_rpc_durations_ms,
+                    0.95,
+                ),
+                "set_velocity_rpc_p99_ms": percentile_ms(
+                    self._set_velocity_rpc_durations_ms,
+                    0.99,
+                ),
+                "set_velocity_rpc_max_ms": (
+                    max(self._set_velocity_rpc_durations_ms)
+                    if self._set_velocity_rpc_durations_ms
+                    else None
                 ),
                 "last_set_velocity_completed_monotonic": (
                     self.last_set_velocity_completed_monotonic
@@ -1396,7 +1512,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             )
         proposal_apply_diagnostics.record_set_velocity(
             result,
-            max(0.0, command["deadline_monotonic"] - command["queued_monotonic"]),
+            queued_monotonic=command["queued_monotonic"],
         )
         return result
 
@@ -1421,15 +1537,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
 
     def enqueue_proposal_apply(command):
         """Keep only the newest validated command while the parent RPC is busy."""
-        while True:
-            try:
-                proposal_apply_queue.put_nowait(command)
-                return
-            except queue.Full:
-                try:
-                    proposal_apply_queue.get_nowait()
-                except queue.Empty:
-                    pass
+        if put_latest(proposal_apply_queue, command):
+            proposal_apply_diagnostics.record_coalesced()
 
     def query_parent_fsm_id():
         nonlocal parent_loco_request_id
@@ -1496,9 +1605,19 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             reason_str,
             watchdog_fault,
         )
-        if watchdog_fault:
+        if watchdog_fault and reason_str != "proposal_ttl_expired":
             proposal_gate.disarm(reason_str)
-        retry_proposal_stop = was_proposal_motion and not confirm_physical_stop
+        recoverable_stop_requested = bool(
+            proposal_gate.armed
+            and reason_str in {"obstacle", "proposal_ttl_expired"}
+            and (was_proposal_motion or reason_str == "proposal_ttl_expired")
+        )
+        proposal_stop_context = bool(
+            was_proposal_motion or recoverable_stop_requested
+        )
+        retry_proposal_stop = (
+            proposal_stop_context and not confirm_physical_stop
+        )
         if move_timer:
             move_timer.cancel()
             move_timer = None
@@ -1506,7 +1625,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         clear_proposal_execution()
         was_moving = state == MotionState.MOVING
 
-        if was_proposal_motion and not confirm_physical_stop:
+        if proposal_stop_context and not confirm_physical_stop:
             # The independent client brakes immediately.  The ordered parent
             # StopMove then runs after any in-flight continuous SetVelocity,
             # preventing a late successful apply from restarting motion.
@@ -1621,11 +1740,16 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             }
             if stop_error:
                 result["error"] = f"StopMove failed: {stop_error}"
-        if was_proposal_motion and reason_str == "obstacle":
+        if recoverable_stop_requested:
             if result.get("stop_confirmed"):
-                proposal_gate.hold_for_obstacle()
+                proposal_gate.hold_after_confirmed_stop(reason_str)
             else:
-                proposal_gate.disarm("obstacle_stop_unconfirmed")
+                unconfirmed_reason = (
+                    "obstacle_stop_unconfirmed"
+                    if reason_str == "obstacle"
+                    else "proposal_ttl_stop_unconfirmed"
+                )
+                proposal_gate.disarm(unconfirmed_reason)
         if was_moving:
             event_data = {"reason": reason_str}
             if reason_str == "obstacle":
@@ -1636,7 +1760,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         result.update({"state": "idle", "reason": reason_str})
         if confirm_physical_stop:
             last_stop_result = dict(result)
-            if retry_proposal_stop:
+            if proposal_stop_context:
                 last_proposal_stop_result = dict(result)
         return result
 
@@ -2937,7 +3061,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     else:
                         reason = "set_velocity_failed"
                     proposal_apply_diagnostics.record_rejected(reason)
-                    proposal_gate.disarm(reason)
+                    if reason == "proposal_ttl_expired":
+                        proposal_gate.request_ttl_stop(time.monotonic())
+                    else:
+                        proposal_gate.disarm(reason)
                     do_stop(reason)
                     continue
                 proposal_apply_diagnostics.record_applied(

--- a/unitree/g1/tests/test_loco_topic_lifecycle.py
+++ b/unitree/g1/tests/test_loco_topic_lifecycle.py
@@ -90,6 +90,7 @@ class FakeSmartMotion:
     def __init__(self):
         self.bound_topic = ""
         self.expected_nav_id = ""
+        self.bind_result = None
         self.unbind_reasons = []
         self.unbind_result = {
             "state": "idle",
@@ -98,6 +99,8 @@ class FakeSmartMotion:
         }
 
     def bind_velocity_proposal(self, topic, expected_nav_id):
+        if self.bind_result is not None:
+            return dict(self.bind_result)
         self.bound_topic = topic
         self.expected_nav_id = expected_nav_id
         return {
@@ -188,6 +191,39 @@ class LocoTopicLifecycleTest(unittest.TestCase):
         self.assertFalse(result["connected"])
         self.assertEqual(result["error"], "expected_nav_id_required")
         self.assertEqual(self.smart_motion.bound_topic, "")
+        self.assertEqual(self.client.stop_count, 1)
+
+    def test_start_preserves_stop_confirmation_diagnostics_on_failure(self):
+        diagnostics = {
+            "stop_move_ret": 0,
+            "stop_move_error": None,
+            "confirmation_started_monotonic": 123.0,
+            "last_odometry_monotonic": 123.4,
+            "last_odometry_age_ms": 100,
+            "last_odometry_velocity": {"x": 0.04, "y": 0.0, "yaw": 0.0},
+            "odometry_callback_count": 42,
+            "odometry_callbacks_since_confirmation": 1,
+            "confirmation_timed_out": True,
+        }
+        self.smart_motion.bind_result = {
+            "error": "StopMove/odometry stop was not confirmed before proposal bind",
+            "connected": False,
+            "armed": False,
+            "stop_confirmed": False,
+            "stop_move_ret": 0,
+            "stop_move_error": None,
+            "stop_confirmation": diagnostics,
+        }
+
+        result = self.plugin.dispatch(
+            "start",
+            {"input_topic": self.topic, "expected_nav_id": self.nav_id},
+        )
+
+        self.assertEqual(result["state"], "error")
+        self.assertFalse(result["connected"])
+        self.assertEqual(result["stop_move_ret"], 0)
+        self.assertEqual(result["stop_confirmation"], diagnostics)
         self.assertEqual(self.client.stop_count, 1)
 
     def test_other_tools_do_not_bind_or_unbind_loco_topic(self):

--- a/unitree/g1/tests/test_loco_topic_lifecycle.py
+++ b/unitree/g1/tests/test_loco_topic_lifecycle.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+
+
+def _install_driver_import_stubs():
+    rclpy = types.ModuleType("rclpy")
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_qos = types.ModuleType("rclpy.qos")
+
+    class Node:
+        pass
+
+    class QoSProfile:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class EnumValue:
+        BEST_EFFORT = "best_effort"
+        RELIABLE = "reliable"
+        KEEP_LAST = "keep_last"
+        VOLATILE = "volatile"
+
+    rclpy_node.Node = Node
+    rclpy_qos.QoSProfile = QoSProfile
+    rclpy_qos.ReliabilityPolicy = EnumValue
+    rclpy_qos.HistoryPolicy = EnumValue
+    rclpy_qos.DurabilityPolicy = EnumValue
+
+    std_msgs = types.ModuleType("std_msgs")
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    std_msgs_msg.Header = type("Header", (), {})
+    std_msgs_msg.String = type("String", (), {})
+
+    audio_msgs = types.ModuleType("audio_msgs")
+    audio_msgs_msg = types.ModuleType("audio_msgs.msg")
+    audio_msgs_msg.AudioChunk = type("AudioChunk", (), {})
+
+    unitree_sdk = types.ModuleType("unitree_sdk2py")
+    unitree_g1 = types.ModuleType("unitree_sdk2py.g1")
+    unitree_audio = types.ModuleType("unitree_sdk2py.g1.audio")
+    unitree_audio_client = types.ModuleType("unitree_sdk2py.g1.audio.g1_audio_client")
+    unitree_audio_client.AudioClient = type("AudioClient", (), {})
+
+    pointcloud_utils = types.ModuleType("pointcloud_utils")
+    pointcloud_utils.gravity_align_inplace = lambda *args, **kwargs: None
+    numpy = types.ModuleType("numpy")
+
+    modules = {
+        "rclpy": rclpy,
+        "rclpy.node": rclpy_node,
+        "rclpy.qos": rclpy_qos,
+        "std_msgs": std_msgs,
+        "std_msgs.msg": std_msgs_msg,
+        "audio_msgs": audio_msgs,
+        "audio_msgs.msg": audio_msgs_msg,
+        "unitree_sdk2py": unitree_sdk,
+        "unitree_sdk2py.g1": unitree_g1,
+        "unitree_sdk2py.g1.audio": unitree_audio,
+        "unitree_sdk2py.g1.audio.g1_audio_client": unitree_audio_client,
+        "pointcloud_utils": pointcloud_utils,
+        "numpy": numpy,
+    }
+    for name, module in modules.items():
+        sys.modules.setdefault(name, module)
+
+
+_install_driver_import_stubs()
+
+from device import LocoPlugin  # noqa: E402
+
+
+class FakeClient:
+    def __init__(self):
+        self.stop_count = 0
+        self.fsm_ids = []
+
+    def StopMove(self):
+        self.stop_count += 1
+        return 0
+
+    def SetFsmId(self, fsm_id):
+        self.fsm_ids.append(fsm_id)
+        return 0
+
+
+class FakeSmartMotion:
+    def __init__(self):
+        self.bound_topic = ""
+        self.unbind_reasons = []
+        self.unbind_result = {
+            "state": "idle",
+            "connected": False,
+            "stop_confirmed": True,
+        }
+
+    def bind_velocity_proposal(self, topic):
+        self.bound_topic = topic
+        return {"connected": True, "armed": True, "topic": topic}
+
+    def unbind_velocity_proposal(self, reason):
+        self.unbind_reasons.append(reason)
+        result = dict(self.unbind_result)
+        if not result.get("connected"):
+            self.bound_topic = ""
+        return result
+
+    def get_velocity_proposal_status(self):
+        return {
+            "connected": bool(self.bound_topic),
+            "armed": bool(self.bound_topic),
+            "topic": self.bound_topic or None,
+        }
+
+
+class LocoTopicLifecycleTest(unittest.TestCase):
+    def setUp(self):
+        self.client = FakeClient()
+        self.smart_motion = FakeSmartMotion()
+        self.plugin = LocoPlugin(
+            {}, "ubuntu", executor=None, loco_client=self.client,
+            smart_motion=self.smart_motion,
+        )
+        self.topic = "/ubuntu/navigation/nav2/velocity_proposal"
+
+    def test_tool_exposes_velocity_proposal_input(self):
+        self.assertEqual(self.plugin.STOP_PRIORITY, 0)
+        tool = self.plugin.get_tools()[0]
+        port = tool["topic_in"]
+        self.assertEqual(len(port), 1)
+        self.assertEqual(port[0]["port"], "velocity_proposal")
+        self.assertEqual(port[0]["topic"], self.topic)
+        self.assertEqual(
+            tool["inputSchema"]["properties"]["action"]["enum"],
+            [
+                "move", "stop_move", "set_stand_height", "get_fsm_id",
+                "get_fsm_mode", "get_balance_mode", "get_swing_height",
+                "get_stand_height", "get_phase", "wave_hand", "shake_hand",
+            ],
+        )
+
+    def test_start_info_stop_owns_real_subscription_lifecycle(self):
+        started = self.plugin.dispatch("start", {"input_topic": self.topic})
+        self.assertTrue(started["connected"])
+        self.assertEqual(self.smart_motion.bound_topic, self.topic)
+
+        info = self.plugin.dispatch("info", {"_tool_name": "loco"})
+        self.assertTrue(info["connected"])
+        self.assertTrue(info["armed"])
+
+        stopped = self.plugin.dispatch("stop", {})
+        self.assertFalse(stopped["connected"])
+        self.assertTrue(stopped["stop_confirmed"])
+        self.assertEqual(self.smart_motion.unbind_reasons, ["canvas_stop"])
+
+    def test_start_accepts_exactly_one_input_topics_entry(self):
+        started = self.plugin.dispatch("start", {"input_topics": [self.topic]})
+        self.assertTrue(started["connected"])
+        self.assertEqual(self.smart_motion.bound_topic, self.topic)
+
+    def test_other_tools_do_not_bind_or_unbind_loco_topic(self):
+        self.smart_motion.bound_topic = self.topic
+
+        started = self.plugin.dispatch(
+            "start", {"_tool_name": "motion_events"}
+        )
+        stopped = self.plugin.dispatch(
+            "stop", {"_tool_name": "switch_mode"}
+        )
+
+        self.assertEqual(started, {"state": "running"})
+        self.assertEqual(stopped, {"state": "idle"})
+        self.assertEqual(self.smart_motion.bound_topic, self.topic)
+        self.assertEqual(self.smart_motion.unbind_reasons, [])
+        self.assertEqual(self.client.stop_count, 0)
+
+    def test_wrong_topic_fails_closed_without_binding(self):
+        self.smart_motion.bound_topic = self.topic
+        result = self.plugin.dispatch(
+            "start", {"input_topic": "/ubuntu/navigation/nav2/cmd_vel_shadow"}
+        )
+        self.assertEqual(result["state"], "error")
+        self.assertFalse(result["connected"])
+        self.assertEqual(self.client.stop_count, 1)
+        self.assertEqual(self.smart_motion.bound_topic, "")
+        self.assertEqual(self.smart_motion.unbind_reasons, ["proposal_bind_rejected"])
+
+    def test_missing_safety_harness_cannot_execute_topic(self):
+        plugin = LocoPlugin({}, "ubuntu", None, self.client, smart_motion=None)
+        result = plugin.dispatch("start", {"input_topic": self.topic})
+        self.assertEqual(result["state"], "error")
+        self.assertFalse(result["connected"])
+        self.assertEqual(self.client.stop_count, 1)
+
+    def test_unconfirmed_stop_falls_back_and_blocks_mode_switch(self):
+        self.smart_motion.bound_topic = self.topic
+        self.smart_motion.unbind_result = {
+            "state": "error",
+            "connected": True,
+            "stop_confirmed": False,
+            "error": "fresh zero-odometry stop was not confirmed",
+        }
+
+        result = self.plugin.dispatch("switch_mode_expert", {"fsm_id": 1})
+
+        self.assertEqual(result["state"], "error")
+        self.assertEqual(self.client.stop_count, 1)
+        self.assertEqual(self.client.fsm_ids, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_loco_topic_lifecycle.py
+++ b/unitree/g1/tests/test_loco_topic_lifecycle.py
@@ -94,6 +94,8 @@ class FakeSmartMotion:
     def __init__(self):
         self.bound_topic = ""
         self.expected_nav_id = ""
+        self.waiting_for_nav_id = False
+        self.binding_mode = None
         self.last_reason = None
         self.proposal_execution = {
             "received": 0,
@@ -115,14 +117,21 @@ class FakeSmartMotion:
         if self.bind_result is not None:
             return dict(self.bind_result)
         self.bound_topic = topic
-        self.expected_nav_id = expected_nav_id
+        self.expected_nav_id = expected_nav_id or ""
+        self.waiting_for_nav_id = not bool(expected_nav_id)
+        self.binding_mode = (
+            "explicit" if expected_nav_id else "first_valid_proposal"
+        )
         return {
             "state": "connected",
             "connected": True,
-            "armed": True,
+            "armed": bool(expected_nav_id),
+            "binding_mode": self.binding_mode,
+            "waiting_for_nav_id": self.waiting_for_nav_id,
+            "auto_bound_nav_id": None,
             "topic": topic,
-            "expected_nav_id": expected_nav_id,
-            "active_nav_id": expected_nav_id,
+            "expected_nav_id": expected_nav_id or None,
+            "active_nav_id": expected_nav_id or None,
         }
 
     def unbind_velocity_proposal(self, reason):
@@ -132,12 +141,17 @@ class FakeSmartMotion:
         if not result.get("connected"):
             self.bound_topic = ""
             self.expected_nav_id = ""
+            self.waiting_for_nav_id = False
+            self.binding_mode = None
         return result
 
     def get_velocity_proposal_status(self):
         return {
             "connected": bool(self.bound_topic),
-            "armed": bool(self.bound_topic),
+            "armed": bool(self.bound_topic and self.expected_nav_id),
+            "binding_mode": self.binding_mode,
+            "waiting_for_nav_id": self.waiting_for_nav_id,
+            "auto_bound_nav_id": None,
             "topic": self.bound_topic or None,
             "expected_nav_id": self.expected_nav_id or None,
             "active_nav_id": self.expected_nav_id or None,
@@ -223,12 +237,28 @@ class LocoTopicLifecycleTest(unittest.TestCase):
         self.assertTrue(started["connected"])
         self.assertEqual(self.smart_motion.bound_topic, self.topic)
 
-    def test_start_without_trusted_nav_id_fails_closed(self):
+    def test_start_without_nav_id_waits_for_first_valid_proposal(self):
         result = self.plugin.dispatch("start", {"input_topic": self.topic})
+
+        self.assertEqual(result["state"], "ready")
+        self.assertTrue(result["connected"])
+        self.assertFalse(result["armed"])
+        self.assertTrue(result["waiting_for_nav_id"])
+        self.assertEqual(result["binding_mode"], "first_valid_proposal")
+        self.assertIsNone(result["expected_nav_id"])
+        self.assertEqual(self.smart_motion.bound_topic, self.topic)
+        self.assertEqual(self.client.stop_count, 0)
+
+    def test_start_with_invalid_nav_id_still_fails_closed(self):
+        result = self.plugin.dispatch(
+            "start",
+            {"input_topic": self.topic, "expected_nav_id": 123},
+        )
 
         self.assertEqual(result["state"], "error")
         self.assertFalse(result["connected"])
-        self.assertEqual(result["error"], "expected_nav_id_required")
+        self.assertEqual(result["error"], "invalid_expected_nav_id")
+        self.assertEqual(result["message"], "invalid_expected_nav_id")
         self.assertEqual(self.smart_motion.bound_topic, "")
         self.assertEqual(self.client.stop_count, 1)
 

--- a/unitree/g1/tests/test_loco_topic_lifecycle.py
+++ b/unitree/g1/tests/test_loco_topic_lifecycle.py
@@ -94,6 +94,15 @@ class FakeSmartMotion:
     def __init__(self):
         self.bound_topic = ""
         self.expected_nav_id = ""
+        self.last_reason = None
+        self.proposal_execution = {
+            "received": 0,
+            "accepted": 0,
+            "rejected": 0,
+            "applied": 0,
+            "last_rejection_reason": None,
+            "last_set_velocity_ret": None,
+        }
         self.bind_result = None
         self.unbind_reasons = []
         self.unbind_result = {
@@ -118,6 +127,7 @@ class FakeSmartMotion:
 
     def unbind_velocity_proposal(self, reason):
         self.unbind_reasons.append(reason)
+        self.last_reason = reason
         result = dict(self.unbind_result)
         if not result.get("connected"):
             self.bound_topic = ""
@@ -131,6 +141,8 @@ class FakeSmartMotion:
             "topic": self.bound_topic or None,
             "expected_nav_id": self.expected_nav_id or None,
             "active_nav_id": self.expected_nav_id or None,
+            "last_reason": self.last_reason,
+            "proposal_execution": dict(self.proposal_execution),
         }
 
 
@@ -179,6 +191,29 @@ class LocoTopicLifecycleTest(unittest.TestCase):
         self.assertFalse(stopped["connected"])
         self.assertTrue(stopped["stop_confirmed"])
         self.assertEqual(self.smart_motion.unbind_reasons, ["canvas_stop"])
+
+    def test_info_retains_proposal_execution_diagnostics_after_unbind(self):
+        self.smart_motion.proposal_execution.update({
+            "received": 3,
+            "accepted": 2,
+            "rejected": 1,
+            "applied": 1,
+            "last_rejection_reason": "set_velocity_failed",
+            "last_set_velocity_ret": 3104,
+        })
+        self.plugin.dispatch(
+            "start",
+            {"input_topic": self.topic, "expected_nav_id": self.nav_id},
+        )
+
+        self.plugin.dispatch("stop", {})
+        info = self.plugin.dispatch("info", {"_tool_name": "loco"})
+
+        self.assertEqual(info["last_reason"], "canvas_stop")
+        self.assertEqual(
+            info["proposal_execution"],
+            self.smart_motion.proposal_execution,
+        )
 
     def test_start_accepts_exactly_one_input_topics_entry(self):
         started = self.plugin.dispatch(

--- a/unitree/g1/tests/test_loco_topic_lifecycle.py
+++ b/unitree/g1/tests/test_loco_topic_lifecycle.py
@@ -89,6 +89,7 @@ class FakeClient:
 class FakeSmartMotion:
     def __init__(self):
         self.bound_topic = ""
+        self.expected_nav_id = ""
         self.unbind_reasons = []
         self.unbind_result = {
             "state": "idle",
@@ -96,15 +97,24 @@ class FakeSmartMotion:
             "stop_confirmed": True,
         }
 
-    def bind_velocity_proposal(self, topic):
+    def bind_velocity_proposal(self, topic, expected_nav_id):
         self.bound_topic = topic
-        return {"connected": True, "armed": True, "topic": topic}
+        self.expected_nav_id = expected_nav_id
+        return {
+            "state": "connected",
+            "connected": True,
+            "armed": True,
+            "topic": topic,
+            "expected_nav_id": expected_nav_id,
+            "active_nav_id": expected_nav_id,
+        }
 
     def unbind_velocity_proposal(self, reason):
         self.unbind_reasons.append(reason)
         result = dict(self.unbind_result)
         if not result.get("connected"):
             self.bound_topic = ""
+            self.expected_nav_id = ""
         return result
 
     def get_velocity_proposal_status(self):
@@ -112,6 +122,8 @@ class FakeSmartMotion:
             "connected": bool(self.bound_topic),
             "armed": bool(self.bound_topic),
             "topic": self.bound_topic or None,
+            "expected_nav_id": self.expected_nav_id or None,
+            "active_nav_id": self.expected_nav_id or None,
         }
 
 
@@ -124,6 +136,7 @@ class LocoTopicLifecycleTest(unittest.TestCase):
             smart_motion=self.smart_motion,
         )
         self.topic = "/ubuntu/navigation/nav2/velocity_proposal"
+        self.nav_id = "nav-001"
 
     def test_tool_exposes_velocity_proposal_input(self):
         self.assertEqual(self.plugin.STOP_PRIORITY, 0)
@@ -142,9 +155,14 @@ class LocoTopicLifecycleTest(unittest.TestCase):
         )
 
     def test_start_info_stop_owns_real_subscription_lifecycle(self):
-        started = self.plugin.dispatch("start", {"input_topic": self.topic})
+        started = self.plugin.dispatch(
+            "start",
+            {"input_topic": self.topic, "expected_nav_id": self.nav_id},
+        )
         self.assertTrue(started["connected"])
+        self.assertEqual(started["state"], "ready")
         self.assertEqual(self.smart_motion.bound_topic, self.topic)
+        self.assertEqual(self.smart_motion.expected_nav_id, self.nav_id)
 
         info = self.plugin.dispatch("info", {"_tool_name": "loco"})
         self.assertTrue(info["connected"])
@@ -156,9 +174,21 @@ class LocoTopicLifecycleTest(unittest.TestCase):
         self.assertEqual(self.smart_motion.unbind_reasons, ["canvas_stop"])
 
     def test_start_accepts_exactly_one_input_topics_entry(self):
-        started = self.plugin.dispatch("start", {"input_topics": [self.topic]})
+        started = self.plugin.dispatch(
+            "start",
+            {"input_topics": [self.topic], "expected_nav_id": self.nav_id},
+        )
         self.assertTrue(started["connected"])
         self.assertEqual(self.smart_motion.bound_topic, self.topic)
+
+    def test_start_without_trusted_nav_id_fails_closed(self):
+        result = self.plugin.dispatch("start", {"input_topic": self.topic})
+
+        self.assertEqual(result["state"], "error")
+        self.assertFalse(result["connected"])
+        self.assertEqual(result["error"], "expected_nav_id_required")
+        self.assertEqual(self.smart_motion.bound_topic, "")
+        self.assertEqual(self.client.stop_count, 1)
 
     def test_other_tools_do_not_bind_or_unbind_loco_topic(self):
         self.smart_motion.bound_topic = self.topic
@@ -179,7 +209,11 @@ class LocoTopicLifecycleTest(unittest.TestCase):
     def test_wrong_topic_fails_closed_without_binding(self):
         self.smart_motion.bound_topic = self.topic
         result = self.plugin.dispatch(
-            "start", {"input_topic": "/ubuntu/navigation/nav2/cmd_vel_shadow"}
+            "start",
+            {
+                "input_topic": "/ubuntu/navigation/nav2/cmd_vel_shadow",
+                "expected_nav_id": self.nav_id,
+            },
         )
         self.assertEqual(result["state"], "error")
         self.assertFalse(result["connected"])
@@ -189,7 +223,10 @@ class LocoTopicLifecycleTest(unittest.TestCase):
 
     def test_missing_safety_harness_cannot_execute_topic(self):
         plugin = LocoPlugin({}, "ubuntu", None, self.client, smart_motion=None)
-        result = plugin.dispatch("start", {"input_topic": self.topic})
+        result = plugin.dispatch(
+            "start",
+            {"input_topic": self.topic, "expected_nav_id": self.nav_id},
+        )
         self.assertEqual(result["state"], "error")
         self.assertFalse(result["connected"])
         self.assertEqual(self.client.stop_count, 1)

--- a/unitree/g1/tests/test_loco_topic_lifecycle.py
+++ b/unitree/g1/tests/test_loco_topic_lifecycle.py
@@ -75,11 +75,15 @@ from device import LocoPlugin  # noqa: E402
 class FakeClient:
     def __init__(self):
         self.stop_count = 0
+        self.stop_ret = 0
+        self.stop_error = None
         self.fsm_ids = []
 
     def StopMove(self):
         self.stop_count += 1
-        return 0
+        if self.stop_error is not None:
+            raise self.stop_error
+        return self.stop_ret
 
     def SetFsmId(self, fsm_id):
         self.fsm_ids.append(fsm_id)
@@ -224,6 +228,35 @@ class LocoTopicLifecycleTest(unittest.TestCase):
         self.assertFalse(result["connected"])
         self.assertEqual(result["stop_move_ret"], 0)
         self.assertEqual(result["stop_confirmation"], diagnostics)
+        self.assertEqual(result["fallback_stop_ret"], 0)
+        self.assertIsNone(result["fallback_stop_error"])
+        self.assertEqual(self.client.stop_count, 1)
+
+    def test_start_preserves_child_diagnostics_when_fallback_stop_raises(self):
+        diagnostics = {
+            "stop_move_ret": 3104,
+            "stop_move_error": None,
+            "confirmation_timed_out": False,
+        }
+        self.smart_motion.bind_result = {
+            "error": "StopMove/odometry stop was not confirmed before proposal bind",
+            "connected": False,
+            "armed": False,
+            "stop_confirmed": False,
+            "stop_move_ret": 3104,
+            "stop_move_error": None,
+            "stop_confirmation": diagnostics,
+        }
+        self.client.stop_error = RuntimeError("fallback unavailable")
+
+        result = self.plugin.dispatch(
+            "start",
+            {"input_topic": self.topic, "expected_nav_id": self.nav_id},
+        )
+
+        self.assertEqual(result["stop_confirmation"], diagnostics)
+        self.assertIsNone(result["fallback_stop_ret"])
+        self.assertEqual(result["fallback_stop_error"], "fallback unavailable")
         self.assertEqual(self.client.stop_count, 1)
 
     def test_other_tools_do_not_bind_or_unbind_loco_topic(self):

--- a/unitree/g1/tests/test_navigation_pointcloud.py
+++ b/unitree/g1/tests/test_navigation_pointcloud.py
@@ -1,0 +1,166 @@
+import struct
+import sys
+import unittest
+
+# Some legacy Driver tests install a minimal numpy import stub before importing
+# device.py. Restore the real dependency when the complete suite runs in one
+# interpreter so this numeric conversion test remains order-independent.
+if not hasattr(sys.modules.get("numpy"), "dtype"):
+    sys.modules.pop("numpy", None)
+import numpy as np
+
+from navigation_pointcloud import (
+    FAST_LIVO_FIELDS,
+    FAST_LIVO_POINT_STEP,
+    FLOAT32,
+    UINT16,
+    rotate_covariance9,
+    rotate_orientation_xyzw,
+    rotate_vector3,
+    unitree_mid360_to_fast_livo,
+    validated_rotation_matrix,
+)
+
+
+UNITREE_FIELDS = [
+    ("x", 0, FLOAT32, 1),
+    ("y", 4, FLOAT32, 1),
+    ("z", 8, FLOAT32, 1),
+    ("intensity", 12, FLOAT32, 1),
+    ("ring", 16, UINT16, 1),
+    ("time", 18, FLOAT32, 1),
+]
+
+
+class Mid360ConversionTest(unittest.TestCase):
+    def make_cloud(self):
+        data = bytearray(2 * 22)
+        struct.pack_into("<ffffHf", data, 0, 1.0, 2.0, 3.0, 42.0, 0, 5_000.0)
+        struct.pack_into(
+            "<ffffHf", data, 22, -1.0, -2.0, -3.0, 163.0, 3, 100_320_000.0
+        )
+        return bytes(data)
+
+    def decode(self, converted):
+        dtype = np.dtype(
+            {
+                "names": [field.name for field in FAST_LIVO_FIELDS],
+                "formats": ["<f4", "<f4", "<f4", "<f4", "u1", "u1", "<f8"],
+                "offsets": [field.offset for field in FAST_LIVO_FIELDS],
+                "itemsize": FAST_LIVO_POINT_STEP,
+            }
+        )
+        return np.frombuffer(converted, dtype=dtype)
+
+    def test_converts_relative_time_to_absolute_nanoseconds(self):
+        header_ns = 1_785_811_000_000_000_000
+        converted = unitree_mid360_to_fast_livo(
+            data=self.make_cloud(),
+            point_count=2,
+            point_step=22,
+            fields=UNITREE_FIELDS,
+            header_stamp_ns=header_ns,
+        )
+        points = self.decode(converted)
+
+        self.assertEqual(len(converted), 2 * FAST_LIVO_POINT_STEP)
+        np.testing.assert_allclose(points["x"], [1.0, -1.0])
+        np.testing.assert_allclose(points["intensity"], [42.0, 163.0])
+        np.testing.assert_array_equal(points["tag"], [0x10, 0x10])
+        np.testing.assert_array_equal(points["line"], [0, 3])
+        np.testing.assert_allclose(
+            points["timestamp"] - np.float64(header_ns),
+            [5_000.0, 100_320_000.0],
+            atol=256.0,
+        )
+
+    def test_rejects_missing_time_field(self):
+        with self.assertRaisesRegex(ValueError, "missing MID360 field: time"):
+            unitree_mid360_to_fast_livo(
+                data=self.make_cloud(),
+                point_count=2,
+                point_step=22,
+                fields=[field for field in UNITREE_FIELDS if field[0] != "time"],
+                header_stamp_ns=1_000_000_000,
+            )
+
+    def test_rejects_short_data(self):
+        with self.assertRaisesRegex(ValueError, "shorter"):
+            unitree_mid360_to_fast_livo(
+                data=b"short",
+                point_count=2,
+                point_step=22,
+                fields=UNITREE_FIELDS,
+                header_stamp_ns=1_000_000_000,
+            )
+
+    def test_applies_fixed_rotation_without_changing_auxiliary_fields(self):
+        rotation = validated_rotation_matrix(
+            [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                -1.0,
+                0.0,
+                0.0,
+                0.0,
+                -1.0,
+            ]
+        )
+        header_ns = 1_785_811_000_000_000_000
+        converted = unitree_mid360_to_fast_livo(
+            data=self.make_cloud(),
+            point_count=2,
+            point_step=22,
+            fields=UNITREE_FIELDS,
+            header_stamp_ns=header_ns,
+            rotation_matrix=rotation,
+        )
+        points = self.decode(converted)
+
+        np.testing.assert_allclose(points["x"], [1.0, -1.0])
+        np.testing.assert_allclose(points["y"], [-2.0, 2.0])
+        np.testing.assert_allclose(points["z"], [-3.0, 3.0])
+        np.testing.assert_allclose(points["intensity"], [42.0, 163.0])
+        np.testing.assert_array_equal(points["tag"], [0x10, 0x10])
+        np.testing.assert_array_equal(points["line"], [0, 3])
+        np.testing.assert_allclose(
+            points["timestamp"] - np.float64(header_ns),
+            [5_000.0, 100_320_000.0],
+            atol=256.0,
+        )
+
+    def test_rotation_helpers_use_the_same_corrected_frame(self):
+        rotation = validated_rotation_matrix(
+            [1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0]
+        )
+
+        np.testing.assert_allclose(
+            rotate_vector3((1.0, 2.0, 3.0), rotation),
+            (1.0, -2.0, -3.0),
+        )
+        np.testing.assert_allclose(
+            rotate_covariance9(
+                [1.0, 2.0, 3.0, 2.0, 4.0, 5.0, 3.0, 5.0, 6.0],
+                rotation,
+            ),
+            [1.0, -2.0, -3.0, -2.0, 4.0, 5.0, -3.0, 5.0, 6.0],
+        )
+        qx, qy, qz, qw = rotate_orientation_xyzw(
+            (0.0, 0.0, 0.0, 1.0), rotation
+        )
+        self.assertAlmostEqual(abs(qx), 1.0)
+        self.assertAlmostEqual(qy, 0.0)
+        self.assertAlmostEqual(qz, 0.0)
+        self.assertAlmostEqual(qw, 0.0)
+
+    def test_rejects_non_rotation_matrix(self):
+        with self.assertRaisesRegex(ValueError, "orthonormal"):
+            validated_rotation_matrix([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 2.0])
+        with self.assertRaisesRegex(ValueError, "proper rotation"):
+            validated_rotation_matrix([-1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_navigation_sensor_card.py
+++ b/unitree/g1/tests/test_navigation_sensor_card.py
@@ -1,0 +1,157 @@
+import ast
+import importlib
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+G1_DIR = Path(__file__).resolve().parents[1]
+
+
+class NavigationSensorCardContractTest(unittest.TestCase):
+    @staticmethod
+    def load_bridge_module():
+        if not hasattr(sys.modules.get("numpy"), "dtype"):
+            sys.modules.pop("numpy", None)
+
+        rclpy = sys.modules.setdefault("rclpy", types.ModuleType("rclpy"))
+        rclpy_node = types.ModuleType("rclpy.node")
+        rclpy_node.Node = type("Node", (), {})
+        rclpy_qos = types.ModuleType("rclpy.qos")
+
+        class QoSProfile:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        policy = type(
+            "Policy",
+            (),
+            {
+                "BEST_EFFORT": "best_effort",
+                "RELIABLE": "reliable",
+                "KEEP_LAST": "keep_last",
+                "VOLATILE": "volatile",
+            },
+        )
+        rclpy_qos.QoSProfile = QoSProfile
+        rclpy_qos.ReliabilityPolicy = policy
+        rclpy_qos.HistoryPolicy = policy
+        rclpy_qos.DurabilityPolicy = policy
+        sys.modules["rclpy.node"] = rclpy_node
+        sys.modules["rclpy.qos"] = rclpy_qos
+        rclpy.node = rclpy_node
+        rclpy.qos = rclpy_qos
+
+        sensor_msgs = types.ModuleType("sensor_msgs")
+        sensor_msgs_msg = types.ModuleType("sensor_msgs.msg")
+        for name in ("Imu", "PointCloud2", "PointField"):
+            setattr(sensor_msgs_msg, name, type(name, (), {}))
+        sensor_msgs.msg = sensor_msgs_msg
+        sys.modules["sensor_msgs"] = sensor_msgs
+        sys.modules["sensor_msgs.msg"] = sensor_msgs_msg
+
+        std_msgs = sys.modules.setdefault("std_msgs", types.ModuleType("std_msgs"))
+        std_msgs_msg = sys.modules.setdefault(
+            "std_msgs.msg", types.ModuleType("std_msgs.msg")
+        )
+        std_msgs_msg.String = type("String", (), {})
+        std_msgs.msg = std_msgs_msg
+
+        channel = types.ModuleType("unitree_sdk2py.core.channel")
+        channel.ChannelSubscriber = type("ChannelSubscriber", (), {})
+        idl = types.ModuleType("unitree_sdk2py.idl.sensor_msgs.msg.dds_")
+        idl.Imu_ = type("Imu_", (), {})
+        idl.PointCloud2_ = type("PointCloud2_", (), {})
+        sys.modules["unitree_sdk2py.core.channel"] = channel
+        sys.modules["unitree_sdk2py.idl.sensor_msgs.msg.dds_"] = idl
+
+        sys.modules.pop("navigation_sensor_bridge", None)
+        return importlib.import_module("navigation_sensor_bridge")
+
+    def test_bundle_registers_the_read_only_sensor_plugin(self):
+        source = (G1_DIR / "main.py").read_text()
+        self.assertIn('plugins_cfg.get("navigation_sensors"', source)
+        self.assertIn("NavigationSensorPlugin", source)
+        ast.parse(source)
+
+    def test_default_config_uses_mid360_raw_dds_and_native_ros_topics(self):
+        config = (G1_DIR / "config.yaml").read_text()
+        for expected in (
+            "navigation_sensors:\n    enabled: true",
+            "raw_cloud_topic: rt/utlidar/cloud_livox_mid360",
+            "raw_imu_topic: rt/utlidar/imu_livox_mid360",
+            "fast_livo_cloud_topic: /ubuntu/navigation/lidar_fast_livo",
+            "imu_topic: /ubuntu/navigation/imu",
+            "publish_raw_cloud: false",
+            "publish_fast_livo_cloud: true",
+        ):
+            self.assertIn(expected, config)
+
+    def test_tools_declare_native_types_qos_and_fail_closed_status(self):
+        source = (G1_DIR / "navigation_sensor_bridge.py").read_text()
+        for expected in (
+            '"navigation_lidar_fast_livo"',
+            '"navigation_imu"',
+            '"navigation_sensor_diagnostics"',
+            '"sensor/pointcloud"',
+            '"sensor_msgs/msg/PointCloud2"',
+            '"sensor_msgs/msg/Imu"',
+            '"RELIABLE + KEEP_LAST(depth=2) + VOLATILE"',
+            '"RELIABLE + KEEP_LAST(depth=200) + VOLATILE"',
+            '"state": "ready" if status["ready"] else "not_ready"',
+            'blockers.append("clock_not_ready")',
+            'blockers.append("cloud_stale")',
+            'blockers.append("imu_stale")',
+        ):
+            self.assertIn(expected, source)
+        self.assertNotIn('"sensor/pointcloud2"', source)
+        ast.parse(source)
+
+    def test_runtime_tool_descriptors_match_fast_livo2_inputs(self):
+        module = self.load_bridge_module()
+        plugin = module.NavigationSensorPlugin.__new__(module.NavigationSensorPlugin)
+        plugin._node = types.SimpleNamespace(
+            _publish_fast_livo_cloud=True,
+            _publish_raw_cloud=False,
+            fast_livo_cloud_topic="/ubuntu/navigation/lidar_fast_livo",
+            cloud_topic="/ubuntu/navigation/lidar",
+            imu_topic="/ubuntu/navigation/imu",
+            diagnostics_topic="/ubuntu/navigation/sensor_diagnostics",
+            status=lambda: {
+                "ready": False,
+                "blockers": ["clock_not_ready"],
+                "receive_age_ms": {"cloud": None, "imu": None},
+                "clock": {"ready": False},
+                "counters": {},
+            },
+        )
+
+        tools = {tool["name"]: tool for tool in plugin.get_tools()}
+        lidar = tools["navigation_lidar_fast_livo"]["topic_out"][0]
+        imu = tools["navigation_imu"]["topic_out"][0]
+        self.assertEqual(lidar["format"], "sensor/pointcloud")
+        self.assertEqual(lidar["ros_type"], "sensor_msgs/msg/PointCloud2")
+        self.assertEqual(lidar["qos"], "RELIABLE + KEEP_LAST(depth=2) + VOLATILE")
+        self.assertEqual(imu["format"], "sensor/imu")
+        self.assertEqual(imu["ros_type"], "sensor_msgs/msg/Imu")
+        self.assertEqual(imu["qos"], "RELIABLE + KEEP_LAST(depth=200) + VOLATILE")
+
+        info = plugin.dispatch(
+            "info", {"_tool_name": "navigation_lidar_fast_livo"}
+        )
+        self.assertEqual(info["state"], "not_ready")
+        self.assertEqual(info["blockers"], ["clock_not_ready"])
+
+    def test_driver_image_contains_the_sensor_card_runtime(self):
+        dockerfile = (G1_DIR / "Dockerfile").read_text()
+        for filename in (
+            "navigation_sensor_bridge.py",
+            "navigation_pointcloud.py",
+            "navigation_time.py",
+        ):
+            self.assertIn(f"COPY {filename} /work/{filename}", dockerfile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_navigation_sensor_card.py
+++ b/unitree/g1/tests/test_navigation_sensor_card.py
@@ -2,8 +2,11 @@ import ast
 import importlib
 from pathlib import Path
 import sys
+import threading
+import time
 import types
 import unittest
+from unittest import mock
 
 
 G1_DIR = Path(__file__).resolve().parents[1]
@@ -73,6 +76,7 @@ class NavigationSensorCardContractTest(unittest.TestCase):
         source = (G1_DIR / "main.py").read_text()
         self.assertIn('plugins_cfg.get("navigation_sensors"', source)
         self.assertIn("NavigationSensorPlugin", source)
+        self.assertIn("network_iface,", source)
         ast.parse(source)
 
     def test_default_config_uses_mid360_raw_dds_and_native_ros_topics(self):
@@ -103,6 +107,8 @@ class NavigationSensorCardContractTest(unittest.TestCase):
             'blockers.append("clock_not_ready")',
             'blockers.append("cloud_stale")',
             'blockers.append("imu_stale")',
+            'blockers.append("worker_not_running")',
+            'subprocess.Popen(',
         ):
             self.assertIn(expected, source)
         self.assertNotIn('"sensor/pointcloud2"', source)
@@ -111,14 +117,14 @@ class NavigationSensorCardContractTest(unittest.TestCase):
     def test_runtime_tool_descriptors_match_fast_livo2_inputs(self):
         module = self.load_bridge_module()
         plugin = module.NavigationSensorPlugin.__new__(module.NavigationSensorPlugin)
-        plugin._node = types.SimpleNamespace(
+        plugin._status_node = types.SimpleNamespace(
             _publish_fast_livo_cloud=True,
             _publish_raw_cloud=False,
             fast_livo_cloud_topic="/ubuntu/navigation/lidar_fast_livo",
             cloud_topic="/ubuntu/navigation/lidar",
             imu_topic="/ubuntu/navigation/imu",
             diagnostics_topic="/ubuntu/navigation/sensor_diagnostics",
-            status=lambda: {
+            status=lambda worker_running: {
                 "ready": False,
                 "blockers": ["clock_not_ready"],
                 "receive_age_ms": {"cloud": None, "imu": None},
@@ -126,6 +132,7 @@ class NavigationSensorCardContractTest(unittest.TestCase):
                 "counters": {},
             },
         )
+        plugin._proc = types.SimpleNamespace(poll=lambda: None, pid=1234)
 
         tools = {tool["name"]: tool for tool in plugin.get_tools()}
         lidar = tools["navigation_lidar_fast_livo"]["topic_out"][0]
@@ -147,10 +154,62 @@ class NavigationSensorCardContractTest(unittest.TestCase):
         dockerfile = (G1_DIR / "Dockerfile").read_text()
         for filename in (
             "navigation_sensor_bridge.py",
+            "navigation_sensor_bridge_main.py",
             "navigation_pointcloud.py",
             "navigation_time.py",
         ):
             self.assertIn(f"COPY {filename} /work/{filename}", dockerfile)
+
+    def test_worker_entry_owns_the_heavy_sensor_node(self):
+        source = (G1_DIR / "navigation_sensor_bridge_main.py").read_text()
+        self.assertIn("_NavigationSensorNode(plugin_config, namespace)", source)
+        self.assertIn("ChannelFactoryInitialize(0, network_interface)", source)
+        self.assertNotIn("NavigationSensorPlugin(", source)
+        ast.parse(source)
+
+    def test_plugin_starts_and_stops_one_isolated_worker(self):
+        module = self.load_bridge_module()
+        plugin = module.NavigationSensorPlugin.__new__(module.NavigationSensorPlugin)
+        plugin._namespace = "ubuntu"
+        plugin._network_iface = "eth0"
+        plugin._worker_path = G1_DIR / "navigation_sensor_bridge_main.py"
+        plugin._proc = None
+        plugin._executor = mock.Mock()
+        plugin._status_node = mock.Mock()
+        proc = mock.Mock(pid=4321)
+        proc.poll.return_value = None
+
+        with mock.patch.object(module.subprocess, "Popen", return_value=proc) as popen:
+            plugin.start()
+            plugin.start()
+
+        popen.assert_called_once()
+        self.assertEqual(
+            popen.call_args.args[0],
+            [sys.executable, str(plugin._worker_path), "eth0"],
+        )
+        plugin.stop()
+        proc.terminate.assert_called_once_with()
+        proc.wait.assert_called_once_with(timeout=5.0)
+        plugin._executor.remove_node.assert_called_once_with(plugin._status_node)
+        plugin._status_node.destroy_node.assert_called_once_with()
+
+    def test_status_monitor_fails_closed_for_dead_or_stale_worker(self):
+        module = self.load_bridge_module()
+        node = module._NavigationSensorStatusNode.__new__(
+            module._NavigationSensorStatusNode
+        )
+        node._lock = threading.RLock()
+        node._last_diagnostics = {"ready": True, "blockers": []}
+        node._last_diagnostics_monotonic = time.monotonic() - 3.0
+
+        stale = node.status(worker_running=True)
+        self.assertFalse(stale["ready"])
+        self.assertIn("diagnostics_stale", stale["blockers"])
+
+        dead = node.status(worker_running=False)
+        self.assertFalse(dead["ready"])
+        self.assertIn("worker_not_running", dead["blockers"])
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_navigation_time.py
+++ b/unitree/g1/tests/test_navigation_time.py
@@ -1,0 +1,104 @@
+import unittest
+
+from navigation_time import ClockOffsetEstimator, split_ns, stamp_to_ns
+
+
+class TimestampHelpersTest(unittest.TestCase):
+    def test_round_trip(self):
+        timestamp_ns = stamp_to_ns(1_769_941_368, 987_654_321)
+        self.assertEqual(split_ns(timestamp_ns), (1_769_941_368, 987_654_321))
+
+    def test_invalid_nanoseconds(self):
+        with self.assertRaises(ValueError):
+            stamp_to_ns(1, 1_000_000_000)
+
+
+class ClockOffsetEstimatorTest(unittest.TestCase):
+    def make_estimator(self):
+        return ClockOffsetEstimator(
+            warmup_samples=3,
+            window_samples=5,
+            reset_threshold_ns=1_000_000_000,
+            reset_confirm_samples=3,
+        )
+
+    def test_uses_minimum_arrival_latency_after_warmup(self):
+        estimator = self.make_estimator()
+        offset = 15_869_770_000_000_000
+        source = 1_769_941_368_000_000_000
+
+        self.assertIsNone(estimator.correct_observation(source, source + offset + 8_000_000))
+        self.assertIsNone(
+            estimator.correct_observation(source + 5_000_000, source + 5_000_000 + offset + 2_000_000)
+        )
+        corrected = estimator.correct_observation(
+            source + 10_000_000, source + 10_000_000 + offset + 5_000_000
+        )
+
+        self.assertEqual(corrected, source + 10_000_000 + offset + 2_000_000)
+        self.assertTrue(estimator.snapshot().ready)
+
+    def test_one_late_callback_is_rejected_without_reset(self):
+        estimator = self.make_estimator()
+        source = 10_000_000_000
+        offset = 20_000_000_000
+        for index in range(3):
+            estimator.correct_observation(
+                source + index * 10_000_000,
+                source + index * 10_000_000 + offset + 1_000_000,
+            )
+
+        late = estimator.correct_observation(
+            source + 30_000_000,
+            source + 30_000_000 + offset + 2_000_000_000,
+        )
+        recovered = estimator.correct_observation(
+            source + 40_000_000,
+            source + 40_000_000 + offset + 2_000_000,
+        )
+
+        self.assertIsNone(late)
+        self.assertIsNotNone(recovered)
+        self.assertEqual(estimator.snapshot().resets, 0)
+
+    def test_persistent_backward_clock_jump_restarts_warmup(self):
+        estimator = self.make_estimator()
+        source = 10_000_000_000
+        offset = 20_000_000_000
+        for index in range(3):
+            estimator.correct_observation(
+                source + index * 10_000_000,
+                source + index * 10_000_000 + offset,
+            )
+
+        for index in range(3):
+            self.assertIsNone(
+                estimator.correct_observation(
+                    source + 30_000_000 + index * 10_000_000,
+                    source + 30_000_000 + index * 10_000_000 + offset + 2_000_000_000,
+                )
+            )
+
+        snapshot = estimator.snapshot()
+        self.assertFalse(snapshot.ready)
+        self.assertEqual(snapshot.resets, 1)
+        self.assertEqual(snapshot.samples, 1)
+
+    def test_forward_clock_jump_restarts_immediately(self):
+        estimator = self.make_estimator()
+        source = 10_000_000_000
+        offset = 20_000_000_000
+        for index in range(3):
+            estimator.correct_observation(
+                source + index * 10_000_000,
+                source + index * 10_000_000 + offset,
+            )
+
+        self.assertIsNone(
+            estimator.correct_observation(source + 2_000_000_000, source + offset + 100_000_000)
+        )
+        self.assertEqual(estimator.snapshot().resets, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_proposal_apply_diagnostics.py
+++ b/unitree/g1/tests/test_proposal_apply_diagnostics.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import unittest
+
+from safety_harness import ProposalApplyDiagnostics
+from velocity_proposal import VelocityProposalGate, ProposalLimits
+
+
+class ProposalApplyDiagnosticsTest(unittest.TestCase):
+    def test_counts_and_last_set_velocity_result_are_reported(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.record_received()
+        diagnostics.record_accepted()
+        diagnostics.record_set_velocity(
+            {
+                "request_id": 12,
+                "ret": 0,
+                "error": None,
+                "completed_monotonic": 34.5,
+                "completed_unix_ms": 56,
+            },
+            duration=0.2,
+        )
+        diagnostics.record_applied()
+
+        self.assertEqual(
+            diagnostics.snapshot(),
+            {
+                "received": 1,
+                "accepted": 1,
+                "rejected": 0,
+                "applied": 1,
+                "last_rejection_reason": None,
+                "last_set_velocity_ret": 0,
+                "last_set_velocity_error": None,
+                "last_set_velocity_request_id": 12,
+                "last_set_velocity_duration_ms": 200,
+                "last_set_velocity_completed_monotonic": 34.5,
+                "last_set_velocity_completed_unix_ms": 56,
+            },
+        )
+
+    def test_rejection_and_apply_failure_remain_after_canvas_stop(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.record_received()
+        diagnostics.record_accepted()
+        diagnostics.record_set_velocity(
+            {
+                "request_id": 13,
+                "ret": 3104,
+                "error": None,
+                "completed_monotonic": 70.0,
+                "completed_unix_ms": 80,
+            },
+            duration=0.15,
+        )
+        diagnostics.record_rejected("set_velocity_failed")
+
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind("/proposal", "nav-1")
+        gate.unbind("canvas_stop")
+        status = gate.snapshot(100.0)
+        status["proposal_execution"] = diagnostics.snapshot()
+
+        self.assertEqual(status["last_reason"], "canvas_stop")
+        self.assertEqual(
+            status["proposal_execution"]["last_rejection_reason"],
+            "set_velocity_failed",
+        )
+        self.assertEqual(
+            status["proposal_execution"]["last_set_velocity_ret"],
+            3104,
+        )
+        self.assertEqual(status["proposal_execution"]["received"], 1)
+        self.assertEqual(status["proposal_execution"]["accepted"], 1)
+        self.assertEqual(status["proposal_execution"]["rejected"], 1)
+        self.assertEqual(status["proposal_execution"]["applied"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_proposal_apply_diagnostics.py
+++ b/unitree/g1/tests/test_proposal_apply_diagnostics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import queue
 import unittest
 
 from safety_harness import (
@@ -8,6 +9,8 @@ from safety_harness import (
     ProposalExecutionLease,
     authoritative_proposal_stop_reason,
     obstacle_observation_applies,
+    percentile_ms,
+    put_latest,
     proposal_decision_requires_physical_stop,
     translation_obstacle_heading,
     velocity_commands_differ,
@@ -35,10 +38,12 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
                 "ret": 0,
                 "error": None,
                 "applied": True,
+                "started_monotonic": 34.3,
                 "completed_monotonic": 34.5,
                 "completed_unix_ms": 56,
+                "duration_ms": 200,
             },
-            duration=0.2,
+            queued_monotonic=34.25,
         )
         diagnostics.record_applied()
 
@@ -50,6 +55,7 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
                 "accepted": 1,
                 "rejected": 0,
                 "applied": 1,
+                "coalesced": 0,
                 "first_received_monotonic": 10.0,
                 "last_received_monotonic": 10.0,
                 "last_receive_gap_ms": None,
@@ -74,6 +80,13 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
                 "last_set_velocity_applied": True,
                 "last_set_velocity_request_id": 12,
                 "last_set_velocity_duration_ms": 200,
+                "last_set_velocity_queue_delay_ms": 50,
+                "last_set_velocity_end_to_end_ms": 250,
+                "set_velocity_rpc_samples": 1,
+                "set_velocity_rpc_p50_ms": 200,
+                "set_velocity_rpc_p95_ms": 200,
+                "set_velocity_rpc_p99_ms": 200,
+                "set_velocity_rpc_max_ms": 200,
                 "last_set_velocity_completed_monotonic": 34.5,
                 "last_set_velocity_completed_unix_ms": 56,
                 "last_set_velocity_stop_ret": None,
@@ -90,10 +103,11 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
                 "request_id": 13,
                 "ret": 3104,
                 "error": None,
+                "started_monotonic": 69.85,
                 "completed_monotonic": 70.0,
                 "completed_unix_ms": 80,
+                "duration_ms": 150,
             },
-            duration=0.15,
         )
         diagnostics.record_rejected("set_velocity_failed")
 
@@ -116,6 +130,31 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
         self.assertEqual(status["proposal_execution"]["accepted"], 1)
         self.assertEqual(status["proposal_execution"]["rejected"], 1)
         self.assertEqual(status["proposal_execution"]["applied"], 0)
+
+    def test_rpc_percentiles_use_measured_result_duration(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.begin_session("nav-latency")
+        for duration_ms in (10, 20, 30, 40, 500):
+            diagnostics.record_set_velocity({"duration_ms": duration_ms})
+
+        status = diagnostics.snapshot()
+
+        self.assertEqual(status["set_velocity_rpc_samples"], 5)
+        self.assertEqual(status["set_velocity_rpc_p50_ms"], 30)
+        self.assertEqual(status["set_velocity_rpc_p95_ms"], 500)
+        self.assertEqual(status["set_velocity_rpc_p99_ms"], 500)
+        self.assertEqual(status["set_velocity_rpc_max_ms"], 500)
+        self.assertEqual(percentile_ms([], 0.99), None)
+
+    def test_latest_only_queue_coalesces_without_backlog(self):
+        commands = queue.Queue(maxsize=1)
+
+        self.assertFalse(put_latest(commands, {"sequence": 1}))
+        self.assertTrue(put_latest(commands, {"sequence": 2}))
+        self.assertTrue(put_latest(commands, {"sequence": 3}))
+
+        self.assertEqual(commands.qsize(), 1)
+        self.assertEqual(commands.get_nowait(), {"sequence": 3})
 
     def test_arrival_timing_and_watchdog_faults_are_reported(self):
         diagnostics = ProposalApplyDiagnostics()

--- a/unitree/g1/tests/test_proposal_apply_diagnostics.py
+++ b/unitree/g1/tests/test_proposal_apply_diagnostics.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 import math
 import queue
+import threading
 import unittest
 
 from safety_harness import (
     ProposalApplyDiagnostics,
     ProposalExecutionLease,
+    ProposalWatchdogTransition,
     authoritative_proposal_stop_reason,
     obstacle_observation_applies,
     percentile_ms,
     put_latest,
+    proposal_apply_result_is_current,
     proposal_decision_requires_physical_stop,
     translation_obstacle_heading,
     velocity_commands_differ,
@@ -220,6 +223,52 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
         self.assertEqual(reset["watchdog_faults_by_reason"], {})
         self.assertIsNone(reset["first_rejection_reason"])
 
+    def test_first_proposal_binding_keeps_preclaim_arrival_evidence(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.begin_session(None)
+        diagnostics.record_received(10.0)
+        diagnostics.record_rejected("proposal_ttl_expired")
+
+        diagnostics.bind_session_nav_id("nav-auto")
+        status = diagnostics.snapshot()
+
+        self.assertEqual(status["session_nav_id"], "nav-auto")
+        self.assertEqual(status["received"], 1)
+        self.assertEqual(status["rejected"], 1)
+        self.assertEqual(
+            status["first_rejection_reason"],
+            "proposal_ttl_expired",
+        )
+
+    def test_next_auto_claim_rolls_diagnostics_to_new_lease(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.begin_session(None)
+        diagnostics.record_received(10.0)
+        diagnostics.bind_claimed_session(
+            "nav-1",
+            received_monotonic=10.0,
+            payload={"issued_at_unix_ms": 900, "ttl_ms": 250},
+            received_unix_ms=1_000,
+        )
+        diagnostics.record_accepted()
+        diagnostics.record_applied("nav-1", 1)
+
+        rolled_over = diagnostics.bind_claimed_session(
+            "nav-2",
+            received_monotonic=20.0,
+            payload={"issued_at_unix_ms": 1_900, "ttl_ms": 250},
+            received_unix_ms=2_000,
+        )
+        status = diagnostics.snapshot()
+
+        self.assertTrue(rolled_over)
+        self.assertEqual(status["session_nav_id"], "nav-2")
+        self.assertEqual(status["received"], 1)
+        self.assertEqual(status["accepted"], 0)
+        self.assertEqual(status["applied"], 0)
+        self.assertEqual(status["first_received_monotonic"], 20.0)
+        self.assertEqual(status["last_proposal_age_ms"], 100)
+
     def test_applied_count_deduplicates_safety_reapply_by_proposal_identity(self):
         diagnostics = ProposalApplyDiagnostics()
         diagnostics.begin_session("nav-1")
@@ -257,6 +306,77 @@ class ProposalExecutionLeaseTest(unittest.TestCase):
         self.assertTrue(lease.renew_if_active(10.30))
         self.assertEqual(lease.watchdog_snapshot(), (generation, 10.40))
 
+    def test_cleared_generation_cannot_publish_late_apply_result(self):
+        lease = ProposalExecutionLease()
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind("/ubuntu/navigation/nav2/velocity_proposal")
+        decision = gate.accept(
+            {
+                "schema": "phanthy.navigation.velocity_proposal.v1",
+                "nav_id": "nav-1",
+                "sequence": 1,
+                "ttl_ms": 250,
+                "issued_at_unix_ms": 1_000,
+                "frame": "base_link",
+                "nav_status": "navigating",
+                "velocity": {"x": 0.1, "y": 0.0, "yaw": 0.0},
+                "shadow_only": True,
+                "physical_execution": False,
+            },
+            now=10.0,
+        )
+        self.assertTrue(decision.execute)
+        generation = lease.arm(10.25)
+        command = {"nav_id": "nav-1", "sequence": 1}
+        self.assertTrue(
+            proposal_apply_result_is_current(
+                command,
+                gate,
+                lease,
+                generation,
+            )
+        )
+
+        lease.clear()
+        self.assertFalse(
+            proposal_apply_result_is_current(
+                command,
+                gate,
+                lease,
+                generation,
+            )
+        )
+
+    def test_superseded_sequence_cannot_publish_apply_result(self):
+        lease = ProposalExecutionLease()
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind("/ubuntu/navigation/nav2/velocity_proposal", "nav-1")
+        first = {
+            "schema": "phanthy.navigation.velocity_proposal.v1",
+            "nav_id": "nav-1",
+            "sequence": 1,
+            "ttl_ms": 250,
+            "issued_at_unix_ms": 1_000,
+            "frame": "base_link",
+            "nav_status": "navigating",
+            "velocity": {"x": 0.1, "y": 0.0, "yaw": 0.0},
+            "shadow_only": True,
+            "physical_execution": False,
+        }
+        self.assertTrue(gate.accept(first, now=10.0).execute)
+        generation = lease.arm(10.25)
+        second = dict(first, sequence=2, issued_at_unix_ms=1_010)
+        self.assertTrue(gate.accept(second, now=10.01).execute)
+
+        self.assertFalse(
+            proposal_apply_result_is_current(
+                {"nav_id": "nav-1", "sequence": 1},
+                gate,
+                lease,
+                generation,
+            )
+        )
+
     def test_watchdog_rechecks_deadline_after_concurrent_renewal(self):
         lease = ProposalExecutionLease()
         generation = lease.arm(10.25)
@@ -290,6 +410,94 @@ class ProposalExecutionLeaseTest(unittest.TestCase):
         lease.clear()
         self.assertTrue(lease.renew_if_active(10.75))
         self.assertIsNotNone(lease.arm(10.75))
+
+    def test_clear_and_observe_fault_serializes_watchdog_transition(self):
+        tripped = ProposalExecutionLease()
+        tripped_generation = tripped.arm(10.25)
+        self.assertTrue(
+            tripped.trip(
+                tripped_generation,
+                "proposal_ttl_expired",
+                now=10.26,
+            )
+        )
+
+        self.assertEqual(
+            tripped.clear_and_observe_fault(),
+            (tripped_generation, "proposal_ttl_expired"),
+        )
+        self.assertIsNone(tripped.current_fault())
+
+        cleared = ProposalExecutionLease()
+        cleared_generation = cleared.arm(20.25)
+        self.assertIsNone(cleared.clear_and_observe_fault())
+        self.assertFalse(
+            cleared.trip(
+                cleared_generation,
+                "proposal_ttl_expired",
+                now=20.26,
+            )
+        )
+
+    def test_watchdog_stop_dispatch_finishes_before_clear_returns(self):
+        lease = ProposalExecutionLease()
+        transition = ProposalWatchdogTransition(lease)
+        generation = lease.arm(30.25)
+        stop_started = threading.Event()
+        release_stop = threading.Event()
+        clear_started = threading.Event()
+        clear_finished = threading.Event()
+        observed_fault = []
+
+        def blocking_stop():
+            stop_started.set()
+            self.assertTrue(release_stop.wait(timeout=1.0))
+
+        watchdog_thread = threading.Thread(
+            target=lambda: transition.trip_and_dispatch_stop(
+                generation,
+                "proposal_ttl_expired",
+                30.26,
+                blocking_stop,
+            )
+        )
+
+        def clear_execution():
+            clear_started.set()
+            observed_fault.append(transition.clear_and_observe_fault())
+            clear_finished.set()
+
+        watchdog_thread.start()
+        self.assertTrue(stop_started.wait(timeout=1.0))
+        clear_thread = threading.Thread(target=clear_execution)
+        clear_thread.start()
+        self.assertTrue(clear_started.wait(timeout=1.0))
+        self.assertFalse(clear_finished.wait(timeout=0.05))
+
+        release_stop.set()
+        watchdog_thread.join(timeout=1.0)
+        clear_thread.join(timeout=1.0)
+
+        self.assertFalse(watchdog_thread.is_alive())
+        self.assertFalse(clear_thread.is_alive())
+        self.assertEqual(
+            observed_fault,
+            [(generation, "proposal_ttl_expired")],
+        )
+
+        stop_calls = []
+        next_generation = lease.arm(31.25)
+        self.assertIsNotNone(next_generation)
+        self.assertIsNone(transition.clear_and_observe_fault())
+        self.assertFalse(
+            transition.trip_and_dispatch_stop(
+                next_generation,
+                "proposal_ttl_expired",
+                31.26,
+                lambda: stop_calls.append("late_stop"),
+            )
+        )
+        self.assertEqual(stop_calls, [])
 
 
 class VelocityCommandDifferenceTest(unittest.TestCase):

--- a/unitree/g1/tests/test_proposal_apply_diagnostics.py
+++ b/unitree/g1/tests/test_proposal_apply_diagnostics.py
@@ -2,20 +2,34 @@ from __future__ import annotations
 
 import unittest
 
-from safety_harness import ProposalApplyDiagnostics
+from safety_harness import (
+    ProposalApplyDiagnostics,
+    ProposalExecutionLease,
+    velocity_commands_differ,
+)
 from velocity_proposal import VelocityProposalGate, ProposalLimits
 
 
 class ProposalApplyDiagnosticsTest(unittest.TestCase):
     def test_counts_and_last_set_velocity_result_are_reported(self):
         diagnostics = ProposalApplyDiagnostics()
-        diagnostics.record_received()
+        diagnostics.begin_session("nav-1")
+        diagnostics.record_received(10.0)
         diagnostics.record_accepted()
         diagnostics.record_set_velocity(
             {
                 "request_id": 12,
+                "rpc_method": "SetVelocity(continuous)",
+                "request": {
+                    "vx": 0.1,
+                    "vy": 0.0,
+                    "vyaw": 0.0,
+                    "nav_id": "nav-1",
+                    "sequence": 1,
+                },
                 "ret": 0,
                 "error": None,
+                "applied": True,
                 "completed_monotonic": 34.5,
                 "completed_unix_ms": 56,
             },
@@ -26,17 +40,39 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
         self.assertEqual(
             diagnostics.snapshot(),
             {
+                "session_nav_id": "nav-1",
                 "received": 1,
                 "accepted": 1,
                 "rejected": 0,
                 "applied": 1,
+                "first_received_monotonic": 10.0,
+                "last_received_monotonic": 10.0,
+                "last_receive_gap_ms": None,
+                "max_receive_gap_ms": None,
+                "last_proposal_age_ms": None,
+                "max_proposal_age_ms": None,
+                "expired_on_arrival": 0,
+                "watchdog_faults_by_reason": {},
+                "first_rejection_reason": None,
                 "last_rejection_reason": None,
+                "rejections_by_reason": {},
+                "last_set_velocity_rpc_method": "SetVelocity(continuous)",
+                "last_set_velocity_request": {
+                    "vx": 0.1,
+                    "vy": 0.0,
+                    "vyaw": 0.0,
+                    "nav_id": "nav-1",
+                    "sequence": 1,
+                },
                 "last_set_velocity_ret": 0,
                 "last_set_velocity_error": None,
+                "last_set_velocity_applied": True,
                 "last_set_velocity_request_id": 12,
                 "last_set_velocity_duration_ms": 200,
                 "last_set_velocity_completed_monotonic": 34.5,
                 "last_set_velocity_completed_unix_ms": 56,
+                "last_set_velocity_stop_ret": None,
+                "last_set_velocity_stop_error": None,
             },
         )
 
@@ -75,6 +111,159 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
         self.assertEqual(status["proposal_execution"]["accepted"], 1)
         self.assertEqual(status["proposal_execution"]["rejected"], 1)
         self.assertEqual(status["proposal_execution"]["applied"], 0)
+
+    def test_arrival_timing_and_watchdog_faults_are_reported(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.begin_session("nav-timing")
+        diagnostics.record_received(10.0)
+        diagnostics.record_received(10.12)
+        diagnostics.record_proposal_arrival(
+            {"issued_at_unix_ms": 1_000, "ttl_ms": 200},
+            received_unix_ms=1_120,
+        )
+        diagnostics.record_proposal_arrival(
+            {"issued_at_unix_ms": 2_000, "ttl_ms": 200},
+            received_unix_ms=2_250,
+        )
+        diagnostics.record_watchdog_fault("proposal_ttl_expired")
+        diagnostics.record_watchdog_fault("proposal_ttl_expired")
+
+        status = diagnostics.snapshot()
+
+        self.assertEqual(status["first_received_monotonic"], 10.0)
+        self.assertEqual(status["last_received_monotonic"], 10.12)
+        self.assertEqual(status["last_receive_gap_ms"], 120)
+        self.assertEqual(status["max_receive_gap_ms"], 120)
+        self.assertEqual(status["last_proposal_age_ms"], 250)
+        self.assertEqual(status["max_proposal_age_ms"], 250)
+        self.assertEqual(status["expired_on_arrival"], 1)
+        self.assertEqual(
+            status["watchdog_faults_by_reason"],
+            {"proposal_ttl_expired": 2},
+        )
+
+    def test_first_rejection_and_breakdown_survive_cleanup_rejection(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.begin_session("nav-9")
+        diagnostics.record_rejected("set_velocity_failed")
+        diagnostics.record_rejected("stop_transition")
+        diagnostics.record_rejected("stop_transition")
+
+        status = diagnostics.snapshot()
+
+        self.assertEqual(status["first_rejection_reason"], "set_velocity_failed")
+        self.assertEqual(status["last_rejection_reason"], "stop_transition")
+        self.assertEqual(
+            status["rejections_by_reason"],
+            {"set_velocity_failed": 1, "stop_transition": 2},
+        )
+
+    def test_new_lease_resets_counts_but_unbind_does_not(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.begin_session("nav-1")
+        diagnostics.record_received()
+        diagnostics.record_rejected("invalid_json")
+
+        retained = diagnostics.snapshot()
+        diagnostics.begin_session("nav-2")
+        reset = diagnostics.snapshot()
+
+        self.assertEqual(retained["session_nav_id"], "nav-1")
+        self.assertEqual(retained["received"], 1)
+        self.assertEqual(reset["session_nav_id"], "nav-2")
+        self.assertEqual(reset["received"], 0)
+        self.assertIsNone(reset["first_received_monotonic"])
+        self.assertEqual(reset["watchdog_faults_by_reason"], {})
+        self.assertIsNone(reset["first_rejection_reason"])
+
+    def test_applied_count_deduplicates_safety_reapply_by_proposal_identity(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.begin_session("nav-1")
+
+        diagnostics.record_applied("nav-1", 4)
+        diagnostics.record_applied("nav-1", 4)
+        diagnostics.record_applied("nav-1", 5)
+
+        self.assertEqual(diagnostics.snapshot()["applied"], 2)
+
+    def test_new_session_can_apply_the_same_sequence_again(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.begin_session("nav-1")
+        diagnostics.record_applied("nav-1", 1)
+
+        diagnostics.begin_session("nav-2")
+        diagnostics.record_applied("nav-2", 1)
+
+        self.assertEqual(diagnostics.snapshot()["applied"], 1)
+
+
+class ProposalExecutionLeaseTest(unittest.TestCase):
+    def test_first_proposal_does_not_activate_before_rpc_arm(self):
+        lease = ProposalExecutionLease()
+
+        self.assertTrue(lease.renew_if_active(10.25))
+        self.assertIsNone(lease.watchdog_snapshot())
+
+    def test_valid_new_proposal_renews_active_deadline_without_shortening(self):
+        lease = ProposalExecutionLease()
+        generation = lease.arm(10.25)
+
+        self.assertTrue(lease.renew_if_active(10.40))
+        self.assertEqual(lease.watchdog_snapshot(), (generation, 10.40))
+        self.assertTrue(lease.renew_if_active(10.30))
+        self.assertEqual(lease.watchdog_snapshot(), (generation, 10.40))
+
+    def test_watchdog_rechecks_deadline_after_concurrent_renewal(self):
+        lease = ProposalExecutionLease()
+        generation = lease.arm(10.25)
+        observed = lease.watchdog_snapshot()
+        lease.renew_if_active(10.50)
+
+        tripped = lease.trip(
+            observed[0],
+            "proposal_ttl_expired",
+            now=10.30,
+        )
+
+        self.assertFalse(tripped)
+        self.assertEqual(lease.watchdog_snapshot(), (generation, 10.50))
+        self.assertIsNone(lease.current_fault())
+
+    def test_fault_cannot_be_renewed_or_cleared_by_later_apply(self):
+        lease = ProposalExecutionLease()
+        generation = lease.arm(10.25)
+
+        self.assertTrue(
+            lease.trip(generation, "proposal_ttl_expired", now=10.26)
+        )
+        self.assertFalse(lease.renew_if_active(10.50))
+        self.assertIsNone(lease.arm(10.50))
+        self.assertEqual(
+            lease.current_fault(),
+            (generation, "proposal_ttl_expired"),
+        )
+
+        lease.clear()
+        self.assertTrue(lease.renew_if_active(10.75))
+        self.assertIsNotNone(lease.arm(10.75))
+
+
+class VelocityCommandDifferenceTest(unittest.TestCase):
+    def test_identical_safety_velocity_is_a_noop(self):
+        self.assertFalse(
+            velocity_commands_differ(
+                (0.15, 0.0, 0.0),
+                (0.15, 0.0, 0.0),
+            )
+        )
+
+    def test_deceleration_and_resume_are_changes(self):
+        self.assertTrue(
+            velocity_commands_differ(
+                (0.15, 0.12, 0.35),
+                (0.15, 0.10, 0.20),
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_proposal_apply_diagnostics.py
+++ b/unitree/g1/tests/test_proposal_apply_diagnostics.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import math
 import unittest
 
 from safety_harness import (
     ProposalApplyDiagnostics,
     ProposalExecutionLease,
+    authoritative_proposal_stop_reason,
+    obstacle_observation_applies,
+    proposal_decision_requires_physical_stop,
+    translation_obstacle_heading,
     velocity_commands_differ,
 )
 from velocity_proposal import VelocityProposalGate, ProposalLimits
@@ -262,6 +267,67 @@ class VelocityCommandDifferenceTest(unittest.TestCase):
             velocity_commands_differ(
                 (0.15, 0.12, 0.35),
                 (0.15, 0.10, 0.20),
+            )
+        )
+
+
+class ObstacleRecoveryPolicyTest(unittest.TestCase):
+    def test_pure_rotation_has_no_translation_obstacle_cone(self):
+        command = {"vx": 0.0, "vy": 0.0, "vyaw": 0.2}
+
+        self.assertIsNone(translation_obstacle_heading(command))
+        self.assertFalse(
+            obstacle_observation_applies(command, 0.0, math.radians(30))
+        )
+
+    def test_matching_translation_cone_remains_fail_closed(self):
+        command = {"vx": 0.1, "vy": 0.0, "vyaw": 0.0}
+
+        self.assertTrue(
+            obstacle_observation_applies(command, 0.0, math.radians(30))
+        )
+
+    def test_stale_forward_cone_does_not_block_escape_direction(self):
+        reverse = {"vx": -0.05, "vy": 0.0, "vyaw": 0.0}
+        lateral = {"vx": 0.0, "vy": 0.1, "vyaw": 0.0}
+
+        self.assertFalse(
+            obstacle_observation_applies(reverse, 0.0, math.radians(30))
+        )
+        self.assertFalse(
+            obstacle_observation_applies(lateral, 0.0, math.radians(30))
+        )
+
+    def test_watchdog_fault_wins_over_concurrent_obstacle_stop(self):
+        self.assertEqual(
+            authoritative_proposal_stop_reason(
+                "obstacle",
+                (4, "proposal_ttl_expired"),
+            ),
+            "proposal_ttl_expired",
+        )
+        self.assertEqual(
+            authoritative_proposal_stop_reason("obstacle", None),
+            "obstacle",
+        )
+
+    def test_recoverable_hold_drains_stale_samples_without_repeated_stop(self):
+        self.assertFalse(
+            proposal_decision_requires_physical_stop(
+                "proposal_ttl_expired",
+                has_proposal=True,
+                proposal_motion_active=False,
+                newly_disarmed=False,
+                recoverable_stop_active=True,
+            )
+        )
+        self.assertTrue(
+            proposal_decision_requires_physical_stop(
+                "proposal_ttl_expired",
+                has_proposal=True,
+                proposal_motion_active=True,
+                newly_disarmed=True,
+                recoverable_stop_active=False,
             )
         )
 

--- a/unitree/g1/tests/test_proposal_rpc_executor.py
+++ b/unitree/g1/tests/test_proposal_rpc_executor.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import queue
+import threading
+import unittest
+
+from rpc_proxy import (
+    PROPOSAL_CONTINUOUS_DURATION_SECONDS,
+    ProposalRpcExecutor,
+    RpcProxy,
+)
+
+
+class FakeClock:
+    def __init__(self, monotonic=10.0, wall=1_800_000_000.0):
+        self.monotonic_value = monotonic
+        self.wall_value = wall
+
+    def monotonic(self):
+        return self.monotonic_value
+
+    def wall(self):
+        return self.wall_value
+
+    def advance(self, seconds):
+        self.monotonic_value += seconds
+        self.wall_value += seconds
+
+
+class FakeLoco:
+    def __init__(self, clock, set_velocity_ret=0, set_velocity_delay=0.0):
+        self.clock = clock
+        self.set_velocity_ret = set_velocity_ret
+        self.set_velocity_delay = set_velocity_delay
+        self.velocity_calls = []
+        self.stop_calls = 0
+
+    def SetVelocity(self, vx, vy, vyaw, duration):
+        self.velocity_calls.append((vx, vy, vyaw, duration))
+        self.clock.advance(self.set_velocity_delay)
+        return self.set_velocity_ret
+
+    def StopMove(self):
+        self.stop_calls += 1
+        return 0
+
+
+class ProposalRpcExecutorTest(unittest.TestCase):
+    def make_executor(self, **loco_kwargs):
+        clock = FakeClock()
+        loco = FakeLoco(clock, **loco_kwargs)
+        executor = ProposalRpcExecutor(
+            loco,
+            monotonic=clock.monotonic,
+            wall_time=clock.wall,
+        )
+        return clock, loco, executor
+
+    def apply(self, executor, deadline=10.25, sequence=1):
+        return executor.apply(
+            0.1,
+            0.02,
+            0.03,
+            deadline_monotonic=deadline,
+            nav_id="nav-1",
+            sequence=sequence,
+            request_id=7,
+        )
+
+    def test_live_proposal_uses_known_working_continuous_velocity_semantics(self):
+        _, loco, executor = self.make_executor()
+
+        result = self.apply(executor)
+
+        self.assertTrue(result["applied"])
+        self.assertEqual(result["ret"], 0)
+        self.assertEqual(result["rpc_method"], "SetVelocity(continuous)")
+        self.assertEqual(
+            loco.velocity_calls,
+            [(0.1, 0.02, 0.03, PROPOSAL_CONTINUOUS_DURATION_SECONDS)],
+        )
+        self.assertTrue(executor.active)
+        self.assertEqual(executor.nav_id, "nav-1")
+        self.assertEqual(executor.sequence, 1)
+
+    def test_deadline_expiry_stops_and_retires_parent_lease(self):
+        clock, loco, executor = self.make_executor()
+        self.apply(executor)
+
+        clock.advance(0.251)
+        stopped = executor.expire_if_due()
+
+        self.assertEqual(stopped["reason"], "proposal_ttl_expired")
+        self.assertEqual(stopped["ret"], 0)
+        self.assertEqual(loco.stop_calls, 1)
+        self.assertFalse(executor.active)
+
+    def test_command_expired_in_queue_is_never_applied(self):
+        _, loco, executor = self.make_executor()
+
+        result = self.apply(executor, deadline=9.99)
+
+        self.assertFalse(result["applied"])
+        self.assertEqual(result["error"], "proposal_ttl_expired_before_rpc")
+        self.assertEqual(loco.velocity_calls, [])
+        self.assertEqual(loco.stop_calls, 1)
+        self.assertFalse(executor.active)
+
+    def test_rpc_completion_after_deadline_is_stopped_fail_closed(self):
+        _, loco, executor = self.make_executor(set_velocity_delay=0.3)
+
+        result = self.apply(executor)
+
+        self.assertEqual(result["ret"], 0)
+        self.assertFalse(result["applied"])
+        self.assertEqual(result["error"], "proposal_ttl_expired_after_rpc")
+        self.assertEqual(loco.stop_calls, 1)
+        self.assertFalse(executor.active)
+
+    def test_nonzero_velocity_rpc_return_triggers_stop(self):
+        _, loco, executor = self.make_executor(set_velocity_ret=3104)
+
+        result = self.apply(executor)
+
+        self.assertEqual(result["ret"], 3104)
+        self.assertFalse(result["applied"])
+        self.assertEqual(loco.stop_calls, 1)
+        self.assertFalse(executor.active)
+
+    def test_newer_proposal_refreshes_parent_deadline_and_identity(self):
+        clock, loco, executor = self.make_executor()
+        self.apply(executor, deadline=10.20, sequence=1)
+        clock.advance(0.1)
+
+        result = self.apply(executor, deadline=10.35, sequence=2)
+
+        self.assertTrue(result["applied"])
+        self.assertEqual(executor.deadline_monotonic, 10.35)
+        self.assertEqual(executor.sequence, 2)
+        self.assertEqual(len(loco.velocity_calls), 2)
+        clock.advance(0.11)
+        self.assertIsNone(executor.expire_if_due())
+
+
+class RpcProxyCorrelationTest(unittest.TestCase):
+    def make_proxy(self):
+        proxy = RpcProxy.__new__(RpcProxy)
+        proxy._lock = threading.Lock()
+        proxy._request_id = 0
+        proxy._cmd_q = queue.Queue()
+        proxy._result_q = queue.Queue()
+        return proxy
+
+    def test_late_timed_out_reply_cannot_satisfy_next_stop(self):
+        proxy = self.make_proxy()
+        first = proxy._call("SetVelocity", timeout=0.01)
+        first_command = proxy._cmd_q.get_nowait()
+        proxy._result_q.put({
+            "request_id": first_command["request_id"],
+            "result": {"stale": True},
+        })
+
+        def respond_to_stop():
+            command = proxy._cmd_q.get(timeout=0.2)
+            proxy._result_q.put({
+                "request_id": command["request_id"],
+                "result": 0,
+            })
+
+        responder = threading.Thread(target=respond_to_stop, daemon=True)
+        responder.start()
+        second = proxy._call("StopMove", timeout=0.2)
+        responder.join(timeout=0.5)
+
+        self.assertIsNone(first)
+        self.assertEqual(second, 0)
+        self.assertFalse(responder.is_alive())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 import unittest
 
 from safety_harness import SmartMotionProxy
@@ -35,6 +36,80 @@ class SmartMotionExitMonitorTest(unittest.TestCase):
 
         proxy._fallback_stop = fail_stop
         proxy._monitor_process_exit()
+
+
+class SmartMotionParentStopSequenceTest(unittest.TestCase):
+    def make_proxy(self, fallback_stop):
+        proxy = SmartMotionProxy.__new__(SmartMotionProxy)
+        proxy._call_lock = threading.RLock()
+        proxy._fallback_stop = fallback_stop
+        return proxy
+
+    def test_bind_brackets_parent_stop_with_child_confirmation(self):
+        calls = []
+        proxy = self.make_proxy(lambda: calls.append(("stop", {})) or 0)
+
+        def fake_call(method, **kwargs):
+            calls.append((method, kwargs))
+            if method == "begin_velocity_proposal_stop_confirmation":
+                return {
+                    "confirmation_start": {
+                        "monotonic": 12.0,
+                        "unix_ms": 34,
+                        "odometry_callback_count": 56,
+                    }
+                }
+            return {"connected": True, "external": kwargs["external_stop_attempt"]}
+
+        proxy._call = fake_call
+        result = proxy.bind_velocity_proposal("/proposal", "nav-1")
+
+        self.assertEqual(
+            [name for name, _ in calls],
+            ["begin_velocity_proposal_stop_confirmation", "stop", "bind_velocity_proposal"],
+        )
+        self.assertTrue(result["connected"])
+        self.assertEqual(result["external"]["stop_move_ret"], 0)
+        self.assertIsNone(result["external"]["stop_move_error"])
+        self.assertEqual(
+            result["external"]["confirmation_start"]["odometry_callback_count"],
+            56,
+        )
+
+    def test_parent_stop_exception_is_forwarded_for_fail_closed_confirmation(self):
+        def fail_stop():
+            raise RuntimeError("parent rpc unavailable")
+
+        proxy = self.make_proxy(fail_stop)
+
+        def fake_call(method, **kwargs):
+            if method == "begin_velocity_proposal_stop_confirmation":
+                return {
+                    "confirmation_start": {
+                        "monotonic": 1.0,
+                        "unix_ms": 2,
+                        "odometry_callback_count": 3,
+                    }
+                }
+            return kwargs["external_stop_attempt"]
+
+        proxy._call = fake_call
+        result = proxy.unbind_velocity_proposal("canvas_stop")
+
+        self.assertIsNone(result["stop_move_ret"])
+        self.assertEqual(result["stop_move_error"], "parent rpc unavailable")
+
+    def test_missing_child_boundary_still_issues_parent_stop_and_fails_closed(self):
+        stop_calls = []
+        proxy = self.make_proxy(lambda: stop_calls.append("stop") or 0)
+        proxy._call = lambda method, **kwargs: {"error": "child unavailable"}
+
+        result = proxy.bind_velocity_proposal("/proposal", "nav-1")
+
+        self.assertEqual(stop_calls, ["stop"])
+        self.assertFalse(result["stop_confirmed"])
+        self.assertEqual(result["stop_move_ret"], 0)
+        self.assertEqual(result["error"], "child unavailable")
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import unittest
+
+from safety_harness import SmartMotionProxy
+
+
+class FakeProcess:
+    def __init__(self):
+        self.join_count = 0
+
+    def join(self):
+        self.join_count += 1
+
+
+class SmartMotionExitMonitorTest(unittest.TestCase):
+    def test_child_exit_always_issues_parent_side_stop(self):
+        process = FakeProcess()
+        stop_calls = []
+        proxy = SmartMotionProxy.__new__(SmartMotionProxy)
+        proxy._proc = process
+        proxy._fallback_stop = lambda: stop_calls.append("StopMove")
+
+        proxy._monitor_process_exit()
+
+        self.assertEqual(process.join_count, 1)
+        self.assertEqual(stop_calls, ["StopMove"])
+
+    def test_stop_failure_does_not_crash_exit_monitor(self):
+        proxy = SmartMotionProxy.__new__(SmartMotionProxy)
+        proxy._proc = FakeProcess()
+
+        def fail_stop():
+            raise RuntimeError("rpc unavailable")
+
+        proxy._fallback_stop = fail_stop
+        proxy._monitor_process_exit()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -490,12 +490,8 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
         )
         self.assertIn("terminal_proposal", callback_source)
         self.assertIn("confirm_physical_stop=terminal_proposal", callback_source)
-        self.assertIn("terminal_stop_clean", callback_source)
-        self.assertIn(
-            'stopped.get("reason") == decision.reason',
-            callback_source,
-        )
-        self.assertIn("resume_waiting_after_terminal_stop", callback_source)
+        self.assertNotIn("terminal_stop_clean", callback_source)
+        self.assertIn("resume_waiting_after_terminal", callback_source)
         self.assertIn("if resumed_waiting:", callback_source)
         self.assertIn("stop_repeat_count = 0", callback_source)
         self.assertIn(

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -473,6 +473,13 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
         self.assertIn("last_proposal_stop_result = None", source)
         self.assertIn("parent_loco_rpc_lock", source)
         self.assertIn("proposal_ros_spin_loop", source)
+        self.assertIn("MultiThreadedExecutor(num_threads=2)", source)
+        self.assertIn("depth=1", source)
+        self.assertIn(
+            'f"/{namespace}/lidar/cloud", on_cloud, _CLOUD_QOS',
+            source,
+        )
+        self.assertNotIn("SingleThreadedExecutor", source)
         callback_source = source[
             source.index("def on_velocity_proposal"):
             source.index("def apply_safety_velocity")

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -10,8 +10,9 @@ import unittest
 from safety_harness import (
     SmartMotionProxy,
     _run_smart_motion_process,
+    request_parent_apply_velocity_proposal,
     request_parent_get_fsm_id,
-    request_parent_set_velocity,
+    request_parent_stop_velocity_proposal,
 )
 
 
@@ -122,13 +123,19 @@ class SmartMotionParentStopSequenceTest(unittest.TestCase):
 
 
 class SmartMotionParentLocoSequenceTest(unittest.TestCase):
-    def start_proxy(self, parent_set_velocity, parent_get_fsm_id=lambda: (0, 500)):
+    def start_proxy(
+        self,
+        parent_apply_velocity,
+        parent_get_fsm_id=lambda: (0, 500),
+        fallback_stop=lambda: 0,
+    ):
         proxy = SmartMotionProxy.__new__(SmartMotionProxy)
         proxy._parent_velocity_queue = queue.Queue()
         proxy._parent_velocity_result_queue = queue.Queue()
         proxy._parent_velocity_shutdown = threading.Event()
-        proxy._parent_set_velocity = parent_set_velocity
+        proxy._parent_apply_velocity_proposal = parent_apply_velocity
         proxy._parent_get_fsm_id = parent_get_fsm_id
+        proxy._fallback_stop = fallback_stop
         proxy._parent_velocity_thread = threading.Thread(
             target=proxy._serve_parent_velocity_requests,
             daemon=True,
@@ -141,44 +148,122 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
         proxy._parent_velocity_thread.join(timeout=0.5)
         self.assertFalse(proxy._parent_velocity_thread.is_alive())
 
-    def test_child_request_executes_set_velocity_on_parent(self):
+    def test_child_request_executes_controlled_velocity_on_parent(self):
         calls = []
-        proxy = self.start_proxy(
-            lambda vx, vy, vyaw, duration: calls.append(
-                (vx, vy, vyaw, duration)
-            ) or 0
-        )
+        def apply(vx, vy, vyaw, deadline, nav_id, sequence, request_id):
+            calls.append(
+                (vx, vy, vyaw, deadline, nav_id, sequence, request_id)
+            )
+            return {"ret": 0, "error": None, "applied": True}
+
+        proxy = self.start_proxy(apply)
+        deadline = time.monotonic() + 0.2
         try:
-            result = request_parent_set_velocity(
+            result = request_parent_apply_velocity_proposal(
                 proxy._parent_velocity_queue,
                 proxy._parent_velocity_result_queue,
                 request_id=7,
                 vx=0.1,
                 vy=0.02,
                 vyaw=0.03,
-                duration=0.2,
+                deadline_monotonic=deadline,
+                nav_id="nav-1",
+                sequence=3,
                 timeout=0.2,
             )
         finally:
             self.stop_proxy(proxy)
 
-        self.assertEqual(calls, [(0.1, 0.02, 0.03, 0.2)])
+        self.assertEqual(
+            calls,
+            [(0.1, 0.02, 0.03, deadline, "nav-1", 3, 7)],
+        )
         self.assertEqual(result["request_id"], 7)
         self.assertEqual(result["ret"], 0)
         self.assertIsNone(result["error"])
         self.assertIsNotNone(result["completed_monotonic"])
 
     def test_parent_nonzero_return_is_correlated(self):
-        proxy = self.start_proxy(lambda *_: 3104)
+        proxy = self.start_proxy(
+            lambda *_: {"ret": 3104, "error": None, "applied": False}
+        )
         try:
-            result = request_parent_set_velocity(
+            result = request_parent_apply_velocity_proposal(
                 proxy._parent_velocity_queue,
                 proxy._parent_velocity_result_queue,
                 request_id=8,
                 vx=0.1,
                 vy=0.0,
                 vyaw=0.0,
-                duration=0.2,
+                deadline_monotonic=time.monotonic() + 0.2,
+                nav_id="nav-1",
+                sequence=4,
+                timeout=0.2,
+            )
+        finally:
+            self.stop_proxy(proxy)
+
+        self.assertEqual(result["ret"], 3104)
+        self.assertIsNone(result["error"])
+
+    def test_runtime_stop_is_ordered_after_inflight_parent_apply(self):
+        calls = []
+        apply_started = threading.Event()
+        release_apply = threading.Event()
+
+        def apply(*_):
+            calls.append("apply_started")
+            apply_started.set()
+            release_apply.wait(timeout=0.5)
+            calls.append("apply_completed")
+            return {"ret": 0, "error": None, "applied": True}
+
+        def stop():
+            calls.append("stop")
+            return 0
+
+        proxy = self.start_proxy(apply, fallback_stop=stop)
+        try:
+            proxy._parent_velocity_queue.put({
+                "method": "apply_velocity_proposal",
+                "request_id": 20,
+                "vx": 0.1,
+                "vy": 0.0,
+                "vyaw": 0.0,
+                "deadline_monotonic": time.monotonic() + 1.0,
+                "nav_id": "nav-1",
+                "sequence": 1,
+            })
+            self.assertTrue(apply_started.wait(timeout=0.2))
+            proxy._parent_velocity_queue.put({
+                "method": "stop_velocity_proposal",
+                "request_id": 21,
+            })
+            time.sleep(0.01)
+            self.assertEqual(calls, ["apply_started"])
+            release_apply.set()
+            first = proxy._parent_velocity_result_queue.get(timeout=0.5)
+            second = proxy._parent_velocity_result_queue.get(timeout=0.5)
+        finally:
+            release_apply.set()
+            self.stop_proxy(proxy)
+
+        self.assertEqual(calls, ["apply_started", "apply_completed", "stop"])
+        self.assertEqual(first["request_id"], 20)
+        self.assertEqual(first["ret"], 0)
+        self.assertEqual(second["request_id"], 21)
+        self.assertEqual(second["ret"], 0)
+
+    def test_runtime_parent_stop_failure_is_reported(self):
+        proxy = self.start_proxy(
+            lambda *_: {"ret": 0, "error": None, "applied": True},
+            fallback_stop=lambda: 3104,
+        )
+        try:
+            result = request_parent_stop_velocity_proposal(
+                proxy._parent_velocity_queue,
+                proxy._parent_velocity_result_queue,
+                request_id=22,
                 timeout=0.2,
             )
         finally:
@@ -193,14 +278,16 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
 
         proxy = self.start_proxy(fail)
         try:
-            result = request_parent_set_velocity(
+            result = request_parent_apply_velocity_proposal(
                 proxy._parent_velocity_queue,
                 proxy._parent_velocity_result_queue,
                 request_id=9,
                 vx=0.1,
                 vy=0.0,
                 vyaw=0.0,
-                duration=0.2,
+                deadline_monotonic=time.monotonic() + 0.2,
+                nav_id="nav-1",
+                sequence=5,
                 timeout=0.2,
             )
         finally:
@@ -214,20 +301,22 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
         result_queue = queue.Queue()
         started = time.monotonic()
 
-        result = request_parent_set_velocity(
+        result = request_parent_apply_velocity_proposal(
             request_queue,
             result_queue,
             request_id=10,
             vx=0.1,
             vy=0.0,
             vyaw=0.0,
-            duration=0.2,
+            deadline_monotonic=time.monotonic() + 0.2,
+            nav_id="nav-1",
+            sequence=6,
             timeout=0.03,
         )
 
         self.assertLess(time.monotonic() - started, 0.15)
         self.assertIsNone(result["ret"])
-        self.assertEqual(result["error"], "parent_set_velocity_timeout")
+        self.assertEqual(result["error"], "parent_velocity_proposal_timeout")
 
     def test_stale_parent_reply_cannot_satisfy_new_request(self):
         request_queue = queue.Queue()
@@ -244,14 +333,16 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
 
         responder = threading.Thread(target=reply_current, daemon=True)
         responder.start()
-        result = request_parent_set_velocity(
+        result = request_parent_apply_velocity_proposal(
             request_queue,
             result_queue,
             request_id=11,
             vx=0.1,
             vy=0.0,
             vyaw=0.0,
-            duration=0.2,
+            deadline_monotonic=time.monotonic() + 0.2,
+            nav_id="nav-1",
+            sequence=7,
             timeout=0.2,
         )
         responder.join(timeout=0.5)
@@ -260,7 +351,10 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
         self.assertEqual(result["ret"], 3104)
 
     def test_child_request_gets_fsm_id_from_parent(self):
-        proxy = self.start_proxy(lambda *_: 0, lambda: (0, 500))
+        proxy = self.start_proxy(
+            lambda *_: {"ret": 0, "error": None, "applied": True},
+            lambda: (0, 500),
+        )
         try:
             result = request_parent_get_fsm_id(
                 proxy._parent_velocity_queue,
@@ -280,7 +374,10 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
         def fail():
             raise RuntimeError("parent FSM RPC unavailable")
 
-        proxy = self.start_proxy(lambda *_: 0, fail)
+        proxy = self.start_proxy(
+            lambda *_: {"ret": 0, "error": None, "applied": True},
+            fail,
+        )
         try:
             result = request_parent_get_fsm_id(
                 proxy._parent_velocity_queue,
@@ -346,9 +443,29 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
 
         self.assertNotIn("proposal_loco_client", source)
         self.assertNotIn("fsm_loco_client", source)
-        self.assertIn("apply_parent_set_velocity", source)
+        self.assertIn("apply_parent_velocity_proposal", source)
+        self.assertIn("proposal_apply_loop", source)
         self.assertIn("query_parent_fsm_id", source)
+        self.assertIn("stop_parent_velocity_proposal", source)
+        self.assertEqual(
+            source.count("= stop_parent_velocity_proposal()"),
+            2,
+        )
+        self.assertIn("last_proposal_stop_result = dict(result)", source)
+        self.assertIn('"last_proposal_stop": (', source)
+        self.assertIn("last_proposal_stop_result = None", source)
         self.assertIn("parent_loco_rpc_lock", source)
+        self.assertIn("proposal_ros_spin_loop", source)
+        callback_source = source[
+            source.index("def on_velocity_proposal"):
+            source.index("def apply_safety_velocity")
+        ]
+        self.assertLess(
+            callback_source.index("refresh_proposal_execution_deadline("),
+            callback_source.index("proposal_apply_diagnostics.record_accepted()"),
+        )
+        self.assertIn('name="g1_loco_proposal_ros"', source)
+        self.assertEqual(source.count("executor.spin_once"), 2)
 
     def test_main_wires_parent_rpc_proxy_loco_calls(self):
         main_source = Path(__file__).resolve().parents[1].joinpath(
@@ -356,7 +473,7 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
         ).read_text(encoding="utf-8")
 
         self.assertIn(
-            "parent_set_velocity=loco_client.SetVelocity",
+            "parent_apply_velocity_proposal=loco_client.ApplyVelocityProposal",
             main_source,
         )
         self.assertIn(

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -86,6 +86,23 @@ class SmartMotionParentStopSequenceTest(unittest.TestCase):
             56,
         )
 
+    def test_bind_without_nav_id_preserves_waiting_mode_request(self):
+        calls = []
+        proxy = self.make_proxy(lambda: 0)
+
+        def fake_call(method, **kwargs):
+            calls.append((method, kwargs))
+            if method == "begin_velocity_proposal_stop_confirmation":
+                return {"confirmation_start": {"monotonic": 1.0}}
+            return {"connected": True, "waiting_for_nav_id": True}
+
+        proxy._call = fake_call
+        result = proxy.bind_velocity_proposal("/proposal")
+
+        self.assertTrue(result["waiting_for_nav_id"])
+        self.assertEqual(calls[-1][0], "bind_velocity_proposal")
+        self.assertIsNone(calls[-1][1]["expected_nav_id"])
+
     def test_parent_stop_exception_is_forwarded_for_fail_closed_confirmation(self):
         def fail_stop():
             raise RuntimeError("parent rpc unavailable")
@@ -464,6 +481,50 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
             callback_source.index("refresh_proposal_execution_deadline("),
             callback_source.index("proposal_apply_diagnostics.record_accepted()"),
         )
+        self.assertIn("terminal_proposal", callback_source)
+        self.assertIn("confirm_physical_stop=terminal_proposal", callback_source)
+        self.assertIn("terminal_stop_clean", callback_source)
+        self.assertIn(
+            'stopped.get("reason") == decision.reason',
+            callback_source,
+        )
+        self.assertIn("resume_waiting_after_terminal_stop", callback_source)
+        self.assertIn("if resumed_waiting:", callback_source)
+        self.assertIn("stop_repeat_count = 0", callback_source)
+        self.assertIn(
+            "retry_proposal_stop = (\n"
+            "            proposal_stop_context and external_stop_attempt is None",
+            source,
+        )
+        stop_source = source[
+            source.index("def do_stop("):
+            source.index("def do_stop_nav")
+        ]
+        self.assertLess(
+            stop_source.index("watchdog_fault = clear_proposal_execution()"),
+            stop_source.index("authoritative_proposal_stop_reason("),
+        )
+        apply_loop_source = source[
+            source.index("def proposal_apply_loop"):
+            source.index("def proposal_watchdog_loop")
+        ]
+        self.assertLess(
+            apply_loop_source.index("proposal_apply_result_is_current("),
+            apply_loop_source.index("record_set_velocity("),
+        )
+        watchdog_loop_source = source[
+            source.index("def proposal_watchdog_loop"):
+            source.index("def consume_proposal_watchdog_fault")
+        ]
+        self.assertIn(
+            "proposal_watchdog_transition.trip_and_dispatch_stop(",
+            watchdog_loop_source,
+        )
+        repeat_stop_source = source[
+            source.index("# Repeat StopMove after emergency_stop"):
+            source.index("# Periodic health log")
+        ]
+        self.assertIn("with motion_command_lock:", repeat_stop_source)
         self.assertIn('name="g1_loco_proposal_ros"', source)
         self.assertEqual(source.count("executor.spin_once"), 2)
 

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -10,6 +10,7 @@ import unittest
 from safety_harness import (
     SmartMotionProxy,
     _run_smart_motion_process,
+    request_parent_get_fsm_id,
     request_parent_set_velocity,
 )
 
@@ -120,13 +121,14 @@ class SmartMotionParentStopSequenceTest(unittest.TestCase):
         self.assertEqual(result["error"], "child unavailable")
 
 
-class SmartMotionParentVelocitySequenceTest(unittest.TestCase):
-    def start_proxy(self, parent_set_velocity):
+class SmartMotionParentLocoSequenceTest(unittest.TestCase):
+    def start_proxy(self, parent_set_velocity, parent_get_fsm_id=lambda: (0, 500)):
         proxy = SmartMotionProxy.__new__(SmartMotionProxy)
         proxy._parent_velocity_queue = queue.Queue()
         proxy._parent_velocity_result_queue = queue.Queue()
         proxy._parent_velocity_shutdown = threading.Event()
         proxy._parent_set_velocity = parent_set_velocity
+        proxy._parent_get_fsm_id = parent_get_fsm_id
         proxy._parent_velocity_thread = threading.Thread(
             target=proxy._serve_parent_velocity_requests,
             daemon=True,
@@ -257,19 +259,108 @@ class SmartMotionParentVelocitySequenceTest(unittest.TestCase):
         self.assertEqual(result["request_id"], 11)
         self.assertEqual(result["ret"], 3104)
 
+    def test_child_request_gets_fsm_id_from_parent(self):
+        proxy = self.start_proxy(lambda *_: 0, lambda: (0, 500))
+        try:
+            result = request_parent_get_fsm_id(
+                proxy._parent_velocity_queue,
+                proxy._parent_velocity_result_queue,
+                request_id=12,
+                timeout=0.2,
+            )
+        finally:
+            self.stop_proxy(proxy)
+
+        self.assertEqual(result["request_id"], 12)
+        self.assertEqual(result["ret"], 0)
+        self.assertEqual(result["fsm_id"], 500)
+        self.assertIsNone(result["error"])
+
+    def test_parent_fsm_exception_is_returned_to_child(self):
+        def fail():
+            raise RuntimeError("parent FSM RPC unavailable")
+
+        proxy = self.start_proxy(lambda *_: 0, fail)
+        try:
+            result = request_parent_get_fsm_id(
+                proxy._parent_velocity_queue,
+                proxy._parent_velocity_result_queue,
+                request_id=13,
+                timeout=0.2,
+            )
+        finally:
+            self.stop_proxy(proxy)
+
+        self.assertIsNone(result["ret"])
+        self.assertIsNone(result["fsm_id"])
+        self.assertEqual(result["error"], "parent FSM RPC unavailable")
+
+    def test_parent_fsm_wait_is_bounded(self):
+        started = time.monotonic()
+        result = request_parent_get_fsm_id(
+            queue.Queue(),
+            queue.Queue(),
+            request_id=14,
+            timeout=0.03,
+        )
+
+        self.assertLess(time.monotonic() - started, 0.15)
+        self.assertIsNone(result["ret"])
+        self.assertEqual(result["error"], "parent_get_fsm_id_timeout")
+
+    def test_stale_set_velocity_reply_cannot_satisfy_fsm_request(self):
+        request_queue = queue.Queue()
+        result_queue = queue.Queue()
+        result_queue.put({
+            "method": "set_velocity",
+            "request_id": 14,
+            "ret": 0,
+            "error": None,
+        })
+
+        def reply_current():
+            time.sleep(0.01)
+            result_queue.put({
+                "method": "get_fsm_id",
+                "request_id": 15,
+                "ret": 0,
+                "fsm_id": 801,
+                "error": None,
+            })
+
+        responder = threading.Thread(target=reply_current, daemon=True)
+        responder.start()
+        result = request_parent_get_fsm_id(
+            request_queue,
+            result_queue,
+            request_id=15,
+            timeout=0.2,
+        )
+        responder.join(timeout=0.5)
+
+        self.assertEqual(result["request_id"], 15)
+        self.assertEqual(result["fsm_id"], 801)
+
     def test_proposal_execution_has_no_child_loco_setvelocity(self):
         source = inspect.getsource(_run_smart_motion_process)
 
         self.assertNotIn("proposal_loco_client", source)
+        self.assertNotIn("fsm_loco_client", source)
         self.assertIn("apply_parent_set_velocity", source)
+        self.assertIn("query_parent_fsm_id", source)
+        self.assertIn("parent_loco_rpc_lock", source)
 
-    def test_main_wires_parent_rpc_proxy_set_velocity(self):
+    def test_main_wires_parent_rpc_proxy_loco_calls(self):
         main_source = Path(__file__).resolve().parents[1].joinpath(
             "main.py"
         ).read_text(encoding="utf-8")
 
         self.assertIn(
             "parent_set_velocity=loco_client.SetVelocity",
+            main_source,
+        )
+        self.assertIn(
+            "parent_get_fsm_id=loco_client.GetFsmId",
             main_source,
         )
 

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import inspect
+from pathlib import Path
+import queue
 import threading
+import time
 import unittest
 
-from safety_harness import SmartMotionProxy
+from safety_harness import (
+    SmartMotionProxy,
+    _run_smart_motion_process,
+    request_parent_set_velocity,
+)
 
 
 class FakeProcess:
@@ -110,6 +118,160 @@ class SmartMotionParentStopSequenceTest(unittest.TestCase):
         self.assertFalse(result["stop_confirmed"])
         self.assertEqual(result["stop_move_ret"], 0)
         self.assertEqual(result["error"], "child unavailable")
+
+
+class SmartMotionParentVelocitySequenceTest(unittest.TestCase):
+    def start_proxy(self, parent_set_velocity):
+        proxy = SmartMotionProxy.__new__(SmartMotionProxy)
+        proxy._parent_velocity_queue = queue.Queue()
+        proxy._parent_velocity_result_queue = queue.Queue()
+        proxy._parent_velocity_shutdown = threading.Event()
+        proxy._parent_set_velocity = parent_set_velocity
+        proxy._parent_velocity_thread = threading.Thread(
+            target=proxy._serve_parent_velocity_requests,
+            daemon=True,
+        )
+        proxy._parent_velocity_thread.start()
+        return proxy
+
+    def stop_proxy(self, proxy):
+        proxy._signal_parent_velocity_shutdown()
+        proxy._parent_velocity_thread.join(timeout=0.5)
+        self.assertFalse(proxy._parent_velocity_thread.is_alive())
+
+    def test_child_request_executes_set_velocity_on_parent(self):
+        calls = []
+        proxy = self.start_proxy(
+            lambda vx, vy, vyaw, duration: calls.append(
+                (vx, vy, vyaw, duration)
+            ) or 0
+        )
+        try:
+            result = request_parent_set_velocity(
+                proxy._parent_velocity_queue,
+                proxy._parent_velocity_result_queue,
+                request_id=7,
+                vx=0.1,
+                vy=0.02,
+                vyaw=0.03,
+                duration=0.2,
+                timeout=0.2,
+            )
+        finally:
+            self.stop_proxy(proxy)
+
+        self.assertEqual(calls, [(0.1, 0.02, 0.03, 0.2)])
+        self.assertEqual(result["request_id"], 7)
+        self.assertEqual(result["ret"], 0)
+        self.assertIsNone(result["error"])
+        self.assertIsNotNone(result["completed_monotonic"])
+
+    def test_parent_nonzero_return_is_correlated(self):
+        proxy = self.start_proxy(lambda *_: 3104)
+        try:
+            result = request_parent_set_velocity(
+                proxy._parent_velocity_queue,
+                proxy._parent_velocity_result_queue,
+                request_id=8,
+                vx=0.1,
+                vy=0.0,
+                vyaw=0.0,
+                duration=0.2,
+                timeout=0.2,
+            )
+        finally:
+            self.stop_proxy(proxy)
+
+        self.assertEqual(result["ret"], 3104)
+        self.assertIsNone(result["error"])
+
+    def test_parent_exception_is_returned_to_child(self):
+        def fail(*_):
+            raise RuntimeError("parent rpc unavailable")
+
+        proxy = self.start_proxy(fail)
+        try:
+            result = request_parent_set_velocity(
+                proxy._parent_velocity_queue,
+                proxy._parent_velocity_result_queue,
+                request_id=9,
+                vx=0.1,
+                vy=0.0,
+                vyaw=0.0,
+                duration=0.2,
+                timeout=0.2,
+            )
+        finally:
+            self.stop_proxy(proxy)
+
+        self.assertIsNone(result["ret"])
+        self.assertEqual(result["error"], "parent rpc unavailable")
+
+    def test_child_wait_is_bounded_when_parent_does_not_reply(self):
+        request_queue = queue.Queue()
+        result_queue = queue.Queue()
+        started = time.monotonic()
+
+        result = request_parent_set_velocity(
+            request_queue,
+            result_queue,
+            request_id=10,
+            vx=0.1,
+            vy=0.0,
+            vyaw=0.0,
+            duration=0.2,
+            timeout=0.03,
+        )
+
+        self.assertLess(time.monotonic() - started, 0.15)
+        self.assertIsNone(result["ret"])
+        self.assertEqual(result["error"], "parent_set_velocity_timeout")
+
+    def test_stale_parent_reply_cannot_satisfy_new_request(self):
+        request_queue = queue.Queue()
+        result_queue = queue.Queue()
+        result_queue.put({"request_id": 10, "ret": 0, "error": None})
+
+        def reply_current():
+            time.sleep(0.01)
+            result_queue.put({
+                "request_id": 11,
+                "ret": 3104,
+                "error": None,
+            })
+
+        responder = threading.Thread(target=reply_current, daemon=True)
+        responder.start()
+        result = request_parent_set_velocity(
+            request_queue,
+            result_queue,
+            request_id=11,
+            vx=0.1,
+            vy=0.0,
+            vyaw=0.0,
+            duration=0.2,
+            timeout=0.2,
+        )
+        responder.join(timeout=0.5)
+
+        self.assertEqual(result["request_id"], 11)
+        self.assertEqual(result["ret"], 3104)
+
+    def test_proposal_execution_has_no_child_loco_setvelocity(self):
+        source = inspect.getsource(_run_smart_motion_process)
+
+        self.assertNotIn("proposal_loco_client", source)
+        self.assertIn("apply_parent_set_velocity", source)
+
+    def test_main_wires_parent_rpc_proxy_set_velocity(self):
+        main_source = Path(__file__).resolve().parents[1].joinpath(
+            "main.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "parent_set_velocity=loco_client.SetVelocity",
+            main_source,
+        )
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_stop_confirmation.py
+++ b/unitree/g1/tests/test_stop_confirmation.py
@@ -6,8 +6,9 @@ import unittest
 
 from safety_harness import (
     OdomStopMonitor,
+    StopConfirmationStart,
+    finish_stop_confirmation,
     issue_stop_and_confirm,
-    resolve_proposal_stop_timeouts,
 )
 
 
@@ -116,23 +117,77 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
             "rpc unavailable",
         )
 
-    def test_stop_rpc_timeout_has_margin_within_confirmation_budget(self):
-        rpc_timeout, confirmation_timeout = resolve_proposal_stop_timeouts({
-            "velocity_proposal_stop_rpc_timeout": 0.1,
-            "velocity_proposal_stop_confirm_timeout": 0.5,
-        })
+    def test_parent_stop_ack_is_confirmed_by_child_odometry(self):
+        start = self.monitor.begin_confirmation()
+        self.monitor.record((0.0, 0.0, 0.0))
+        completed = time.monotonic()
 
-        self.assertEqual(rpc_timeout, 0.2)
-        self.assertEqual(confirmation_timeout, 0.5)
+        result = finish_stop_confirmation(
+            monitor=self.monitor,
+            start=start,
+            stop_move_ret=0,
+            stop_move_error=None,
+            stop_move_completed_monotonic=completed,
+            timeout=0.2,
+            max_age=0.5,
+            linear_epsilon=0.03,
+            yaw_epsilon=0.05,
+        )
 
-    def test_stop_rpc_timeout_never_exceeds_confirmation_budget(self):
-        rpc_timeout, confirmation_timeout = resolve_proposal_stop_timeouts({
-            "velocity_proposal_stop_rpc_timeout": 10.0,
-            "velocity_proposal_stop_confirm_timeout": 0.4,
-        })
+        self.assertTrue(result["stop_confirmed"])
+        diagnostics = result["stop_confirmation"]
+        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 1)
+        self.assertEqual(diagnostics["odometry_callbacks_during_stop_move"], 1)
 
-        self.assertEqual(rpc_timeout, 0.4)
-        self.assertEqual(confirmation_timeout, 0.4)
+    def test_parent_stop_failure_stays_fail_closed_with_zero_odometry(self):
+        start = StopConfirmationStart(
+            monotonic=time.monotonic(),
+            unix_ms=round(time.time() * 1000),
+            odometry_callback_count=0,
+        )
+        self.monitor.record((0.0, 0.0, 0.0))
+
+        result = finish_stop_confirmation(
+            monitor=self.monitor,
+            start=start,
+            stop_move_ret=3104,
+            stop_move_error=None,
+            stop_move_completed_monotonic=time.monotonic(),
+            timeout=0.2,
+            max_age=0.5,
+            linear_epsilon=0.03,
+            yaw_epsilon=0.05,
+        )
+
+        self.assertFalse(result["stop_confirmed"])
+        self.assertEqual(result["ret"], 3104)
+        self.assertEqual(
+            result["stop_confirmation"]["odometry_callbacks_since_confirmation"],
+            1,
+        )
+
+    def test_parent_completion_count_excludes_later_ipc_callbacks(self):
+        start = self.monitor.begin_confirmation()
+        self.monitor.record((0.0, 0.0, 0.0))
+        completed = time.monotonic()
+        self.monitor.record((0.0, 0.0, 0.0))
+
+        result = finish_stop_confirmation(
+            monitor=self.monitor,
+            start=start,
+            stop_move_ret=0,
+            stop_move_error=None,
+            stop_move_completed_monotonic=completed,
+            timeout=0.2,
+            max_age=0.5,
+            linear_epsilon=0.03,
+            yaw_epsilon=0.05,
+        )
+
+        diagnostics = result["stop_confirmation"]
+        self.assertTrue(result["stop_confirmed"])
+        self.assertEqual(diagnostics["odometry_callbacks_during_stop_move"], 1)
+        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 2)
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_stop_confirmation.py
+++ b/unitree/g1/tests/test_stop_confirmation.py
@@ -7,8 +7,10 @@ import unittest
 from safety_harness import (
     OdomStopMonitor,
     StopConfirmationStart,
+    aggregate_stop_attempts,
     finish_stop_confirmation,
     issue_stop_and_confirm,
+    resolve_stop_confirmation_timeout,
 )
 
 
@@ -67,6 +69,37 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
             result["stop_confirmation"]["odometry_callbacks_during_stop_move"],
             0,
         )
+
+    def test_zero_frame_after_old_half_second_window_is_confirmed(self):
+        callback_finished = threading.Event()
+
+        def publish_gait_settled_zero():
+            try:
+                time.sleep(0.55)
+                self.monitor.record((0.0, 0.0, 0.0))
+            finally:
+                callback_finished.set()
+
+        publisher = threading.Thread(
+            target=publish_gait_settled_zero,
+            daemon=True,
+        )
+        publisher.start()
+
+        result = self.confirm(
+            lambda: 0,
+            timeout=resolve_stop_confirmation_timeout(0.5),
+        )
+
+        self.assertTrue(callback_finished.wait(0.5))
+        publisher.join(timeout=0.5)
+        self.assertTrue(result["stop_confirmed"])
+        self.assertFalse(result["stop_confirmation"]["confirmation_timed_out"])
+
+    def test_stop_confirmation_timeout_is_sdk_aware_and_bounded(self):
+        self.assertEqual(resolve_stop_confirmation_timeout(0.1), 1.0)
+        self.assertEqual(resolve_stop_confirmation_timeout(2.0), 2.0)
+        self.assertEqual(resolve_stop_confirmation_timeout(10.0), 3.0)
 
     def test_nonzero_frame_fails_closed_and_reports_last_velocity(self):
         def publish_nonzero():
@@ -188,6 +221,47 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
         self.assertTrue(result["stop_confirmed"])
         self.assertEqual(diagnostics["odometry_callbacks_during_stop_move"], 1)
         self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 2)
+
+    def test_bounded_retry_keeps_first_failed_confirmation(self):
+        first = {
+            "ret": 0,
+            "stop_confirmed": False,
+            "stop_confirmation": {
+                "confirmation_timed_out": True,
+                "last_odometry_velocity": {
+                    "x": 0.1,
+                    "y": 0.0,
+                    "yaw": 0.0,
+                },
+            },
+        }
+        second = {
+            "ret": 0,
+            "stop_confirmed": True,
+            "stop_confirmation": {
+                "confirmation_timed_out": False,
+                "last_odometry_velocity": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "yaw": 0.0,
+                },
+            },
+        }
+
+        result = aggregate_stop_attempts([first, second])
+
+        self.assertTrue(result["stop_confirmed"])
+        self.assertEqual(result["stop_attempt_count"], 2)
+        self.assertTrue(
+            result["stop_attempts"][0]["stop_confirmation"][
+                "confirmation_timed_out"
+            ]
+        )
+        self.assertFalse(
+            result["stop_attempts"][1]["stop_confirmation"][
+                "confirmation_timed_out"
+            ]
+        )
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_stop_confirmation.py
+++ b/unitree/g1/tests/test_stop_confirmation.py
@@ -4,7 +4,11 @@ import threading
 import time
 import unittest
 
-from safety_harness import OdomStopMonitor, issue_stop_and_confirm
+from safety_harness import (
+    OdomStopMonitor,
+    issue_stop_and_confirm,
+    resolve_proposal_stop_timeouts,
+)
 
 
 class StopMoveConfirmationIntegrationTest(unittest.TestCase):
@@ -111,6 +115,24 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
             result["stop_confirmation"]["stop_move_error"],
             "rpc unavailable",
         )
+
+    def test_stop_rpc_timeout_has_margin_within_confirmation_budget(self):
+        rpc_timeout, confirmation_timeout = resolve_proposal_stop_timeouts({
+            "velocity_proposal_stop_rpc_timeout": 0.1,
+            "velocity_proposal_stop_confirm_timeout": 0.5,
+        })
+
+        self.assertEqual(rpc_timeout, 0.2)
+        self.assertEqual(confirmation_timeout, 0.5)
+
+    def test_stop_rpc_timeout_never_exceeds_confirmation_budget(self):
+        rpc_timeout, confirmation_timeout = resolve_proposal_stop_timeouts({
+            "velocity_proposal_stop_rpc_timeout": 10.0,
+            "velocity_proposal_stop_confirm_timeout": 0.4,
+        })
+
+        self.assertEqual(rpc_timeout, 0.4)
+        self.assertEqual(confirmation_timeout, 0.4)
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_stop_confirmation.py
+++ b/unitree/g1/tests/test_stop_confirmation.py
@@ -30,7 +30,8 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
 
     def test_zero_frame_arriving_during_synchronous_stopmove_is_confirmed(self):
         def stop_move():
-            self.monitor.record((0.0, 0.0, 0.0))
+            for _ in range(3):
+                self.monitor.record((0.0, 0.0, 0.0))
             return 0
 
         result = self.confirm(stop_move)
@@ -39,8 +40,9 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
         diagnostics = result["stop_confirmation"]
         self.assertEqual(diagnostics["stop_move_ret"], 0)
         self.assertIsNone(diagnostics["stop_move_error"])
-        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 1)
-        self.assertEqual(diagnostics["odometry_callbacks_during_stop_move"], 1)
+        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 3)
+        self.assertEqual(diagnostics["odometry_callbacks_during_stop_move"], 3)
+        self.assertEqual(diagnostics["consecutive_zero_samples"], 3)
         self.assertEqual(
             diagnostics["last_odometry_velocity"],
             {"x": 0.0, "y": 0.0, "yaw": 0.0},
@@ -52,7 +54,8 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
         def publish_delayed_zero():
             try:
                 time.sleep(0.03)
-                self.monitor.record((0.0, 0.0, 0.0))
+                for _ in range(3):
+                    self.monitor.record((0.0, 0.0, 0.0))
             finally:
                 callback_finished.set()
 
@@ -76,7 +79,8 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
         def publish_gait_settled_zero():
             try:
                 time.sleep(0.55)
-                self.monitor.record((0.0, 0.0, 0.0))
+                for _ in range(3):
+                    self.monitor.record((0.0, 0.0, 0.0))
             finally:
                 callback_finished.set()
 
@@ -99,7 +103,52 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
     def test_stop_confirmation_timeout_is_sdk_aware_and_bounded(self):
         self.assertEqual(resolve_stop_confirmation_timeout(0.1), 1.0)
         self.assertEqual(resolve_stop_confirmation_timeout(2.0), 2.0)
-        self.assertEqual(resolve_stop_confirmation_timeout(10.0), 3.0)
+        self.assertEqual(resolve_stop_confirmation_timeout(10.0), 5.0)
+
+    def test_single_zero_frame_does_not_unlock_the_next_task(self):
+        def publish_one_zero():
+            time.sleep(0.02)
+            self.monitor.record((0.0, 0.0, 0.0))
+
+        publisher = threading.Thread(target=publish_one_zero, daemon=True)
+        publisher.start()
+
+        result = self.confirm(lambda: 0, timeout=0.08)
+
+        publisher.join(timeout=0.5)
+        self.assertFalse(result["stop_confirmed"])
+        diagnostics = result["stop_confirmation"]
+        self.assertTrue(diagnostics["confirmation_timed_out"])
+        self.assertEqual(diagnostics["required_consecutive_zero_samples"], 3)
+        self.assertEqual(diagnostics["consecutive_zero_samples"], 1)
+
+    def test_nonzero_frame_resets_the_consecutive_zero_window(self):
+        def publish_settling_sequence():
+            time.sleep(0.02)
+            for velocity in (
+                (0.0, 0.0, 0.0),
+                (0.0, 0.0, 0.0),
+                (0.04, 0.0, 0.0),
+                (0.0, 0.0, 0.0),
+                (0.0, 0.0, 0.0),
+                (0.0, 0.0, 0.0),
+            ):
+                self.monitor.record(velocity)
+
+        publisher = threading.Thread(
+            target=publish_settling_sequence,
+            daemon=True,
+        )
+        publisher.start()
+
+        result = self.confirm(lambda: 0, timeout=0.2)
+
+        publisher.join(timeout=0.5)
+        self.assertTrue(result["stop_confirmed"])
+        self.assertEqual(
+            result["stop_confirmation"]["consecutive_zero_samples"],
+            3,
+        )
 
     def test_nonzero_frame_fails_closed_and_reports_last_velocity(self):
         def publish_nonzero():
@@ -152,7 +201,8 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
 
     def test_parent_stop_ack_is_confirmed_by_child_odometry(self):
         start = self.monitor.begin_confirmation()
-        self.monitor.record((0.0, 0.0, 0.0))
+        for _ in range(3):
+            self.monitor.record((0.0, 0.0, 0.0))
         completed = time.monotonic()
 
         result = finish_stop_confirmation(
@@ -169,8 +219,8 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
 
         self.assertTrue(result["stop_confirmed"])
         diagnostics = result["stop_confirmation"]
-        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 1)
-        self.assertEqual(diagnostics["odometry_callbacks_during_stop_move"], 1)
+        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 3)
+        self.assertEqual(diagnostics["odometry_callbacks_during_stop_move"], 3)
 
     def test_parent_stop_failure_stays_fail_closed_with_zero_odometry(self):
         start = StopConfirmationStart(
@@ -203,7 +253,8 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
         start = self.monitor.begin_confirmation()
         self.monitor.record((0.0, 0.0, 0.0))
         completed = time.monotonic()
-        self.monitor.record((0.0, 0.0, 0.0))
+        for _ in range(2):
+            self.monitor.record((0.0, 0.0, 0.0))
 
         result = finish_stop_confirmation(
             monitor=self.monitor,
@@ -220,7 +271,7 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
         diagnostics = result["stop_confirmation"]
         self.assertTrue(result["stop_confirmed"])
         self.assertEqual(diagnostics["odometry_callbacks_during_stop_move"], 1)
-        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 2)
+        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 3)
 
     def test_bounded_retry_keeps_first_failed_confirmation(self):
         first = {

--- a/unitree/g1/tests/test_stop_confirmation.py
+++ b/unitree/g1/tests/test_stop_confirmation.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+
+from safety_harness import OdomStopMonitor, issue_stop_and_confirm
+
+
+class StopMoveConfirmationIntegrationTest(unittest.TestCase):
+    def setUp(self):
+        self.monitor = OdomStopMonitor()
+
+    def confirm(self, stop_move, timeout=0.2):
+        return issue_stop_and_confirm(
+            stop_move=stop_move,
+            monitor=self.monitor,
+            timeout=timeout,
+            max_age=0.5,
+            linear_epsilon=0.03,
+            yaw_epsilon=0.05,
+        )
+
+    def test_zero_frame_arriving_during_synchronous_stopmove_is_confirmed(self):
+        def stop_move():
+            self.monitor.record((0.0, 0.0, 0.0))
+            return 0
+
+        result = self.confirm(stop_move)
+
+        self.assertTrue(result["stop_confirmed"])
+        diagnostics = result["stop_confirmation"]
+        self.assertEqual(diagnostics["stop_move_ret"], 0)
+        self.assertIsNone(diagnostics["stop_move_error"])
+        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 1)
+        self.assertEqual(diagnostics["odometry_callbacks_during_stop_move"], 1)
+        self.assertEqual(
+            diagnostics["last_odometry_velocity"],
+            {"x": 0.0, "y": 0.0, "yaw": 0.0},
+        )
+
+    def test_zero_frame_arriving_after_stopmove_waits_on_condition(self):
+        callback_finished = threading.Event()
+
+        def publish_delayed_zero():
+            try:
+                time.sleep(0.03)
+                self.monitor.record((0.0, 0.0, 0.0))
+            finally:
+                callback_finished.set()
+
+        publisher = threading.Thread(target=publish_delayed_zero, daemon=True)
+        publisher.start()
+
+        result = self.confirm(lambda: 0)
+
+        self.assertTrue(callback_finished.wait(0.5))
+        publisher.join(timeout=0.5)
+        self.assertTrue(result["stop_confirmed"])
+        self.assertFalse(result["stop_confirmation"]["confirmation_timed_out"])
+        self.assertEqual(
+            result["stop_confirmation"]["odometry_callbacks_during_stop_move"],
+            0,
+        )
+
+    def test_nonzero_frame_fails_closed_and_reports_last_velocity(self):
+        def publish_nonzero():
+            time.sleep(0.02)
+            self.monitor.record((0.04, 0.0, 0.0))
+
+        publisher = threading.Thread(target=publish_nonzero, daemon=True)
+        publisher.start()
+
+        result = self.confirm(lambda: 0, timeout=0.08)
+
+        publisher.join(timeout=0.5)
+        self.assertFalse(result["stop_confirmed"])
+        diagnostics = result["stop_confirmation"]
+        self.assertTrue(diagnostics["confirmation_timed_out"])
+        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 1)
+        self.assertEqual(
+            diagnostics["last_odometry_velocity"],
+            {"x": 0.04, "y": 0.0, "yaw": 0.0},
+        )
+
+    def test_no_new_frame_times_out_with_callback_counts(self):
+        self.monitor.record((0.0, 0.0, 0.0))
+
+        result = self.confirm(lambda: 0, timeout=0.05)
+
+        self.assertFalse(result["stop_confirmed"])
+        diagnostics = result["stop_confirmation"]
+        self.assertTrue(diagnostics["confirmation_timed_out"])
+        self.assertEqual(diagnostics["odometry_callback_count"], 1)
+        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 0)
+        self.assertIsNotNone(diagnostics["confirmation_started_monotonic"])
+        self.assertIsNotNone(diagnostics["confirmation_started_unix_ms"])
+        self.assertIsNotNone(diagnostics["last_odometry_age_ms"])
+
+    def test_stopmove_exception_is_reported_without_waiting(self):
+        def stop_move():
+            raise RuntimeError("rpc unavailable")
+
+        started = time.monotonic()
+        result = self.confirm(stop_move, timeout=0.2)
+
+        self.assertLess(time.monotonic() - started, 0.1)
+        self.assertFalse(result["stop_confirmed"])
+        self.assertIsNone(result["ret"])
+        self.assertEqual(
+            result["stop_confirmation"]["stop_move_error"],
+            "rpc unavailable",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -421,6 +421,31 @@ class ProposalGateTest(unittest.TestCase):
         self.assertTrue(next_task.execute)
         self.assertEqual(gate.expected_nav_id, "nav-002")
 
+    def test_expired_terminal_zero_can_close_current_first_valid_task(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+        self.assertTrue(gate.accept(proposal(nav_id="nav-001"), now=10.0).execute)
+
+        terminal = gate.accept(
+            proposal(
+                nav_id="nav-001",
+                sequence=2,
+                nav_status="stopped",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.5,
+            now_unix_ms=1_800_000_000_500,
+        )
+
+        self.assertTrue(terminal.stop)
+        self.assertFalse(terminal.execute)
+        self.assertEqual(terminal.reason, "proposal_zero")
+        self.assertEqual(gate.last_reason, "nav_task_terminal")
+        self.assertTrue(gate.resume_waiting_after_terminal_stop(True))
+        self.assertTrue(
+            gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.6).execute
+        )
+
     def test_unconfirmed_terminal_stop_remains_fail_closed(self):
         gate = VelocityProposalGate(ProposalLimits())
         gate.bind(EXPECTED_TOPIC)

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -232,6 +232,39 @@ class ProposalGateTest(unittest.TestCase):
         self.assertFalse(self.gate.armed)
         self.assertFalse(self.gate.accept(proposal(sequence=2), now=50.202).execute)
 
+    def test_end_to_end_ttl_rejects_proposal_already_expired_at_driver(self):
+        rejected = self.gate.accept(
+            proposal(issued_at_unix_ms=1_000, ttl_ms=200),
+            now=50.0,
+            now_unix_ms=1_201,
+        )
+
+        self.assertTrue(rejected.stop)
+        self.assertEqual(rejected.reason, "proposal_ttl_expired")
+        self.assertFalse(self.gate.armed)
+        self.assertEqual(self.gate.last_reason, "proposal_ttl_expired")
+
+    def test_end_to_end_ttl_uses_only_remaining_producer_lease(self):
+        accepted = self.gate.accept(
+            proposal(issued_at_unix_ms=1_000, ttl_ms=200),
+            now=50.0,
+            now_unix_ms=1_150,
+        )
+
+        self.assertTrue(accepted.execute)
+        self.assertAlmostEqual(accepted.duration, 0.05)
+        self.assertAlmostEqual(self.gate.deadline_monotonic, 50.05)
+
+    def test_future_producer_timestamp_cannot_extend_max_ttl(self):
+        accepted = self.gate.accept(
+            proposal(issued_at_unix_ms=2_000, ttl_ms=200),
+            now=50.0,
+            now_unix_ms=1_000,
+        )
+
+        self.assertAlmostEqual(accepted.duration, 0.2)
+        self.assertAlmostEqual(self.gate.deadline_monotonic, 50.2)
+
     def test_invalid_payload_disarms_until_explicit_bind(self):
         rejected = self.gate.accept(proposal(frame="map"), now=10.0)
         self.assertTrue(rejected.stop)

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -222,15 +222,21 @@ class ProposalGateTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.gate.bind(EXPECTED_TOPIC, "nav-001")
 
-    def test_watchdog_uses_local_monotonic_deadline(self):
+    def test_watchdog_requests_stop_without_retiring_trusted_lease(self):
         accepted = self.gate.accept(proposal(ttl_ms=200), now=50.0)
         self.assertAlmostEqual(accepted.duration, 0.2)
         self.assertFalse(self.gate.watchdog(now=50.199).stop)
         expired = self.gate.watchdog(now=50.201)
         self.assertTrue(expired.stop)
         self.assertEqual(expired.reason, "proposal_ttl_expired")
-        self.assertFalse(self.gate.armed)
-        self.assertFalse(self.gate.accept(proposal(sequence=2), now=50.202).execute)
+        self.assertTrue(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
+
+        self.gate.hold_after_confirmed_stop("proposal_ttl_expired")
+        recovered = self.gate.accept(proposal(sequence=2), now=50.202)
+        self.assertTrue(recovered.execute)
+        self.assertTrue(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
 
     def test_end_to_end_ttl_rejects_proposal_already_expired_at_driver(self):
         rejected = self.gate.accept(
@@ -241,8 +247,18 @@ class ProposalGateTest(unittest.TestCase):
 
         self.assertTrue(rejected.stop)
         self.assertEqual(rejected.reason, "proposal_ttl_expired")
-        self.assertFalse(self.gate.armed)
+        self.assertTrue(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
         self.assertEqual(self.gate.last_reason, "proposal_ttl_expired")
+
+        self.gate.hold_after_confirmed_stop("proposal_ttl_expired")
+        self.assertEqual(
+            self.gate.last_reason,
+            "proposal_ttl_stop_recoverable",
+        )
+        self.assertTrue(
+            self.gate.accept(proposal(sequence=2), now=50.1).execute
+        )
 
     def test_confirmed_obstacle_stop_keeps_lease_for_fresh_escape_command(self):
         self.assertTrue(self.gate.accept(proposal(sequence=1), now=50.0).execute)
@@ -276,6 +292,29 @@ class ProposalGateTest(unittest.TestCase):
         self.assertTrue(escape.execute)
         self.assertTrue(self.gate.armed)
         self.assertFalse(self.gate.recoverable_stop_active)
+
+    def test_stale_samples_drain_during_confirmed_ttl_hold(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=1), now=50.0).execute)
+        self.gate.watchdog(now=50.3)
+        self.gate.hold_after_confirmed_stop("proposal_ttl_expired")
+
+        stale = self.gate.accept(
+            proposal(sequence=2, issued_at_unix_ms=1_000, ttl_ms=200),
+            now=50.4,
+            now_unix_ms=1_201,
+        )
+
+        self.assertTrue(stale.stop)
+        self.assertEqual(stale.reason, "proposal_ttl_expired")
+        self.assertTrue(self.gate.armed)
+        self.assertTrue(self.gate.recoverable_stop_active)
+        self.assertEqual(
+            self.gate.last_reason,
+            "proposal_ttl_stop_recoverable",
+        )
+        self.assertTrue(
+            self.gate.accept(proposal(sequence=3), now=50.5).execute
+        )
 
     def test_hard_fault_still_disarms_from_recoverable_obstacle_stop(self):
         self.assertTrue(self.gate.accept(proposal(sequence=1), now=10.0).execute)

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -8,6 +8,7 @@ from velocity_proposal import (
     ProposalLimits,
     VelocityProposalGate,
     VelocityProposalValidationError,
+    resolve_expected_nav_id,
     resolve_input_topic,
     validate_velocity_proposal,
     velocity_proposal_port,
@@ -78,6 +79,22 @@ class TopicResolutionTest(unittest.TestCase):
             with self.subTest(args=args), self.assertRaises(ValueError):
                 resolve_input_topic(args, EXPECTED_TOPIC)
 
+    def test_resolves_trusted_expected_nav_id_from_control_plane(self):
+        self.assertEqual(
+            resolve_expected_nav_id({"expected_nav_id": " nav-001 "}),
+            "nav-001",
+        )
+
+    def test_rejects_missing_or_invalid_expected_nav_id(self):
+        for args in (
+            {},
+            {"expected_nav_id": ""},
+            {"expected_nav_id": 123},
+            {"expected_nav_id": "x" * 129},
+        ):
+            with self.subTest(args=args), self.assertRaises(ValueError):
+                resolve_expected_nav_id(args)
+
 
 class ProposalValidationTest(unittest.TestCase):
     def setUp(self):
@@ -145,7 +162,15 @@ class ProposalValidationTest(unittest.TestCase):
 class ProposalGateTest(unittest.TestCase):
     def setUp(self):
         self.gate = VelocityProposalGate(ProposalLimits())
-        self.gate.bind(EXPECTED_TOPIC)
+        self.gate.bind(EXPECTED_TOPIC, "nav-001")
+
+    def test_first_packet_must_match_control_plane_nav_lease(self):
+        rejected = self.gate.accept(
+            proposal(nav_id="attacker-selected", sequence=1), now=10.0
+        )
+        self.assertTrue(rejected.stop)
+        self.assertEqual(rejected.reason, "nav_id_mismatch")
+        self.assertFalse(self.gate.armed)
 
     def test_sequence_must_strictly_increase_for_active_nav(self):
         first = self.gate.accept(proposal(sequence=10), now=100.0)
@@ -163,7 +188,7 @@ class ProposalGateTest(unittest.TestCase):
         self.assertTrue(rejected.stop)
         self.assertEqual(rejected.reason, "nav_id_mismatch")
 
-    def test_terminal_zero_releases_nav_lease(self):
+    def test_terminal_zero_retires_and_disarms_nav_lease(self):
         self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
         terminal = self.gate.accept(
             proposal(
@@ -174,8 +199,15 @@ class ProposalGateTest(unittest.TestCase):
             now=10.1,
         )
         self.assertTrue(terminal.stop)
+        self.assertFalse(self.gate.armed)
         next_task = self.gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.2)
-        self.assertTrue(next_task.execute)
+        self.assertFalse(next_task.execute)
+        self.assertTrue(next_task.stop)
+
+        self.gate.bind(EXPECTED_TOPIC, "nav-002")
+        self.assertTrue(
+            self.gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.3).execute
+        )
 
     def test_completed_nav_id_cannot_be_replayed(self):
         self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
@@ -187,9 +219,8 @@ class ProposalGateTest(unittest.TestCase):
             ),
             now=10.1,
         )
-        replay = self.gate.accept(proposal(sequence=3), now=10.2)
-        self.assertTrue(replay.stop)
-        self.assertEqual(replay.reason, "retired_nav_id_replay")
+        with self.assertRaises(ValueError):
+            self.gate.bind(EXPECTED_TOPIC, "nav-001")
 
     def test_watchdog_uses_local_monotonic_deadline(self):
         accepted = self.gate.accept(proposal(ttl_ms=200), now=50.0)
@@ -207,8 +238,33 @@ class ProposalGateTest(unittest.TestCase):
         self.assertFalse(self.gate.armed)
         still_rejected = self.gate.accept(proposal(sequence=2), now=10.1)
         self.assertFalse(still_rejected.execute)
-        self.gate.bind(EXPECTED_TOPIC)
-        self.assertTrue(self.gate.accept(proposal(), now=10.2).execute)
+        with self.assertRaises(ValueError):
+            self.gate.bind(EXPECTED_TOPIC, "nav-001")
+        self.gate.bind(EXPECTED_TOPIC, "nav-002")
+        self.assertTrue(
+            self.gate.accept(proposal(nav_id="nav-002"), now=10.2).execute
+        )
+
+    def test_canvas_unbind_retires_nav_id_against_delayed_replay(self):
+        self.gate.unbind("canvas_stop")
+        with self.assertRaises(ValueError):
+            self.gate.bind(EXPECTED_TOPIC, "nav-001")
+
+    def test_repeated_identical_bind_is_idempotent_without_sequence_reset(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=10), now=10.0).execute)
+        self.gate.bind(EXPECTED_TOPIC, "nav-001")
+        replay = self.gate.accept(proposal(sequence=10), now=10.1)
+        self.assertTrue(replay.stop)
+        self.assertEqual(replay.reason, "sequence_not_increasing")
+
+    def test_retired_nav_ids_are_not_dropped_after_a_fixed_window(self):
+        self.gate.unbind("canvas_stop")
+        for index in range(2, 41):
+            self.gate.bind(EXPECTED_TOPIC, f"nav-{index:03d}")
+            self.gate.unbind("canvas_stop")
+        for index in range(1, 41):
+            with self.subTest(index=index), self.assertRaises(ValueError):
+                self.gate.bind(EXPECTED_TOPIC, f"nav-{index:03d}")
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -244,6 +244,70 @@ class ProposalGateTest(unittest.TestCase):
         self.assertFalse(self.gate.armed)
         self.assertEqual(self.gate.last_reason, "proposal_ttl_expired")
 
+    def test_confirmed_obstacle_stop_keeps_lease_for_fresh_escape_command(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=1), now=50.0).execute)
+        self.gate.hold_for_obstacle()
+
+        held = self.gate.snapshot(50.1)
+        self.assertTrue(held["connected"])
+        self.assertTrue(held["armed"])
+        self.assertTrue(held["recoverable_stop_active"])
+        self.assertEqual(held["active_nav_id"], "nav-001")
+        self.assertEqual(held["last_reason"], "obstacle_stop_recoverable")
+
+        stale = self.gate.accept(
+            proposal(sequence=2, issued_at_unix_ms=1_000, ttl_ms=200),
+            now=50.2,
+            now_unix_ms=1_201,
+        )
+        self.assertTrue(stale.stop)
+        self.assertEqual(stale.reason, "proposal_ttl_expired")
+        self.assertTrue(self.gate.armed)
+        self.assertTrue(self.gate.recoverable_stop_active)
+        self.assertEqual(self.gate.last_sequence, 2)
+
+        escape = self.gate.accept(
+            proposal(
+                sequence=3,
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.2},
+            ),
+            now=50.3,
+        )
+        self.assertTrue(escape.execute)
+        self.assertTrue(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
+
+    def test_hard_fault_still_disarms_from_recoverable_obstacle_stop(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=1), now=10.0).execute)
+        self.gate.hold_for_obstacle()
+
+        rejected = self.gate.accept(
+            proposal(sequence=2, frame="map"),
+            now=10.1,
+        )
+
+        self.assertTrue(rejected.stop)
+        self.assertEqual(rejected.reason, "frame_mismatch")
+        self.assertFalse(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
+
+    def test_terminal_zero_retires_recoverable_obstacle_lease(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=1), now=10.0).execute)
+        self.gate.hold_for_obstacle()
+
+        terminal = self.gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+
+        self.assertTrue(terminal.stop)
+        self.assertFalse(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
+
     def test_end_to_end_ttl_uses_only_remaining_producer_lease(self):
         accepted = self.gate.accept(
             proposal(issued_at_unix_ms=1_000, ttl_ms=200),

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -386,7 +386,7 @@ class ProposalGateTest(unittest.TestCase):
             self.gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.3).execute
         )
 
-    def test_confirmed_terminal_stop_rearms_first_valid_binding_for_next_task(self):
+    def test_terminal_stop_rearms_first_valid_binding_for_next_task(self):
         gate = VelocityProposalGate(ProposalLimits())
         gate.bind(EXPECTED_TOPIC)
         self.assertTrue(gate.accept(proposal(nav_id="nav-001"), now=10.0).execute)
@@ -402,7 +402,7 @@ class ProposalGateTest(unittest.TestCase):
 
         self.assertTrue(terminal.stop)
         self.assertFalse(gate.armed)
-        self.assertTrue(gate.resume_waiting_after_terminal_stop(True))
+        self.assertTrue(gate.resume_waiting_after_terminal())
         self.assertTrue(gate.waiting_for_nav_id)
         self.assertEqual(gate.expected_nav_id, "")
 
@@ -441,12 +441,12 @@ class ProposalGateTest(unittest.TestCase):
         self.assertFalse(terminal.execute)
         self.assertEqual(terminal.reason, "proposal_zero")
         self.assertEqual(gate.last_reason, "nav_task_terminal")
-        self.assertTrue(gate.resume_waiting_after_terminal_stop(True))
+        self.assertTrue(gate.resume_waiting_after_terminal())
         self.assertTrue(
             gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.6).execute
         )
 
-    def test_unconfirmed_terminal_stop_remains_fail_closed(self):
+    def test_terminal_task_releases_without_stop_receipt_lock(self):
         gate = VelocityProposalGate(ProposalLimits())
         gate.bind(EXPECTED_TOPIC)
         self.assertTrue(gate.accept(proposal(), now=10.0).execute)
@@ -459,10 +459,10 @@ class ProposalGateTest(unittest.TestCase):
             now=10.1,
         )
 
-        self.assertFalse(gate.resume_waiting_after_terminal_stop(False))
+        self.assertTrue(gate.resume_waiting_after_terminal())
         self.assertFalse(gate.armed)
-        self.assertFalse(gate.waiting_for_nav_id)
-        self.assertEqual(gate.last_reason, "nav_task_terminal_stop_unconfirmed")
+        self.assertTrue(gate.waiting_for_nav_id)
+        self.assertEqual(gate.last_reason, "waiting_for_nav_id")
 
     def test_late_terminal_confirmation_cannot_rearm_after_unbind(self):
         gate = VelocityProposalGate(ProposalLimits())
@@ -478,7 +478,7 @@ class ProposalGateTest(unittest.TestCase):
         )
         gate.unbind("canvas_stop")
 
-        self.assertFalse(gate.resume_waiting_after_terminal_stop(True))
+        self.assertFalse(gate.resume_waiting_after_terminal())
         self.assertFalse(gate.connected_topic)
         self.assertFalse(gate.waiting_for_nav_id)
         self.assertEqual(gate.last_reason, "canvas_stop")
@@ -493,14 +493,14 @@ class ProposalGateTest(unittest.TestCase):
             ),
             now=10.1,
         )
-        self.assertFalse(self.gate.resume_waiting_after_terminal_stop(True))
+        self.assertFalse(self.gate.resume_waiting_after_terminal())
         self.assertFalse(self.gate.waiting_for_nav_id)
 
         gate = VelocityProposalGate(ProposalLimits())
         gate.bind(EXPECTED_TOPIC)
         self.assertTrue(gate.accept(proposal(), now=20.0).execute)
         gate.disarm("manual_override")
-        self.assertFalse(gate.resume_waiting_after_terminal_stop(True))
+        self.assertFalse(gate.resume_waiting_after_terminal())
         self.assertFalse(gate.waiting_for_nav_id)
         self.assertEqual(gate.last_reason, "manual_override")
 

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import math
+import unittest
+
+from velocity_proposal import (
+    DEFAULT_VELOCITY_PROPOSAL_TOPIC,
+    ProposalLimits,
+    VelocityProposalGate,
+    VelocityProposalValidationError,
+    resolve_input_topic,
+    validate_velocity_proposal,
+    velocity_proposal_port,
+)
+
+
+EXPECTED_TOPIC = "/ubuntu/navigation/nav2/velocity_proposal"
+
+
+def proposal(**changes):
+    value = {
+        "schema": "phanthy.navigation.velocity_proposal.v1",
+        "nav_id": "nav-001",
+        "sequence": 1,
+        "issued_at_unix_ms": 1_800_000_000_000,
+        "ttl_ms": 200,
+        "frame": "base_link",
+        "shadow_only": True,
+        "physical_execution": False,
+        "nav_status": "navigating",
+        "velocity": {"x": 0.10, "y": 0.02, "yaw": 0.15},
+    }
+    value.update(changes)
+    return value
+
+
+class TopicResolutionTest(unittest.TestCase):
+    def test_n5_topic_is_not_namespace_dependent(self):
+        self.assertEqual(DEFAULT_VELOCITY_PROPOSAL_TOPIC, EXPECTED_TOPIC)
+
+    def test_port_matches_n5_contract(self):
+        self.assertEqual(
+            velocity_proposal_port(EXPECTED_TOPIC),
+            {
+                "port": "velocity_proposal",
+                "topic": EXPECTED_TOPIC,
+                "format": "data/json",
+                "ros_type": "std_msgs/msg/String",
+                "qos": "RELIABLE + KEEP_LAST(depth=10) + VOLATILE",
+                "schema": "phanthy.navigation.velocity_proposal.v1",
+            },
+        )
+
+    def test_accepts_single_input_topic(self):
+        self.assertEqual(
+            resolve_input_topic({"input_topic": EXPECTED_TOPIC}, EXPECTED_TOPIC),
+            EXPECTED_TOPIC,
+        )
+
+    def test_accepts_single_input_topics_entry(self):
+        self.assertEqual(
+            resolve_input_topic({"input_topics": [EXPECTED_TOPIC]}, EXPECTED_TOPIC),
+            EXPECTED_TOPIC,
+        )
+
+    def test_rejects_empty_multiple_or_unexpected_topics(self):
+        for args in (
+            {},
+            {"input_topics": []},
+            {"input_topics": [EXPECTED_TOPIC, ""]},
+            {"input_topics": [EXPECTED_TOPIC, "/other"]},
+            {
+                "input_topic": EXPECTED_TOPIC,
+                "input_topics": [EXPECTED_TOPIC],
+            },
+            {"input_topic": "/ubuntu/navigation/nav2/cmd_vel_shadow"},
+        ):
+            with self.subTest(args=args), self.assertRaises(ValueError):
+                resolve_input_topic(args, EXPECTED_TOPIC)
+
+
+class ProposalValidationTest(unittest.TestCase):
+    def setUp(self):
+        self.limits = ProposalLimits()
+
+    def test_valid_proposal(self):
+        result = validate_velocity_proposal(proposal(), self.limits)
+        self.assertEqual(result.nav_id, "nav-001")
+        self.assertEqual(result.ttl_ms, 200)
+        self.assertFalse(result.is_zero)
+
+    def test_rejects_wrong_schema_frame_or_flags(self):
+        cases = (
+            {"schema": "other"},
+            {"frame": "map"},
+            {"shadow_only": False},
+            {"physical_execution": True},
+        )
+        for changes in cases:
+            with self.subTest(changes=changes), self.assertRaises(VelocityProposalValidationError):
+                validate_velocity_proposal(proposal(**changes), self.limits)
+
+    def test_rejects_invalid_identity_timing_and_status_fields(self):
+        cases = (
+            {"nav_id": ""},
+            {"sequence": True},
+            {"issued_at_unix_ms": math.inf},
+            {"ttl_ms": True},
+            {"nav_status": "unknown"},
+            {"nav_status": None, "status": "navigating"},
+            {"nav_status": "navigating", "status": "navigating"},
+        )
+        for changes in cases:
+            with self.subTest(changes=changes), self.assertRaises(VelocityProposalValidationError):
+                validate_velocity_proposal(proposal(**changes), self.limits)
+
+    def test_rejects_nonfinite_and_each_speed_limit(self):
+        velocities = (
+            {"x": math.nan, "y": 0.0, "yaw": 0.0},
+            {"x": 0.151, "y": 0.0, "yaw": 0.0},
+            {"x": -0.051, "y": 0.0, "yaw": 0.0},
+            {"x": 0.0, "y": 0.121, "yaw": 0.0},
+            {"x": 0.0, "y": 0.0, "yaw": 0.351},
+            {"x": 0.15, "y": 0.11, "yaw": 0.0},
+        )
+        for velocity in velocities:
+            with self.subTest(velocity=velocity), self.assertRaises(VelocityProposalValidationError):
+                validate_velocity_proposal(proposal(velocity=velocity), self.limits)
+
+    def test_rejects_ttl_above_250_ms(self):
+        with self.assertRaises(VelocityProposalValidationError):
+            validate_velocity_proposal(proposal(ttl_ms=251), self.limits)
+
+    def test_terminal_status_requires_zero_velocity(self):
+        with self.assertRaises(VelocityProposalValidationError):
+            validate_velocity_proposal(proposal(nav_status="arrived"), self.limits)
+        result = validate_velocity_proposal(
+            proposal(nav_status="arrived", velocity={"x": 0.0, "y": 0.0, "yaw": 0.0}),
+            self.limits,
+        )
+        self.assertTrue(result.is_terminal)
+        self.assertTrue(result.is_zero)
+
+
+class ProposalGateTest(unittest.TestCase):
+    def setUp(self):
+        self.gate = VelocityProposalGate(ProposalLimits())
+        self.gate.bind(EXPECTED_TOPIC)
+
+    def test_sequence_must_strictly_increase_for_active_nav(self):
+        first = self.gate.accept(proposal(sequence=10), now=100.0)
+        second = self.gate.accept(proposal(sequence=11), now=100.05)
+        replay = self.gate.accept(proposal(sequence=11), now=100.10)
+        self.assertTrue(first.execute)
+        self.assertTrue(second.execute)
+        self.assertTrue(replay.stop)
+        self.assertFalse(self.gate.armed)
+        self.assertEqual(replay.reason, "sequence_not_increasing")
+
+    def test_nav_id_cannot_change_mid_task(self):
+        self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
+        rejected = self.gate.accept(proposal(nav_id="nav-002", sequence=2), now=10.1)
+        self.assertTrue(rejected.stop)
+        self.assertEqual(rejected.reason, "nav_id_mismatch")
+
+    def test_terminal_zero_releases_nav_lease(self):
+        self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
+        terminal = self.gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+        self.assertTrue(terminal.stop)
+        next_task = self.gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.2)
+        self.assertTrue(next_task.execute)
+
+    def test_completed_nav_id_cannot_be_replayed(self):
+        self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
+        self.gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+        replay = self.gate.accept(proposal(sequence=3), now=10.2)
+        self.assertTrue(replay.stop)
+        self.assertEqual(replay.reason, "retired_nav_id_replay")
+
+    def test_watchdog_uses_local_monotonic_deadline(self):
+        accepted = self.gate.accept(proposal(ttl_ms=200), now=50.0)
+        self.assertAlmostEqual(accepted.duration, 0.2)
+        self.assertFalse(self.gate.watchdog(now=50.199).stop)
+        expired = self.gate.watchdog(now=50.201)
+        self.assertTrue(expired.stop)
+        self.assertEqual(expired.reason, "proposal_ttl_expired")
+        self.assertFalse(self.gate.armed)
+        self.assertFalse(self.gate.accept(proposal(sequence=2), now=50.202).execute)
+
+    def test_invalid_payload_disarms_until_explicit_bind(self):
+        rejected = self.gate.accept(proposal(frame="map"), now=10.0)
+        self.assertTrue(rejected.stop)
+        self.assertFalse(self.gate.armed)
+        still_rejected = self.gate.accept(proposal(sequence=2), now=10.1)
+        self.assertFalse(still_rejected.execute)
+        self.gate.bind(EXPECTED_TOPIC)
+        self.assertTrue(self.gate.accept(proposal(), now=10.2).execute)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -10,6 +10,7 @@ from velocity_proposal import (
     VelocityProposalValidationError,
     resolve_expected_nav_id,
     resolve_input_topic,
+    resolve_proposal_limits,
     validate_velocity_proposal,
     velocity_proposal_port,
 )
@@ -106,6 +107,46 @@ class ProposalValidationTest(unittest.TestCase):
         self.assertEqual(result.ttl_ms, 200)
         self.assertFalse(result.is_zero)
 
+    def test_accepts_declared_loco_component_endpoints(self):
+        velocities = (
+            {"x": 1.0, "y": 0.0, "yaw": 0.0},
+            {"x": -1.0, "y": 0.0, "yaw": 0.0},
+            {"x": 0.0, "y": 1.0, "yaw": 0.0},
+            {"x": 0.0, "y": -1.0, "yaw": 0.0},
+            {"x": 1.0, "y": 1.0, "yaw": 0.0},
+            {"x": 0.0, "y": 0.0, "yaw": 2.0},
+            {"x": 0.0, "y": 0.0, "yaw": -2.0},
+        )
+        for velocity in velocities:
+            with self.subTest(velocity=velocity):
+                validate_velocity_proposal(
+                    proposal(velocity=velocity),
+                    self.limits,
+                )
+
+    def test_resolves_config_within_driver_envelope(self):
+        limits = resolve_proposal_limits({})
+        self.assertEqual(limits.min_x, -1.0)
+        self.assertEqual(limits.max_x, 1.0)
+        self.assertEqual(limits.max_abs_y, 1.0)
+        self.assertEqual(limits.max_abs_yaw, 2.0)
+        self.assertAlmostEqual(limits.max_planar_speed, math.sqrt(2.0))
+
+        loosened = resolve_proposal_limits(
+            {
+                "velocity_proposal_min_x": -2.0,
+                "velocity_proposal_max_x": 2.0,
+                "velocity_proposal_max_abs_y": 2.0,
+                "velocity_proposal_max_abs_yaw": 3.0,
+                "velocity_proposal_max_planar_speed": 2.0,
+            }
+        )
+        self.assertEqual(loosened.min_x, -1.0)
+        self.assertEqual(loosened.max_x, 1.0)
+        self.assertEqual(loosened.max_abs_y, 1.0)
+        self.assertEqual(loosened.max_abs_yaw, 2.0)
+        self.assertAlmostEqual(loosened.max_planar_speed, math.sqrt(2.0))
+
     def test_rejects_wrong_schema_frame_or_flags(self):
         cases = (
             {"schema": "other"},
@@ -134,15 +175,22 @@ class ProposalValidationTest(unittest.TestCase):
     def test_rejects_nonfinite_and_each_speed_limit(self):
         velocities = (
             {"x": math.nan, "y": 0.0, "yaw": 0.0},
-            {"x": 0.151, "y": 0.0, "yaw": 0.0},
-            {"x": -0.051, "y": 0.0, "yaw": 0.0},
-            {"x": 0.0, "y": 0.121, "yaw": 0.0},
-            {"x": 0.0, "y": 0.0, "yaw": 0.351},
-            {"x": 0.15, "y": 0.11, "yaw": 0.0},
+            {"x": 1.001, "y": 0.0, "yaw": 0.0},
+            {"x": -1.001, "y": 0.0, "yaw": 0.0},
+            {"x": 0.0, "y": 1.001, "yaw": 0.0},
+            {"x": 0.0, "y": 0.0, "yaw": 2.001},
         )
         for velocity in velocities:
             with self.subTest(velocity=velocity), self.assertRaises(VelocityProposalValidationError):
                 validate_velocity_proposal(proposal(velocity=velocity), self.limits)
+
+    def test_rejects_tightened_planar_speed(self):
+        limits = ProposalLimits(max_planar_speed=1.0)
+        with self.assertRaises(VelocityProposalValidationError):
+            validate_velocity_proposal(
+                proposal(velocity={"x": 0.8, "y": 0.8, "yaw": 0.0}),
+                limits,
+            )
 
     def test_rejects_ttl_above_250_ms(self):
         with self.assertRaises(VelocityProposalValidationError):
@@ -163,6 +211,135 @@ class ProposalGateTest(unittest.TestCase):
     def setUp(self):
         self.gate = VelocityProposalGate(ProposalLimits())
         self.gate.bind(EXPECTED_TOPIC, "nav-001")
+
+    def test_missing_expected_nav_id_waits_without_arming(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+
+        status = gate.snapshot(10.0)
+        self.assertTrue(status["connected"])
+        self.assertFalse(status["armed"])
+        self.assertTrue(status["waiting_for_nav_id"])
+        self.assertEqual(status["binding_mode"], "first_valid_proposal")
+        self.assertIsNone(status["expected_nav_id"])
+        self.assertIsNone(status["auto_bound_nav_id"])
+
+    def test_first_fresh_valid_proposal_atomically_claims_lease(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+
+        accepted = gate.accept(
+            proposal(issued_at_unix_ms=1_000, ttl_ms=200),
+            now=50.0,
+            now_unix_ms=1_100,
+        )
+
+        self.assertTrue(accepted.execute)
+        status = gate.snapshot(50.0)
+        self.assertTrue(status["armed"])
+        self.assertFalse(status["waiting_for_nav_id"])
+        self.assertEqual(status["expected_nav_id"], "nav-001")
+        self.assertEqual(status["active_nav_id"], "nav-001")
+        self.assertEqual(status["auto_bound_nav_id"], "nav-001")
+        self.assertEqual(status["binding_mode"], "first_valid_proposal")
+
+    def test_invalid_or_expired_proposal_cannot_claim_waiting_lease(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+
+        invalid = gate.accept(proposal(frame="map"), now=50.0)
+        expired = gate.accept(
+            proposal(issued_at_unix_ms=1_000, ttl_ms=200),
+            now=50.1,
+            now_unix_ms=1_201,
+        )
+
+        self.assertFalse(invalid.execute)
+        self.assertFalse(invalid.stop)
+        self.assertEqual(invalid.reason, "frame_mismatch")
+        self.assertFalse(expired.execute)
+        self.assertFalse(expired.stop)
+        self.assertEqual(expired.reason, "proposal_ttl_expired")
+        self.assertTrue(gate.waiting_for_nav_id)
+        self.assertFalse(gate.armed)
+        self.assertEqual(gate.expected_nav_id, "")
+
+        fresh = gate.accept(
+            proposal(nav_id="nav-002", issued_at_unix_ms=1_300),
+            now=50.2,
+            now_unix_ms=1_301,
+        )
+        self.assertTrue(fresh.execute)
+        self.assertEqual(gate.expected_nav_id, "nav-002")
+
+    def test_zero_or_terminal_proposal_cannot_claim_waiting_lease(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+
+        zero = gate.accept(
+            proposal(
+                nav_id="nav-old",
+                sequence=10,
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=50.0,
+        )
+        terminal = gate.accept(
+            proposal(
+                nav_id="nav-old",
+                sequence=11,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=50.1,
+        )
+
+        for decision in (zero, terminal):
+            self.assertFalse(decision.execute)
+            self.assertFalse(decision.stop)
+            self.assertEqual(decision.reason, "waiting_for_active_proposal")
+        self.assertTrue(gate.waiting_for_nav_id)
+        self.assertFalse(gate.armed)
+        self.assertEqual(gate.expected_nav_id, "")
+
+        active = gate.accept(
+            proposal(nav_id="nav-002", sequence=1),
+            now=50.2,
+        )
+        self.assertTrue(active.execute)
+        self.assertEqual(gate.expected_nav_id, "nav-002")
+
+    def test_rotation_only_proposal_can_claim_waiting_lease(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+
+        rotation = gate.accept(
+            proposal(
+                nav_id="nav-rotate",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.25},
+            ),
+            now=50.0,
+        )
+
+        self.assertTrue(rotation.execute)
+        self.assertTrue(gate.armed)
+        self.assertEqual(gate.expected_nav_id, "nav-rotate")
+
+    def test_retired_nav_id_cannot_reclaim_waiting_lease(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC, "nav-001")
+        gate.unbind("canvas_stop")
+        gate.bind(EXPECTED_TOPIC)
+
+        replay = gate.accept(proposal(nav_id="nav-001"), now=50.0)
+
+        self.assertFalse(replay.execute)
+        self.assertEqual(replay.reason, "retired_nav_id_replay")
+        self.assertTrue(gate.waiting_for_nav_id)
+        self.assertFalse(gate.armed)
+        self.assertTrue(
+            gate.accept(proposal(nav_id="nav-002"), now=50.1).execute
+        )
 
     def test_first_packet_must_match_control_plane_nav_lease(self):
         rejected = self.gate.accept(
@@ -208,6 +385,99 @@ class ProposalGateTest(unittest.TestCase):
         self.assertTrue(
             self.gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.3).execute
         )
+
+    def test_confirmed_terminal_stop_rearms_first_valid_binding_for_next_task(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+        self.assertTrue(gate.accept(proposal(nav_id="nav-001"), now=10.0).execute)
+        terminal = gate.accept(
+            proposal(
+                nav_id="nav-001",
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+
+        self.assertTrue(terminal.stop)
+        self.assertFalse(gate.armed)
+        self.assertTrue(gate.resume_waiting_after_terminal_stop(True))
+        self.assertTrue(gate.waiting_for_nav_id)
+        self.assertEqual(gate.expected_nav_id, "")
+
+        replay = gate.accept(
+            proposal(nav_id="nav-001", sequence=3),
+            now=10.2,
+        )
+        self.assertFalse(replay.execute)
+        self.assertEqual(replay.reason, "retired_nav_id_replay")
+        self.assertTrue(gate.waiting_for_nav_id)
+
+        next_task = gate.accept(
+            proposal(nav_id="nav-002", sequence=1),
+            now=10.3,
+        )
+        self.assertTrue(next_task.execute)
+        self.assertEqual(gate.expected_nav_id, "nav-002")
+
+    def test_unconfirmed_terminal_stop_remains_fail_closed(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+        self.assertTrue(gate.accept(proposal(), now=10.0).execute)
+        gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+
+        self.assertFalse(gate.resume_waiting_after_terminal_stop(False))
+        self.assertFalse(gate.armed)
+        self.assertFalse(gate.waiting_for_nav_id)
+        self.assertEqual(gate.last_reason, "nav_task_terminal_stop_unconfirmed")
+
+    def test_late_terminal_confirmation_cannot_rearm_after_unbind(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+        self.assertTrue(gate.accept(proposal(), now=10.0).execute)
+        gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+        gate.unbind("canvas_stop")
+
+        self.assertFalse(gate.resume_waiting_after_terminal_stop(True))
+        self.assertFalse(gate.connected_topic)
+        self.assertFalse(gate.waiting_for_nav_id)
+        self.assertEqual(gate.last_reason, "canvas_stop")
+
+    def test_explicit_or_manual_override_lease_never_auto_rearms(self):
+        self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
+        self.gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+        self.assertFalse(self.gate.resume_waiting_after_terminal_stop(True))
+        self.assertFalse(self.gate.waiting_for_nav_id)
+
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+        self.assertTrue(gate.accept(proposal(), now=20.0).execute)
+        gate.disarm("manual_override")
+        self.assertFalse(gate.resume_waiting_after_terminal_stop(True))
+        self.assertFalse(gate.waiting_for_nav_id)
+        self.assertEqual(gate.last_reason, "manual_override")
 
     def test_completed_nav_id_cannot_be_replayed(self):
         self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -1,0 +1,303 @@
+"""Pure validation and lease state for the N5 Nav2 velocity proposal gate.
+
+This module deliberately has no ROS 2 or Unitree dependency.  The SmartMotion
+subprocess owns physical execution; it may act only on a ProposalDecision
+returned here.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+
+VELOCITY_PROPOSAL_SCHEMA = "phanthy.navigation.velocity_proposal.v1"
+DEFAULT_VELOCITY_PROPOSAL_TOPIC = "/ubuntu/navigation/nav2/velocity_proposal"
+TERMINAL_STATUSES = {
+    "paused",
+    "arrived",
+    "cancelled",
+    "stopped",
+    "error",
+    "aborted",
+    "rejected",
+}
+ACTIVE_STATUSES = {"planning", "navigating", "replanning", "running", "active"}
+ALLOWED_STATUSES = TERMINAL_STATUSES | ACTIVE_STATUSES
+_STATUS_FIELD = "nav_status"
+_UNSUPPORTED_STATUS_ALIASES = {"status", "navigation_status", "navigation_state"}
+
+
+def velocity_proposal_port(topic: str) -> dict:
+    """Return the authoritative N5 canvas port declaration."""
+    return {
+        "port": "velocity_proposal",
+        "topic": topic,
+        "format": "data/json",
+        "ros_type": "std_msgs/msg/String",
+        "qos": "RELIABLE + KEEP_LAST(depth=10) + VOLATILE",
+        "schema": VELOCITY_PROPOSAL_SCHEMA,
+    }
+
+
+class VelocityProposalValidationError(ValueError):
+    """Validation error with a stable fail-closed reason code."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class ProposalLimits:
+    schema: str = VELOCITY_PROPOSAL_SCHEMA
+    frame: str = "base_link"
+    max_ttl_ms: int = 250
+    min_x: float = -0.05
+    max_x: float = 0.15
+    max_abs_y: float = 0.12
+    max_abs_yaw: float = 0.35
+    max_planar_speed: float = 0.18
+
+
+@dataclass(frozen=True)
+class ValidatedVelocityProposal:
+    nav_id: str
+    sequence: int
+    issued_at_unix_ms: float
+    ttl_ms: int
+    frame: str
+    status: str
+    x: float
+    y: float
+    yaw: float
+
+    @property
+    def is_zero(self) -> bool:
+        return self.x == 0.0 and self.y == 0.0 and self.yaw == 0.0
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in TERMINAL_STATUSES
+
+
+@dataclass(frozen=True)
+class ProposalDecision:
+    execute: bool = False
+    stop: bool = False
+    reason: str = ""
+    duration: float = 0.0
+    proposal: Optional[ValidatedVelocityProposal] = None
+
+
+def resolve_input_topic(args: Mapping[str, Any], expected_topic: str) -> str:
+    """Resolve the canvas connection and reject every topic except the N5 port."""
+    has_input_topic = bool(str(args.get("input_topic") or "").strip())
+    has_input_topics = args.get("input_topics") is not None
+    if has_input_topic and has_input_topics:
+        raise ValueError("input_topic_and_input_topics_are_mutually_exclusive")
+    topics = []
+    input_topics = args.get("input_topics")
+    if input_topics is not None:
+        if not isinstance(input_topics, (list, tuple)):
+            raise ValueError("input_topics_must_be_a_list")
+        if len(input_topics) != 1:
+            raise ValueError("exactly_one_velocity_proposal_topic_required")
+        topics.append(str(input_topics[0]).strip())
+    input_topic = str(args.get("input_topic") or "").strip()
+    if input_topic and input_topic not in topics:
+        topics.append(input_topic)
+    if len(topics) != 1:
+        raise ValueError("exactly_one_velocity_proposal_topic_required")
+    if topics[0] != expected_topic:
+        raise ValueError("unexpected_velocity_proposal_topic")
+    return topics[0]
+
+
+def _finite_number(value: Any, code: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise VelocityProposalValidationError(code)
+    result = float(value)
+    if not math.isfinite(result):
+        raise VelocityProposalValidationError(code)
+    return result
+
+
+def _status(payload: Mapping[str, Any]) -> str:
+    if any(field in payload for field in _UNSUPPORTED_STATUS_ALIASES):
+        raise VelocityProposalValidationError("unsupported_navigation_status_field")
+    status = payload.get(_STATUS_FIELD)
+    if not isinstance(status, str) or not status.strip():
+        raise VelocityProposalValidationError("invalid_navigation_status")
+    normalized = status.strip().lower()
+    if normalized not in ALLOWED_STATUSES:
+        raise VelocityProposalValidationError("unsupported_navigation_status")
+    return normalized
+
+
+def validate_velocity_proposal(
+    payload: Mapping[str, Any],
+    limits: ProposalLimits,
+) -> ValidatedVelocityProposal:
+    if not isinstance(payload, Mapping):
+        raise VelocityProposalValidationError("proposal_must_be_object")
+    if payload.get("schema") != limits.schema:
+        raise VelocityProposalValidationError("schema_mismatch")
+    if payload.get("frame") != limits.frame:
+        raise VelocityProposalValidationError("frame_mismatch")
+    if payload.get("shadow_only") is not True:
+        raise VelocityProposalValidationError("shadow_only_flag_required")
+    if payload.get("physical_execution") is not False:
+        raise VelocityProposalValidationError("physical_execution_flag_must_be_false")
+
+    nav_id = payload.get("nav_id")
+    if not isinstance(nav_id, str) or not nav_id.strip() or len(nav_id) > 128:
+        raise VelocityProposalValidationError("invalid_nav_id")
+    sequence = payload.get("sequence")
+    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 0:
+        raise VelocityProposalValidationError("invalid_sequence")
+    ttl_ms = payload.get("ttl_ms")
+    if (
+        isinstance(ttl_ms, bool)
+        or not isinstance(ttl_ms, int)
+        or ttl_ms <= 0
+        or ttl_ms > limits.max_ttl_ms
+    ):
+        raise VelocityProposalValidationError("invalid_ttl_ms")
+    issued_at = _finite_number(payload.get("issued_at_unix_ms"), "invalid_issued_at_unix_ms")
+
+    velocity = payload.get("velocity")
+    if not isinstance(velocity, Mapping):
+        raise VelocityProposalValidationError("velocity_must_be_object")
+    x = _finite_number(velocity.get("x"), "invalid_velocity_x")
+    y = _finite_number(velocity.get("y"), "invalid_velocity_y")
+    yaw = _finite_number(velocity.get("yaw"), "invalid_velocity_yaw")
+    if x < limits.min_x or x > limits.max_x:
+        raise VelocityProposalValidationError("velocity_x_limit")
+    if abs(y) > limits.max_abs_y:
+        raise VelocityProposalValidationError("velocity_y_limit")
+    if abs(yaw) > limits.max_abs_yaw:
+        raise VelocityProposalValidationError("velocity_yaw_limit")
+    if math.hypot(x, y) > limits.max_planar_speed:
+        raise VelocityProposalValidationError("planar_speed_limit")
+
+    result = ValidatedVelocityProposal(
+        nav_id=nav_id.strip(),
+        sequence=sequence,
+        issued_at_unix_ms=issued_at,
+        ttl_ms=ttl_ms,
+        frame=limits.frame,
+        status=_status(payload),
+        x=x,
+        y=y,
+        yaw=yaw,
+    )
+    if result.is_terminal and not result.is_zero:
+        raise VelocityProposalValidationError("terminal_status_requires_zero_velocity")
+    return result
+
+
+class VelocityProposalGate:
+    """Connection, task lease, replay protection, and monotonic TTL state."""
+
+    def __init__(self, limits: ProposalLimits):
+        self.limits = limits
+        self.connected_topic = ""
+        self.armed = False
+        self.active_nav_id = ""
+        self.retired_nav_ids: list[str] = []
+        self.last_sequence = -1
+        self.last_receive_monotonic = 0.0
+        self.deadline_monotonic = 0.0
+        self.last_reason = "not_connected"
+
+    def bind(self, topic: str) -> None:
+        self.connected_topic = topic
+        self.armed = True
+        self.active_nav_id = ""
+        self.retired_nav_ids = []
+        self.last_sequence = -1
+        self.last_receive_monotonic = 0.0
+        self.deadline_monotonic = 0.0
+        self.last_reason = ""
+
+    def unbind(self, reason: str = "canvas_stop") -> None:
+        self.connected_topic = ""
+        self.armed = False
+        self.active_nav_id = ""
+        self.retired_nav_ids = []
+        self.last_sequence = -1
+        self.last_receive_monotonic = 0.0
+        self.deadline_monotonic = 0.0
+        self.last_reason = reason
+
+    def disarm(self, reason: str) -> None:
+        self.armed = False
+        self.deadline_monotonic = 0.0
+        self.last_reason = reason
+
+    def accept(self, payload: Mapping[str, Any], now: float) -> ProposalDecision:
+        if not self.connected_topic:
+            return ProposalDecision(stop=True, reason="proposal_not_connected")
+        if not self.armed:
+            return ProposalDecision(stop=True, reason=self.last_reason or "proposal_not_armed")
+        try:
+            proposal = validate_velocity_proposal(payload, self.limits)
+        except VelocityProposalValidationError as exc:
+            self.disarm(exc.code)
+            return ProposalDecision(stop=True, reason=exc.code)
+
+        if not self.active_nav_id:
+            if proposal.nav_id in self.retired_nav_ids:
+                self.disarm("retired_nav_id_replay")
+                return ProposalDecision(
+                    stop=True,
+                    reason="retired_nav_id_replay",
+                    proposal=proposal,
+                )
+            self.active_nav_id = proposal.nav_id
+            self.last_sequence = -1
+        elif proposal.nav_id != self.active_nav_id:
+            self.disarm("nav_id_mismatch")
+            return ProposalDecision(stop=True, reason="nav_id_mismatch", proposal=proposal)
+        if proposal.sequence <= self.last_sequence:
+            self.disarm("sequence_not_increasing")
+            return ProposalDecision(stop=True, reason="sequence_not_increasing", proposal=proposal)
+
+        self.last_sequence = proposal.sequence
+        self.last_receive_monotonic = now
+        if proposal.is_zero:
+            self.deadline_monotonic = 0.0
+            if proposal.is_terminal:
+                self.retired_nav_ids.append(proposal.nav_id)
+                del self.retired_nav_ids[:-32]
+                self.active_nav_id = ""
+                self.last_sequence = -1
+            self.last_reason = proposal.status
+            return ProposalDecision(stop=True, reason="proposal_zero", proposal=proposal)
+
+        duration = proposal.ttl_ms / 1000.0
+        self.deadline_monotonic = now + duration
+        self.last_reason = ""
+        return ProposalDecision(execute=True, duration=duration, proposal=proposal)
+
+    def watchdog(self, now: float) -> ProposalDecision:
+        if self.deadline_monotonic <= 0.0 or now < self.deadline_monotonic:
+            return ProposalDecision()
+        self.disarm("proposal_ttl_expired")
+        return ProposalDecision(stop=True, reason=self.last_reason)
+
+    def snapshot(self, now: float) -> dict:
+        age_ms = None
+        if self.last_receive_monotonic > 0.0:
+            age_ms = max(0, round((now - self.last_receive_monotonic) * 1000))
+        return {
+            "connected": bool(self.connected_topic),
+            "armed": self.armed,
+            "topic": self.connected_topic or None,
+            "active_nav_id": self.active_nav_id or None,
+            "last_sequence": self.last_sequence if self.last_sequence >= 0 else None,
+            "last_message_age_ms": age_ms,
+            "last_reason": self.last_reason or None,
+        }

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -263,11 +263,50 @@ class VelocityProposalGate:
 
     def hold_for_obstacle(self) -> None:
         """Keep the nav lease armed after a confirmed local obstacle stop."""
+        self.hold_after_confirmed_stop("obstacle")
+
+    def hold_after_confirmed_stop(self, reason: str) -> None:
+        """Keep a trusted nav lease after a confirmed recoverable stop.
+
+        Ordinary obstacle stops and a single proposal TTL lapse are local
+        braking events, not proof that the Agent Core lease is invalid.  The
+        caller must only enter this state after StopMove has been acknowledged
+        and fresh odometry has confirmed zero velocity.
+        """
         if not self.armed:
             return
+        recoverable_reasons = {
+            "obstacle": "obstacle_stop_recoverable",
+            "proposal_ttl_expired": "proposal_ttl_stop_recoverable",
+        }
+        if reason not in recoverable_reasons:
+            raise ValueError("unsupported_recoverable_stop_reason")
         self.deadline_monotonic = 0.0
-        self.last_reason = "obstacle_stop_recoverable"
+        self.last_reason = recoverable_reasons[reason]
         self.recoverable_stop_active = True
+
+    def request_ttl_stop(
+        self,
+        now: float,
+        proposal: Optional[ValidatedVelocityProposal] = None,
+    ) -> ProposalDecision:
+        """Request fail-closed braking without retiring the trusted lease.
+
+        The lease remains armed only so the stop path can move it into a
+        recoverable hold after measured zero velocity.  No new command can be
+        executed while that serialized stop confirmation is in progress.
+        """
+        if proposal is not None:
+            self.last_sequence = proposal.sequence
+            self.last_receive_monotonic = now
+        self.deadline_monotonic = 0.0
+        self.last_reason = "proposal_ttl_expired"
+        self.recoverable_stop_active = False
+        return ProposalDecision(
+            stop=True,
+            reason="proposal_ttl_expired",
+            proposal=proposal,
+        )
 
     def _retire_expected_nav_id(self) -> None:
         if self.expected_nav_id:
@@ -320,18 +359,14 @@ class VelocityProposalGate:
                     self.last_sequence = proposal.sequence
                     self.last_receive_monotonic = now
                     self.deadline_monotonic = 0.0
-                    self.last_reason = "obstacle_stop_recoverable"
+                    # Preserve whether this hold came from an obstacle or a
+                    # prior TTL stop while stale retained samples drain.
                     return ProposalDecision(
                         stop=True,
                         reason="proposal_ttl_expired",
                         proposal=proposal,
                     )
-                self.disarm("proposal_ttl_expired")
-                return ProposalDecision(
-                    stop=True,
-                    reason="proposal_ttl_expired",
-                    proposal=proposal,
-                )
+                return self.request_ttl_stop(now, proposal)
             # A future producer timestamp may not extend the configured TTL.
             duration = min(duration, remaining)
 
@@ -353,8 +388,7 @@ class VelocityProposalGate:
     def watchdog(self, now: float) -> ProposalDecision:
         if self.deadline_monotonic <= 0.0 or now < self.deadline_monotonic:
             return ProposalDecision()
-        self.disarm("proposal_ttl_expired")
-        return ProposalDecision(stop=True, reason=self.last_reason)
+        return self.request_ttl_stop(now)
 
     def snapshot(self, now: float) -> dict:
         age_ms = None

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -507,6 +507,23 @@ class VelocityProposalGate:
             self.disarm("sequence_not_increasing")
             return ProposalDecision(stop=True, reason="sequence_not_increasing", proposal=proposal)
 
+        if proposal.is_terminal:
+            # A terminal proposal is schema-validated to carry exact zero
+            # velocity.  For the currently bound nav_id, accepting it after
+            # its motion TTL has elapsed can only stop and retire the lease;
+            # it can never authorize stale motion.  This keeps consecutive
+            # first-valid tasks recoverable when a loaded ROS executor delays
+            # the one-shot terminal sample beyond the 250 ms motion budget.
+            self.last_sequence = proposal.sequence
+            self.last_receive_monotonic = now
+            self.deadline_monotonic = 0.0
+            self.disarm("nav_task_terminal")
+            return ProposalDecision(
+                stop=True,
+                reason="proposal_zero",
+                proposal=proposal,
+            )
+
         if duration <= 0.0:
             if now_unix_ms is not None:
                 if self.recoverable_stop_active:
@@ -531,10 +548,7 @@ class VelocityProposalGate:
         self.last_receive_monotonic = now
         if proposal.is_zero:
             self.deadline_monotonic = 0.0
-            if proposal.is_terminal:
-                self.disarm("nav_task_terminal")
-            else:
-                self.last_reason = proposal.status
+            self.last_reason = proposal.status
             return ProposalDecision(stop=True, reason="proposal_zero", proposal=proposal)
 
         self.deadline_monotonic = now + duration

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -330,13 +330,12 @@ class VelocityProposalGate:
         self.last_reason = reason
         self.recoverable_stop_active = False
 
-    def resume_waiting_after_terminal_stop(self, stop_confirmed: bool) -> bool:
-        """Allow the next automatic task only after measured terminal stop.
+    def resume_waiting_after_terminal(self) -> bool:
+        """Release an automatic terminal task and wait for the next nav id.
 
-        The completed task has already been retired by ``disarm``.  Explicit
-        control-plane leases and every other disarm reason remain fail-closed;
-        in particular, a manual override can never be reclaimed by an incoming
-        proposal without a new lifecycle authorization.
+        Terminal StopMove and odometry results remain diagnostic evidence, but
+        they do not latch the first-valid Canvas connection.  Explicit leases
+        and non-terminal safety disarms still require a new lifecycle bind.
         """
         if (
             not self.connected_topic
@@ -345,9 +344,6 @@ class VelocityProposalGate:
             or self.waiting_for_nav_id
             or self.last_reason != "nav_task_terminal"
         ):
-            return False
-        if not stop_confirmed:
-            self.last_reason = "nav_task_terminal_stop_unconfirmed"
             return False
         self.waiting_for_nav_id = True
         self.expected_nav_id = ""

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -226,6 +226,7 @@ class VelocityProposalGate:
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = "not_connected"
+        self.recoverable_stop_active = False
 
     def bind(self, topic: str, expected_nav_id: str) -> None:
         nav_id = resolve_expected_nav_id({"expected_nav_id": expected_nav_id})
@@ -240,6 +241,7 @@ class VelocityProposalGate:
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = ""
+        self.recoverable_stop_active = False
 
     def unbind(self, reason: str = "canvas_stop") -> None:
         self._retire_expected_nav_id()
@@ -250,12 +252,22 @@ class VelocityProposalGate:
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = reason
+        self.recoverable_stop_active = False
 
     def disarm(self, reason: str) -> None:
         self._retire_expected_nav_id()
         self.armed = False
         self.deadline_monotonic = 0.0
         self.last_reason = reason
+        self.recoverable_stop_active = False
+
+    def hold_for_obstacle(self) -> None:
+        """Keep the nav lease armed after a confirmed local obstacle stop."""
+        if not self.armed:
+            return
+        self.deadline_monotonic = 0.0
+        self.last_reason = "obstacle_stop_recoverable"
+        self.recoverable_stop_active = True
 
     def _retire_expected_nav_id(self) -> None:
         if self.expected_nav_id:
@@ -299,6 +311,21 @@ class VelocityProposalGate:
                 - float(now_unix_ms)
             ) / 1000.0
             if remaining <= 0.0:
+                if self.recoverable_stop_active:
+                    # Stop confirmation can outlive the proposal TTL while
+                    # ROS retains newer samples.  The robot is already at a
+                    # confirmed stop, so reject this stale sample without
+                    # retiring the task lease; only a fresh later sample may
+                    # resume execution.
+                    self.last_sequence = proposal.sequence
+                    self.last_receive_monotonic = now
+                    self.deadline_monotonic = 0.0
+                    self.last_reason = "obstacle_stop_recoverable"
+                    return ProposalDecision(
+                        stop=True,
+                        reason="proposal_ttl_expired",
+                        proposal=proposal,
+                    )
                 self.disarm("proposal_ttl_expired")
                 return ProposalDecision(
                     stop=True,
@@ -320,6 +347,7 @@ class VelocityProposalGate:
 
         self.deadline_monotonic = now + duration
         self.last_reason = ""
+        self.recoverable_stop_active = False
         return ProposalDecision(execute=True, duration=duration, proposal=proposal)
 
     def watchdog(self, now: float) -> ProposalDecision:
@@ -341,4 +369,5 @@ class VelocityProposalGate:
             "last_sequence": self.last_sequence if self.last_sequence >= 0 else None,
             "last_message_age_ms": age_ms,
             "last_reason": self.last_reason or None,
+            "recoverable_stop_active": self.recoverable_stop_active,
         }

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -28,6 +28,12 @@ ALLOWED_STATUSES = TERMINAL_STATUSES | ACTIVE_STATUSES
 _STATUS_FIELD = "nav_status"
 _UNSUPPORTED_STATUS_ALIASES = {"status", "navigation_status", "navigation_state"}
 
+DRIVER_MIN_X = -1.0
+DRIVER_MAX_X = 1.0
+DRIVER_MAX_ABS_Y = 1.0
+DRIVER_MAX_ABS_YAW = 2.0
+DRIVER_MAX_PLANAR_SPEED = math.sqrt(2.0)
+
 
 def velocity_proposal_port(topic: str) -> dict:
     """Return the authoritative N5 canvas port declaration."""
@@ -54,11 +60,52 @@ class ProposalLimits:
     schema: str = VELOCITY_PROPOSAL_SCHEMA
     frame: str = "base_link"
     max_ttl_ms: int = 250
-    min_x: float = -0.05
-    max_x: float = 0.15
-    max_abs_y: float = 0.12
-    max_abs_yaw: float = 0.35
-    max_planar_speed: float = 0.18
+    min_x: float = DRIVER_MIN_X
+    max_x: float = DRIVER_MAX_X
+    max_abs_y: float = DRIVER_MAX_ABS_Y
+    max_abs_yaw: float = DRIVER_MAX_ABS_YAW
+    max_planar_speed: float = DRIVER_MAX_PLANAR_SPEED
+
+
+def resolve_proposal_limits(config: Mapping[str, Any]) -> ProposalLimits:
+    """Resolve deploy-time tightening against the Driver's fixed envelope."""
+    return ProposalLimits(
+        frame="base_link",
+        max_ttl_ms=min(
+            250,
+            int(config.get("velocity_proposal_max_ttl_ms", 250)),
+        ),
+        min_x=max(
+            DRIVER_MIN_X,
+            float(config.get("velocity_proposal_min_x", DRIVER_MIN_X)),
+        ),
+        max_x=min(
+            DRIVER_MAX_X,
+            float(config.get("velocity_proposal_max_x", DRIVER_MAX_X)),
+        ),
+        max_abs_y=min(
+            DRIVER_MAX_ABS_Y,
+            float(config.get("velocity_proposal_max_abs_y", DRIVER_MAX_ABS_Y)),
+        ),
+        max_abs_yaw=min(
+            DRIVER_MAX_ABS_YAW,
+            float(
+                config.get(
+                    "velocity_proposal_max_abs_yaw",
+                    DRIVER_MAX_ABS_YAW,
+                )
+            ),
+        ),
+        max_planar_speed=min(
+            DRIVER_MAX_PLANAR_SPEED,
+            float(
+                config.get(
+                    "velocity_proposal_max_planar_speed",
+                    DRIVER_MAX_PLANAR_SPEED,
+                )
+            ),
+        ),
+    )
 
 
 @dataclass(frozen=True)
@@ -220,6 +267,8 @@ class VelocityProposalGate:
         self.limits = limits
         self.connected_topic = ""
         self.armed = False
+        self.binding_mode = ""
+        self.waiting_for_nav_id = False
         self.expected_nav_id = ""
         self.retired_nav_ids: set[str] = set()
         self.last_sequence = -1
@@ -228,7 +277,22 @@ class VelocityProposalGate:
         self.last_reason = "not_connected"
         self.recoverable_stop_active = False
 
-    def bind(self, topic: str, expected_nav_id: str) -> None:
+    def bind(self, topic: str, expected_nav_id: Optional[str] = None) -> None:
+        if expected_nav_id is None or expected_nav_id == "":
+            if self.is_waiting_on(topic):
+                return
+            self.connected_topic = topic
+            self.armed = False
+            self.binding_mode = "first_valid_proposal"
+            self.waiting_for_nav_id = True
+            self.expected_nav_id = ""
+            self.last_sequence = -1
+            self.last_receive_monotonic = 0.0
+            self.deadline_monotonic = 0.0
+            self.last_reason = "waiting_for_nav_id"
+            self.recoverable_stop_active = False
+            return
+
         nav_id = resolve_expected_nav_id({"expected_nav_id": expected_nav_id})
         if self.is_bound_to(topic, nav_id):
             return
@@ -236,6 +300,8 @@ class VelocityProposalGate:
             raise ValueError("retired_nav_id_replay")
         self.connected_topic = topic
         self.armed = True
+        self.binding_mode = "explicit"
+        self.waiting_for_nav_id = False
         self.expected_nav_id = nav_id
         self.last_sequence = -1
         self.last_receive_monotonic = 0.0
@@ -247,6 +313,8 @@ class VelocityProposalGate:
         self._retire_expected_nav_id()
         self.connected_topic = ""
         self.armed = False
+        self.binding_mode = ""
+        self.waiting_for_nav_id = False
         self.expected_nav_id = ""
         self.last_sequence = -1
         self.last_receive_monotonic = 0.0
@@ -257,9 +325,38 @@ class VelocityProposalGate:
     def disarm(self, reason: str) -> None:
         self._retire_expected_nav_id()
         self.armed = False
+        self.waiting_for_nav_id = False
         self.deadline_monotonic = 0.0
         self.last_reason = reason
         self.recoverable_stop_active = False
+
+    def resume_waiting_after_terminal_stop(self, stop_confirmed: bool) -> bool:
+        """Allow the next automatic task only after measured terminal stop.
+
+        The completed task has already been retired by ``disarm``.  Explicit
+        control-plane leases and every other disarm reason remain fail-closed;
+        in particular, a manual override can never be reclaimed by an incoming
+        proposal without a new lifecycle authorization.
+        """
+        if (
+            not self.connected_topic
+            or self.binding_mode != "first_valid_proposal"
+            or self.armed
+            or self.waiting_for_nav_id
+            or self.last_reason != "nav_task_terminal"
+        ):
+            return False
+        if not stop_confirmed:
+            self.last_reason = "nav_task_terminal_stop_unconfirmed"
+            return False
+        self.waiting_for_nav_id = True
+        self.expected_nav_id = ""
+        self.last_sequence = -1
+        self.last_receive_monotonic = 0.0
+        self.deadline_monotonic = 0.0
+        self.last_reason = "waiting_for_nav_id"
+        self.recoverable_stop_active = False
+        return True
 
     def hold_for_obstacle(self) -> None:
         """Keep the nav lease armed after a confirmed local obstacle stop."""
@@ -319,6 +416,44 @@ class VelocityProposalGate:
             and self.expected_nav_id == expected_nav_id
         )
 
+    def is_waiting_on(self, topic: str) -> bool:
+        return bool(
+            self.connected_topic == topic
+            and self.binding_mode == "first_valid_proposal"
+            and self.waiting_for_nav_id
+            and not self.armed
+            and not self.expected_nav_id
+        )
+
+    def _claim_first_valid_proposal(self, nav_id: str) -> None:
+        if not self.waiting_for_nav_id:
+            raise ValueError("not_waiting_for_nav_id")
+        resolved = resolve_expected_nav_id({"expected_nav_id": nav_id})
+        if resolved in self.retired_nav_ids:
+            raise ValueError("retired_nav_id_replay")
+        self.expected_nav_id = resolved
+        self.armed = True
+        self.waiting_for_nav_id = False
+        self.last_reason = ""
+
+    @staticmethod
+    def _remaining_duration(
+        proposal: ValidatedVelocityProposal,
+        now_unix_ms: Optional[float],
+    ) -> float:
+        duration = proposal.ttl_ms / 1000.0
+        if now_unix_ms is None:
+            return duration
+        remaining = (
+            proposal.issued_at_unix_ms
+            + proposal.ttl_ms
+            - float(now_unix_ms)
+        ) / 1000.0
+        if remaining <= 0.0:
+            return 0.0
+        # A future producer timestamp may not extend the configured TTL.
+        return min(duration, remaining)
+
     def accept(
         self,
         payload: Mapping[str, Any],
@@ -327,13 +462,43 @@ class VelocityProposalGate:
     ) -> ProposalDecision:
         if not self.connected_topic:
             return ProposalDecision(stop=True, reason="proposal_not_connected")
-        if not self.armed:
+        if not self.armed and not self.waiting_for_nav_id:
             return ProposalDecision(stop=True, reason=self.last_reason or "proposal_not_armed")
         try:
             proposal = validate_velocity_proposal(payload, self.limits)
         except VelocityProposalValidationError as exc:
+            if self.waiting_for_nav_id:
+                return ProposalDecision(reason=exc.code)
             self.disarm(exc.code)
             return ProposalDecision(stop=True, reason=exc.code)
+
+        duration = self._remaining_duration(proposal, now_unix_ms)
+        if self.waiting_for_nav_id:
+            if duration <= 0.0:
+                return ProposalDecision(
+                    reason="proposal_ttl_expired",
+                    proposal=proposal,
+                )
+            if proposal.nav_id in self.retired_nav_ids:
+                return ProposalDecision(
+                    reason="retired_nav_id_replay",
+                    proposal=proposal,
+                )
+            if proposal.is_zero:
+                # A retained zero/terminal sample from an earlier task must
+                # not claim a newly waiting lease.  Only an executable command
+                # establishes physical-control intent for a new nav_id.
+                return ProposalDecision(
+                    reason="waiting_for_active_proposal",
+                    proposal=proposal,
+                )
+            try:
+                self._claim_first_valid_proposal(proposal.nav_id)
+            except ValueError as exc:
+                return ProposalDecision(
+                    reason=str(exc),
+                    proposal=proposal,
+                )
 
         if proposal.nav_id != self.expected_nav_id:
             self.disarm("nav_id_mismatch")
@@ -342,14 +507,8 @@ class VelocityProposalGate:
             self.disarm("sequence_not_increasing")
             return ProposalDecision(stop=True, reason="sequence_not_increasing", proposal=proposal)
 
-        duration = proposal.ttl_ms / 1000.0
-        if now_unix_ms is not None:
-            remaining = (
-                proposal.issued_at_unix_ms
-                + proposal.ttl_ms
-                - float(now_unix_ms)
-            ) / 1000.0
-            if remaining <= 0.0:
+        if duration <= 0.0:
+            if now_unix_ms is not None:
                 if self.recoverable_stop_active:
                     # Stop confirmation can outlive the proposal TTL while
                     # ROS retains newer samples.  The robot is already at a
@@ -367,8 +526,6 @@ class VelocityProposalGate:
                         proposal=proposal,
                     )
                 return self.request_ttl_stop(now, proposal)
-            # A future producer timestamp may not extend the configured TTL.
-            duration = min(duration, remaining)
 
         self.last_sequence = proposal.sequence
         self.last_receive_monotonic = now
@@ -397,6 +554,14 @@ class VelocityProposalGate:
         return {
             "connected": bool(self.connected_topic),
             "armed": self.armed,
+            "binding_mode": self.binding_mode or None,
+            "waiting_for_nav_id": self.waiting_for_nav_id,
+            "auto_bound_nav_id": (
+                self.expected_nav_id
+                if self.binding_mode == "first_valid_proposal"
+                and self.expected_nav_id
+                else None
+            ),
             "topic": self.connected_topic or None,
             "expected_nav_id": self.expected_nav_id or None,
             "active_nav_id": self.expected_nav_id if self.armed else None,

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -115,6 +115,21 @@ def resolve_input_topic(args: Mapping[str, Any], expected_topic: str) -> str:
     return topics[0]
 
 
+def resolve_expected_nav_id(args: Mapping[str, Any]) -> str:
+    """Resolve the task lease supplied by the trusted lifecycle control plane."""
+    value = args.get("expected_nav_id")
+    if value is None or value == "":
+        raise ValueError("expected_nav_id_required")
+    if not isinstance(value, str):
+        raise ValueError("invalid_expected_nav_id")
+    nav_id = value.strip()
+    if not nav_id:
+        raise ValueError("expected_nav_id_required")
+    if len(nav_id) > 128:
+        raise ValueError("invalid_expected_nav_id")
+    return nav_id
+
+
 def _finite_number(value: Any, code: str) -> float:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise VelocityProposalValidationError(code)
@@ -205,37 +220,53 @@ class VelocityProposalGate:
         self.limits = limits
         self.connected_topic = ""
         self.armed = False
-        self.active_nav_id = ""
-        self.retired_nav_ids: list[str] = []
+        self.expected_nav_id = ""
+        self.retired_nav_ids: set[str] = set()
         self.last_sequence = -1
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = "not_connected"
 
-    def bind(self, topic: str) -> None:
+    def bind(self, topic: str, expected_nav_id: str) -> None:
+        nav_id = resolve_expected_nav_id({"expected_nav_id": expected_nav_id})
+        if self.is_bound_to(topic, nav_id):
+            return
+        if nav_id in self.retired_nav_ids:
+            raise ValueError("retired_nav_id_replay")
         self.connected_topic = topic
         self.armed = True
-        self.active_nav_id = ""
-        self.retired_nav_ids = []
+        self.expected_nav_id = nav_id
         self.last_sequence = -1
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = ""
 
     def unbind(self, reason: str = "canvas_stop") -> None:
+        self._retire_expected_nav_id()
         self.connected_topic = ""
         self.armed = False
-        self.active_nav_id = ""
-        self.retired_nav_ids = []
+        self.expected_nav_id = ""
         self.last_sequence = -1
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = reason
 
     def disarm(self, reason: str) -> None:
+        self._retire_expected_nav_id()
         self.armed = False
         self.deadline_monotonic = 0.0
         self.last_reason = reason
+
+    def _retire_expected_nav_id(self) -> None:
+        if self.expected_nav_id:
+            self.retired_nav_ids.add(self.expected_nav_id)
+
+    def is_bound_to(self, topic: str, expected_nav_id: str) -> bool:
+        return bool(
+            self.armed
+            and self.connected_topic == topic
+            and self.expected_nav_id == expected_nav_id
+        )
 
     def accept(self, payload: Mapping[str, Any], now: float) -> ProposalDecision:
         if not self.connected_topic:
@@ -248,17 +279,7 @@ class VelocityProposalGate:
             self.disarm(exc.code)
             return ProposalDecision(stop=True, reason=exc.code)
 
-        if not self.active_nav_id:
-            if proposal.nav_id in self.retired_nav_ids:
-                self.disarm("retired_nav_id_replay")
-                return ProposalDecision(
-                    stop=True,
-                    reason="retired_nav_id_replay",
-                    proposal=proposal,
-                )
-            self.active_nav_id = proposal.nav_id
-            self.last_sequence = -1
-        elif proposal.nav_id != self.active_nav_id:
+        if proposal.nav_id != self.expected_nav_id:
             self.disarm("nav_id_mismatch")
             return ProposalDecision(stop=True, reason="nav_id_mismatch", proposal=proposal)
         if proposal.sequence <= self.last_sequence:
@@ -270,11 +291,9 @@ class VelocityProposalGate:
         if proposal.is_zero:
             self.deadline_monotonic = 0.0
             if proposal.is_terminal:
-                self.retired_nav_ids.append(proposal.nav_id)
-                del self.retired_nav_ids[:-32]
-                self.active_nav_id = ""
-                self.last_sequence = -1
-            self.last_reason = proposal.status
+                self.disarm("nav_task_terminal")
+            else:
+                self.last_reason = proposal.status
             return ProposalDecision(stop=True, reason="proposal_zero", proposal=proposal)
 
         duration = proposal.ttl_ms / 1000.0
@@ -296,7 +315,8 @@ class VelocityProposalGate:
             "connected": bool(self.connected_topic),
             "armed": self.armed,
             "topic": self.connected_topic or None,
-            "active_nav_id": self.active_nav_id or None,
+            "expected_nav_id": self.expected_nav_id or None,
+            "active_nav_id": self.expected_nav_id if self.armed else None,
             "last_sequence": self.last_sequence if self.last_sequence >= 0 else None,
             "last_message_age_ms": age_ms,
             "last_reason": self.last_reason or None,

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -1,8 +1,8 @@
 """Pure validation and lease state for the N5 Nav2 velocity proposal gate.
 
 This module deliberately has no ROS 2 or Unitree dependency.  The SmartMotion
-subprocess owns physical execution; it may act only on a ProposalDecision
-returned here.
+subprocess owns validation and authorization; only a ProposalDecision returned
+here may be forwarded to the parent Driver RPC worker for physical execution.
 """
 
 from __future__ import annotations
@@ -268,7 +268,12 @@ class VelocityProposalGate:
             and self.expected_nav_id == expected_nav_id
         )
 
-    def accept(self, payload: Mapping[str, Any], now: float) -> ProposalDecision:
+    def accept(
+        self,
+        payload: Mapping[str, Any],
+        now: float,
+        now_unix_ms: Optional[float] = None,
+    ) -> ProposalDecision:
         if not self.connected_topic:
             return ProposalDecision(stop=True, reason="proposal_not_connected")
         if not self.armed:
@@ -286,6 +291,23 @@ class VelocityProposalGate:
             self.disarm("sequence_not_increasing")
             return ProposalDecision(stop=True, reason="sequence_not_increasing", proposal=proposal)
 
+        duration = proposal.ttl_ms / 1000.0
+        if now_unix_ms is not None:
+            remaining = (
+                proposal.issued_at_unix_ms
+                + proposal.ttl_ms
+                - float(now_unix_ms)
+            ) / 1000.0
+            if remaining <= 0.0:
+                self.disarm("proposal_ttl_expired")
+                return ProposalDecision(
+                    stop=True,
+                    reason="proposal_ttl_expired",
+                    proposal=proposal,
+                )
+            # A future producer timestamp may not extend the configured TTL.
+            duration = min(duration, remaining)
+
         self.last_sequence = proposal.sequence
         self.last_receive_monotonic = now
         if proposal.is_zero:
@@ -296,7 +318,6 @@ class VelocityProposalGate:
                 self.last_reason = proposal.status
             return ProposalDecision(stop=True, reason="proposal_zero", proposal=proposal)
 
-        duration = proposal.ttl_ms / 1000.0
         self.deadline_monotonic = now + duration
         self.last_reason = ""
         return ProposalDecision(execute=True, duration=duration, proposal=proposal)


### PR DESCRIPTION
## Summary

- Preserve the two original G1 velocity-proposal commits as separate commits with their original Author metadata; all later fixes are additive commits.
- Bind `velocity_proposal.v1` to one trusted `expected_nav_id`, validate schema/identity/sequence/TTL/frame/speed, and fail closed on every invalid or stale proposal.
- Execute approved proposal velocity, FSM queries, and ordered StopMove calls through the parent Driver `RpcProxy`; the SmartMotion child retains safety gating and odometry observation.
- Replace polling with a bounded `Condition` wait for a fresh post-StopMove zero-odometry sample and retain StopMove ret/error/timing, odometry velocity/age, and callback counts.
- Keep proposal execution diagnostics across cleanup: received/accepted/applied/rejected counts, rejection breakdown, callback timing, watchdog faults, correlated SetVelocity result, and the complete terminal stop-attempt history.
- Treat ordinary obstacle stops and isolated proposal TTL gaps as recoverable only after StopMove plus fresh zero odometry succeeds. Keep the authorized lease, drain stale samples, and evaluate the next fresh proposal normally. FSM, emergency-stop, sensor, identity, RPC, and unconfirmed-stop faults still disarm fail closed.
- Keep proposal execution latest-only with a capacity-one queue and expose actual SetVelocity RPC, queue, and end-to-end latency plus rolling p50/p95/p99/max diagnostics. The prior `last_set_velocity_duration_ms` value incorrectly reported remaining TTL budget rather than measured RPC time.
- Add Driver-only proposal RPC, lifecycle, correlation, TTL, watchdog, stop-confirmation, and diagnostics tests.

## Root causes

### Stop confirmation

The previous path created the confirmation boundary only after synchronous StopMove returned. A valid zero-velocity odometry callback received during the RPC was therefore classified as old, producing a false negative even though odometry and FSM callbacks were healthy.

The final handshake records the boundary before StopMove, executes the ordered parent RPC without holding the odometry callback lock, and waits on a bounded `Condition` for a newer zero sample. Failures retain the StopMove acknowledgement/error, confirmation start, last odometry timestamp/age/velocity, and callback counts.

Hardware also showed that Unitree `LocoClient.StopMove()` is `SetVelocity(0, 0, 0)` with the SDK's default one-second duration: ret=0 acknowledges the RPC but does not mean the gait has already settled. The physical confirmation window is therefore bounded at two seconds, never shorter than the SDK command itself. Zero-speed thresholds remain unchanged (`0.03 m/s` linear and `0.05 rad/s` yaw), and the subscription/lease remains retained until confirmation succeeds.

### Proposal execution

The original bind/unbind test covered only subscription and StopMove. Actual proposal motion still used a SmartMotion-child LocoClient, while the known-working direct motion path used the parent Driver RPC worker. Child-side FSM queries had the same split path and could report `main_control_not_ready` despite a valid parent FSM 500 response.

Approved proposals now use one correlated parent `ApplyVelocityProposal` path. A dedicated ROS executor keeps proposal callbacks responsive while the parent RPC is in flight; the parent owns a short monotonic lease around the known-working continuous SetVelocity command and issues StopMove on expiry or error. Parent FSM and stop requests share serialized request IDs so stale or cross-method replies cannot satisfy a newer request.

### Obstacle recovery

The original obstacle path used a forward translation cone even for pure rotation and permanently disarmed the navigation lease after any obstacle stop. Nav2 could therefore neither rotate nor issue a safe escape command after the Driver stopped near an obstacle.

A confirmed ordinary obstacle stop now enters a recoverable hold while keeping the trusted `nav_id` lease armed. Stale queued samples are drained without repeating StopMove, a fresh proposal is evaluated again, and pure rotation has no translation corridor. A zero terminal proposal retires the lease normally. Unconfirmed StopMove, hard watchdog faults, FSM, emergency-stop, stale sensor, malformed input, and parent RPC faults still permanently disarm the session.

### TTL recovery and latency diagnostics

The previous TTL watchdog permanently disarmed a valid navigation lease after one transient proposal gap. Cleanup then caused every later proposal to be rejected, even though StopMove had succeeded. Separately, `last_set_velocity_duration_ms` was populated from the proposal's remaining TTL budget, making healthy low-millisecond RPCs appear to take about 244 ms.

A TTL lapse still stops immediately, but the same lease becomes recoverable only after the ordered parent StopMove returns successfully and a newer odometry sample confirms zero velocity. The next fresh, increasing sequence can then resume execution. The apply queue remains capacity one and replaces an older pending velocity with the newest command. Diagnostics now distinguish actual RPC duration, queue delay, end-to-end duration, coalesced commands, and rolling RPC percentiles.

## Impact

Changes are limited to `unitree/g1`. Driver startup remains disconnected and disarmed. The proposal subscriber is created only after a successful bind stop confirmation, and stop/unbind confirms fresh zero odometry before teardown. Missing proposals and expired samples still stop fail closed; only a confirmed zero-speed stop preserves the current trusted lease for a later fresh proposal. Nonzero terminal, mismatched, replayed, malformed, or failed inputs remain hard failures.

## Tests and evidence

- `cd unitree/g1 && PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py' -v`: 97 tests passed.
- `cd unitree/g1 && python3 -m py_compile main.py safety_harness.py rpc_proxy.py velocity_proposal.py`
- `git diff --check`
- Coverage includes timely/delayed/nonzero/no-frame stop confirmation, SDK-aware bounded settling, parent RPC timeout/correlation, TTL expiry before/after RPC, lease renewal races, terminal zero, nav-id and sequence rejection, diagnostics retention, subscription lifecycle, recoverable obstacle hold, pure rotation, stale obstacle cones, escape directions, and hard-fault disarm.

## Shanghai G1 hardware validation

Driver-only validation passed on candidate content `3f21a24508e2626311b686f714b02f29420cd1c21de184699680f6f5efb0963f`; Nav2 and Agent Core were not invoked:

- Bind: parent FSM 500, StopMove ret=0, and fresh zero odometry confirmed before subscription.
- Direct stream: 6 proposals received (5 nonzero plus terminal zero), 5 accepted, 5 applied, 0 rejected; maximum callback age was 8 ms and maximum receive gap was 107 ms.
- Parent SetVelocity: `SetVelocity(continuous)`, ret=0, no error, correlated request ID present.
- Native `/ubuntu/loco/state`: 0.1008 m measured displacement for the finite 0.15 m/s probe, clearly above localization drift.
- Terminal stop: the first short attempt retained its nonzero-odom timeout; the bounded second attempt confirmed fresh zero odometry after gait settling (`x=0.0253`, `y=-0.0140`, `yaw=0.0469`).
- Unbind: StopMove ret=0 and fresh zero odometry confirmed before subscription teardown (`x=-0.0127`, `y=-0.0127`, `yaw=-0.0053`).
- Final state: disconnected, disarmed, unsubscribed; terminal proposal and stop diagnostics survived `canvas_stop` cleanup.

The recoverable-obstacle candidate content `26d1929a7078e3988c6e65749b51952ec57d7ff299d66755d013b4e9498a0148` also passed an owner-run Shanghai G1 Driver-only hardware test:

- Forward proposals: 12 received, 12 accepted, 11 applied, no rejection; the physical obstacle triggered `reason=obstacle` and confirmed zero odometry.
- Recoverable hold: `connected=true`, `armed=true`, `driver_authorized=true`, `recoverable_stop_active=true`; the trusted lease and proposal subscription were retained.
- Pure rotation with the obstacle still present: 8 proposals received, 7 accepted and applied, peak measured yaw speed `0.2184 rad/s`; no `obstacle_stop_latched` rejection.
- Terminal zero: the bounded retry retained the first nonzero confirmation attempt and the second attempt confirmed zero speed.
- Unbind: StopMove ret=0, fresh zero odometry confirmed, and final state was disconnected, disarmed, and unsubscribed.
- Nav2 and Agent Core were not invoked by this Driver-only acceptance.

The final TTL-recovery candidate content `c6afbad9bb66c8026da70e9d81a47763015f807ebd769e9b769e0e58d0f5b23a` passed a separate owner-run Shanghai G1 Driver-only hardware test:

- Phase A applied 12/12 finite proposals, then a deliberate TTL gap triggered one watchdog stop. Parent StopMove returned 0, fresh zero odometry was confirmed, and the same `nav_id` remained connected, armed, and authorized in `proposal_ttl_stop_recoverable` hold.
- Phase B resumed the same lease with 15 fresh proposals at 0.15 m/s, producing 0.1298 m native odometry displacement before terminal zero.
- Final execution counters were 28 received, 27 accepted, 27 applied, 0 rejected, and 0 coalesced. SetVelocity RPC p99/max were 4 ms; final queue delay was 11 ms and end-to-end latency was 13 ms.
- Terminal zero was confirmed after the bounded retry, unbind StopMove returned 0 with fresh zero odometry, and final state was disconnected, disarmed, and unsubscribed.
- Evidence log: `/private/tmp/g1-pr103-ttl-recovery-ttl-20260805T195117Z.log`. Nav2 and Agent Core were not invoked.

## Ownership

- Directory and behavior owners: Unitree G1 Driver maintainers.
- Hardware acceptance: Shanghai G1 owner, using the physical remote/E-stop and owner-gated commands.
- Review target: `4paradigm/phanthymotus-driver` maintainers.

## Demo in 5 minutes

1. Run the 97-test command above.
2. Start the G1 Driver and verify `loco.info` is disconnected, disarmed, and unsubscribed.
3. Owner binds a unique `expected_nav_id`, publishes bounded forward proposals toward a static obstacle, and observes a confirmed `obstacle_stop_recoverable` hold.
4. With the obstacle still present, publish bounded pure-rotation proposals followed by terminal zero.
5. Verify measured yaw motion, confirmed zero speed, then `loco.stop`; final info must be disconnected, disarmed, and unsubscribed.

## Failure path

Invalid schema, frame, `nav_id`, sequence, speed, stale sensor state, disallowed FSM, emergency-stop, parent RPC error, or unconfirmed physical stop disarms the lease and issues StopMove. An ordinary obstacle or TTL-gap recovery is enabled only after StopMove plus a newer zero-odometry sample succeeds; otherwise it remains a hard failure.

## Scope / Non-goals

Changes are restricted to the existing G1 loco actuator and its tests. This PR does not embed Nav2, generate maps/TF/paths, change Core or Card behavior, widen velocity limits, bypass stop confirmation, or add device permissions.

## Safety and permissions

The Driver starts disconnected and disarmed. Proposal execution requires the exact control-plane `nav_id`, allowed FSM, fresh safety inputs, bounded velocity, increasing sequence, and TTL no greater than 250 ms. Stop, timeout, cancellation, invalid input, and hard faults remain fail closed. Hardware validation requires an on-site owner with the physical remote/E-stop.

## Compatibility and license

The existing `phanthy.navigation.velocity_proposal.v1` schema and ROS topic remain unchanged. No dependency or license changes are introduced.

## Rollback

Revert this PR or restore the previous G1 Driver image. The Driver then returns to its previous behavior; startup remains disconnected and disarmed.

## Dependencies / Next

No new repository dependency is introduced. End-to-end navigation arrival remains a separate consumer-level validation using the existing navigation card and Nav2 stack.
