### PR TITLE
feat(g1): 增加传统导航 LIO shadow 与受控建图

### DIFF
--- a/unitree/g1/Dockerfile
+++ b/unitree/g1/Dockerfile
@@ -2,10 +2,13 @@ ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base:latest
 ARG PYPI_MIRROR=https://pypi.org/simple/
 FROM ${ROS_BASE_IMAGE}
 ARG PYPI_MIRROR
+ARG UBUNTU_PORTS_MIRROR=http://ports.ubuntu.com/ubuntu-ports
 
 WORKDIR /work
 
-RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
+RUN sed -i "s|http://mirrors.tencentyun.com/ubuntu-ports|${UBUNTU_PORTS_MIRROR}|g" \
+        /etc/apt/sources.list && \
+    apt-get -o Acquire::AllowInsecureRepositories=true update && \
     apt-get install -y --no-install-recommends --allow-unauthenticated \
         python3-pip \
         python3-colcon-common-extensions \
@@ -33,7 +36,7 @@ RUN curl -fsSL ${CYCLONEDDS_URL} \
     rm -rf /tmp/cyclonedds-0.10.5
 
 ENV CYCLONEDDS_HOME=/opt/cyclonedds
-ENV LD_LIBRARY_PATH=/opt/cyclonedds/lib:${LD_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH=/opt/cyclonedds/lib
 
 RUN pip3 install --no-cache-dir --no-binary cyclonedds -i ${PYPI_MIRROR} cyclonedds==0.10.5
 
@@ -52,8 +55,13 @@ COPY ext_devices.py /work/ext_devices.py
 COPY safety_harness.py /work/safety_harness.py
 COPY scan_context.py /work/scan_context.py
 COPY controlled_spatial.py /work/controlled_spatial.py
+COPY controlled_spatial_contract.py /work/controlled_spatial_contract.py
 COPY controlled_spatial_map.py /work/controlled_spatial_map.py
 COPY pointcloud_utils.py /work/pointcloud_utils.py
+COPY navigation_time.py /work/navigation_time.py
+COPY navigation_pointcloud.py /work/navigation_pointcloud.py
+COPY navigation_sensor_bridge.py /work/navigation_sensor_bridge.py
+COPY navigation_sensor_bridge_main.py /work/navigation_sensor_bridge_main.py
 COPY test_slam_rpc.py /work/test_slam_rpc.py
 COPY config.yaml /work/config.yaml
 COPY deploy/     /deploy/

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -20,6 +20,27 @@ plugins:
     enabled: true
   lidar:
     enabled: true
+  # FAST-LIVO2/EGO 传统导航的原始传感器桥。默认关闭；shadow 部署时再启用，
+  # 并关闭上面的 lidar 与 controlled_spatial(_map)，避免重复处理点云。
+  navigation_sensors:
+    enabled: false
+    raw_cloud_topic: rt/utlidar/cloud_livox_mid360
+    raw_imu_topic: rt/utlidar/imu_livox_mid360
+    # G1 shadow 默认只发估计器输入；双路大点云会压低 Jetson 上的发布频率。
+    publish_raw_cloud: false
+    publish_fast_livo_cloud: true
+    raw_lidar_frame: livox_raw_frame
+    lidar_frame: livox_frame
+    imu_frame: livox_frame
+    # G1 的 MID360 固定倒装。点云和雷达内置 IMU 必须一起做 Rx(pi)，
+    # FAST-LIVO2 内部的 LiDAR-to-IMU 外参因此仍保持单位阵。
+    sensor_rotation_matrix: [1.0, 0.0, 0.0,
+                             0.0, -1.0, 0.0,
+                             0.0, 0.0, -1.0]
+    clock_warmup_samples: 32
+    clock_window_samples: 400
+    clock_reset_threshold_ms: 1000
+    clock_reset_confirm_samples: 8
   slam:
     enabled: false
     map_dir: /opt/phanthy-motus/data/maps

--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -22,6 +22,8 @@ import sqlite3
 import threading
 import time
 
+from controlled_spatial_contract import controlled_spatial_tool_definition
+
 
 # ── RPC Error Codes ──────────────────────────────────────────────────────────
 
@@ -335,60 +337,7 @@ class ControlledSpatialPlugin:
         return [self._tool_def()]
 
     def _tool_def(self) -> dict:
-        return {
-            "name": "controlled_spatial",
-            "type": "actuator",
-            "multiInstance": False,
-            "description": (
-                "Controlled mapping & navigation — user manually drives the robot during mapping. "
-                "Supports: start/stop mapping, tag places, list/delete maps, load map, navigate between tags."
-            ),
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string",
-                        "enum": [
-                            "start_mapping", "stop_mapping",
-                            "tag_place", "untag_place", "list_tags",
-                            "list_maps", "delete_map",
-                            "load_map",
-                            "navigate_to_tag", "navigate_to_pose",
-                            "wait_navigation_done",
-                            "pause_nav", "resume_nav", "stop_nav",
-                        ],
-                        "description": "Action to perform",
-                    },
-                    "map_name": {"type": "string", "description": "Map name (for start_mapping, delete_map, load_map)"},
-                    "name": {"type": "string", "description": "POI tag name"},
-                    "description": {"type": "string", "description": "POI description"},
-                    "tag_name": {"type": "string", "description": "Target tag name for navigation"},
-                    "x": {"type": "number", "description": "Target X coordinate (meters)"},
-                    "y": {"type": "number", "description": "Target Y coordinate (meters)"},
-                    "yaw": {"type": "number", "description": "Target yaw (radians)"},
-                    "speed": {"type": "number", "description": "Navigation speed 0.2-0.8 m/s (default 0.5)"},
-                    "mode": {"type": "integer", "description": "Obstacle mode: 1=stop(default), 0=detour"},
-                    "stall_timeout": {"type": "number", "description": "Seconds without movement before declaring timeout (default 90)"},
-                },
-                "required": ["action"],
-                "x-action-params": {
-                    "start_mapping": {"params": ["map_name"], "description": "Start SLAM mapping with given map name"},
-                    "stop_mapping": {"params": [], "description": "Stop mapping and save the map"},
-                    "tag_place": {"params": ["name", "description"], "description": "Tag current position with a semantic name"},
-                    "untag_place": {"params": ["name"], "description": "Remove a place tag"},
-                    "list_tags": {"params": [], "description": "List all tags in current map with relative positions"},
-                    "list_maps": {"params": [], "description": "List all saved maps"},
-                    "delete_map": {"params": ["map_name"], "description": "Delete a map and its associated data"},
-                    "load_map": {"params": ["map_name"], "description": "Load a map (robot must be at map origin)"},
-                    "navigate_to_tag": {"params": ["tag_name", "speed", "mode"], "description": "Navigate to a tagged place (non-blocking). mode: 1=stop-on-obstacle (default), 0=detour. MUST be followed by a separate wait_navigation_done call in the same turn to wait for arrival before proceeding."},
-                    "navigate_to_pose": {"params": ["x", "y", "yaw", "speed", "mode"], "description": "Navigate to coordinates (non-blocking). mode: 1=stop-on-obstacle (default), 0=detour. MUST be followed by a separate wait_navigation_done call in the same turn to wait for arrival before proceeding."},
-                    "wait_navigation_done": {"params": ["stall_timeout"], "description": "Block until the previous navigate_to_tag or navigate_to_pose completes. Returns on arrival, timeout, or error. Always call after navigate_to_tag/navigate_to_pose."},
-                    "pause_nav": {"params": [], "description": "Pause navigation"},
-                    "resume_nav": {"params": [], "description": "Resume navigation"},
-                    "stop_nav": {"params": [], "description": "Stop and cancel navigation"},
-                },
-            },
-        }
+        return controlled_spatial_tool_definition()
 
     def start(self) -> None:
         pass
@@ -681,7 +630,7 @@ class ControlledSpatialPlugin:
             return _rpc_error("NavigateTo", code, resp)
 
         elif action == "wait_navigation_done":
-            stall_timeout = float(args.get("stall_timeout", 60))
+            stall_timeout = float(args.get("stall_timeout", 90))
 
             # Delegate to smart_motion subprocess which has its own rt/slam_info
             # subscription and can reliably detect nav arrival via DDS callback

--- a/unitree/g1/controlled_spatial_contract.py
+++ b/unitree/g1/controlled_spatial_contract.py
@@ -1,0 +1,151 @@
+"""Canonical MCP card contract shared by native and traditional navigation."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+
+CONTROLLED_SPATIAL_ACTIONS = (
+    "start_mapping",
+    "stop_mapping",
+    "tag_place",
+    "untag_place",
+    "list_tags",
+    "list_maps",
+    "delete_map",
+    "load_map",
+    "navigate_to_tag",
+    "navigate_to_pose",
+    "wait_navigation_done",
+    "pause_nav",
+    "resume_nav",
+    "stop_nav",
+)
+
+CONTROLLED_SPATIAL_ACTION_PARAMS = {
+    "start_mapping": {
+        "params": ["map_name"],
+        "description": "Start SLAM mapping with given map name",
+    },
+    "stop_mapping": {
+        "params": [],
+        "description": "Stop mapping and save the map",
+    },
+    "tag_place": {
+        "params": ["name", "description"],
+        "description": "Tag current position with a semantic name",
+    },
+    "untag_place": {
+        "params": ["name"],
+        "description": "Remove a place tag",
+    },
+    "list_tags": {
+        "params": [],
+        "description": "List all tags in current map with relative positions",
+    },
+    "list_maps": {"params": [], "description": "List all saved maps"},
+    "delete_map": {
+        "params": ["map_name"],
+        "description": "Delete a map and its associated data",
+    },
+    "load_map": {
+        "params": ["map_name"],
+        "description": "Load a map (robot must be at map origin)",
+    },
+    "navigate_to_tag": {
+        "params": ["tag_name", "speed", "mode"],
+        "description": (
+            "Navigate to a tagged place (non-blocking). mode: "
+            "1=stop-on-obstacle (default), 0=detour. MUST be followed by a "
+            "separate wait_navigation_done call in the same turn to wait for "
+            "arrival before proceeding."
+        ),
+    },
+    "navigate_to_pose": {
+        "params": ["x", "y", "yaw", "speed", "mode"],
+        "description": (
+            "Navigate to coordinates (non-blocking). mode: "
+            "1=stop-on-obstacle (default), 0=detour. MUST be followed by a "
+            "separate wait_navigation_done call in the same turn to wait for "
+            "arrival before proceeding."
+        ),
+    },
+    "wait_navigation_done": {
+        "params": ["stall_timeout"],
+        "description": (
+            "Block until the previous navigate_to_tag or navigate_to_pose "
+            "completes. Returns on arrival, timeout, or error. Always call "
+            "after navigate_to_tag/navigate_to_pose."
+        ),
+    },
+    "pause_nav": {"params": [], "description": "Pause navigation"},
+    "resume_nav": {"params": [], "description": "Resume navigation"},
+    "stop_nav": {"params": [], "description": "Stop and cancel navigation"},
+}
+
+_CONTROLLED_SPATIAL_TOOL = {
+    "name": "controlled_spatial",
+    "type": "actuator",
+    "multiInstance": False,
+    "description": (
+        "Controlled mapping & navigation — user manually drives the robot "
+        "during mapping. Supports: start/stop mapping, tag places, list/delete "
+        "maps, load map, navigate between tags."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": list(CONTROLLED_SPATIAL_ACTIONS),
+                "description": "Action to perform",
+            },
+            "map_name": {
+                "type": "string",
+                "description": "Map name (for start_mapping, delete_map, load_map)",
+            },
+            "name": {"type": "string", "description": "POI tag name"},
+            "description": {
+                "type": "string",
+                "description": "POI description",
+            },
+            "tag_name": {
+                "type": "string",
+                "description": "Target tag name for navigation",
+            },
+            "x": {
+                "type": "number",
+                "description": "Target X coordinate (meters)",
+            },
+            "y": {
+                "type": "number",
+                "description": "Target Y coordinate (meters)",
+            },
+            "yaw": {
+                "type": "number",
+                "description": "Target yaw (radians)",
+            },
+            "speed": {
+                "type": "number",
+                "description": "Navigation speed 0.2-0.8 m/s (default 0.5)",
+            },
+            "mode": {
+                "type": "integer",
+                "description": "Obstacle mode: 1=stop(default), 0=detour",
+            },
+            "stall_timeout": {
+                "type": "number",
+                "description": (
+                    "Seconds without movement before declaring timeout (default 90)"
+                ),
+            },
+        },
+        "required": ["action"],
+        "x-action-params": CONTROLLED_SPATIAL_ACTION_PARAMS,
+    },
+}
+
+
+def controlled_spatial_tool_definition() -> dict:
+    """Return an isolated copy so callers cannot mutate the shared contract."""
+    return deepcopy(_CONTROLLED_SPATIAL_TOOL)

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -120,6 +120,13 @@ class G1DeviceBundle:
             self._plugins.append(LidarPlugin(plugins_cfg["lidar"], namespace, executor))
             print("[bundle] LidarPlugin loaded")
 
+        if plugins_cfg.get("navigation_sensors", {}).get("enabled", False):
+            from navigation_sensor_bridge import NavigationSensorPlugin
+            self._plugins.append(
+                NavigationSensorPlugin(plugins_cfg["navigation_sensors"], namespace, executor)
+            )
+            print("[bundle] NavigationSensorPlugin loaded (shadow sensor bridge)")
+
         if plugins_cfg.get("slam", {}).get("enabled", False):
             from device import SpatialPlugin
             self._plugins.append(SpatialPlugin(plugins_cfg["slam"], namespace, executor, slam_client, smart_motion=smart_motion))

--- a/unitree/g1/navigation_pointcloud.py
+++ b/unitree/g1/navigation_pointcloud.py
@@ -1,0 +1,241 @@
+"""MID360 PointCloud2 layout conversion for the FAST-LIVO2 ROS2 MID360 port."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+# sensor_msgs/msg/PointField datatype constants
+UINT8 = 2
+UINT16 = 4
+FLOAT32 = 7
+FLOAT64 = 8
+
+
+@dataclass(frozen=True)
+class PointFieldSpec:
+    name: str
+    offset: int
+    datatype: int
+    count: int = 1
+
+
+# Match the PCL point layout used by the ROS2 MID360 FAST-LIVO2 port:
+# PCL_ADD_POINT4D, intensity, tag, line, alignment padding, timestamp.
+FAST_LIVO_FIELDS = (
+    PointFieldSpec("x", 0, FLOAT32),
+    PointFieldSpec("y", 4, FLOAT32),
+    PointFieldSpec("z", 8, FLOAT32),
+    PointFieldSpec("intensity", 16, FLOAT32),
+    PointFieldSpec("tag", 20, UINT8),
+    PointFieldSpec("line", 21, UINT8),
+    PointFieldSpec("timestamp", 24, FLOAT64),
+)
+FAST_LIVO_POINT_STEP = 32
+_FAST_LIVO_DTYPE = np.dtype(
+    {
+        "names": [field.name for field in FAST_LIVO_FIELDS],
+        "formats": ["<f4", "<f4", "<f4", "<f4", "u1", "u1", "<f8"],
+        "offsets": [field.offset for field in FAST_LIVO_FIELDS],
+        "itemsize": FAST_LIVO_POINT_STEP,
+    }
+)
+
+_EXPECTED_INPUT_TYPES = {
+    "x": FLOAT32,
+    "y": FLOAT32,
+    "z": FLOAT32,
+    "intensity": FLOAT32,
+    "ring": UINT16,
+    "time": FLOAT32,
+}
+_INPUT_DTYPES = {
+    "x": "<f4",
+    "y": "<f4",
+    "z": "<f4",
+    "intensity": "<f4",
+    "ring": "<u2",
+    "time": "<f4",
+}
+
+
+def validated_rotation_matrix(values: object | None) -> np.ndarray:
+    """Return a proper 3x3 rotation matrix from a row-major config value."""
+    if values is None:
+        return np.eye(3, dtype=np.float64)
+
+    rotation = np.asarray(values, dtype=np.float64)
+    if rotation.size != 9:
+        raise ValueError("sensor_rotation_matrix must contain 9 values")
+    rotation = rotation.reshape(3, 3)
+    if not np.isfinite(rotation).all():
+        raise ValueError("sensor_rotation_matrix contains non-finite values")
+    if not np.allclose(rotation @ rotation.T, np.eye(3), atol=1e-6):
+        raise ValueError("sensor_rotation_matrix must be orthonormal")
+    if not np.isclose(np.linalg.det(rotation), 1.0, atol=1e-6):
+        raise ValueError("sensor_rotation_matrix must be a proper rotation")
+    return rotation
+
+
+def rotate_vector3(values: object, rotation: np.ndarray) -> tuple[float, float, float]:
+    """Rotate one xyz vector from the raw MID360 frame into navigation frame."""
+    vector = np.asarray(values, dtype=np.float64)
+    if vector.size != 3:
+        raise ValueError("vector must contain 3 values")
+    rotated = rotation @ vector.reshape(3)
+    return tuple(float(value) for value in rotated)
+
+
+def rotate_covariance9(values: object, rotation: np.ndarray) -> list[float]:
+    """Rotate a row-major 3x3 covariance into the navigation frame."""
+    covariance = np.asarray(values, dtype=np.float64)
+    if covariance.size != 9:
+        raise ValueError("covariance must contain 9 values")
+    rotated = rotation @ covariance.reshape(3, 3) @ rotation.T
+    return [float(value) for value in rotated.reshape(9)]
+
+
+def rotate_orientation_xyzw(
+    values: object, rotation: np.ndarray
+) -> tuple[float, float, float, float]:
+    """Express a raw-frame orientation quaternion in the corrected frame.
+
+    ``rotation`` maps raw sensor vectors into the corrected navigation frame.
+    An IMU orientation describes the raw sensor frame in the world, so the
+    corrected-frame orientation is ``R_world_raw * rotation.T``.
+    """
+    quaternion = np.asarray(values, dtype=np.float64)
+    if quaternion.size != 4:
+        raise ValueError("quaternion must contain 4 values")
+    norm = float(np.linalg.norm(quaternion))
+    if not np.isfinite(norm) or norm < 1e-12:
+        raise ValueError("quaternion must be finite and non-zero")
+    x, y, z, w = quaternion / norm
+    raw_to_world = np.array(
+        [
+            [1.0 - 2.0 * (y * y + z * z), 2.0 * (x * y - z * w), 2.0 * (x * z + y * w)],
+            [2.0 * (x * y + z * w), 1.0 - 2.0 * (x * x + z * z), 2.0 * (y * z - x * w)],
+            [2.0 * (x * z - y * w), 2.0 * (y * z + x * w), 1.0 - 2.0 * (x * x + y * y)],
+        ],
+        dtype=np.float64,
+    )
+    corrected_to_world = raw_to_world @ rotation.T
+
+    trace = float(np.trace(corrected_to_world))
+    if trace > 0.0:
+        scale = 2.0 * np.sqrt(trace + 1.0)
+        qw = 0.25 * scale
+        qx = (corrected_to_world[2, 1] - corrected_to_world[1, 2]) / scale
+        qy = (corrected_to_world[0, 2] - corrected_to_world[2, 0]) / scale
+        qz = (corrected_to_world[1, 0] - corrected_to_world[0, 1]) / scale
+    else:
+        index = int(np.argmax(np.diag(corrected_to_world)))
+        if index == 0:
+            scale = 2.0 * np.sqrt(
+                1.0 + corrected_to_world[0, 0]
+                - corrected_to_world[1, 1]
+                - corrected_to_world[2, 2]
+            )
+            qw = (corrected_to_world[2, 1] - corrected_to_world[1, 2]) / scale
+            qx = 0.25 * scale
+            qy = (corrected_to_world[0, 1] + corrected_to_world[1, 0]) / scale
+            qz = (corrected_to_world[0, 2] + corrected_to_world[2, 0]) / scale
+        elif index == 1:
+            scale = 2.0 * np.sqrt(
+                1.0 + corrected_to_world[1, 1]
+                - corrected_to_world[0, 0]
+                - corrected_to_world[2, 2]
+            )
+            qw = (corrected_to_world[0, 2] - corrected_to_world[2, 0]) / scale
+            qx = (corrected_to_world[0, 1] + corrected_to_world[1, 0]) / scale
+            qy = 0.25 * scale
+            qz = (corrected_to_world[1, 2] + corrected_to_world[2, 1]) / scale
+        else:
+            scale = 2.0 * np.sqrt(
+                1.0 + corrected_to_world[2, 2]
+                - corrected_to_world[0, 0]
+                - corrected_to_world[1, 1]
+            )
+            qw = (corrected_to_world[1, 0] - corrected_to_world[0, 1]) / scale
+            qx = (corrected_to_world[0, 2] + corrected_to_world[2, 0]) / scale
+            qy = (corrected_to_world[1, 2] + corrected_to_world[2, 1]) / scale
+            qz = 0.25 * scale
+
+    corrected = np.array([qx, qy, qz, qw], dtype=np.float64)
+    corrected /= np.linalg.norm(corrected)
+    return tuple(float(value) for value in corrected)
+
+
+def unitree_mid360_to_fast_livo(
+    *,
+    data: bytes,
+    point_count: int,
+    point_step: int,
+    fields: list[tuple[str, int, int, int]],
+    header_stamp_ns: int,
+    rotation_matrix: np.ndarray | None = None,
+) -> bytes:
+    """Convert Unitree's packed MID360 points to the ROS2 port's PCL schema.
+
+    Unitree provides ``time`` as a per-point offset in nanoseconds.  The target
+    FAST-LIVO2 MID360 handler expects ``timestamp`` as an absolute nanosecond
+    value and subtracts the ROS header internally.
+    """
+    point_count = int(point_count)
+    point_step = int(point_step)
+    header_stamp_ns = int(header_stamp_ns)
+    if point_count < 1 or point_step < 1 or header_stamp_ns <= 0:
+        raise ValueError("point_count, point_step and header_stamp_ns must be positive")
+    if len(data) < point_count * point_step:
+        raise ValueError("point cloud data is shorter than point_count * point_step")
+
+    field_map = {name: (int(offset), int(datatype), int(count)) for name, offset, datatype, count in fields}
+    for name, expected_type in _EXPECTED_INPUT_TYPES.items():
+        if name not in field_map:
+            raise ValueError(f"missing MID360 field: {name}")
+        offset, datatype, count = field_map[name]
+        if datatype != expected_type or count != 1:
+            raise ValueError(
+                f"unexpected MID360 field {name}: datatype={datatype}, count={count}"
+            )
+        if offset < 0 or offset + np.dtype(_INPUT_DTYPES[name]).itemsize > point_step:
+            raise ValueError(f"MID360 field {name} exceeds point_step")
+
+    def view(name: str) -> np.ndarray:
+        offset = field_map[name][0]
+        return np.ndarray(
+            shape=(point_count,),
+            dtype=_INPUT_DTYPES[name],
+            buffer=data,
+            offset=offset,
+            strides=(point_step,),
+        )
+
+    ring = view("ring")
+    if int(ring.max(initial=0)) > 255:
+        raise ValueError("MID360 ring value exceeds uint8 line range")
+
+    relative_time_ns = view("time")
+    if not np.isfinite(relative_time_ns).all() or float(relative_time_ns.min()) < 0:
+        raise ValueError("MID360 time contains negative or non-finite values")
+
+    rotation = validated_rotation_matrix(rotation_matrix)
+    xyz = np.column_stack((view("x"), view("y"), view("z"))).astype(
+        np.float32, copy=False
+    )
+    if not np.array_equal(rotation, np.eye(3)):
+        xyz = xyz @ rotation.astype(np.float32).T
+
+    converted = np.zeros(point_count, dtype=_FAST_LIVO_DTYPE)
+    converted["x"] = xyz[:, 0]
+    converted["y"] = xyz[:, 1]
+    converted["z"] = xyz[:, 2]
+    converted["intensity"] = view("intensity")
+    converted["tag"] = 0x10
+    converted["line"] = ring.astype(np.uint8, copy=False)
+    converted["timestamp"] = np.float64(header_stamp_ns) + relative_time_ns.astype(
+        np.float64, copy=False
+    )
+    return converted.tobytes(order="C")

--- a/unitree/g1/navigation_sensor_bridge.py
+++ b/unitree/g1/navigation_sensor_bridge.py
@@ -1,0 +1,551 @@
+"""Raw MID360 DDS to standard ROS2 sensor topics for traditional navigation.
+
+The bridge is intentionally independent from the dashboard-oriented LidarPlugin.
+It preserves raw PointCloud2 fields, normalizes LiDAR/IMU timestamps into the
+Jetson ROS clock domain, and applies one fixed mounting rotation to both the
+estimator point cloud and IMU.  It never applies dynamic gravity alignment.
+"""
+
+from __future__ import annotations
+
+from array import array
+import json
+import queue
+import threading
+import time
+
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import Imu, PointCloud2, PointField
+from std_msgs.msg import String
+
+from navigation_pointcloud import (
+    FAST_LIVO_FIELDS,
+    FAST_LIVO_POINT_STEP,
+    rotate_covariance9,
+    rotate_orientation_xyzw,
+    rotate_vector3,
+    unitree_mid360_to_fast_livo,
+    validated_rotation_matrix,
+)
+from navigation_time import ClockOffsetEstimator, split_ns, stamp_to_ns
+from unitree_sdk2py.core.channel import ChannelSubscriber
+from unitree_sdk2py.idl.sensor_msgs.msg.dds_ import Imu_, PointCloud2_
+
+
+_RAW_CLOUD_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=2,
+    durability=DurabilityPolicy.VOLATILE,
+)
+_FAST_LIVO_CLOUD_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=2,
+    durability=DurabilityPolicy.VOLATILE,
+)
+_IMU_QOS = QoSProfile(
+    # The pinned FAST-LIVO2 port uses the ROS default reliable subscription.
+    # A reliable publisher remains compatible with best-effort diagnostics,
+    # while the inverse pairing silently disconnects the estimator input.
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=200,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+
+def _absolute_topic(value: str | None, fallback: str) -> str:
+    topic = (value or fallback).strip()
+    return topic if topic.startswith("/") else f"/{topic}"
+
+
+class _NavigationSensorNode(Node):
+    def __init__(self, config: dict, namespace: str):
+        super().__init__("g1_navigation_sensor_bridge")
+
+        prefix = f"/{namespace}/navigation"
+        self.cloud_topic = _absolute_topic(config.get("cloud_topic"), f"{prefix}/lidar")
+        self.fast_livo_cloud_topic = _absolute_topic(
+            config.get("fast_livo_cloud_topic"), f"{prefix}/lidar_fast_livo"
+        )
+        self._publish_raw_cloud = bool(config.get("publish_raw_cloud", True))
+        self._publish_fast_livo_cloud = bool(
+            config.get("publish_fast_livo_cloud", True)
+        )
+        self.imu_topic = _absolute_topic(config.get("imu_topic"), f"{prefix}/imu")
+        self.diagnostics_topic = _absolute_topic(
+            config.get("diagnostics_topic"), f"{prefix}/sensor_diagnostics"
+        )
+        self._raw_cloud_topic = config.get(
+            "raw_cloud_topic", "rt/utlidar/cloud_livox_mid360"
+        )
+        self._raw_imu_topic = config.get(
+            "raw_imu_topic", "rt/utlidar/imu_livox_mid360"
+        )
+        self._raw_lidar_frame = config.get("raw_lidar_frame", "livox_raw_frame")
+        self._lidar_frame = config.get("lidar_frame", "livox_frame")
+        self._imu_frame = config.get("imu_frame", self._lidar_frame)
+        self._sensor_rotation = validated_rotation_matrix(
+            config.get("sensor_rotation_matrix")
+        )
+
+        # Do not use ``self._clock``: rclpy.node.Node owns that attribute and
+        # get_clock() returns it internally.
+        self._clock_offset = ClockOffsetEstimator(
+            warmup_samples=int(config.get("clock_warmup_samples", 32)),
+            window_samples=int(config.get("clock_window_samples", 400)),
+            reset_threshold_ns=int(
+                float(config.get("clock_reset_threshold_ms", 1000.0)) * 1_000_000
+            ),
+            reset_confirm_samples=int(config.get("clock_reset_confirm_samples", 8)),
+        )
+
+        self._cloud_pub = (
+            self.create_publisher(PointCloud2, self.cloud_topic, _RAW_CLOUD_QOS)
+            if self._publish_raw_cloud
+            else None
+        )
+        self._fast_livo_cloud_pub = (
+            self.create_publisher(
+                PointCloud2,
+                self.fast_livo_cloud_topic,
+                _FAST_LIVO_CLOUD_QOS,
+            )
+            if self._publish_fast_livo_cloud
+            else None
+        )
+        self._imu_pub = self.create_publisher(Imu, self.imu_topic, _IMU_QOS)
+        self._diagnostics_pub = self.create_publisher(String, self.diagnostics_topic, 10)
+
+        self._cloud_queue: queue.Queue = queue.Queue(maxsize=2)
+        self._imu_queue: queue.Queue = queue.Queue(maxsize=4)
+        self._stop = threading.Event()
+        self._cloud_worker = threading.Thread(
+            target=self._cloud_loop, name="navigation_cloud", daemon=True
+        )
+        self._imu_worker = threading.Thread(
+            target=self._imu_loop, name="navigation_imu", daemon=True
+        )
+        self._cloud_worker.start()
+        self._imu_worker.start()
+
+        self._last_stamp_ns = {"cloud": 0, "imu": 0}
+        self._last_diagnostics_time = 0.0
+        self._counters = {
+            "cloud_received": 0,
+            "cloud_published": 0,
+            "cloud_dropped": 0,
+            "fast_livo_cloud_published": 0,
+            "fast_livo_cloud_dropped": 0,
+            "imu_received": 0,
+            "imu_published": 0,
+            "imu_dropped": 0,
+            "stamp_clamped": 0,
+        }
+
+        self._cloud_sub = ChannelSubscriber(self._raw_cloud_topic, PointCloud2_)
+        self._cloud_sub.Init(self._on_cloud, 1)
+        self._imu_sub = ChannelSubscriber(self._raw_imu_topic, Imu_)
+        # Direct callback avoids the SDK BQueue dropping new samples when its
+        # single slot is occupied.  This callback only timestamps and enqueues.
+        self._imu_sub.Init(self._on_imu)
+        cloud_outputs = []
+        if self._publish_fast_livo_cloud:
+            cloud_outputs.append(self.fast_livo_cloud_topic)
+        if self._publish_raw_cloud:
+            cloud_outputs.append(self.cloud_topic)
+        self.get_logger().info(
+            f"Navigation sensors: {self._raw_cloud_topic} -> "
+            f"{','.join(cloud_outputs) or '(disabled)'}; "
+            f"{self._raw_imu_topic} -> {self.imu_topic}; "
+            f"raw_frame={self._raw_lidar_frame}, corrected_frame={self._lidar_frame}, "
+            f"sensor_rotation={self._sensor_rotation.reshape(9).tolist()}"
+        )
+
+    def _correct_stamp(self, source_stamp, stream: str) -> int | None:
+        try:
+            source_ns = stamp_to_ns(source_stamp.sec, source_stamp.nanosec)
+            host_ns = self.get_clock().now().nanoseconds
+            corrected_ns = self._clock_offset.correct_observation(source_ns, host_ns)
+        except (AttributeError, TypeError, ValueError) as exc:
+            self.get_logger().warning(f"invalid {stream} timestamp: {exc}")
+            return None
+
+        if corrected_ns is None:
+            return None
+        if corrected_ns <= self._last_stamp_ns[stream]:
+            corrected_ns = self._last_stamp_ns[stream] + 1
+            self._counters["stamp_clamped"] += 1
+        self._last_stamp_ns[stream] = corrected_ns
+        return corrected_ns
+
+    @staticmethod
+    def _set_stamp(header, timestamp_ns: int, frame_id: str) -> None:
+        sec, nanosec = split_ns(timestamp_ns)
+        header.stamp.sec = sec
+        header.stamp.nanosec = nanosec
+        header.frame_id = frame_id
+
+    def _on_cloud(self, msg) -> None:
+        self._counters["cloud_received"] += 1
+        corrected_ns = self._correct_stamp(msg.header.stamp, "cloud")
+        if corrected_ns is None:
+            self._counters["cloud_dropped"] += 1
+            self._maybe_publish_diagnostics()
+            return
+
+        fields = [
+            (str(field.name), int(field.offset), int(field.datatype), int(field.count))
+            for field in msg.fields
+        ]
+        item = (
+            corrected_ns,
+            int(msg.height),
+            int(msg.width),
+            fields,
+            bool(msg.is_bigendian),
+            int(msg.point_step),
+            int(msg.row_step),
+            bytes(msg.data),
+            bool(msg.is_dense),
+        )
+        try:
+            self._cloud_queue.put_nowait(item)
+        except queue.Full:
+            try:
+                self._cloud_queue.get_nowait()
+            except queue.Empty:
+                pass
+            self._counters["cloud_dropped"] += 1
+            self._cloud_queue.put_nowait(item)
+        self._maybe_publish_diagnostics()
+
+    def _cloud_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                item = self._cloud_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if item is None:
+                break
+
+            (
+                corrected_ns,
+                height,
+                width,
+                fields,
+                is_bigendian,
+                point_step,
+                row_step,
+                data,
+                is_dense,
+            ) = item
+            expected_size = row_step * height
+            if point_step <= 0 or height <= 0 or width <= 0 or len(data) < expected_size:
+                self._counters["cloud_dropped"] += 1
+                continue
+
+            # The estimator input is the priority path.  Publishing the raw and
+            # adapted 0.4/0.6 MB clouds together can saturate Python ROS2
+            # serialization on the live Jetson, so the raw diagnostic output is
+            # independently switchable.
+            if self._fast_livo_cloud_pub is not None:
+                try:
+                    converted = unitree_mid360_to_fast_livo(
+                        data=data,
+                        point_count=height * width,
+                        point_step=point_step,
+                        fields=fields,
+                        header_stamp_ns=corrected_ns,
+                        rotation_matrix=self._sensor_rotation,
+                    )
+                    fast_livo = PointCloud2()
+                    self._set_stamp(
+                        fast_livo.header, corrected_ns, self._lidar_frame
+                    )
+                    fast_livo.height = 1
+                    fast_livo.width = height * width
+                    fast_livo.fields = [
+                        PointField(
+                            name=field.name,
+                            offset=field.offset,
+                            datatype=field.datatype,
+                            count=field.count,
+                        )
+                        for field in FAST_LIVO_FIELDS
+                    ]
+                    fast_livo.is_bigendian = False
+                    fast_livo.point_step = FAST_LIVO_POINT_STEP
+                    fast_livo.row_step = FAST_LIVO_POINT_STEP * fast_livo.width
+                    # Humble's generated setter validates a bytes object one
+                    # element at a time in debug mode.  array('B') takes its
+                    # constant-time fast path for large PointCloud2 payloads.
+                    fast_livo.data = array("B", converted)
+                    fast_livo.is_dense = is_dense
+                    self._fast_livo_cloud_pub.publish(fast_livo)
+                    self._counters["fast_livo_cloud_published"] += 1
+                except (TypeError, ValueError) as exc:
+                    self._counters["fast_livo_cloud_dropped"] += 1
+                    if self._counters["fast_livo_cloud_dropped"] <= 3:
+                        self.get_logger().warning(
+                            f"FAST-LIVO cloud conversion failed: {exc}"
+                        )
+
+            if self._cloud_pub is not None:
+                out = PointCloud2()
+                self._set_stamp(out.header, corrected_ns, self._raw_lidar_frame)
+                out.height = height
+                out.width = width
+                out.fields = [
+                    PointField(
+                        name=name,
+                        offset=offset,
+                        datatype=datatype,
+                        count=count,
+                    )
+                    for name, offset, datatype, count in fields
+                ]
+                out.is_bigendian = is_bigendian
+                out.point_step = point_step
+                out.row_step = row_step
+                out.data = array("B", data)
+                out.is_dense = is_dense
+                self._cloud_pub.publish(out)
+                self._counters["cloud_published"] += 1
+
+    def _on_imu(self, msg) -> None:
+        self._counters["imu_received"] += 1
+        corrected_ns = self._correct_stamp(msg.header.stamp, "imu")
+        if corrected_ns is None:
+            self._counters["imu_dropped"] += 1
+            self._maybe_publish_diagnostics()
+            return
+
+        try:
+            self._imu_queue.put_nowait((corrected_ns, msg))
+        except queue.Full:
+            # Prefer fresh inertial data over completing a stale backlog.
+            try:
+                self._imu_queue.get_nowait()
+            except queue.Empty:
+                pass
+            self._counters["imu_dropped"] += 1
+            self._imu_queue.put_nowait((corrected_ns, msg))
+        self._maybe_publish_diagnostics()
+
+    def _imu_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                item = self._imu_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if item is None:
+                break
+            corrected_ns, msg = item
+
+            out = Imu()
+            self._set_stamp(out.header, corrected_ns, self._imu_frame)
+
+            q = msg.orientation
+            q_norm_sq = (
+                float(q.x) ** 2
+                + float(q.y) ** 2
+                + float(q.z) ** 2
+                + float(q.w) ** 2
+            )
+            if q_norm_sq > 0.25:
+                qx, qy, qz, qw = rotate_orientation_xyzw(
+                    (float(q.x), float(q.y), float(q.z), float(q.w)),
+                    self._sensor_rotation,
+                )
+                out.orientation.x = qx
+                out.orientation.y = qy
+                out.orientation.z = qz
+                out.orientation.w = qw
+                out.orientation_covariance = rotate_covariance9(
+                    msg.orientation_covariance, self._sensor_rotation
+                )
+            else:
+                # The live MID360 stream reports an all-zero quaternion.  Publish
+                # identity and mark orientation unavailable per REP-145.
+                out.orientation.w = 1.0
+                out.orientation_covariance[0] = -1.0
+
+            wx, wy, wz = rotate_vector3(
+                (
+                    float(msg.angular_velocity.x),
+                    float(msg.angular_velocity.y),
+                    float(msg.angular_velocity.z),
+                ),
+                self._sensor_rotation,
+            )
+            out.angular_velocity.x = wx
+            out.angular_velocity.y = wy
+            out.angular_velocity.z = wz
+            out.angular_velocity_covariance = rotate_covariance9(
+                msg.angular_velocity_covariance, self._sensor_rotation
+            )
+            ax, ay, az = rotate_vector3(
+                (
+                    float(msg.linear_acceleration.x),
+                    float(msg.linear_acceleration.y),
+                    float(msg.linear_acceleration.z),
+                ),
+                self._sensor_rotation,
+            )
+            out.linear_acceleration.x = ax
+            out.linear_acceleration.y = ay
+            out.linear_acceleration.z = az
+            out.linear_acceleration_covariance = rotate_covariance9(
+                msg.linear_acceleration_covariance, self._sensor_rotation
+            )
+            self._imu_pub.publish(out)
+            self._counters["imu_published"] += 1
+
+    def _maybe_publish_diagnostics(self) -> None:
+        now = time.monotonic()
+        if now - self._last_diagnostics_time < 1.0:
+            return
+        self._last_diagnostics_time = now
+        clock = self._clock_offset.snapshot().to_dict()
+        if clock["offset_ns"] is not None:
+            clock["offset_sec"] = round(clock["offset_ns"] / 1_000_000_000, 6)
+        if clock["residual_ns"] is not None:
+            clock["residual_ms"] = round(clock["residual_ns"] / 1_000_000, 3)
+        out = String()
+        out.data = json.dumps(
+            {
+                "clock": clock,
+                "counters": dict(self._counters),
+                "raw_topics": {
+                    "cloud": self._raw_cloud_topic,
+                    "imu": self._raw_imu_topic,
+                },
+                "frames": {
+                    "raw_lidar": self._raw_lidar_frame,
+                    "lidar": self._lidar_frame,
+                    "imu": self._imu_frame,
+                },
+                "sensor_rotation_matrix": [
+                    float(value) for value in self._sensor_rotation.reshape(9)
+                ],
+            },
+            separators=(",", ":"),
+        )
+        self._diagnostics_pub.publish(out)
+
+    def close(self) -> None:
+        for subscriber in (self._cloud_sub, self._imu_sub):
+            try:
+                subscriber.Close()
+            except Exception:
+                pass
+        self._stop.set()
+        for work_queue in (self._cloud_queue, self._imu_queue):
+            try:
+                work_queue.put_nowait(None)
+            except queue.Full:
+                try:
+                    work_queue.get_nowait()
+                except queue.Empty:
+                    pass
+                work_queue.put_nowait(None)
+        self._cloud_worker.join(timeout=2.0)
+        self._imu_worker.join(timeout=2.0)
+
+
+class NavigationSensorPlugin:
+    PREFIX = "navigation_sensors"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor):
+        self._executor = executor
+        self._node = _NavigationSensorNode(plugin_config, namespace)
+        executor.add_node(self._node)
+
+    def get_tools(self) -> list[dict]:
+        tools = []
+        if self._node._publish_fast_livo_cloud:
+            tools.append(
+                self._tool(
+                    "navigation_lidar_fast_livo",
+                    "MID360 PointCloud2 adapted for the pinned FAST-LIVO2 ROS2 port",
+                    self._node.fast_livo_cloud_topic,
+                    "sensor/pointcloud2",
+                )
+            )
+        if self._node._publish_raw_cloud:
+            tools.append(
+                self._tool(
+                    "navigation_lidar",
+                    "Standard PointCloud2 with raw MID360 fields and per-point time preserved",
+                    self._node.cloud_topic,
+                    "sensor/pointcloud2",
+                )
+            )
+        tools.extend(
+            [
+                self._tool(
+                    "navigation_imu",
+                    "Standard IMU for FAST-LIVO2 in the same normalized clock domain as LiDAR",
+                    self._node.imu_topic,
+                    "sensor/imu",
+                ),
+                self._tool(
+                    "navigation_sensor_diagnostics",
+                    "Navigation sensor clock and drop diagnostics",
+                    self._node.diagnostics_topic,
+                    "data/json",
+                ),
+            ]
+        )
+        return tools
+
+    @staticmethod
+    def _tool(name: str, description: str, topic: str, message_format: str) -> dict:
+        return {
+            "name": name,
+            "type": "sensor",
+            "multiInstance": False,
+            "description": f"{description}. Publishes to {topic}",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": topic, "format": message_format}],
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        self._node.close()
+        try:
+            self._executor.remove_node(self._node)
+            self._node.destroy_node()
+        except Exception:
+            pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action in {"start", "info"}:
+            tool_name = args.get("_tool_name", "")
+            topic_map = {
+                "navigation_lidar": (self._node.cloud_topic, "sensor/pointcloud2"),
+                "navigation_lidar_fast_livo": (
+                    self._node.fast_livo_cloud_topic,
+                    "sensor/pointcloud2",
+                ),
+                "navigation_imu": (self._node.imu_topic, "sensor/imu"),
+                "navigation_sensor_diagnostics": (
+                    self._node.diagnostics_topic,
+                    "data/json",
+                ),
+            }
+            topic, message_format = topic_map.get(
+                tool_name, (self._node.diagnostics_topic, "data/json")
+            )
+            return {
+                "state": "running",
+                "topic_out": [{"topic": topic, "format": message_format}],
+            }
+        if action == "stop":
+            return {"state": "idle"}
+        return None

--- a/unitree/g1/navigation_sensor_bridge_main.py
+++ b/unitree/g1/navigation_sensor_bridge_main.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Standalone, read-only G1 navigation sensor bridge for N2 shadow runs."""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import socket
+import sys
+import threading
+from pathlib import Path
+
+import rclpy
+from rclpy.executors import MultiThreadedExecutor
+import yaml
+
+from navigation_sensor_bridge import NavigationSensorPlugin
+from unitree_sdk2py.core.channel import ChannelFactoryInitialize
+
+
+def _load_config() -> dict:
+    path = Path(os.environ.get("CONFIG_PATH", Path(__file__).with_name("config.yaml")))
+    with path.open() as stream:
+        config = yaml.safe_load(stream)
+    if not isinstance(config, dict):
+        raise ValueError(f"navigation bridge config must be a mapping: {path}")
+    return config
+
+
+def _resolve_namespace(config: dict) -> str:
+    value = os.environ.get("ROS_NAMESPACE", "").strip()
+    if not value:
+        value = str(config.get("ros_namespace", "")).strip()
+    if not value:
+        value = socket.gethostname()
+    value = re.sub(r"[^a-zA-Z0-9_]", "_", value.strip("/"))
+    if not value:
+        raise ValueError("ROS namespace resolves to an empty value")
+    return value
+
+
+def main() -> int:
+    network_interface = (
+        sys.argv[1] if len(sys.argv) > 1 else os.environ.get("NETWORK_INTERFACE", "eth0")
+    )
+    config = _load_config()
+    plugin_config = config.get("plugins", {}).get("navigation_sensors", {})
+    if not plugin_config.get("enabled", False):
+        raise RuntimeError("plugins.navigation_sensors.enabled must be true")
+
+    namespace = _resolve_namespace(config)
+    ChannelFactoryInitialize(0, network_interface)
+    print(
+        f"[navigation-shadow] DDS initialized on {network_interface}; "
+        f"ROS namespace={namespace}",
+        flush=True,
+    )
+
+    rclpy.init()
+    executor = MultiThreadedExecutor(num_threads=3)
+    plugin = NavigationSensorPlugin(plugin_config, namespace, executor)
+    stop = threading.Event()
+
+    def _request_stop(signum, _frame):
+        print(f"[navigation-shadow] signal {signum}, shutting down", flush=True)
+        stop.set()
+
+    signal.signal(signal.SIGTERM, _request_stop)
+    signal.signal(signal.SIGINT, _request_stop)
+
+    try:
+        while rclpy.ok() and not stop.is_set():
+            executor.spin_once(timeout_sec=0.2)
+    finally:
+        plugin.stop()
+        executor.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unitree/g1/navigation_time.py
+++ b/unitree/g1/navigation_time.py
@@ -1,0 +1,150 @@
+"""Clock-domain normalization helpers for the G1 navigation sensor bridge.
+
+Unitree's MID360 publishes LiDAR and IMU headers in a shared sensor clock that
+is not guaranteed to match the Jetson system clock.  Estimators and planners
+must still receive ROS timestamps in one coherent clock domain.  This module is
+kept free of ROS dependencies so the correction policy can be unit tested on a
+development machine.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import asdict, dataclass
+import threading
+
+
+NSEC_PER_SEC = 1_000_000_000
+
+
+def stamp_to_ns(sec: int, nanosec: int) -> int:
+    """Convert a ROS-style ``sec``/``nanosec`` pair to integer nanoseconds."""
+    if not 0 <= int(nanosec) < NSEC_PER_SEC:
+        raise ValueError(f"nanosec out of range: {nanosec}")
+    return int(sec) * NSEC_PER_SEC + int(nanosec)
+
+
+def split_ns(timestamp_ns: int) -> tuple[int, int]:
+    """Split integer nanoseconds into a normalized ROS timestamp pair."""
+    sec, nanosec = divmod(int(timestamp_ns), NSEC_PER_SEC)
+    return sec, nanosec
+
+
+@dataclass(frozen=True)
+class ClockSnapshot:
+    ready: bool
+    samples: int
+    offset_ns: int | None
+    residual_ns: int | None
+    resets: int
+    rejected: int
+    pending_reset_samples: int
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class ClockOffsetEstimator:
+    """Estimate ``host_time - sensor_time`` from callback arrival times.
+
+    Transport and scheduling latency is non-negative, so the minimum candidate
+    in a rolling window is a better offset estimate than an average.  A single
+    late callback is rejected instead of shifting every subsequent timestamp.
+    Persistent jumps are treated as a source-clock reset and require a new
+    warm-up period.
+    """
+
+    def __init__(
+        self,
+        *,
+        warmup_samples: int = 32,
+        window_samples: int = 400,
+        reset_threshold_ns: int = NSEC_PER_SEC,
+        reset_confirm_samples: int = 8,
+    ) -> None:
+        if warmup_samples < 1:
+            raise ValueError("warmup_samples must be positive")
+        if window_samples < warmup_samples:
+            raise ValueError("window_samples must be >= warmup_samples")
+        if reset_threshold_ns < 1:
+            raise ValueError("reset_threshold_ns must be positive")
+        if reset_confirm_samples < 2:
+            raise ValueError("reset_confirm_samples must be >= 2")
+
+        self._warmup_samples = warmup_samples
+        self._reset_threshold_ns = reset_threshold_ns
+        self._reset_confirm_samples = reset_confirm_samples
+        self._candidates: deque[int] = deque(maxlen=window_samples)
+        self._pending_reset: list[int] = []
+        self._offset_ns: int | None = None
+        self._residual_ns: int | None = None
+        self._ready = False
+        self._resets = 0
+        self._rejected = 0
+        self._lock = threading.Lock()
+
+    def correct_observation(self, source_ns: int, host_arrival_ns: int) -> int | None:
+        """Observe one sample and return its corrected host timestamp when ready.
+
+        ``None`` means the sample must not be published: either the initial
+        offset is still warming up or the observation looks like a clock jump.
+        """
+        source_ns = int(source_ns)
+        host_arrival_ns = int(host_arrival_ns)
+        if source_ns <= 0 or host_arrival_ns <= 0:
+            raise ValueError("timestamps must be positive")
+
+        candidate = host_arrival_ns - source_ns
+        with self._lock:
+            if self._offset_ns is None:
+                self._accept_locked(candidate)
+            else:
+                delta = candidate - self._offset_ns
+                if delta < -self._reset_threshold_ns:
+                    # The source clock jumped forward.  Re-baseline immediately;
+                    # normal callback latency cannot make this candidate smaller.
+                    self._reset_locked(candidate)
+                elif delta > self._reset_threshold_ns:
+                    # This may be one delayed callback or a source clock that
+                    # jumped backwards.  Require consecutive evidence so a large
+                    # point-cloud callback cannot reset the IMU clock domain.
+                    self._pending_reset.append(candidate)
+                    self._rejected += 1
+                    self._residual_ns = delta
+                    if len(self._pending_reset) >= self._reset_confirm_samples:
+                        self._reset_locked(min(self._pending_reset))
+                    return None
+                else:
+                    self._pending_reset.clear()
+                    self._accept_locked(candidate)
+
+            if not self._ready:
+                return None
+            return source_ns + int(self._offset_ns)
+
+    def snapshot(self) -> ClockSnapshot:
+        with self._lock:
+            return ClockSnapshot(
+                ready=self._ready,
+                samples=len(self._candidates),
+                offset_ns=self._offset_ns,
+                residual_ns=self._residual_ns,
+                resets=self._resets,
+                rejected=self._rejected,
+                pending_reset_samples=len(self._pending_reset),
+            )
+
+    def _accept_locked(self, candidate: int) -> None:
+        self._candidates.append(candidate)
+        self._offset_ns = min(self._candidates)
+        self._residual_ns = candidate - self._offset_ns
+        self._ready = len(self._candidates) >= self._warmup_samples
+
+    def _reset_locked(self, candidate: int) -> None:
+        self._candidates.clear()
+        self._pending_reset.clear()
+        self._offset_ns = None
+        self._residual_ns = None
+        self._ready = False
+        self._resets += 1
+        self._accept_locked(candidate)

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -112,7 +112,7 @@ class SmartMotionProxy:
     def stop_nav(self) -> dict:
         return self._call("stop_nav")
 
-    def wait_nav_done(self, stall_timeout: float = 60) -> dict:
+    def wait_nav_done(self, stall_timeout: float = 90) -> dict:
         return self._call("wait_nav_done", stall_timeout=stall_timeout,
                           timeout=stall_timeout + 30)
 
@@ -610,7 +610,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         return {"ret": ret, "vx": clamped_vx, "vy": clamped_vy, "vyaw": clamped_vyaw,
                 "duration": duration, "state": state.value}
 
-    def handle_navigate_to(x, y, yaw, target_name, speed=0.5, mode=1, stall_timeout=60):
+    def handle_navigate_to(x, y, yaw, target_name, speed=0.5, mode=1, stall_timeout=90):
         nonlocal state, nav_cmd, speed_zone, nav_arrived_flag, nav_arrived_error
 
         if state == MotionState.MOVING:
@@ -647,7 +647,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         # Return immediately — non-blocking. wait_navigation_done handles arrival detection.
         return {"status": "navigating", "target": label, "pose": {"x": x, "y": y, "yaw": yaw}}
 
-    def handle_wait_nav_done(stall_timeout=60):
+    def handle_wait_nav_done(stall_timeout=90):
         """Block until navigation completes or robot is stuck.
         Arrival detection: pose-based (distance to target < 0.3m).
         Also checks ctrl_info.is_arrived if SLAM service ever publishes it.
@@ -878,7 +878,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                                             cmd.get("target_name", ""),
                                             speed=cmd.get("speed", 0.5),
                                             mode=cmd.get("mode", 1),
-                                            stall_timeout=cmd.get("stall_timeout", 60))
+                                            stall_timeout=cmd.get("stall_timeout", 90))
             elif method == "pause_nav":
                 result = handle_pause_nav(cmd.get("reason", "command"))
             elif method == "resume_nav":
@@ -886,7 +886,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             elif method == "stop_nav":
                 result = do_stop_nav()
             elif method == "wait_nav_done":
-                result = handle_wait_nav_done(cmd.get("stall_timeout", 60))
+                result = handle_wait_nav_done(cmd.get("stall_timeout", 90))
             elif method == "get_state":
                 result = handle_get_state()
             elif method == "start_mapping":

--- a/unitree/g1/tests/test_controlled_spatial_contract.py
+++ b/unitree/g1/tests/test_controlled_spatial_contract.py
@@ -1,0 +1,85 @@
+import unittest
+
+from controlled_spatial import ControlledSpatialPlugin
+from controlled_spatial_contract import (
+    CONTROLLED_SPATIAL_ACTION_PARAMS,
+    CONTROLLED_SPATIAL_ACTIONS,
+    controlled_spatial_tool_definition,
+)
+
+
+EXPECTED_ACTION_PARAMS = {
+    "start_mapping": ["map_name"],
+    "stop_mapping": [],
+    "tag_place": ["name", "description"],
+    "untag_place": ["name"],
+    "list_tags": [],
+    "list_maps": [],
+    "delete_map": ["map_name"],
+    "load_map": ["map_name"],
+    "navigate_to_tag": ["tag_name", "speed", "mode"],
+    "navigate_to_pose": ["x", "y", "yaw", "speed", "mode"],
+    "wait_navigation_done": ["stall_timeout"],
+    "pause_nav": [],
+    "resume_nav": [],
+    "stop_nav": [],
+}
+
+
+class ControlledSpatialContractTest(unittest.TestCase):
+    def test_runtime_plugin_uses_the_canonical_card(self):
+        plugin = ControlledSpatialPlugin.__new__(ControlledSpatialPlugin)
+        self.assertEqual(plugin._tool_def(), controlled_spatial_tool_definition())
+
+    def test_card_matches_the_controlled_spatial_standard(self):
+        tool = controlled_spatial_tool_definition()
+        schema = tool["inputSchema"]
+
+        self.assertEqual(tool["name"], "controlled_spatial")
+        self.assertEqual(tool["type"], "actuator")
+        self.assertFalse(tool["multiInstance"])
+        self.assertEqual(schema["required"], ["action"])
+        self.assertEqual(
+            tuple(schema["properties"]["action"]["enum"]),
+            CONTROLLED_SPATIAL_ACTIONS,
+        )
+        self.assertEqual(set(schema["x-action-params"]), set(CONTROLLED_SPATIAL_ACTIONS))
+        self.assertEqual(
+            {
+                action: spec["params"]
+                for action, spec in schema["x-action-params"].items()
+            },
+            EXPECTED_ACTION_PARAMS,
+        )
+        self.assertEqual(schema["x-action-params"], CONTROLLED_SPATIAL_ACTION_PARAMS)
+
+    def test_each_call_gets_an_independent_contract_copy(self):
+        first = controlled_spatial_tool_definition()
+        second = controlled_spatial_tool_definition()
+        first["inputSchema"]["properties"]["action"]["enum"].append("invalid")
+        self.assertNotEqual(first, second)
+        self.assertNotIn(
+            "invalid", second["inputSchema"]["properties"]["action"]["enum"]
+        )
+
+    def test_wait_navigation_done_uses_the_advertised_90_second_default(self):
+        class SmartMotionStub:
+            def __init__(self):
+                self.stall_timeout = None
+
+            def wait_nav_done(self, *, stall_timeout):
+                self.stall_timeout = stall_timeout
+                return {"status": "arrived"}
+
+        smart_motion = SmartMotionStub()
+        plugin = ControlledSpatialPlugin.__new__(ControlledSpatialPlugin)
+        plugin._smart_motion = smart_motion
+
+        result = plugin.dispatch("wait_navigation_done", {})
+
+        self.assertEqual(result, {"status": "arrived"})
+        self.assertEqual(smart_motion.stall_timeout, 90.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_navigation_pointcloud.py
+++ b/unitree/g1/tests/test_navigation_pointcloud.py
@@ -1,0 +1,160 @@
+import struct
+import unittest
+
+import numpy as np
+
+from navigation_pointcloud import (
+    FAST_LIVO_FIELDS,
+    FAST_LIVO_POINT_STEP,
+    FLOAT32,
+    UINT16,
+    rotate_covariance9,
+    rotate_orientation_xyzw,
+    rotate_vector3,
+    unitree_mid360_to_fast_livo,
+    validated_rotation_matrix,
+)
+
+
+UNITREE_FIELDS = [
+    ("x", 0, FLOAT32, 1),
+    ("y", 4, FLOAT32, 1),
+    ("z", 8, FLOAT32, 1),
+    ("intensity", 12, FLOAT32, 1),
+    ("ring", 16, UINT16, 1),
+    ("time", 18, FLOAT32, 1),
+]
+
+
+class Mid360ConversionTest(unittest.TestCase):
+    def make_cloud(self):
+        data = bytearray(2 * 22)
+        struct.pack_into("<ffffHf", data, 0, 1.0, 2.0, 3.0, 42.0, 0, 5_000.0)
+        struct.pack_into(
+            "<ffffHf", data, 22, -1.0, -2.0, -3.0, 163.0, 3, 100_320_000.0
+        )
+        return bytes(data)
+
+    def decode(self, converted):
+        dtype = np.dtype(
+            {
+                "names": [field.name for field in FAST_LIVO_FIELDS],
+                "formats": ["<f4", "<f4", "<f4", "<f4", "u1", "u1", "<f8"],
+                "offsets": [field.offset for field in FAST_LIVO_FIELDS],
+                "itemsize": FAST_LIVO_POINT_STEP,
+            }
+        )
+        return np.frombuffer(converted, dtype=dtype)
+
+    def test_converts_relative_time_to_absolute_nanoseconds(self):
+        header_ns = 1_785_811_000_000_000_000
+        converted = unitree_mid360_to_fast_livo(
+            data=self.make_cloud(),
+            point_count=2,
+            point_step=22,
+            fields=UNITREE_FIELDS,
+            header_stamp_ns=header_ns,
+        )
+        points = self.decode(converted)
+
+        self.assertEqual(len(converted), 2 * FAST_LIVO_POINT_STEP)
+        np.testing.assert_allclose(points["x"], [1.0, -1.0])
+        np.testing.assert_allclose(points["intensity"], [42.0, 163.0])
+        np.testing.assert_array_equal(points["tag"], [0x10, 0x10])
+        np.testing.assert_array_equal(points["line"], [0, 3])
+        np.testing.assert_allclose(
+            points["timestamp"] - np.float64(header_ns),
+            [5_000.0, 100_320_000.0],
+            atol=256.0,
+        )
+
+    def test_rejects_missing_time_field(self):
+        with self.assertRaisesRegex(ValueError, "missing MID360 field: time"):
+            unitree_mid360_to_fast_livo(
+                data=self.make_cloud(),
+                point_count=2,
+                point_step=22,
+                fields=[field for field in UNITREE_FIELDS if field[0] != "time"],
+                header_stamp_ns=1_000_000_000,
+            )
+
+    def test_rejects_short_data(self):
+        with self.assertRaisesRegex(ValueError, "shorter"):
+            unitree_mid360_to_fast_livo(
+                data=b"short",
+                point_count=2,
+                point_step=22,
+                fields=UNITREE_FIELDS,
+                header_stamp_ns=1_000_000_000,
+            )
+
+    def test_applies_fixed_rotation_without_changing_auxiliary_fields(self):
+        rotation = validated_rotation_matrix(
+            [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                -1.0,
+                0.0,
+                0.0,
+                0.0,
+                -1.0,
+            ]
+        )
+        header_ns = 1_785_811_000_000_000_000
+        converted = unitree_mid360_to_fast_livo(
+            data=self.make_cloud(),
+            point_count=2,
+            point_step=22,
+            fields=UNITREE_FIELDS,
+            header_stamp_ns=header_ns,
+            rotation_matrix=rotation,
+        )
+        points = self.decode(converted)
+
+        np.testing.assert_allclose(points["x"], [1.0, -1.0])
+        np.testing.assert_allclose(points["y"], [-2.0, 2.0])
+        np.testing.assert_allclose(points["z"], [-3.0, 3.0])
+        np.testing.assert_allclose(points["intensity"], [42.0, 163.0])
+        np.testing.assert_array_equal(points["tag"], [0x10, 0x10])
+        np.testing.assert_array_equal(points["line"], [0, 3])
+        np.testing.assert_allclose(
+            points["timestamp"] - np.float64(header_ns),
+            [5_000.0, 100_320_000.0],
+            atol=256.0,
+        )
+
+    def test_rotation_helpers_use_the_same_corrected_frame(self):
+        rotation = validated_rotation_matrix(
+            [1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0]
+        )
+
+        np.testing.assert_allclose(
+            rotate_vector3((1.0, 2.0, 3.0), rotation),
+            (1.0, -2.0, -3.0),
+        )
+        np.testing.assert_allclose(
+            rotate_covariance9(
+                [1.0, 2.0, 3.0, 2.0, 4.0, 5.0, 3.0, 5.0, 6.0],
+                rotation,
+            ),
+            [1.0, -2.0, -3.0, -2.0, 4.0, 5.0, -3.0, 5.0, 6.0],
+        )
+        qx, qy, qz, qw = rotate_orientation_xyzw(
+            (0.0, 0.0, 0.0, 1.0), rotation
+        )
+        self.assertAlmostEqual(abs(qx), 1.0)
+        self.assertAlmostEqual(qy, 0.0)
+        self.assertAlmostEqual(qz, 0.0)
+        self.assertAlmostEqual(qw, 0.0)
+
+    def test_rejects_non_rotation_matrix(self):
+        with self.assertRaisesRegex(ValueError, "orthonormal"):
+            validated_rotation_matrix([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 2.0])
+        with self.assertRaisesRegex(ValueError, "proper rotation"):
+            validated_rotation_matrix([-1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_navigation_time.py
+++ b/unitree/g1/tests/test_navigation_time.py
@@ -1,0 +1,104 @@
+import unittest
+
+from navigation_time import ClockOffsetEstimator, split_ns, stamp_to_ns
+
+
+class TimestampHelpersTest(unittest.TestCase):
+    def test_round_trip(self):
+        timestamp_ns = stamp_to_ns(1_769_941_368, 987_654_321)
+        self.assertEqual(split_ns(timestamp_ns), (1_769_941_368, 987_654_321))
+
+    def test_invalid_nanoseconds(self):
+        with self.assertRaises(ValueError):
+            stamp_to_ns(1, 1_000_000_000)
+
+
+class ClockOffsetEstimatorTest(unittest.TestCase):
+    def make_estimator(self):
+        return ClockOffsetEstimator(
+            warmup_samples=3,
+            window_samples=5,
+            reset_threshold_ns=1_000_000_000,
+            reset_confirm_samples=3,
+        )
+
+    def test_uses_minimum_arrival_latency_after_warmup(self):
+        estimator = self.make_estimator()
+        offset = 15_869_770_000_000_000
+        source = 1_769_941_368_000_000_000
+
+        self.assertIsNone(estimator.correct_observation(source, source + offset + 8_000_000))
+        self.assertIsNone(
+            estimator.correct_observation(source + 5_000_000, source + 5_000_000 + offset + 2_000_000)
+        )
+        corrected = estimator.correct_observation(
+            source + 10_000_000, source + 10_000_000 + offset + 5_000_000
+        )
+
+        self.assertEqual(corrected, source + 10_000_000 + offset + 2_000_000)
+        self.assertTrue(estimator.snapshot().ready)
+
+    def test_one_late_callback_is_rejected_without_reset(self):
+        estimator = self.make_estimator()
+        source = 10_000_000_000
+        offset = 20_000_000_000
+        for index in range(3):
+            estimator.correct_observation(
+                source + index * 10_000_000,
+                source + index * 10_000_000 + offset + 1_000_000,
+            )
+
+        late = estimator.correct_observation(
+            source + 30_000_000,
+            source + 30_000_000 + offset + 2_000_000_000,
+        )
+        recovered = estimator.correct_observation(
+            source + 40_000_000,
+            source + 40_000_000 + offset + 2_000_000,
+        )
+
+        self.assertIsNone(late)
+        self.assertIsNotNone(recovered)
+        self.assertEqual(estimator.snapshot().resets, 0)
+
+    def test_persistent_backward_clock_jump_restarts_warmup(self):
+        estimator = self.make_estimator()
+        source = 10_000_000_000
+        offset = 20_000_000_000
+        for index in range(3):
+            estimator.correct_observation(
+                source + index * 10_000_000,
+                source + index * 10_000_000 + offset,
+            )
+
+        for index in range(3):
+            self.assertIsNone(
+                estimator.correct_observation(
+                    source + 30_000_000 + index * 10_000_000,
+                    source + 30_000_000 + index * 10_000_000 + offset + 2_000_000_000,
+                )
+            )
+
+        snapshot = estimator.snapshot()
+        self.assertFalse(snapshot.ready)
+        self.assertEqual(snapshot.resets, 1)
+        self.assertEqual(snapshot.samples, 1)
+
+    def test_forward_clock_jump_restarts_immediately(self):
+        estimator = self.make_estimator()
+        source = 10_000_000_000
+        offset = 20_000_000_000
+        for index in range(3):
+            estimator.correct_observation(
+                source + index * 10_000_000,
+                source + index * 10_000_000 + offset,
+            )
+
+        self.assertIsNone(
+            estimator.correct_observation(source + 2_000_000_000, source + offset + 100_000_000)
+        )
+        self.assertEqual(estimator.snapshot().resets, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_traditional_navigation_assets.py
+++ b/unitree/g1/tests/test_traditional_navigation_assets.py
@@ -1,0 +1,202 @@
+import hashlib
+import re
+from pathlib import Path
+import unittest
+
+G1_DIR = Path(__file__).resolve().parents[1]
+NAV_DIR = G1_DIR / "traditional_navigation"
+
+
+def load_source_lock() -> dict[str, str]:
+    values = {}
+    for raw_line in (NAV_DIR / "source-lock.env").read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, value = line.split("=", 1)
+        values[key] = value
+    return values
+
+
+class TraditionalNavigationAssetsTest(unittest.TestCase):
+    def test_all_source_revisions_are_full_git_shas(self):
+        source_lock = load_source_lock()
+        commits = {
+            key: value for key, value in source_lock.items() if key.endswith("_COMMIT")
+        }
+        self.assertEqual(len(commits), 5)
+        for key, value in commits.items():
+            self.assertRegex(value, r"^[0-9a-f]{40}$", key)
+
+    def test_fast_livo_config_is_lio_only_and_non_persistent(self):
+        config = (NAV_DIR / "g1_lio.yaml").read_text()
+        for required_line in (
+            "      img_en: 0",
+            "      lidar_en: 1",
+            "      model: Pinhole",
+            "      imu_en: true",
+            "      filter_size_surf: 0.1",
+            "      lidar_type: 7",
+            "      scan_line: 4",
+            "      pcd_save_en: false",
+            "      colmap_output_en: false",
+            "      dense_map_en: false",
+        ):
+            self.assertIn(required_line, config)
+
+    def test_shadow_compose_has_no_robot_write_surface(self):
+        compose = (NAV_DIR / "compose.shadow.yml").read_text()
+        self.assertIn('profiles: ["lio-shadow"]', compose)
+        self.assertIn("read_only: true", compose)
+        self.assertIn('restart: "no"', compose)
+        self.assertNotIn("privileged:", compose)
+        self.assertIn("cap_drop:\n      - ALL", compose)
+        self.assertIn("navigation/lidar_fast_livo", compose)
+        self.assertIn("navigation/odom", compose)
+        self.assertIn("navigation/tf_lio_raw", compose)
+        self.assertIn('PCD_SAVE_EN: "false"', compose)
+        self.assertIn("pcd_save.pcd_save_en:=$${PCD_SAVE_EN}", compose)
+        self.assertIn(
+            "exec /opt/fast_livo_ws/install/fast_livo/lib/fast_livo/fastlivo_mapping",
+            compose,
+        )
+        self.assertNotIn("exec ros2 run fast_livo", compose)
+        self.assertNotRegex(compose, re.compile(r"cmd_vel|SmartMotion|/action/"))
+
+    def test_mapping_override_is_explicit_and_only_writes_the_map_directory(self):
+        mapping = (NAV_DIR / "compose.mapping.yml").read_text()
+
+        self.assertIn('PCD_SAVE_EN: "true"', mapping)
+        self.assertIn(
+            'PCD_SAVE_INTERVAL: "${G1_PCD_SAVE_INTERVAL:-600}"', mapping
+        )
+        self.assertIn(
+            'com.phanthy.navigation.pcd_save_interval: '
+            '"${G1_PCD_SAVE_INTERVAL:-600}"',
+            mapping,
+        )
+        self.assertIn('group_add:\n      - "${G1_MAP_GID:-1000}"', mapping)
+        self.assertIn(
+            "${G1_MAP_DIR:?set G1_MAP_DIR to a dedicated empty directory}",
+            mapping,
+        )
+        self.assertIn(
+            "com.phanthy.navigation.map_name: "
+            "${G1_MAP_NAME:?set G1_MAP_NAME to the controlled_spatial map_name}",
+            mapping,
+        )
+        self.assertIn("com.phanthy.navigation.mode: mapping", mapping)
+        self.assertIn("/opt/fast_livo_ws/src/fast_livo/Log/pcd:rw", mapping)
+        self.assertIn("stop_signal: SIGINT", mapping)
+        self.assertIn("stop_grace_period: 120s", mapping)
+        self.assertNotRegex(mapping, re.compile(r"cmd_vel|SmartMotion|/action/|/dev:/dev"))
+
+    def test_sensor_bridge_is_an_isolated_non_privileged_sidecar(self):
+        compose = (NAV_DIR / "compose.shadow.yml").read_text()
+        driver_config = (NAV_DIR / "driver.shadow.yaml").read_text()
+        driver_dockerfile = (G1_DIR / "Dockerfile").read_text()
+        bridge_source = (G1_DIR / "navigation_sensor_bridge.py").read_text()
+
+        self.assertIn("sensor-bridge:", compose)
+        self.assertIn("navigation_sensor_bridge_main.py", compose)
+        self.assertIn("condition: service_healthy", compose)
+        self.assertNotIn("/dev:/dev", compose)
+        self.assertNotIn("pid: host", compose)
+        self.assertNotIn("privileged: true", compose)
+        self.assertIn("navigation_sensor_bridge_main.py", driver_dockerfile)
+
+        self.assertIn("navigation_sensors:\n    enabled: true", driver_config)
+        self.assertIn("publish_raw_cloud: false", driver_config)
+        self.assertIn("publish_fast_livo_cloud: true", driver_config)
+        self.assertIn("raw_lidar_frame: livox_raw_frame", driver_config)
+        self.assertIn(
+            "sensor_rotation_matrix: [1.0, 0.0, 0.0,",
+            driver_config,
+        )
+        self.assertIn("rotation_matrix=self._sensor_rotation", bridge_source)
+        self.assertIn("rotate_orientation_xyzw(", bridge_source)
+        self.assertGreaterEqual(bridge_source.count("rotate_vector3("), 2)
+        self.assertGreaterEqual(bridge_source.count("rotate_covariance9("), 3)
+        imu_qos = bridge_source.split("_IMU_QOS =", 1)[1].split(")", 1)[0]
+        self.assertIn("ReliabilityPolicy.RELIABLE", imu_qos)
+        self.assertNotRegex(
+            driver_config,
+            re.compile(r"(?:loco|arm|motion_switcher):\s*\n\s+enabled:\s*true"),
+        )
+
+    def test_dockerfile_requires_each_build_source_lock(self):
+        dockerfile = (NAV_DIR / "Dockerfile.fast-livo2").read_text()
+        source_lock = load_source_lock()
+        for key in (
+            "FAST_LIVO2_COMMIT",
+            "RPG_VIKIT_COMMIT",
+            "LIVOX_ROS_DRIVER2_COMMIT",
+            "LIVOX_SDK2_COMMIT",
+            "SOPHUS_COMMIT",
+        ):
+            self.assertIn(f"ARG {key}", dockerfile)
+            self.assertIn(source_lock[key], (NAV_DIR / "source-lock.env").read_text())
+        self.assertNotIn("checkout main", dockerfile)
+        self.assertNotIn("checkout ros2", dockerfile)
+
+    def test_fast_livo_runtime_patch_is_content_locked(self):
+        dockerfile = (NAV_DIR / "Dockerfile.fast-livo2").read_text()
+        compose = (NAV_DIR / "compose.shadow.yml").read_text()
+        source_lock = load_source_lock()
+        patch = (NAV_DIR / "fast-livo2-runtime.patch").read_bytes()
+        expected_hash = source_lock["FAST_LIVO2_RUNTIME_PATCH_SHA256"]
+
+        self.assertEqual(hashlib.sha256(patch).hexdigest(), expected_hash)
+        self.assertRegex(expected_hash, r"^[0-9a-f]{64}$")
+        self.assertIn("ARG FAST_LIVO2_RUNTIME_PATCH_SHA256", dockerfile)
+        self.assertIn("sha256sum -c -", dockerfile)
+        self.assertIn("git apply --check", dockerfile)
+        self.assertIn("git apply /tmp/fast-livo2-runtime.patch", dockerfile)
+        self.assertIn("FAST_LIVO2_RUNTIME_PATCH_SHA256:", compose)
+
+    def test_fast_livo_runtime_patch_recovers_after_forward_imu_gap(self):
+        patch = (NAV_DIR / "fast-livo2-runtime.patch").read_text()
+        gap_condition = (
+            "if (last_timestamp_imu > 0.0 && "
+            "timestamp > last_timestamp_imu + 0.2)"
+        )
+        self.assertIn(gap_condition, patch)
+
+        gap_block = patch.split(gap_condition, 1)[1].split(
+            "last_timestamp_imu = timestamp;", 1
+        )[0]
+        patched_gap_block = "\n".join(
+            line[1:]
+            for line in gap_block.splitlines()
+            if not line.startswith("-")
+        )
+        self.assertNotIn("return;", patched_gap_block)
+        self.assertIn("accepting current sample to resynchronize", patched_gap_block)
+
+    def test_hotfix_build_reuses_a_content_locked_base_without_network_fetches(self):
+        dockerfile = (NAV_DIR / "Dockerfile.fast-livo2-hotfix").read_text()
+        source_lock = load_source_lock()
+
+        self.assertRegex(source_lock["FAST_LIVO2_BASE_IMAGE_TAG"], r"^[0-9a-z.-]+$")
+        self.assertRegex(
+            source_lock["FAST_LIVO2_BASE_RUNTIME_PATCH_SHA256"],
+            r"^[0-9a-f]{64}$",
+        )
+        self.assertIn("ARG FAST_LIVO2_BASE_IMAGE", dockerfile)
+        self.assertIn("FROM ${FAST_LIVO2_BASE_IMAGE}", dockerfile)
+        self.assertIn('git reset --hard "${FAST_LIVO2_COMMIT}"', dockerfile)
+        self.assertIn("git apply --check", dockerfile)
+        self.assertIn("cd /opt/fast_livo_ws &&", dockerfile)
+        self.assertIn("--packages-select fast_livo", dockerfile)
+        self.assertIn("--cmake-clean-cache", dockerfile)
+        self.assertIn(
+            "/opt/fast_livo_ws/install/fast_livo/lib/fast_livo/fastlivo_mapping",
+            dockerfile,
+        )
+        self.assertIn("accepting current sample to resynchronize", dockerfile)
+        self.assertNotIn("apt-get", dockerfile)
+        self.assertNotIn("git fetch", dockerfile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/traditional_navigation/Dockerfile.fast-livo2
+++ b/unitree/g1/traditional_navigation/Dockerfile.fast-livo2
@@ -1,0 +1,152 @@
+ARG ROS_BASE_IMAGE=ros:humble-ros-base-jammy
+FROM ${ROS_BASE_IMAGE}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG FAST_LIVO2_REPO
+ARG FAST_LIVO2_COMMIT
+ARG RPG_VIKIT_REPO
+ARG RPG_VIKIT_COMMIT
+ARG LIVOX_ROS_DRIVER2_REPO
+ARG LIVOX_ROS_DRIVER2_COMMIT
+ARG LIVOX_SDK2_REPO
+ARG LIVOX_SDK2_COMMIT
+ARG SOPHUS_REPO
+ARG SOPHUS_COMMIT
+
+LABEL org.opencontainers.image.title="Phanthy Motus G1 FAST-LIVO2 shadow" \
+      org.opencontainers.image.source="${FAST_LIVO2_REPO}" \
+      org.opencontainers.image.revision="${FAST_LIVO2_COMMIT}" \
+      org.opencontainers.image.licenses="GPL-2.0"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    ROS_DOMAIN_ID=42 \
+    RMW_IMPLEMENTATION=rmw_fastrtps_cpp \
+    FASTDDS_BUILTIN_TRANSPORTS=DEFAULT \
+    LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
+
+RUN for revision in \
+      "${FAST_LIVO2_COMMIT}" \
+      "${RPG_VIKIT_COMMIT}" \
+      "${LIVOX_ROS_DRIVER2_COMMIT}" \
+      "${LIVOX_SDK2_COMMIT}" \
+      "${SOPHUS_COMMIT}"; do \
+      [[ "${revision}" =~ ^[0-9a-f]{40}$ ]] || { \
+        echo "source revision is not a full Git SHA: ${revision}" >&2; exit 2; \
+      }; \
+    done
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential \
+      cmake \
+      git \
+      libapr1-dev \
+      libboost-all-dev \
+      libeigen3-dev \
+      libfmt-dev \
+      libopencv-dev \
+      libpcl-dev \
+      python3-colcon-common-extensions \
+      ros-humble-ament-cmake-auto \
+      ros-humble-cv-bridge \
+      ros-humble-image-transport \
+      ros-humble-pcl-conversions \
+      ros-humble-pcl-ros \
+      ros-humble-rosidl-default-generators \
+      ros-humble-tf2-geometry-msgs \
+      ros-humble-tf2-ros \
+      ros-humble-visualization-msgs && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git init /tmp/livox-sdk2 && \
+    cd /tmp/livox-sdk2 && \
+    git remote add origin "${LIVOX_SDK2_REPO}" && \
+    git fetch --depth 1 origin "${LIVOX_SDK2_COMMIT}" && \
+    git checkout --detach FETCH_HEAD && \
+    test "$(git rev-parse HEAD)" = "${LIVOX_SDK2_COMMIT}" && \
+    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build --parallel 2 && \
+    cmake --install build && \
+    rm -rf /tmp/livox-sdk2 && \
+    ldconfig
+
+RUN git init /tmp/sophus && \
+    cd /tmp/sophus && \
+    git remote add origin "${SOPHUS_REPO}" && \
+    git fetch --depth 1 origin "${SOPHUS_COMMIT}" && \
+    git checkout --detach FETCH_HEAD && \
+    test "$(git rev-parse HEAD)" = "${SOPHUS_COMMIT}" && \
+    cmake -S . -B build \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SOPHUS_TESTS=OFF && \
+    cmake --build build --parallel 2 && \
+    cmake --install build && \
+    rm -rf /tmp/sophus && \
+    ldconfig
+
+WORKDIR /opt/fast_livo_ws/src
+
+RUN git init livox_ros_driver2 && \
+    cd livox_ros_driver2 && \
+    git remote add origin "${LIVOX_ROS_DRIVER2_REPO}" && \
+    git fetch --depth 1 origin "${LIVOX_ROS_DRIVER2_COMMIT}" && \
+    git checkout --detach FETCH_HEAD && \
+    test "$(git rev-parse HEAD)" = "${LIVOX_ROS_DRIVER2_COMMIT}" && \
+    cp package_ROS2.xml package.xml && \
+    cp -r launch_ROS2 launch
+
+RUN git init rpg_vikit_ros2_fisheye && \
+    cd rpg_vikit_ros2_fisheye && \
+    git remote add origin "${RPG_VIKIT_REPO}" && \
+    git fetch --depth 1 origin "${RPG_VIKIT_COMMIT}" && \
+    git checkout --detach FETCH_HEAD && \
+    test "$(git rev-parse HEAD)" = "${RPG_VIKIT_COMMIT}"
+
+RUN git init fast_livo && \
+    cd fast_livo && \
+    git remote add origin "${FAST_LIVO2_REPO}" && \
+    git fetch --depth 1 origin "${FAST_LIVO2_COMMIT}" && \
+    git checkout --detach FETCH_HEAD && \
+    test "$(git rev-parse HEAD)" = "${FAST_LIVO2_COMMIT}"
+
+WORKDIR /opt/fast_livo_ws
+
+RUN source /opt/ros/humble/setup.bash && \
+    colcon build \
+      --executor sequential \
+      --packages-select livox_ros_driver2 vikit_common vikit_ros \
+      --cmake-args \
+        -DROS_EDITION=ROS2 \
+        -DDISTRO_ROS=humble \
+        -DCMAKE_BUILD_TYPE=Release && \
+    source install/setup.bash && \
+    colcon build \
+      --executor sequential \
+      --packages-select fast_livo \
+      --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+ARG FAST_LIVO2_RUNTIME_PATCH_SHA256
+COPY fast-livo2-runtime.patch /tmp/fast-livo2-runtime.patch
+RUN [[ "${FAST_LIVO2_RUNTIME_PATCH_SHA256}" =~ ^[0-9a-f]{64}$ ]] && \
+    printf '%s  %s\n' \
+      "${FAST_LIVO2_RUNTIME_PATCH_SHA256}" \
+      /tmp/fast-livo2-runtime.patch | sha256sum -c - && \
+    cd /opt/fast_livo_ws/src/fast_livo && \
+    git apply --check /tmp/fast-livo2-runtime.patch && \
+    git apply /tmp/fast-livo2-runtime.patch
+
+RUN source /opt/ros/humble/setup.bash && \
+    source install/setup.bash && \
+    colcon build \
+      --executor sequential \
+      --packages-select fast_livo \
+      --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+LABEL org.opencontainers.image.fast-livo2-runtime-patch="${FAST_LIVO2_RUNTIME_PATCH_SHA256}"
+
+RUN mkdir -p /opt/phanthy/config
+COPY g1_lio.yaml /opt/phanthy/config/g1_lio.yaml
+
+ENV ROS_LOG_DIR=/tmp/ros-log
+
+CMD ["/bin/bash", "-lc", "source /opt/ros/humble/setup.bash && source /opt/fast_livo_ws/install/setup.bash && exec ros2 run fast_livo fastlivo_mapping --ros-args --params-file /opt/phanthy/config/g1_lio.yaml"]

--- a/unitree/g1/traditional_navigation/Dockerfile.fast-livo2-hotfix
+++ b/unitree/g1/traditional_navigation/Dockerfile.fast-livo2-hotfix
@@ -1,0 +1,52 @@
+ARG FAST_LIVO2_BASE_IMAGE=phanthy-fast-livo2:g1-1fcd0d0-n2qos1
+FROM ${FAST_LIVO2_BASE_IMAGE}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG FAST_LIVO2_COMMIT
+ARG FAST_LIVO2_RUNTIME_PATCH_SHA256
+ARG FAST_LIVO2_PCD_SAVE_PATCH_SHA256
+
+# The validated base image already contains every arm64 dependency and the
+# locked upstream checkout. Rebuild only fast_livo so field deployment can
+# transfer this tiny context and compile locally instead of streaming ~973 MB.
+COPY fast-livo2-runtime.patch /tmp/fast-livo2-runtime.patch
+COPY fast-livo2-pcd-save.patch /tmp/fast-livo2-pcd-save.patch
+RUN [[ "${FAST_LIVO2_COMMIT}" =~ ^[0-9a-f]{40}$ ]] && \
+    [[ "${FAST_LIVO2_RUNTIME_PATCH_SHA256}" =~ ^[0-9a-f]{64}$ ]] && \
+    [[ "${FAST_LIVO2_PCD_SAVE_PATCH_SHA256}" =~ ^[0-9a-f]{64}$ ]] && \
+    printf '%s  %s\n' \
+      "${FAST_LIVO2_RUNTIME_PATCH_SHA256}" \
+      /tmp/fast-livo2-runtime.patch | sha256sum -c - && \
+    printf '%s  %s\n' \
+      "${FAST_LIVO2_PCD_SAVE_PATCH_SHA256}" \
+      /tmp/fast-livo2-pcd-save.patch | sha256sum -c - && \
+    cd /opt/fast_livo_ws/src/fast_livo && \
+    test "$(git rev-parse HEAD)" = "${FAST_LIVO2_COMMIT}" && \
+    git reset --hard "${FAST_LIVO2_COMMIT}" && \
+    git apply --check /tmp/fast-livo2-runtime.patch && \
+    git apply /tmp/fast-livo2-runtime.patch && \
+    git apply --check /tmp/fast-livo2-pcd-save.patch && \
+    git apply /tmp/fast-livo2-pcd-save.patch && \
+    source /opt/ros/humble/setup.bash && \
+    source /opt/fast_livo_ws/install/setup.bash && \
+    cd /opt/fast_livo_ws && \
+    colcon build \
+      --executor sequential \
+      --packages-select fast_livo \
+      --cmake-clean-cache \
+      --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+RUN strings /opt/fast_livo_ws/install/fast_livo/lib/fast_livo/fastlivo_mapping \
+      > /tmp/fastlivo_mapping.strings && \
+    grep -Fq "accepting current sample to resynchronize" \
+      /tmp/fastlivo_mapping.strings && \
+    grep -Fq "PCD checkpoint completed" \
+      /tmp/fastlivo_mapping.strings && \
+    grep -Fq "PCD finalization completed" \
+      /tmp/fastlivo_mapping.strings && \
+    ! grep -Fq "imu time stamp Jumps" /tmp/fastlivo_mapping.strings && \
+    rm /tmp/fastlivo_mapping.strings
+
+LABEL org.opencontainers.image.fast-livo2-runtime-patch="${FAST_LIVO2_RUNTIME_PATCH_SHA256}"
+LABEL org.opencontainers.image.fast-livo2-pcd-save-patch="${FAST_LIVO2_PCD_SAVE_PATCH_SHA256}"

--- a/unitree/g1/traditional_navigation/Dockerfile.fast-livo2-rgb-hotfix
+++ b/unitree/g1/traditional_navigation/Dockerfile.fast-livo2-rgb-hotfix
@@ -1,0 +1,45 @@
+ARG FAST_LIVO2_RGB_BASE_IMAGE=phanthy-fast-livo2:g1-1fcd0d0-n3save1
+FROM ${FAST_LIVO2_RGB_BASE_IMAGE}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG FAST_LIVO2_COMMIT
+ARG FAST_LIVO2_RGB_QOS_PATCH_SHA256
+
+# Keep the validated LIO/map-save image immutable. The RGB variant makes the
+# camera reader compatible with the G1 driver's BEST_EFFORT sensor stream and
+# bounds both DDS histories and application buffers. A missing camera frame can
+# therefore no longer make LiDAR/IMU data accumulate until the container OOMs.
+# This preview-only derivative also keeps the validated LIO state and retains
+# only the current camera frame for point coloring; it does not build the
+# uncalibrated visual feature map.
+COPY fast-livo2-rgb-qos.patch /tmp/fast-livo2-rgb-qos.patch
+RUN [[ "${FAST_LIVO2_COMMIT}" =~ ^[0-9a-f]{40}$ ]] && \
+    [[ "${FAST_LIVO2_RGB_QOS_PATCH_SHA256}" =~ ^[0-9a-f]{64}$ ]] && \
+    printf '%s  %s\n' \
+      "${FAST_LIVO2_RGB_QOS_PATCH_SHA256}" \
+      /tmp/fast-livo2-rgb-qos.patch | sha256sum -c - && \
+    cd /opt/fast_livo_ws/src/fast_livo && \
+    test "$(git rev-parse HEAD)" = "${FAST_LIVO2_COMMIT}" && \
+    grep -Fq 'PCD checkpoint completed' src/LIVMapper.cpp && \
+    git apply --check /tmp/fast-livo2-rgb-qos.patch && \
+    git apply /tmp/fast-livo2-rgb-qos.patch && \
+    git diff --check && \
+    grep -Fq 'rclcpp::SensorDataQoS image_qos' src/LIVMapper.cpp && \
+    grep -Fq 'kMaxBufferedLidarFrames = 8' src/LIVMapper.cpp && \
+    grep -Fq 'kMaxBufferedImuSamples = 400' src/LIVMapper.cpp && \
+    grep -Fq 'kMaxBufferedImages = 4' src/LIVMapper.cpp && \
+    grep -Fq 'prepareFrameForColorization' src/LIVMapper.cpp && \
+    grep -Fq 'void VIOManager::prepareFrameForColorization' src/vio.cpp && \
+    ! grep -Fq 'vio_manager->processFrame(LidarMeasures.measures.back().img' src/LIVMapper.cpp && \
+    ! grep -Fq 'img_topic, 200000' src/LIVMapper.cpp && \
+    source /opt/ros/humble/setup.bash && \
+    source /opt/fast_livo_ws/install/setup.bash && \
+    cd /opt/fast_livo_ws && \
+    colcon build \
+      --executor sequential \
+      --packages-select fast_livo \
+      --cmake-clean-cache \
+      --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+LABEL org.opencontainers.image.fast-livo2-rgb-qos-patch="${FAST_LIVO2_RGB_QOS_PATCH_SHA256}"

--- a/unitree/g1/traditional_navigation/README.md
+++ b/unitree/g1/traditional_navigation/README.md
@@ -1,0 +1,249 @@
+# G1 FAST-LIVO2 shadow
+
+本目录当前可运行 N2 的 LIO shadow：纯传感器 sidecar 从 G1 原始 DDS 发布标准化 MID360 点云/IMU，FAST-LIVO2 输出里程计与注册点云；不连接 EGO、不连接运控。N3 已增加显式、受控的 PCD 持久化入口，地图加载与全局重定位仍是下一道独立门禁。
+
+对 Agent 只暴露既有 `controlled_spatial` 卡片，不新增传统导航专用工具。卡片名称、描述、14 个 action、字段和 `x-action-params` 统一由 `../controlled_spatial_contract.py` 生成；原生 SLAM 与传统导航后端必须遵守同一契约。`navigate_to_tag` / `navigate_to_pose` 保持非阻塞，调用方必须在同一轮继续调用 `wait_navigation_done`，其默认 `stall_timeout` 为 90 秒。
+
+## 边界
+
+- FAST-LIVO2 采用尚未合并的 ROS2/MID360 PR #318，固定为 `source-lock.env` 中的完整 commit。
+- FAST-LIVO2（GPL-2.0）和 Vikit（GPL-3.0）在独立镜像内构建，不把上游源码复制进驱动镜像。
+- Compose 同时启动 `sensor-bridge` 和 `fast-livo2`，二者都使用显式 `lio-shadow` profile、非特权、只读根文件系统、`cap_drop=ALL`、`restart: no`，没有 `/dev`、host PID、运动话题或设备写权限。
+- `sensor-bridge` 只运行 `navigation_sensor_bridge_main.py`，不进入 G1 driver 主入口，不创建 MCP 服务或运动插件，也不替换现有 `embodied-unitree-g1`。
+- G1 的 MID360 固定倒装。桥接层对点云和雷达内置 IMU 同时应用 `Rx(pi)`，不做随姿态变化的重力对齐；两路相对外参仍为单位阵。北京 G1 双 IMU 静态数据验证后的重力方向夹角为 `1.34°`，上海 G1 仍须复测。
+- 锁定分支即使 `img_en=0` 也会构造 VIO，所以配置中有一组只为满足启动契约的 Pinhole 占位值。它不是 D435i 标定，不得用来开启视觉融合。
+- 上游帧名仍为 `camera_init -> aft_mapped`；其 `/tf` 被隔离到 `/<ns>/navigation/tf_lio_raw`。N4 前由地面适配层转换为冻结的 `map -> odom -> base_link -> livox_frame`，N2 不向全局 `/tf` 注入未验帧。
+
+验证顺序是“有合适 G1 就优先真机”。暂无合适机器人时，远端算力环境只做编译、单测和录包回放初验，不作为正式运行位置或真机验收替代。
+
+## 本地构建检查
+
+在本目录运行：
+
+```bash
+docker build \
+  --platform linux/arm64 \
+  -t phanthy-g1-driver:navigation-sensors-rx180 \
+  -f ../Dockerfile \
+  ..
+
+docker compose \
+  --env-file source-lock.env \
+  -f compose.shadow.yml \
+  --profile lio-shadow \
+  config
+
+docker compose \
+  --env-file source-lock.env \
+  -f compose.shadow.yml \
+  --profile lio-shadow \
+  build fast-livo2
+```
+
+构建必须显示 5 个源码仓均 checkout 到 `source-lock.env` 的完整 SHA；任一 revision 非 40 位 SHA 时 Dockerfile 会直接失败。
+
+2026-08-04 已完成一次真实 `linux/arm64` 构建：镜像约 971 MB，锁定 revision `1fcd0d05cadaeb25ca59fd87cda95aaaee41e3ea`。ROS package/动态链接离线 smoke test、12 秒节点启动和真实 Compose healthcheck 均通过；这些仍不等于 G1 实时数据验收。
+
+同日完成 G1 driver 目标镜像真实 `linux/arm64` 构建。当前坐标修正版为 `phanthy-g1-driver:navigation-sensors-rx180`，镜像 ID `sha256:e0ce5d75750e522fa10db304472feab322fbd3e0710cc38bf396c4fa2784f7f4`，逻辑大小 342,131,607 bytes。一次性容器成功导入桥接模块并把实测样例 `[-0.5205, 0.0213, -0.8561]` 校正为 `[-0.5205, -0.0213, 0.8561]`；真实 Compose 启动后两个容器均为 `healthy`，且仍为只读、非特权、`cap_drop=ALL`。基础镜像遗留的腾讯云内网 APT 源已通过 `UBUNTU_PORTS_MIRROR` 构建参数改为默认使用公开 Ubuntu ARM 源，内网构建时仍可显式覆盖。
+
+真机复核后发现，上游 FAST-LIVO2 在单次前向 IMU 间隙超过 0.2 秒时会永久拒收后续样本，因为拒绝路径没有推进时间基线。`fast-livo2-runtime.patch` 现在接受间隙后的首个样本以重新同步。内容锁定的 hotfix 镜像 `phanthy-fast-livo2:g1-1fcd0d0-n2gap1` 已完成本地 arm64 真实构建，镜像 ID 为 `sha256:ba214f2512b57f1339cde7ed0d17f62d67b76e99fbeb45f74fc1c0426eb894b9`；确定性 `0.35 s` 间隙注入测试得到 `odom_before_gap=38`、`odom_after_gap=52`、`legacy_rejections=0`。`Dockerfile.fast-livo2-hotfix` 可在 G1 上复用已验证的 `n2qos1` 镜像，仅传输补丁和构建文件，不必重新传输约 973 MB 镜像。
+
+上海首次长图实采在正确收到 `SIGINT` 后以 `133/SIGTRAP` 退出，13 分钟累计点云没有落盘；同镜像 10 秒合成数据可正常保存，只能排除通用参数和退出信号问题，不能覆盖 G1 的 bind mount DAC 权限。`fast-livo2-pcd-save.patch` 把纯 LIO 的 PCL 反射写盘替换为原子的 XYZ+intensity 二进制 PCD writer，并把长图改为运行中 checkpoint、退出保存尾段。新镜像 `phanthy-fast-livo2:g1-1fcd0d0-n3save1` 的本地 arm64 镜像 ID 为 `sha256:26bce71e5e0b056525f048114d873130203864cd356fc7339e6b99a721b512dc`；合成 ROS2 流以 20 帧间隔产生 4 个运行中 checkpoint 和 1 个尾段，SIGINT 退出码为 0，既有 IMU gap 回归仍得到 `odom_before_gap=38`、`odom_after_gap=52`。
+
+上海第一次 `n3save1` 短测进一步定位到真实写入门禁：地图目录为宿主机 `unitree:unitree`、`0775`，映射容器虽然显示为 root，但 `cap_drop=ALL` 后没有 `CAP_DAC_OVERRIDE`，容器内 `test -w` 为 false，checkpoint 因而持续失败。第一次修正把 FAST-LIVO2 主进程改成目录 UID/GID，虽然能创建 `lidar_poses.txt`，但 host IPC 下始终没有注册 `/laserMapping`，健康检查失败。最终 mapping override 保留已验证的 root 运行身份，只把地图目录 GID 加入 supplementary groups，使用普通 group write 权限落盘；不增加 capability，也不把目录放宽为 world-writable。
+
+北京 G1 复用锁定基础镜像完成远端 hotfix 构建，build context 为 23.55 kB；真机镜像 ID 是 `sha256:9151c5b22fddb3533045a92588a3ca10670b17aea83b7b448e8ed8c8d471218f`。重建后 IMU 为 `199.64 Hz`、里程计与注册点云均为 `9.96 Hz`，clock reset/rejected/stamp clamped 均为 0，两个 shadow 无重启/OOM且安全属性未变。短窗口没有自然触发大 IMU 间隙，所以真机只证明新镜像可持续正常运行；断流恢复结论仍以确定性注入测试为准。
+
+## 现场启动前提
+
+以下操作会修改机器人运行状态，只能由现场人员执行：
+
+1. 把 `source-lock.env` 中的两个 arm64 镜像和运行配置部署到 G1；若机器人已有锁定的 `n2qos1` 基础镜像，可改用 `Dockerfile.fast-livo2-hotfix` 在本机构建新 FAST-LIVO2 镜像。
+2. 确认 `driver.shadow.yaml` 只开启 `navigation_sensors`，且 `publish_raw_cloud: false`、`publish_fast_livo_cloud: true`。
+3. 以实际主机名设置 `ROS_NAMESPACE`，以实际 DDS 网卡设置 `NETWORK_INTERFACE`，再显式启用 `lio-shadow` profile。
+4. 短时功能验证可与现有 driver 并行；正式测 CPU/内存预算时必须把现有 driver 的重复点云处理计入结果，或另约受控窗口停用重复链路。
+
+启动后仍是 shadow：现有 `embodied-unitree-g1` 不被替换，两个新容器没有 `/cmd_vel`、SmartMotion 或 action-service 连接。
+
+仓内正式入口是 `deploy-g1-navigation-shadow.sh`。它从自身所在目录解析资产，不依赖本机绝对仓库路径；`preflight` 只读，其余模式均要求现场人员显式设置 `CONFIRM_G1_SHADOW_WRITE=YES`：
+
+```bash
+# 只读：连接、时钟、主 driver、本地镜像与磁盘前检
+./deploy-g1-navigation-shadow.sh preflight g1-sh-wifi ubuntu eth0
+
+# 现场人员执行：复用已加载镜像恢复普通 LIO shadow
+CONFIRM_G1_SHADOW_WRITE=YES \
+  ./deploy-g1-navigation-shadow.sh resume g1-sh-wifi ubuntu eth0
+
+# 现场人员执行：开始/停止一张显式命名的地图
+G1_MAP_NAME=sh_n3_smoke CONFIRM_G1_SHADOW_WRITE=YES \
+  ./deploy-g1-navigation-shadow.sh start_mapping g1-sh-wifi ubuntu eth0
+G1_MAP_NAME=sh_n3_smoke CONFIRM_G1_SHADOW_WRITE=YES \
+  ./deploy-g1-navigation-shadow.sh stop_mapping g1-sh-wifi ubuntu eth0
+```
+
+`start_mapping` 默认每 600 个 LIO 帧保存一个 checkpoint；短测可显式设置 `G1_PCD_SAVE_INTERVAL=20`。启动时脚本读取专用地图目录 UID/GID，保持 FAST-LIVO2 的既有 root 身份，把目录 GID 作为 supplementary group，并把 group 注入、ROS health 与容器内目录可写性同时作为硬门禁。`stop_mapping` 在任何写操作前 fail-closed 校验当前容器确实处于 mapping 模式，且 map name 与 bind 目录同时匹配；随后单独停止 FAST-LIVO2 并报告退出码，不读取 G1 上的 Docker 日志，再清理 mapping、恢复普通只读 shadow，最后校验产物。即使产物报告失败，也不能把 sidecar 留在停止状态。`ubuntu` 和 `eth0` 必须分别替换为当台 G1 的实际 ROS namespace 与 DDS 网卡。
+
+脚本回归入口为 `bash tests/test-navigation-shells.sh`。它使用 fake SSH/Docker 做真实 shell 调用，覆盖：跨工作目录解析、无确认拒写、preflight 无远端写命令、map name/interval 校验、mapping UID/GID 与可写门禁、stop 前保存退出码、恢复 shadow 后再统计 PCD，以及 awk 转义回归。`bash tests/run-pcd-save-smoke.sh` 则运行真实 ROS2 合成点云，验证运行中 checkpoint、退出尾段、PCD 头和退出码。
+
+## N2 只读验收
+
+北京代理数据的目标频率是：适配点云约 10 Hz、IMU约 200 Hz。现场至少检查：
+
+```bash
+ros2 topic hz /ubuntu/navigation/lidar_fast_livo
+ros2 topic hz /ubuntu/navigation/imu
+ros2 topic hz /ubuntu/navigation/odom
+ros2 topic hz /ubuntu/navigation/cloud_registered
+ros2 topic echo /ubuntu/navigation/sensor_diagnostics --once
+```
+
+阶段结论窗口按用户决定以约 20 分钟为上限，不再等待固定 30 分钟才推进：窗口内要求无 clock reset，点云/IMU无持续积压，`odom` 单调且静止漂移可记录，容器没有 OOM/重启，全程无运动输出。身份/外参未核验、频率不达标或时间回退时立即停止 shadow，不进入建图；更长 soak 作为后续发布质量项单独安排。
+
+上海现场使用仓内只读采样脚本汇总相同证据：
+
+```bash
+./accept-g1-navigation-shadow.sh preflight g1-sh-wifi ubuntu eth0
+./accept-g1-navigation-shadow.sh lio g1-sh-wifi ubuntu eth0
+```
+
+`lio` 依次采样四路 topic、读取 sensor diagnostics、容器资源和最近 10 分钟 gap/sync 日志，不修改机器人状态。输出按 `上海G1验收记录模板.md` 留档。
+
+北京 G1 在 2026-08-04 14:48:48–15:08:18 完成约 19 分 30 秒阶段验收：两个容器始终 `healthy`，重启 0、OOM 0；clock reset/rejected/stamp clamped 均为 0；原始点云丢 3/11,829（约 0.025%），FAST-LIVO2 适配点云丢 0，IMU 丢 426/237,145（约 0.18%）；同步 warning 77 次且没有 fatal。按用户决定，该结果形成 N2 阶段结论并允许继续后续 shadow 设计；它不替代未来发布质量所需的更长稳定性测试。
+
+## N3 前置边界
+
+锁定的 FAST-LIVO2 只实现 PCD 落盘，没有 PCD 加载、`/initialpose` 或 scan-to-map 全局重定位。因此“保存一张地图后重启 LIO”不是重定位。
+
+地图生成使用单独的 `compose.mapping.yml` override：普通 shadow 固定 `PCD_SAVE_EN=false`；mapping 必须显式提供一个专用 `G1_MAP_DIR`，只有 `/opt/fast_livo_ws/src/fast_livo/Log/pcd` 是持久可写目录。mapping 容器继续保持 `read_only`、非特权、`cap_drop=ALL` 和既有 root 主进程，只追加地图目录 GID，让无 DAC override 的进程通过 `0775` group write 落盘。默认 `interval=600`，运行中生成按 LIO 时间命名的 PCD，正常退出再生成 `tail_raw_points.pcd`；每个文件都先写 `.tmp`，完整关闭后才原子改名，避免半成品被验收。FAST-LIVO2 必须以安装后的 C++ 二进制直接作为 PID 1；使用 `ros2 run` 包装器时停止信号不会可靠转发。纯 LIO 文件固定为 `FIELDS x y z intensity`、`DATA binary`；多段地图的合并与体素降采样属于后续地图制品步骤，不能把任意单段误当成完整地图。
+
+停止建图后必须按同一个 `G1_MAP_NAME` 做产物只读验收，不能仅凭接口返回成功：
+
+```bash
+G1_MAP_NAME=sh_n3_smoke \
+  ./accept-g1-navigation-shadow.sh map g1-sh-wifi ubuntu eth0
+```
+
+该检查要求至少一份非空 PCD，读取 `POINTS` / `DATA` 头、文件大小和修改时间，并同步报告 `/tmp/nav_result.json` 是否存在及其当前内容。后续重定位传入的地图路径必须与这里实际验收的文件完全一致。
+
+已审查的 G1/Humble 候选 `deepglint/FAST_LIO_LOCALIZATION_HUMANOID@df4772ec4797172430e7efe990711d09a529f4ad` 确认了 G1 MID360 倒装且点云/IMU要一起旋转，并提供离线点云配准节点；但其 `open3d_loc` 没有明确许可证，CMake 写死 Open3D 路径，ARM 预编译包标为未充分测试，默认话题/QoS/TF也不符合本接口。它只能作为算法参考，完成许可证和 arm64 构建审查前不进入运行镜像。
+
+## RGB-LIVO 可视化增强（独立门禁）
+
+RGB-LIVO 只用于生成带真实颜色的 PCD 和更直观的 RViz 预览，不接地图加载、重定位、规划或运动执行。普通 `compose.shadow.yml` 仍固定 `img_en=0`，现有 LIO/N3 建图入口不受影响。`compose.rgb-preview.yml` 只由显式的 `start_rgb_preview` 模式选中，并把云、里程计、路径和 TF 全部隔离到 `*_rgb_preview` 话题。
+
+当前决策（2026-08-05）：导航与建图继续以纯 LiDAR/LIO 为准，RGB 不进入当前交付。上海完整 RGB 预览图虽成功恢复并以 `RGB8` 显示，但现场目视明显比纯 LIO 模糊；现有命令和恢复工具仅保留为实验资产。必须先对这台 G1 的 D435i 与 MID360 完成 FAST-Calib 联合外参标定，生成实测 `Rcl/Pcl`，并重新通过静态边缘对齐、慢速运动成图和清晰度对比，之后才允许恢复 RGB 集成。
+
+G1 的 `/ubuntu/camera/rgb` 是 `sensor_msgs/msg/CompressedImage` 且发布 QoS 为 `BEST_EFFORT`。锁定的 FAST-LIVO2 原始图像订阅使用默认 `RELIABLE` 和 200000 深度队列，与该发布端不兼容。`fast-livo2-rgb-qos.patch` 把图像订阅改成深度 4 的 `SensorDataQoS`，并把解码后的 Image、LiDAR、IMU 应用层队列分别限制为 4、8、400；丢弃 LiDAR 帧时同步丢弃对应时间戳，避免相机断流后同步器不消费而让其他传感器 backlog 持续吃满 6 GiB。`Dockerfile.fast-livo2-rgb-hotfix` 从已验的 `n3save1` 派生，不改变普通 LIO 镜像。
+
+2026-08-05 上海 G1 无 RViz/无 SSH bridge 对照确认：D435i 仍保留 publisher 端点但 8 秒内没有相机帧时，RGB 输出和 PCD 均不推进，旧镜像 `n3rgbqos1` 的 `fastlivo_mapping` RSS 在 76 秒内约从 306 MiB 增至 811 MiB。该斜率来自 LIVO 等待图像时无上限累积 LiDAR/IMU 应用队列，不是 RViz bridge。第一版隔离修复标签为 `n3rgbguard1`；RGB override 的 healthcheck 还必须在 5 秒窗口收到至少一个非空 `/navigation/cloud_registered_rgb`，不能再只凭 `/laserMapping` 节点存在判 healthy。
+
+同日 Docker Desktop 真实 arm64 编译通过：镜像 `phanthy-fast-livo2:g1-1fcd0d0-n3rgbguard1`，ID `sha256:b342dc56ff75592d0baf65c17eb8eab43a16343f51ea8810d70d7e102fa9410a`，逻辑大小 979,408,355 bytes；镜像内 revision 为 `1fcd0d05cadaeb25ca59fd87cda95aaaee41e3ea`，RGB patch 标签与 `source-lock.rgb.env` 的 SHA256 一致。
+
+相机恢复后又暴露出第二条独立增长链：`Feature::img_` 会让每个仍在视觉地图中的参考帧长期持有整张 1920×1080 灰度图。上海真机的 `n3rgbguard1` 在 RGB 约 6 Hz、PCD 每 20 帧成功清空的情况下，RSS 仍在 20 秒内从约 2.29 GiB 增到 2.61 GiB，约 `16 MiB/s`；这与每秒保留约 6 张 2.07 MB 灰度帧加特征对象的开销吻合。静态预览既没有实测外参/时偏，也不应让相机参与状态估计，因此当前 `source-lock.rgb.env` 已切到 `n3rgbpreview2`：它只保留已验证的 LIO 位姿和当前相机帧进行投影着色，跳过 `processFrame()` 的视觉特征建图。它是有色点云预览，不是已经验收的视觉里程计。
+
+`n3rgbpreview2` 已完成 Docker Desktop 真实 arm64 编译，镜像 ID 为 `sha256:715cf510d2899a47071d66a20925a77b4b894ee9df1cec9b419e0850d284c94d`，逻辑大小 979,753,189 bytes；镜像内 revision、补丁 SHA256、`prepareFrameForColorization` 路径和安装后二进制 smoke 均通过。真机内存是否稳定仍须部署该新标签后单独验收，不能沿用旧镜像结论。
+
+复现构建：
+
+```bash
+set -a
+source source-lock.env
+source source-lock.rgb.env
+set +a
+
+docker build \
+  --platform linux/arm64 \
+  --pull=false \
+  --build-arg FAST_LIVO2_RGB_BASE_IMAGE="${FAST_LIVO2_RGB_BASE_IMAGE}" \
+  --build-arg FAST_LIVO2_COMMIT="${FAST_LIVO2_COMMIT}" \
+  --build-arg FAST_LIVO2_RGB_QOS_PATCH_SHA256="${FAST_LIVO2_RGB_QOS_PATCH_SHA256}" \
+  -t "${FAST_LIVO2_RGB_IMAGE}" \
+  -f Dockerfile.fast-livo2-rgb-hotfix \
+  .
+```
+
+生产门禁仍保持 fail-closed：
+
+```bash
+./accept-g1-navigation-shadow.sh rgb g1-sh-wifi ubuntu eth0
+```
+
+该模式同时检查 D435i USB 枚举、RGB publisher/type/频率以及 `/home/unitree/.sensor-collector/calibration.json`。2026-08-04 恢复后的上海真机证据为：D435i serial `346522072810`，`1920x1080@15` 工厂内参可读，RealSense 三个模块的 global time 已开启；但 RGB 实测只有约 `6.6–6.9 Hz`，且当前 Driver 把 ROS header 盖为回调到达时间，所以仍不能认定为已验证的动态 RGB-LIVO。上海这台 D435i 已多次出现“USB 仍枚举、publisher 仍存在、实际无帧”的线缆故障；现场遇到该症状先重新插拔相机线，再做软件重启或参数判断。
+
+`render-g1-livo-config.py` 复用 sensor-collector 的快照格式，只在下列条件全部成立时生成可运行 YAML：
+
+- `calibration_id` 与规范化 JSON SHA256 一致，D435i serial 和精确运行 profile 一致；
+- `ground_truth.transforms.lidar_to_camera` 状态为 `calibrated/measured/verified`，R 为合法旋转矩阵、T 为合理米制平移；
+- 相机时间戳来自 RealSense hardware/global time，实测 `img_time_offset_s` 存在，RGB↔MID360 绝对 skew p95 不超过 20 ms；
+- 内参与畸变模型可被 FAST-LIVO2 的 Pinhole 模型正确解释。
+
+相机恢复并补齐联合标定后，在 Mac 上生成配置：
+
+```bash
+./render-g1-livo-config.py \
+  <(ssh g1-sh-wifi 'cat /home/unitree/.sensor-collector/calibration.json') \
+  /private/tmp/g1_livo.yaml
+```
+
+生成器默认对齐当前 Driver 的 `1920x1080@15`，任何缺失或占位值都会返回非零且不创建输出。只有生成器与 `accept ... rgb` 同时绿灯，才能升级为动态 RGB mapping shadow；当前强行复用 LIO 的单位阵/零平移占位值会产生错色重影，不能作为“照片纹理”验收。
+
+为了在实测外参前先看方向和大致对齐，脚本另提供一个显式的静态预览通道。它先从 `rt/lowstate` 识别机型；上海真机已证实 `mode_machine=4`，对应宇树公开的 `g1_23dof_rev_1_0`。候选外参组合公开机身安装位、RealSense 当台工厂 depth→color 外参、optical frame 旋转，并抵消 sensor bridge 已经施加的 `Rx(pi)`。生成物固定标记为 `nominal_public_urdf` + `callback_arrival_preview` + `preview_only: true`，默认生产生成器仍会拒绝它。探针会在 native DDS/RealSense 析构前强制 flush stdout；部署端不再把 SSH 退出 0 当成成功，而是硬校验 JSON 并最多重试 3 次。3 次仍无效时在任何机器人写入前退出。
+
+当前发布版 Driver 仍以 librealsense 回调到达时刻给 RGB header 盖章。不能把 `ros2 topic delay` 看到的约 0.2 秒直接写成时偏，因为它还包含 JPEG 编码和 DDS 传输；`probe-g1-rgb-time-offset.sh` 会在没有 mapping/RGB preview 活动时短暂停止并恢复 `embodied-unitree-g1`，用同一 Driver 镜像独占 D435I，连续比较 RealSense `GLOBAL_TIME` 帧时刻与主机交付时刻。输出的 `img_time_offset` 是回调延迟中位数的负值；回调延迟残差 p95 超过 20 ms、相机 serial/profile 不匹配、机器人重启导致 boot ID 改变时都 fail-closed。
+
+现场人员先生成本次开机有效的时间探针：
+
+```bash
+G1_RGB_TIME_PROBE_OUTPUT=/private/tmp/g1-rgb-time-offset-shanghai.json \
+CONFIRM_G1_SHADOW_WRITE=YES \
+  ./probe-g1-rgb-time-offset.sh unitree@10.110.12.110 120
+```
+
+随后把该文件显式交给 RGB 入口：
+
+```bash
+G1_MAP_NAME=sh_rgb_full_nominal_20260805 \
+G1_PCD_SAVE_INTERVAL=20 \
+G1_RGB_TIME_PROBE=/private/tmp/g1-rgb-time-offset-shanghai.json \
+CONFIRM_G1_SHADOW_WRITE=YES \
+  ./deploy-g1-navigation-shadow.sh \
+  start_rgb_preview unitree@10.110.12.110 ubuntu eth0
+```
+
+这一模式标记为 `nominal_public_urdf + measured_callback_latency + slow_manual_preview`：先静止 20 秒初始化，再慢速人工驾驶并避免快速转身。它比零时偏静态预览更适合生成一张粗真彩地图，但只校正 Driver 回调时间，不等于 D435I↔MID360 的硬件触发或端到端时偏精标，生产门禁继续保持关闭。
+
+由现场人员执行静态预览：
+
+```bash
+G1_MAP_NAME=sh_rgb_static_20260804 \
+G1_PCD_SAVE_INTERVAL=20 \
+CONFIRM_G1_SHADOW_WRITE=YES \
+  ./deploy-g1-navigation-shadow.sh \
+  start_rgb_preview unitree@10.110.12.110 ubuntu eth0
+```
+
+开始后先让机器人静止 20 秒，RViz 添加 `PointCloud2` 话题 `/ubuntu/navigation/cloud_registered_rgb`，颜色变换选 `RGB8`。这一轮只看固定边缘是否大致对齐，不让机器人走动，也不将点云用于导航。预览镜像优先在 G1 上复用已有的 `n3save1` 基础层小上下文构建，不传输整镜像；已有同 checksum 镜像时直接复用。若相机或同步链路没有产生非空 RGB 云，Compose 启动门禁会把容器判为 unhealthy，不得继续打开 RViz 等待。
+
+```bash
+G1_MAP_NAME=sh_rgb_static_20260804 \
+CONFIRM_G1_SHADOW_WRITE=YES \
+  ./deploy-g1-navigation-shadow.sh \
+  stop_rgb_preview unitree@10.110.12.110 ubuntu eth0
+```
+
+`stop_rgb_preview` 在写操作前同时校验 mode/map/bind 目录，优先恢复普通只读 LIO，再要求产物中至少一份 PCD 的头是 `FIELDS x y z rgb`，并保留本次候选标定 JSON。若静态边缘已明显错位，不调参“凑齐”；直接停止预览，转入标定板 + FAST-Calib 的实测外参流程。
+
+若机器人在 RGB preview 期间整机重启，容器会以 `255` 退出，不能再调用正常停止入口并把这轮冒充为 clean shutdown。运行中的时间戳 PCD checkpoint 已经是统一世界坐标系，可由恢复脚本原子合并；它要求退出容器的 mode、map、bind 目录和 `255` 退出码全部匹配，保留所有原始分片，生成 `all_rgb_points.recovered.pcd` 与 `rgb-recovery-manifest.json`，随后恢复普通只读 LIO：
+
+```bash
+G1_MAP_NAME=sh_rgb_full_nominal_20260805 \
+CONFIRM_G1_SHADOW_WRITE=YES \
+  ./recover-g1-rgb-preview.sh unitree@10.110.12.110 ubuntu eth0
+```
+
+恢复清单固定标记 `clean_shutdown=false`、`unsaved_tail_recovered=false`：最后一个 checkpoint 之后、重启之前仍在内存中的尾段无法恢复。恢复只处理形如 `<秒>.<纳秒>.pcd` 的 RGB checkpoint，并逐个校验 PCD 头、payload 长度、有限坐标和最终 SHA256；不会递归吸收既有聚合文件。异常重启后若出现“文件长度已分配但内容全部为 `0x00`”的掉电写回残片，恢复入口只跳过这种可证实的全零文件，并把文件名、大小和原因写入 manifest；截断、错头或含非零未知数据的文件仍会 fail-closed。机器人重启后原时间探针因 boot ID 改变而失效，若要继续新的 RGB preview 必须重新测量。
+
+## 回滚
+
+现场人员对同一 Compose 执行 `down` 即可同时停止 sidecar 和 FAST-LIVO2。现有 G1 driver 从未被替换；N2 不写地图、不修改主运控，也不需要清理机器人数据。

--- a/unitree/g1/traditional_navigation/accept-g1-navigation-shadow.sh
+++ b/unitree/g1/traditional_navigation/accept-g1-navigation-shadow.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly REMOTE_MAP_ROOT="/home/unitree/phanthy-navigation-maps"
+readonly SSH_OPTS=(
+  -o ClearAllForwardings=yes
+  -o ControlMaster=no
+  -o ControlPath=none
+  -o BatchMode=yes
+  -o ConnectTimeout=8
+)
+
+usage() {
+  echo "Usage: $0 <preflight|lio|rgb|map> <ssh-target> [ros-namespace] [network-interface]" >&2
+  echo "Examples:" >&2
+  echo "  $0 preflight g1-sh-wifi ubuntu eth0" >&2
+  echo "  $0 lio g1-sh-wifi ubuntu eth0" >&2
+  echo "  $0 rgb g1-sh-wifi ubuntu eth0" >&2
+  echo "  G1_MAP_NAME=sh_n3_smoke $0 map g1-sh-wifi ubuntu eth0" >&2
+}
+
+if (( $# < 2 || $# > 4 )); then
+  usage
+  exit 2
+fi
+
+readonly MODE="$1"
+readonly SSH_TARGET="$2"
+readonly ROS_NAMESPACE_VALUE="${3:-ubuntu}"
+readonly NETWORK_INTERFACE_VALUE="${4:-eth0}"
+
+case "${MODE}" in
+  preflight|lio|rgb|map) ;;
+  *) usage; exit 2 ;;
+esac
+
+[[ "${SSH_TARGET}" =~ ^[a-zA-Z0-9_.@-]+$ ]] || {
+  echo "invalid ssh target: ${SSH_TARGET}" >&2
+  exit 2
+}
+[[ "${ROS_NAMESPACE_VALUE}" =~ ^[a-zA-Z0-9_]+$ ]] || {
+  echo "invalid ROS namespace: ${ROS_NAMESPACE_VALUE}" >&2
+  exit 2
+}
+[[ "${NETWORK_INTERFACE_VALUE}" =~ ^[a-zA-Z0-9_.:-]+$ ]] || {
+  echo "invalid network interface: ${NETWORK_INTERFACE_VALUE}" >&2
+  exit 2
+}
+
+MAP_NAME="${G1_MAP_NAME:-}"
+if [[ "${MODE}" == map ]]; then
+  [[ "${MAP_NAME}" =~ ^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$ ]] || {
+    echo "G1_MAP_NAME must match [a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}" >&2
+    exit 2
+  }
+fi
+readonly MAP_NAME
+readonly REMOTE_MAP_DIR="${REMOTE_MAP_ROOT}/${MAP_NAME}"
+
+run_preflight() {
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set -e
+    test \"\$(uname -m)\" = aarch64
+    test \"\$(timedatectl show -p NTPSynchronized --value)\" = yes
+    echo 'acceptance=preflight target=${SSH_TARGET}'
+    echo \"time=\$(date -Iseconds) uptime=\$(uptime -p) boot_id=\$(cat /proc/sys/kernel/random/boot_id) ntp=yes\"
+    ip -br link show '${NETWORK_INTERFACE_VALUE}'
+    docker compose version
+    docker inspect embodied-unitree-g1 \
+      --format 'main={{.Name}} image={{.Config.Image}} running={{.State.Running}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} started={{.State.StartedAt}} restarts={{.RestartCount}} oom={{.State.OOMKilled}}'
+    for container in phanthy-navigation-sensors-shadow phanthy-fast-livo2-shadow; do
+      if docker inspect \"\${container}\" >/dev/null 2>&1; then
+        docker inspect \"\${container}\" \
+          --format 'shadow={{.Name}} image={{.Config.Image}} running={{.State.Running}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} read_only={{.HostConfig.ReadonlyRootfs}} privileged={{.HostConfig.Privileged}} capdrop={{json .HostConfig.CapDrop}} devices={{json .HostConfig.Devices}} restarts={{.RestartCount}} oom={{.State.OOMKilled}} mode={{index .Config.Labels \"com.phanthy.navigation.mode\"}} map_name={{index .Config.Labels \"com.phanthy.navigation.map_name\"}}'
+      else
+        echo \"shadow=\${container} state=absent\"
+      fi
+    done
+    df -h /home/unitree
+  "
+}
+
+if [[ "${MODE}" == preflight ]]; then
+  run_preflight
+  echo "PREFLIGHT ACCEPTANCE COMPLETE: read-only checks only"
+  exit 0
+fi
+
+if [[ "${MODE}" == lio ]]; then
+  run_preflight
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set -e
+    test \"\$(docker inspect phanthy-navigation-sensors-shadow --format '{{.State.Running}}')\" = true
+    test \"\$(docker inspect phanthy-navigation-sensors-shadow --format '{{.State.Health.Status}}')\" = healthy
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{.State.Running}}')\" = true
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{.State.Health.Status}}')\" = healthy
+    test \"\$(docker inspect phanthy-navigation-sensors-shadow --format '{{.HostConfig.ReadonlyRootfs}}')\" = true
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{.HostConfig.ReadonlyRootfs}}')\" = true
+    test \"\$(docker inspect phanthy-navigation-sensors-shadow --format '{{.HostConfig.Privileged}}')\" = false
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{.HostConfig.Privileged}}')\" = false
+    test \"\$(docker inspect phanthy-navigation-sensors-shadow --format '{{json .HostConfig.CapDrop}}')\" = '[\"ALL\"]'
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{json .HostConfig.CapDrop}}')\" = '[\"ALL\"]'
+    sensor_devices=\"\$(docker inspect phanthy-navigation-sensors-shadow --format '{{json .HostConfig.Devices}}')\"
+    livo_devices=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{json .HostConfig.Devices}}')\"
+    test \"\${sensor_devices}\" = null || test \"\${sensor_devices}\" = '[]'
+    test \"\${livo_devices}\" = null || test \"\${livo_devices}\" = '[]'
+    test \"\$(docker inspect phanthy-navigation-sensors-shadow --format '{{.RestartCount}}')\" -eq 0
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{.RestartCount}}')\" -eq 0
+    test \"\$(docker inspect phanthy-navigation-sensors-shadow --format '{{.State.OOMKilled}}')\" = false
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{.State.OOMKilled}}')\" = false
+    test \"\$(docker inspect embodied-unitree-g1 --format '{{.State.Running}}')\" = true
+
+    sample_topic() {
+      topic=\"\$1\"
+      echo \"=== topic_hz \${topic} ===\"
+      topic_output=\"\$(
+        docker exec phanthy-fast-livo2-shadow /bin/bash -lc \
+          \"source /opt/ros/humble/setup.bash && source /opt/fast_livo_ws/install/setup.bash && timeout --signal=INT 8 ros2 topic hz '\${topic}'\" \
+          2>&1 || true
+      )\"
+      printf '%s\\n' \"\${topic_output}\"
+      printf '%s\\n' \"\${topic_output}\" | grep -q 'average rate'
+    }
+
+    sample_topic '/${ROS_NAMESPACE_VALUE}/navigation/lidar_fast_livo'
+    sample_topic '/${ROS_NAMESPACE_VALUE}/navigation/imu'
+    sample_topic '/${ROS_NAMESPACE_VALUE}/navigation/odom'
+    sample_topic '/${ROS_NAMESPACE_VALUE}/navigation/cloud_registered'
+
+    echo '=== sensor_diagnostics ==='
+    docker exec phanthy-fast-livo2-shadow /bin/bash -lc \
+      \"source /opt/ros/humble/setup.bash && source /opt/fast_livo_ws/install/setup.bash && timeout 10 ros2 topic echo '/${ROS_NAMESPACE_VALUE}/navigation/sensor_diagnostics' --once\"
+
+    echo '=== container_stats ==='
+    docker stats --no-stream --format 'container={{.Name}} cpu={{.CPUPerc}} memory={{.MemUsage}} net={{.NetIO}} block={{.BlockIO}}' \
+      phanthy-navigation-sensors-shadow phanthy-fast-livo2-shadow
+
+    fast_logs=\"\$(docker logs --since 10m phanthy-fast-livo2-shadow 2>&1 || true)\"
+    gap_recovery=\"\$(printf '%s\\n' \"\${fast_logs}\" | grep -c 'accepting current sample to resynchronize' || true)\"
+    legacy_rejection=\"\$(printf '%s\\n' \"\${fast_logs}\" | grep -c 'imu time stamp Jumps' || true)\"
+    sync_warning=\"\$(printf '%s\\n' \"\${fast_logs}\" | grep -c 'IMU and LiDAR not synced' || true)\"
+    echo \"log_window=10m gap_recovery=\${gap_recovery} legacy_rejection=\${legacy_rejection} sync_warning=\${sync_warning}\"
+    test \"\${legacy_rejection}\" -eq 0
+  "
+  echo "LIO ACCEPTANCE SAMPLE COMPLETE: no robot state changed"
+  exit 0
+fi
+
+if [[ "${MODE}" == rgb ]]; then
+  run_preflight
+  rgb_sensor_status=0
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set +e
+    readiness_status=0
+    blocker() {
+      echo \"BLOCKER: \$*\"
+      readiness_status=1
+    }
+
+    echo 'acceptance=rgb_sensor topic=/${ROS_NAMESPACE_VALUE}/camera/rgb'
+    d435_usb=\"\$(lsusb | grep -i '8086:0b3a' | head -n 1)\"
+    if test -n \"\${d435_usb}\"; then
+      echo \"d435_usb=present device=\${d435_usb}\"
+    else
+      echo 'd435_usb=missing expected=8086:0b3a'
+      blocker 'D435i 未在 USB 枚举；先检查相机供电和 USB 线'
+    fi
+
+    camera_command=\"source /opt/ros/humble/setup.bash && source /ros_ws/install/setup.bash\"
+    camera_type=\"\$(docker exec embodied-unitree-g1 /bin/bash -lc \
+      \"\${camera_command} && ros2 topic type '/${ROS_NAMESPACE_VALUE}/camera/rgb'\" 2>/dev/null)\"
+    echo \"camera_type=\${camera_type:-absent}\"
+    if test \"\${camera_type}\" != 'sensor_msgs/msg/CompressedImage'; then
+      blocker '相机 topic 必须是 sensor_msgs/msg/CompressedImage'
+    fi
+
+    camera_info=\"\$(docker exec embodied-unitree-g1 /bin/bash -lc \
+      \"\${camera_command} && ros2 topic info -v '/${ROS_NAMESPACE_VALUE}/camera/rgb'\" 2>&1)\"
+    printf '%s\\n' \"\${camera_info}\"
+    if ! printf '%s\\n' \"\${camera_info}\" | grep -Eq '^Publisher count: [1-9][0-9]*$'; then
+      blocker 'D435i RGB topic 当前没有 publisher'
+    else
+      camera_hz=\"\$(docker exec embodied-unitree-g1 /bin/bash -lc \
+        \"\${camera_command} && timeout --signal=INT 10 ros2 topic hz '/${ROS_NAMESPACE_VALUE}/camera/rgb' --wall-time\" 2>&1)\"
+      printf '%s\\n' \"\${camera_hz}\"
+      camera_rate=\"\$(printf '%s\\n' \"\${camera_hz}\" | sed -n 's/^average rate: //p' | tail -n 1)\"
+      if test -z \"\${camera_rate}\" || ! awk -v rate=\"\${camera_rate}\" 'BEGIN { exit !(rate >= 10.0) }'; then
+        blocker 'D435i RGB 实测频率必须至少 10 Hz'
+      else
+        echo \"camera_rate_hz=\${camera_rate}\"
+      fi
+    fi
+
+    if test -f /home/unitree/.sensor-collector/calibration.json; then
+      echo 'calibration_snapshot=present path=/home/unitree/.sensor-collector/calibration.json'
+    else
+      echo 'calibration_snapshot=absent'
+      blocker '缺少 sensor-collector calibration.json'
+    fi
+    echo \"rgb_sensor_ready=\$((readiness_status == 0))\"
+    exit \"\${readiness_status}\"
+  " || rgb_sensor_status=$?
+
+  rgb_calibration_status=0
+  PYTHONDONTWRITEBYTECODE=1 python3 "${SCRIPT_DIR}/render-g1-livo-config.py" \
+    <(ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" \
+      'cat /home/unitree/.sensor-collector/calibration.json') \
+    || rgb_calibration_status=$?
+
+  if (( rgb_sensor_status != 0 || rgb_calibration_status != 0 )); then
+    echo "RGB-LIVO READINESS BLOCKED: sensor=${rgb_sensor_status} calibration=${rgb_calibration_status}" >&2
+    exit 1
+  fi
+  echo "RGB-LIVO READINESS COMPLETE: read-only checks only"
+  exit 0
+fi
+
+run_preflight
+ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+  set -e
+  test -d '${REMOTE_MAP_DIR}'
+  pcd_count=\"\$(find '${REMOTE_MAP_DIR}' -maxdepth 1 -type f -name '*.pcd' -size +0c | wc -l)\"
+  pcd_bytes=\"\$(find '${REMOTE_MAP_DIR}' -maxdepth 1 -type f -name '*.pcd' -size +0c -printf '%s\\n' | awk '{ total += \$1 } END { print total + 0 }')\"
+  echo 'acceptance=map map_name=${MAP_NAME} map_dir=${REMOTE_MAP_DIR}'
+  echo \"pcd_count=\${pcd_count} pcd_bytes=\${pcd_bytes}\"
+  test \"\${pcd_count}\" -ge 1
+
+  while IFS= read -r pcd; do
+    test -n \"\${pcd}\"
+    echo \"=== pcd \${pcd} ===\"
+    stat --printf='size=%s modified=%y\\n' \"\${pcd}\"
+    pcd_header=\"\$(sed -n '1,/^DATA /p' \"\${pcd}\")\"
+    printf '%s\\n' \"\${pcd_header}\"
+    printf '%s\\n' \"\${pcd_header}\" | grep -Eq '^POINTS [1-9][0-9]*$'
+    printf '%s\\n' \"\${pcd_header}\" | grep -Eq '^DATA (ascii|binary|binary_compressed)$'
+  done < <(find '${REMOTE_MAP_DIR}' -maxdepth 1 -type f -name '*.pcd' -size +0c -print | sort)
+
+  if test -f /tmp/nav_result.json; then
+    echo '=== nav_result.json ==='
+    cat /tmp/nav_result.json
+  else
+    echo 'nav_result=absent'
+  fi
+"
+echo "MAP ARTIFACT ACCEPTANCE COMPLETE: read-only checks only"

--- a/unitree/g1/traditional_navigation/compose.mapping.yml
+++ b/unitree/g1/traditional_navigation/compose.mapping.yml
@@ -1,0 +1,24 @@
+services:
+  fast-livo2:
+    labels:
+      com.phanthy.navigation.mode: mapping
+      com.phanthy.navigation.map_name: ${G1_MAP_NAME:?set G1_MAP_NAME to the controlled_spatial map_name}
+      com.phanthy.navigation.pcd_save_interval: "${G1_PCD_SAVE_INTERVAL:-600}"
+      com.phanthy.navigation.map_owner: "${G1_MAP_UID:-1000}:${G1_MAP_GID:-1000}"
+    # Keep the root identity already validated with host IPC, but grant the
+    # bind directory's ordinary group write bit without adding capabilities.
+    group_add:
+      - "${G1_MAP_GID:-1000}"
+    environment:
+      # Checkpoint the map about once per minute at a 10 Hz LIO rate, then save
+      # the remaining tail on graceful shutdown. This bounds data loss if final
+      # process teardown fails after a long mapping run.
+      PCD_SAVE_EN: "true"
+      PCD_SAVE_INTERVAL: "${G1_PCD_SAVE_INTERVAL:-600}"
+      PCD_SAVE_TYPE: "0"
+    volumes:
+      - ${G1_MAP_DIR:?set G1_MAP_DIR to a dedicated empty directory}:/opt/fast_livo_ws/src/fast_livo/Log/pcd:rw
+    # The base profile stays on Docker's default signal/10 seconds because it
+    # never saves a map. Mapping uses SIGINT for the final tail checkpoint.
+    stop_signal: SIGINT
+    stop_grace_period: 120s

--- a/unitree/g1/traditional_navigation/compose.rgb-preview.yml
+++ b/unitree/g1/traditional_navigation/compose.rgb-preview.yml
@@ -1,0 +1,58 @@
+services:
+  fast-livo2:
+    image: ${FAST_LIVO2_RGB_IMAGE:?use --env-file source-lock.rgb.env}
+    labels:
+      com.phanthy.navigation.mode: rgb_preview
+      com.phanthy.navigation.rgb_evidence: nominal_public_urdf
+      com.phanthy.navigation.rgb_time_evidence: ${G1_RGB_TIME_EVIDENCE:-unverified_callback_arrival}
+      com.phanthy.navigation.rgb_motion_policy: ${G1_RGB_MOTION_POLICY:-stationary_only}
+      com.phanthy.navigation.rgb_pipeline: lio_colorize_only
+    volumes:
+      - ${G1_RGB_CONFIG_PATH:?set G1_RGB_CONFIG_PATH to the generated preview YAML}:/config/g1_livo.rgb-preview.yaml:ro
+    command: >-
+      /bin/bash -lc '
+      source /opt/ros/humble/setup.bash &&
+      source /opt/fast_livo_ws/install/setup.bash &&
+      exec /opt/fast_livo_ws/install/fast_livo/lib/fast_livo/fastlivo_mapping --ros-args
+      --params-file /config/g1_livo.rgb-preview.yaml
+      -p pcd_save.pcd_save_en:=$${PCD_SAVE_EN}
+      -p pcd_save.interval:=$${PCD_SAVE_INTERVAL}
+      -p pcd_save.type:=$${PCD_SAVE_TYPE}
+      --log-level warn
+      -r /livox/lidar:=/$${ROS_NAMESPACE}/navigation/lidar_fast_livo
+      -r /livox/imu:=/$${ROS_NAMESPACE}/navigation/imu
+      -r /left_camera/image:=/$${ROS_NAMESPACE}/camera/rgb
+      -r /cloud_registered:=/$${ROS_NAMESPACE}/navigation/cloud_registered_rgb
+      -r /aft_mapped_to_init:=/$${ROS_NAMESPACE}/navigation/odom_rgb_preview
+      -r /path:=/$${ROS_NAMESPACE}/navigation/path_rgb_preview
+      -r /Laser_map:=/$${ROS_NAMESPACE}/navigation/laser_map_rgb_preview
+      -r /LIVO2/imu_propagate:=/$${ROS_NAMESPACE}/navigation/imu_propagated_odom_rgb_preview
+      -r /cloud_visual_sub_map_before:=/$${ROS_NAMESPACE}/navigation/debug/rgb_cloud_visual_sub_map
+      -r /cloud_effected:=/$${ROS_NAMESPACE}/navigation/debug/rgb_cloud_effected
+      -r /visualization_marker:=/$${ROS_NAMESPACE}/navigation/debug/rgb_visualization_marker
+      -r /planner_normal:=/$${ROS_NAMESPACE}/navigation/debug/rgb_planner_normal
+      -r /voxels:=/$${ROS_NAMESPACE}/navigation/debug/rgb_voxels
+      -r /planes:=/$${ROS_NAMESPACE}/navigation/debug/rgb_planes
+      -r /dyn_obj:=/$${ROS_NAMESPACE}/navigation/debug/rgb_dyn_obj
+      -r /dyn_obj_removed:=/$${ROS_NAMESPACE}/navigation/debug/rgb_dyn_obj_removed
+      -r /dyn_obj_dbg_hist:=/$${ROS_NAMESPACE}/navigation/debug/rgb_dyn_obj_history
+      -r /mavros/vision_pose/pose:=/$${ROS_NAMESPACE}/navigation/debug/rgb_vision_pose
+      -r /rgb_img:=/$${ROS_NAMESPACE}/navigation/rgb_overlay
+      -r /tf:=/$${ROS_NAMESPACE}/navigation/tf_livo_rgb_preview_raw
+      -r /tf_static:=/$${ROS_NAMESPACE}/navigation/tf_static_livo_rgb_preview_raw
+      > /dev/null'
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          /bin/bash -lc "source /opt/ros/humble/setup.bash &&
+          source /opt/fast_livo_ws/install/setup.bash &&
+          timeout 5 stdbuf -oL ros2 topic echo
+          /$${ROS_NAMESPACE}/navigation/cloud_registered_rgb
+          sensor_msgs/msg/PointCloud2
+          --qos-reliability reliable --field width |
+          awk '/^[1-9][0-9]*$$/ {found=1} END {exit !found}'"
+      interval: 10s
+      timeout: 7s
+      retries: 3
+      start_period: 30s

--- a/unitree/g1/traditional_navigation/compose.shadow.yml
+++ b/unitree/g1/traditional_navigation/compose.shadow.yml
@@ -1,0 +1,145 @@
+name: g1-traditional-navigation-shadow
+
+services:
+  sensor-bridge:
+    profiles: ["lio-shadow"]
+    image: ${G1_DRIVER_IMAGE:?use --env-file source-lock.env}
+    container_name: phanthy-navigation-sensors-shadow
+    network_mode: host
+    ipc: host
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    restart: "no"
+    cpus: "3.0"
+    mem_limit: 2g
+    environment:
+      ROS_DOMAIN_ID: "42"
+      RMW_IMPLEMENTATION: rmw_fastrtps_cpp
+      FASTDDS_BUILTIN_TRANSPORTS: DEFAULT
+      ROS_NAMESPACE: ${ROS_NAMESPACE:-ubuntu}
+      NETWORK_INTERFACE: ${NETWORK_INTERFACE:-eth0}
+      CONFIG_PATH: /config/driver.shadow.yaml
+      ROS_LOG_DIR: /tmp/ros-log
+    volumes:
+      - ./driver.shadow.yaml:/config/driver.shadow.yaml:ro
+    tmpfs:
+      - /tmp:rw,size=256m,mode=1777
+    command: >-
+      /bin/bash -lc '
+      source /opt/ros/humble/setup.bash &&
+      source /ros_ws/install/setup.bash &&
+      exec python3 /work/navigation_sensor_bridge_main.py "$${NETWORK_INTERFACE}"'
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - /bin/bash -lc 'source /opt/ros/humble/setup.bash && source /ros_ws/install/setup.bash && ros2 node list | grep -qx /g1_navigation_sensor_bridge'
+      interval: 5s
+      timeout: 3s
+      retries: 6
+      start_period: 10s
+    logging:
+      driver: local
+      options:
+        max-size: "20m"
+        max-file: "3"
+    stop_grace_period: 10s
+
+  fast-livo2:
+    profiles: ["lio-shadow"]
+    depends_on:
+      sensor-bridge:
+        condition: service_healthy
+    build:
+      context: .
+      dockerfile: Dockerfile.fast-livo2
+      args:
+        FAST_LIVO2_REPO: ${FAST_LIVO2_REPO:?use --env-file source-lock.env}
+        FAST_LIVO2_COMMIT: ${FAST_LIVO2_COMMIT:?use --env-file source-lock.env}
+        FAST_LIVO2_RUNTIME_PATCH_SHA256: ${FAST_LIVO2_RUNTIME_PATCH_SHA256:?use --env-file source-lock.env}
+        RPG_VIKIT_REPO: ${RPG_VIKIT_REPO:?use --env-file source-lock.env}
+        RPG_VIKIT_COMMIT: ${RPG_VIKIT_COMMIT:?use --env-file source-lock.env}
+        LIVOX_ROS_DRIVER2_REPO: ${LIVOX_ROS_DRIVER2_REPO:?use --env-file source-lock.env}
+        LIVOX_ROS_DRIVER2_COMMIT: ${LIVOX_ROS_DRIVER2_COMMIT:?use --env-file source-lock.env}
+        LIVOX_SDK2_REPO: ${LIVOX_SDK2_REPO:?use --env-file source-lock.env}
+        LIVOX_SDK2_COMMIT: ${LIVOX_SDK2_COMMIT:?use --env-file source-lock.env}
+        SOPHUS_REPO: ${SOPHUS_REPO:?use --env-file source-lock.env}
+        SOPHUS_COMMIT: ${SOPHUS_COMMIT:?use --env-file source-lock.env}
+    image: phanthy-fast-livo2:g1-${FAST_LIVO2_IMAGE_TAG:?use --env-file source-lock.env}
+    container_name: phanthy-fast-livo2-shadow
+    network_mode: host
+    ipc: host
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    restart: "no"
+    cpus: "4.0"
+    mem_limit: 6g
+    environment:
+      ROS_DOMAIN_ID: "42"
+      RMW_IMPLEMENTATION: rmw_fastrtps_cpp
+      FASTDDS_BUILTIN_TRANSPORTS: DEFAULT
+      ROS_NAMESPACE: ${ROS_NAMESPACE:-ubuntu}
+      ROS_LOG_DIR: /tmp/ros-log
+      # N2 is fail-closed. compose.mapping.yml is the only checked-in override
+      # that enables map writes and gives the output a persistent bind mount.
+      PCD_SAVE_EN: "false"
+      PCD_SAVE_INTERVAL: "-1"
+      PCD_SAVE_TYPE: "0"
+    volumes:
+      - ./g1_lio.yaml:/config/g1_lio.yaml:ro
+    tmpfs:
+      - /tmp:rw,size=512m,mode=1777
+      - /opt/fast_livo_ws/src/fast_livo/Log:rw,size=512m,mode=1777
+    # Keep the installed C++ node as PID 1. The ros2 CLI wrapper forks a child
+    # and does not reliably forward Docker stop signals to map finalization.
+    command: >-
+      /bin/bash -lc '
+      source /opt/ros/humble/setup.bash &&
+      source /opt/fast_livo_ws/install/setup.bash &&
+      exec /opt/fast_livo_ws/install/fast_livo/lib/fast_livo/fastlivo_mapping --ros-args
+      --params-file /config/g1_lio.yaml
+      -p pcd_save.pcd_save_en:=$${PCD_SAVE_EN}
+      -p pcd_save.interval:=$${PCD_SAVE_INTERVAL}
+      -p pcd_save.type:=$${PCD_SAVE_TYPE}
+      --log-level warn
+      -r /livox/lidar:=/$${ROS_NAMESPACE}/navigation/lidar_fast_livo
+      -r /livox/imu:=/$${ROS_NAMESPACE}/navigation/imu
+      -r /left_camera/image:=/$${ROS_NAMESPACE}/navigation/camera_disabled
+      -r /cloud_registered:=/$${ROS_NAMESPACE}/navigation/cloud_registered
+      -r /aft_mapped_to_init:=/$${ROS_NAMESPACE}/navigation/odom
+      -r /path:=/$${ROS_NAMESPACE}/navigation/path
+      -r /Laser_map:=/$${ROS_NAMESPACE}/navigation/laser_map
+      -r /LIVO2/imu_propagate:=/$${ROS_NAMESPACE}/navigation/imu_propagated_odom
+      -r /cloud_visual_sub_map_before:=/$${ROS_NAMESPACE}/navigation/debug/cloud_visual_sub_map
+      -r /cloud_effected:=/$${ROS_NAMESPACE}/navigation/debug/cloud_effected
+      -r /visualization_marker:=/$${ROS_NAMESPACE}/navigation/debug/visualization_marker
+      -r /planner_normal:=/$${ROS_NAMESPACE}/navigation/debug/planner_normal
+      -r /voxels:=/$${ROS_NAMESPACE}/navigation/debug/voxels
+      -r /planes:=/$${ROS_NAMESPACE}/navigation/debug/planes
+      -r /dyn_obj:=/$${ROS_NAMESPACE}/navigation/debug/dyn_obj
+      -r /dyn_obj_removed:=/$${ROS_NAMESPACE}/navigation/debug/dyn_obj_removed
+      -r /dyn_obj_dbg_hist:=/$${ROS_NAMESPACE}/navigation/debug/dyn_obj_history
+      -r /mavros/vision_pose/pose:=/$${ROS_NAMESPACE}/navigation/debug/vision_pose
+      -r /rgb_img:=/$${ROS_NAMESPACE}/navigation/debug/rgb_disabled
+      -r /tf:=/$${ROS_NAMESPACE}/navigation/tf_lio_raw
+      -r /tf_static:=/$${ROS_NAMESPACE}/navigation/tf_static_lio_raw
+      > /dev/null'
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - /bin/bash -lc 'source /opt/ros/humble/setup.bash && source /opt/fast_livo_ws/install/setup.bash && ros2 node list | grep -qx /laserMapping'
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    logging:
+      driver: local
+      options:
+        max-size: "20m"
+        max-file: "3"
+    stop_grace_period: 10s

--- a/unitree/g1/traditional_navigation/deploy-g1-navigation-shadow.sh
+++ b/unitree/g1/traditional_navigation/deploy-g1-navigation-shadow.sh
@@ -1,0 +1,728 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly NAV_DIR="${SCRIPT_DIR}"
+readonly REMOTE_DIR="/home/unitree/phanthy-navigation-shadow-n2"
+readonly REMOTE_MAP_ROOT="/home/unitree/phanthy-navigation-maps"
+readonly LOCAL_DOCKER_CONTEXT="${LOCAL_DOCKER_CONTEXT:-desktop-linux}"
+readonly -a LOCAL_DOCKER=(docker --context "${LOCAL_DOCKER_CONTEXT}")
+
+usage() {
+  echo "Usage: $0 <preflight|up|sensor-up|fast-up|fast-build-up|resume|down|start_mapping|stop_mapping|start_rgb_preview|stop_rgb_preview> <ssh-target> [ros-namespace] [network-interface]" >&2
+  echo "Example: $0 preflight g1-sh-wifi ubuntu eth0" >&2
+  echo "Mapping example: G1_MAP_NAME=sh_n3_smoke $0 start_mapping g1-sh-wifi ubuntu eth0" >&2
+  echo "RGB preview: G1_MAP_NAME=sh_rgb_static $0 start_rgb_preview g1-sh-wifi ubuntu eth0" >&2
+}
+
+if (( $# < 2 || $# > 4 )); then
+  usage
+  exit 2
+fi
+
+readonly MODE="$1"
+readonly SSH_TARGET="$2"
+readonly ROS_NAMESPACE_VALUE="${3:-ubuntu}"
+readonly NETWORK_INTERFACE_VALUE="${4:-eth0}"
+
+case "${MODE}" in
+  preflight|up|sensor-up|fast-up|fast-build-up|resume|down|start_mapping|stop_mapping|start_rgb_preview|stop_rgb_preview) ;;
+  *) usage; exit 2 ;;
+esac
+
+[[ "${SSH_TARGET}" =~ ^[a-zA-Z0-9_.@-]+$ ]] || {
+  echo "invalid ssh target: ${SSH_TARGET}" >&2
+  exit 2
+}
+[[ "${ROS_NAMESPACE_VALUE}" =~ ^[a-zA-Z0-9_]+$ ]] || {
+  echo "invalid ROS namespace: ${ROS_NAMESPACE_VALUE}" >&2
+  exit 2
+}
+[[ "${NETWORK_INTERFACE_VALUE}" =~ ^[a-zA-Z0-9_.:-]+$ ]] || {
+  echo "invalid network interface: ${NETWORK_INTERFACE_VALUE}" >&2
+  exit 2
+}
+
+MAP_NAME="${G1_MAP_NAME:-}"
+PCD_SAVE_INTERVAL_VALUE="${G1_PCD_SAVE_INTERVAL:-600}"
+if [[ "${MODE}" == start_mapping || "${MODE}" == stop_mapping || \
+      "${MODE}" == start_rgb_preview || "${MODE}" == stop_rgb_preview ]]; then
+  [[ "${MAP_NAME}" =~ ^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$ ]] || {
+    echo "G1_MAP_NAME must match [a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}" >&2
+    exit 2
+  }
+fi
+if [[ "${MODE}" == start_mapping || "${MODE}" == start_rgb_preview ]]; then
+  [[ "${PCD_SAVE_INTERVAL_VALUE}" =~ ^[1-9][0-9]{0,5}$ ]] || {
+    echo "G1_PCD_SAVE_INTERVAL must be an integer from 1 to 999999" >&2
+    exit 2
+  }
+fi
+readonly MAP_NAME
+readonly PCD_SAVE_INTERVAL_VALUE
+readonly REMOTE_MAP_DIR="${REMOTE_MAP_ROOT}/${MAP_NAME}"
+readonly RGB_TIME_PROBE_PATH="${G1_RGB_TIME_PROBE:-}"
+RGB_MOTION_POLICY_VALUE="stationary_only"
+RGB_TIME_EVIDENCE_VALUE="unverified_callback_arrival"
+
+for required_file in \
+  source-lock.env \
+  compose.shadow.yml \
+  compose.mapping.yml \
+  driver.shadow.yaml \
+  g1_lio.yaml \
+  Dockerfile.fast-livo2-hotfix \
+  fast-livo2-runtime.patch \
+  fast-livo2-pcd-save.patch; do
+  test -f "${NAV_DIR}/${required_file}" || {
+    echo "missing asset: ${NAV_DIR}/${required_file}" >&2
+    exit 1
+  }
+done
+
+if [[ "${MODE}" == start_rgb_preview || "${MODE}" == stop_rgb_preview ]]; then
+  for required_file in \
+    source-lock.rgb.env \
+    compose.rgb-preview.yml \
+    Dockerfile.fast-livo2-rgb-hotfix \
+    fast-livo2-rgb-qos.patch \
+    probe-g1-rgb-profile.py \
+    probe-g1-rgb-time-offset.py \
+    derive-g1-rgb-preview-calibration.py \
+    render-g1-livo-config.py; do
+    test -f "${NAV_DIR}/${required_file}" || {
+      echo "missing RGB preview asset: ${NAV_DIR}/${required_file}" >&2
+      exit 1
+    }
+  done
+fi
+
+if [[ "${MODE}" == start_rgb_preview && -n "${RGB_TIME_PROBE_PATH}" ]]; then
+  test -f "${RGB_TIME_PROBE_PATH}" || {
+    echo "missing G1_RGB_TIME_PROBE file: ${RGB_TIME_PROBE_PATH}" >&2
+    exit 1
+  }
+  python3 "${NAV_DIR}/probe-g1-rgb-time-offset.py" \
+    --validate "${RGB_TIME_PROBE_PATH}"
+  RGB_MOTION_POLICY_VALUE="slow_manual_preview"
+  RGB_TIME_EVIDENCE_VALUE="measured_callback_latency"
+fi
+readonly RGB_MOTION_POLICY_VALUE
+readonly RGB_TIME_EVIDENCE_VALUE
+
+set -a
+# shellcheck disable=SC1091
+source "${NAV_DIR}/source-lock.env"
+set +a
+
+if [[ "${MODE}" == start_rgb_preview || "${MODE}" == stop_rgb_preview ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${NAV_DIR}/source-lock.rgb.env"
+  set +a
+fi
+
+readonly FAST_LIVO_IMAGE="phanthy-fast-livo2:g1-${FAST_LIVO2_IMAGE_TAG}"
+readonly FAST_LIVO_BASE_IMAGE="phanthy-fast-livo2:g1-${FAST_LIVO2_BASE_IMAGE_TAG}"
+readonly FAST_LIVO_RGB_IMAGE="${FAST_LIVO2_RGB_IMAGE:-}"
+readonly FAST_LIVO_RGB_BASE_IMAGE="${FAST_LIVO2_RGB_BASE_IMAGE:-}"
+readonly SSH_OPTS=(
+  -o ClearAllForwardings=yes
+  -o ControlMaster=no
+  -o ControlPath=none
+  -o BatchMode=yes
+  -o ConnectTimeout=8
+)
+
+RGB_PREVIEW_TEMP_DIR=""
+cleanup_rgb_preview_temp() {
+  if [[ -n "${RGB_PREVIEW_TEMP_DIR}" && -d "${RGB_PREVIEW_TEMP_DIR}" && \
+        "${RGB_PREVIEW_TEMP_DIR}" == /private/tmp/g1-rgb-preview.* ]]; then
+    rm -rf -- "${RGB_PREVIEW_TEMP_DIR}"
+  fi
+}
+trap cleanup_rgb_preview_temp EXIT
+
+if [[ "${MODE}" == start_rgb_preview || "${MODE}" == stop_rgb_preview ]]; then
+  test "${FAST_LIVO_RGB_BASE_IMAGE}" = "${FAST_LIVO_IMAGE}" || {
+    echo "RGB preview base must equal the locked N3 map-save image" >&2
+    exit 1
+  }
+fi
+
+declare -a LOCAL_IMAGES=()
+case "${MODE}" in
+  resume|down|fast-build-up|start_mapping|stop_mapping|start_rgb_preview|stop_rgb_preview) ;;
+  sensor-up) LOCAL_IMAGES=("${G1_DRIVER_IMAGE}") ;;
+  fast-up) LOCAL_IMAGES=("${FAST_LIVO_IMAGE}") ;;
+  *) LOCAL_IMAGES=("${G1_DRIVER_IMAGE}" "${FAST_LIVO_IMAGE}") ;;
+esac
+
+if (( ${#LOCAL_IMAGES[@]} == 0 )); then
+  echo "[preflight] local images skipped (mode=${MODE}, no image transfer)"
+else
+  docker context inspect "${LOCAL_DOCKER_CONTEXT}" >/dev/null
+
+  for image_name in "${LOCAL_IMAGES[@]}"; do
+    if ! image_arch="$(
+      "${LOCAL_DOCKER[@]}" image inspect --platform linux/arm64 "${image_name}" \
+        --format '{{.Architecture}}' 2>/dev/null
+    )"; then
+      echo "missing local image in Docker context ${LOCAL_DOCKER_CONTEXT}: ${image_name}" >&2
+      "${LOCAL_DOCKER[@]}" image ls --format '{{.Repository}}:{{.Tag}} {{.ID}}' >&2
+      exit 1
+    fi
+    test "${image_arch}" = "arm64" || {
+      echo "image is not arm64: ${image_name} (${image_arch})" >&2
+      exit 1
+    }
+  done
+
+  echo "[preflight] local images (context=${LOCAL_DOCKER_CONTEXT})"
+  "${LOCAL_DOCKER[@]}" image inspect --platform linux/arm64 \
+    "${LOCAL_IMAGES[@]}" \
+    --format '{{.RepoTags}} id={{.Id}} arch={{.Architecture}} size={{.Size}}'
+fi
+
+echo "[preflight] remote target"
+ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" '
+  set -e
+  test "$(uname -m)" = aarch64
+  test -w /home/unitree
+  test "$(timedatectl show -p NTPSynchronized --value)" = yes
+  echo "time=$(date -Iseconds) uptime=$(uptime -p) boot_id=$(cat /proc/sys/kernel/random/boot_id) ntp=yes"
+  docker compose version
+  docker inspect embodied-unitree-g1 \
+    --format "current={{.Name}} image={{.Config.Image}} running={{.State.Running}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} started={{.State.StartedAt}}"
+  df -h /home/unitree
+'
+
+if [[ "${MODE}" == fast-build-up ]]; then
+  echo "[preflight] remote hotfix base"
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set -e
+    test \"\$(docker image inspect '${G1_DRIVER_IMAGE}' --format '{{.Architecture}}')\" = arm64
+    test \"\$(docker image inspect '${FAST_LIVO_BASE_IMAGE}' --format '{{.Architecture}}')\" = arm64
+    test \"\$(docker image inspect '${FAST_LIVO_BASE_IMAGE}' --format '{{index .Config.Labels \"org.opencontainers.image.revision\"}}')\" = '${FAST_LIVO2_COMMIT}'
+    test \"\$(docker image inspect '${FAST_LIVO_BASE_IMAGE}' --format '{{index .Config.Labels \"org.opencontainers.image.fast-livo2-runtime-patch\"}}')\" = '${FAST_LIVO2_BASE_RUNTIME_PATCH_SHA256}'
+  "
+fi
+
+if [[ "${MODE}" == start_mapping ]]; then
+  echo "[preflight] mapping target"
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set -e
+    test \"\$(docker image inspect '${G1_DRIVER_IMAGE}' --format '{{.Architecture}}')\" = arm64
+    test \"\$(docker image inspect '${FAST_LIVO_IMAGE}' --format '{{.Architecture}}')\" = arm64
+    test \"\$(docker image inspect '${FAST_LIVO_IMAGE}' --format '{{index .Config.Labels \"org.opencontainers.image.fast-livo2-runtime-patch\"}}')\" = '${FAST_LIVO2_RUNTIME_PATCH_SHA256}'
+    test \"\$(docker image inspect '${FAST_LIVO_IMAGE}' --format '{{index .Config.Labels \"org.opencontainers.image.fast-livo2-pcd-save-patch\"}}')\" = '${FAST_LIVO2_PCD_SAVE_PATCH_SHA256}'
+    current_mode=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.mode\"}}' 2>/dev/null || true)\"
+    if test \"\${current_mode}\" = mapping || test \"\${current_mode}\" = rgb_preview; then
+      current_map=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.map_name\"}}')\"
+      echo \"controlled write mode already active: mode=\${current_mode} map=\${current_map}\" >&2
+      exit 1
+    fi
+    if test -e '${REMOTE_MAP_DIR}'; then
+      test -d '${REMOTE_MAP_DIR}'
+      test -z \"\$(find '${REMOTE_MAP_DIR}' -mindepth 1 -maxdepth 1 -print -quit)\" || {
+        echo 'refusing to overwrite non-empty map directory: ${REMOTE_MAP_DIR}' >&2
+        exit 1
+      }
+    fi
+    echo 'map_name=${MAP_NAME} map_dir=${REMOTE_MAP_DIR} state=ready'
+  "
+fi
+
+if [[ "${MODE}" == start_rgb_preview ]]; then
+  echo "[preflight] RGB preview target and live nominal calibration"
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set -e
+    test \"\$(docker image inspect '${G1_DRIVER_IMAGE}' --format '{{.Architecture}}')\" = arm64
+    test \"\$(docker image inspect '${FAST_LIVO_RGB_BASE_IMAGE}' --format '{{.Architecture}}')\" = arm64
+    test \"\$(docker image inspect '${FAST_LIVO_RGB_BASE_IMAGE}' --format '{{index .Config.Labels \"org.opencontainers.image.revision\"}}')\" = '${FAST_LIVO2_COMMIT}'
+    test \"\$(docker image inspect '${FAST_LIVO_RGB_BASE_IMAGE}' --format '{{index .Config.Labels \"org.opencontainers.image.fast-livo2-runtime-patch\"}}')\" = '${FAST_LIVO2_RUNTIME_PATCH_SHA256}'
+    test \"\$(docker image inspect '${FAST_LIVO_RGB_BASE_IMAGE}' --format '{{index .Config.Labels \"org.opencontainers.image.fast-livo2-pcd-save-patch\"}}')\" = '${FAST_LIVO2_PCD_SAVE_PATCH_SHA256}'
+    current_mode=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.mode\"}}' 2>/dev/null || true)\"
+    if test \"\${current_mode}\" = mapping || test \"\${current_mode}\" = rgb_preview; then
+      current_map=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.map_name\"}}')\"
+      echo \"controlled write mode already active: mode=\${current_mode} map=\${current_map}\" >&2
+      exit 1
+    fi
+    if test -e '${REMOTE_MAP_DIR}'; then
+      test -d '${REMOTE_MAP_DIR}'
+      test -z \"\$(find '${REMOTE_MAP_DIR}' -mindepth 1 -maxdepth 1 -print -quit)\" || {
+        echo 'refusing to overwrite non-empty RGB preview directory: ${REMOTE_MAP_DIR}' >&2
+        exit 1
+      }
+    fi
+    test \"\$(docker inspect embodied-unitree-g1 --format '{{.State.Running}}')\" = true
+    echo 'map_name=${MAP_NAME} map_dir=${REMOTE_MAP_DIR} state=ready'
+  "
+
+  RGB_PREVIEW_TEMP_DIR="$(mktemp -d /private/tmp/g1-rgb-preview.XXXXXX)"
+  rgb_probe_ready=false
+  for rgb_probe_attempt in 1 2 3; do
+    : > "${RGB_PREVIEW_TEMP_DIR}/live-probe.json"
+    : > "${RGB_PREVIEW_TEMP_DIR}/probe.stderr"
+    : > "${RGB_PREVIEW_TEMP_DIR}/derive.stderr"
+    rgb_probe_ssh_status=0
+    ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" \
+      "docker exec -i embodied-unitree-g1 python3 - '${NETWORK_INTERFACE_VALUE}' 1920 1080 15" \
+      < "${NAV_DIR}/probe-g1-rgb-profile.py" \
+      > "${RGB_PREVIEW_TEMP_DIR}/live-probe.json" \
+      2> "${RGB_PREVIEW_TEMP_DIR}/probe.stderr" \
+      || rgb_probe_ssh_status=$?
+    rgb_probe_derive_status=not_run
+    if [[ "${rgb_probe_ssh_status}" -eq 0 ]]; then
+      rgb_derive_command=(
+        python3 "${NAV_DIR}/derive-g1-rgb-preview-calibration.py"
+        "${RGB_PREVIEW_TEMP_DIR}/live-probe.json"
+        "${RGB_PREVIEW_TEMP_DIR}/rgb-preview-calibration.json"
+      )
+      if [[ -n "${RGB_TIME_PROBE_PATH}" ]]; then
+        rgb_derive_command+=(--time-offset-probe "${RGB_TIME_PROBE_PATH}")
+      fi
+      if "${rgb_derive_command[@]}" \
+          2> "${RGB_PREVIEW_TEMP_DIR}/derive.stderr"; then
+        rgb_probe_ready=true
+        break
+      else
+        rgb_probe_derive_status=$?
+      fi
+    fi
+    rgb_probe_bytes="$(wc -c < "${RGB_PREVIEW_TEMP_DIR}/live-probe.json" | tr -d ' ')"
+    echo "RGB probe attempt=${rgb_probe_attempt} invalid ssh_status=${rgb_probe_ssh_status} derive_status=${rgb_probe_derive_status} bytes=${rgb_probe_bytes}" >&2
+    sed -n '1,20p' "${RGB_PREVIEW_TEMP_DIR}/probe.stderr" >&2
+    sed -n '1,20p' "${RGB_PREVIEW_TEMP_DIR}/derive.stderr" >&2
+    sleep 1
+  done
+  if [[ "${rgb_probe_ready}" != true ]]; then
+    echo "RGB preview preflight failed: no valid live probe JSON after 3 attempts; no robot state was changed" >&2
+    exit 1
+  fi
+  python3 "${NAV_DIR}/render-g1-livo-config.py" \
+    "${RGB_PREVIEW_TEMP_DIR}/rgb-preview-calibration.json" \
+    "${RGB_PREVIEW_TEMP_DIR}/g1_livo.rgb-preview.yaml" \
+    --allow-nominal-preview
+fi
+
+if [[ "${MODE}" == stop_mapping ]]; then
+  echo "[preflight] active mapping identity"
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set -e
+    actual_mode=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.mode\"}}')\"
+    actual_map=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.map_name\"}}')\"
+    actual_dir=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{range .Mounts}}{{if eq .Destination \"/opt/fast_livo_ws/src/fast_livo/Log/pcd\"}}{{.Source}}{{end}}{{end}}')\"
+    if ! { test \"\${actual_mode}\" = mapping && \
+           test \"\${actual_map}\" = '${MAP_NAME}' && \
+           test \"\${actual_dir}\" = '${REMOTE_MAP_DIR}'; }; then
+      echo \"refusing stop_mapping identity mismatch: requested_map=${MAP_NAME} actual_mode=\${actual_mode} actual_map=\${actual_map} actual_dir=\${actual_dir}\" >&2
+      exit 1
+    fi
+    mapping_interval=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.pcd_save_interval\"}}')\"
+    mapping_user=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{.Config.User}}')\"
+    mapping_groups=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{json .HostConfig.GroupAdd}}')\"
+    echo \"map_name=${MAP_NAME} map_dir=${REMOTE_MAP_DIR} pcd_save_interval=\${mapping_interval} container_user=\${mapping_user} group_add=\${mapping_groups} state=mapping\"
+  "
+fi
+
+if [[ "${MODE}" == stop_rgb_preview ]]; then
+  echo "[preflight] active RGB preview identity"
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set -e
+    actual_mode=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.mode\"}}')\"
+    actual_map=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.map_name\"}}')\"
+    actual_dir=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{range .Mounts}}{{if eq .Destination \"/opt/fast_livo_ws/src/fast_livo/Log/pcd\"}}{{.Source}}{{end}}{{end}}')\"
+    if ! { test \"\${actual_mode}\" = rgb_preview && \
+           test \"\${actual_map}\" = '${MAP_NAME}' && \
+           test \"\${actual_dir}\" = '${REMOTE_MAP_DIR}'; }; then
+      echo \"refusing stop_rgb_preview identity mismatch: requested_map=${MAP_NAME} actual_mode=\${actual_mode} actual_map=\${actual_map} actual_dir=\${actual_dir}\" >&2
+      exit 1
+    fi
+    preview_interval=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.pcd_save_interval\"}}')\"
+    echo \"map_name=${MAP_NAME} map_dir=${REMOTE_MAP_DIR} pcd_save_interval=\${preview_interval} state=rgb_preview\"
+  "
+fi
+
+if [[ "${MODE}" == preflight ]]; then
+  echo "PREFLIGHT OK: no robot state changed"
+  exit 0
+fi
+
+if [[ "${CONFIRM_G1_SHADOW_WRITE:-}" != "YES" ]]; then
+  echo "Refusing robot write. Re-run with CONFIRM_G1_SHADOW_WRITE=YES." >&2
+  exit 2
+fi
+
+if [[ "${MODE}" == down ]]; then
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set -e
+    test -d '${REMOTE_DIR}'
+    cd '${REMOTE_DIR}'
+    ROS_NAMESPACE='${ROS_NAMESPACE_VALUE}' \
+    NETWORK_INTERFACE='${NETWORK_INTERFACE_VALUE}' \
+      docker compose --env-file source-lock.env \
+        -f compose.shadow.yml --profile lio-shadow down
+  "
+  echo "N2 shadow stopped; existing embodied-unitree-g1 was not modified."
+  exit 0
+fi
+
+if [[ "${MODE}" == stop_mapping ]]; then
+  echo "[mapping] stop and save map_name=${MAP_NAME}"
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set -u
+    cd '${REMOTE_DIR}'
+
+    mapping_stop_status=0
+    ROS_NAMESPACE='${ROS_NAMESPACE_VALUE}' \
+    NETWORK_INTERFACE='${NETWORK_INTERFACE_VALUE}' \
+    G1_MAP_NAME='${MAP_NAME}' \
+    G1_MAP_DIR='${REMOTE_MAP_DIR}' \
+      docker compose --env-file source-lock.env \
+        -f compose.shadow.yml -f compose.mapping.yml \
+        --profile lio-shadow stop fast-livo2 || mapping_stop_status=\$?
+
+    mapping_exit_code=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{.State.ExitCode}}' 2>/dev/null || echo inspect_failed)\"
+    echo \"mapping_stop_status=\${mapping_stop_status} mapping_exit_code=\${mapping_exit_code}\"
+    mapping_cleanup_status=0
+    ROS_NAMESPACE='${ROS_NAMESPACE_VALUE}' \
+    NETWORK_INTERFACE='${NETWORK_INTERFACE_VALUE}' \
+    G1_MAP_NAME='${MAP_NAME}' \
+    G1_MAP_DIR='${REMOTE_MAP_DIR}' \
+      docker compose --env-file source-lock.env \
+        -f compose.shadow.yml -f compose.mapping.yml \
+        --profile lio-shadow down || mapping_cleanup_status=\$?
+
+    # Restore ordinary shadow before reporting map artifacts. Reporting errors
+    # must never leave the read-only LIO sidecars stopped.
+    mapping_restore_status=0
+    ROS_NAMESPACE='${ROS_NAMESPACE_VALUE}' \
+    NETWORK_INTERFACE='${NETWORK_INTERFACE_VALUE}' \
+      docker compose --env-file source-lock.env \
+        -f compose.shadow.yml --profile lio-shadow \
+        up -d --no-build --wait --wait-timeout 90 || mapping_restore_status=\$?
+    docker inspect phanthy-navigation-sensors-shadow phanthy-fast-livo2-shadow \
+      --format '{{.Name}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} read_only={{.HostConfig.ReadonlyRootfs}} privileged={{.HostConfig.Privileged}} capdrop={{json .HostConfig.CapDrop}}' \
+      || mapping_restore_status=\$?
+
+    pcd_count=\"\$(find '${REMOTE_MAP_DIR}' -maxdepth 1 -type f -name '*.pcd' -size +0c | wc -l)\"
+    pcd_bytes=\"\$(find '${REMOTE_MAP_DIR}' -maxdepth 1 -type f -name '*.pcd' -size +0c -printf '%s\\n' | awk '{ total += \$1 } END { print total + 0 }')\"
+    echo \"map_name=${MAP_NAME} pcd_count=\${pcd_count} pcd_bytes=\${pcd_bytes}\"
+    find '${REMOTE_MAP_DIR}' -maxdepth 1 -type f -name '*.pcd' -printf '%f %s bytes\\n' | sort
+    test \"\${mapping_stop_status}\" -eq 0
+    test \"\${mapping_cleanup_status}\" -eq 0
+    test \"\${mapping_restore_status}\" -eq 0
+    test \"\${mapping_exit_code}\" = 0
+    test \"\${pcd_count}\" -ge 1
+  "
+  echo "Mapping stopped and saved. Plain read-only LIO shadow was restored."
+  exit 0
+fi
+
+if [[ "${MODE}" == stop_rgb_preview ]]; then
+  echo "[rgb-preview] stop and save map_name=${MAP_NAME}"
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set -uo pipefail
+    cd '${REMOTE_DIR}'
+
+    preview_stop_status=0
+    ROS_NAMESPACE='${ROS_NAMESPACE_VALUE}' \
+    NETWORK_INTERFACE='${NETWORK_INTERFACE_VALUE}' \
+    G1_MAP_NAME='${MAP_NAME}' \
+    G1_MAP_DIR='${REMOTE_MAP_DIR}' \
+    G1_RGB_CONFIG_PATH='${REMOTE_DIR}/g1_livo.rgb-preview.yaml' \
+      docker compose --env-file source-lock.env --env-file source-lock.rgb.env \
+        -f compose.shadow.yml -f compose.mapping.yml -f compose.rgb-preview.yml \
+        --profile lio-shadow stop fast-livo2 || preview_stop_status=\$?
+
+    preview_exit_code=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{.State.ExitCode}}' 2>/dev/null || echo inspect_failed)\"
+    echo \"rgb_preview_stop_status=\${preview_stop_status} rgb_preview_exit_code=\${preview_exit_code}\"
+
+    preview_cleanup_status=0
+    ROS_NAMESPACE='${ROS_NAMESPACE_VALUE}' \
+    NETWORK_INTERFACE='${NETWORK_INTERFACE_VALUE}' \
+    G1_MAP_NAME='${MAP_NAME}' \
+    G1_MAP_DIR='${REMOTE_MAP_DIR}' \
+    G1_RGB_CONFIG_PATH='${REMOTE_DIR}/g1_livo.rgb-preview.yaml' \
+      docker compose --env-file source-lock.env --env-file source-lock.rgb.env \
+        -f compose.shadow.yml -f compose.mapping.yml -f compose.rgb-preview.yml \
+        --profile lio-shadow down || preview_cleanup_status=\$?
+
+    # Always restore the ordinary LIO shadow before inspecting preview output.
+    preview_restore_status=0
+    ROS_NAMESPACE='${ROS_NAMESPACE_VALUE}' \
+    NETWORK_INTERFACE='${NETWORK_INTERFACE_VALUE}' \
+      docker compose --env-file source-lock.env \
+        -f compose.shadow.yml --profile lio-shadow \
+        up -d --no-build --wait --wait-timeout 90 || preview_restore_status=\$?
+    docker inspect phanthy-navigation-sensors-shadow phanthy-fast-livo2-shadow \
+      --format '{{.Name}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} read_only={{.HostConfig.ReadonlyRootfs}} privileged={{.HostConfig.Privileged}} capdrop={{json .HostConfig.CapDrop}}' \
+      || preview_restore_status=\$?
+
+    pcd_count=\"\$(find '${REMOTE_MAP_DIR}' -maxdepth 1 -type f -name '*.pcd' -size +0c | wc -l)\"
+    pcd_bytes=\"\$(find '${REMOTE_MAP_DIR}' -maxdepth 1 -type f -name '*.pcd' -size +0c -printf '%s\\n' | awk '{ total += \$1 } END { print total + 0 }')\"
+    rgb_pcd_count=0
+    first_rgb_pcd=''
+    for pcd_file in '${REMOTE_MAP_DIR}'/*.pcd; do
+      test -f \"\${pcd_file}\" || continue
+      if sed -n '1,12p' \"\${pcd_file}\" | grep -q '^FIELDS x y z rgb'; then
+        rgb_pcd_count=\$((rgb_pcd_count + 1))
+        if test -z \"\${first_rgb_pcd}\"; then
+          first_rgb_pcd=\"\${pcd_file}\"
+        fi
+      fi
+    done
+    echo \"map_name=${MAP_NAME} pcd_count=\${pcd_count} rgb_pcd_count=\${rgb_pcd_count} pcd_bytes=\${pcd_bytes}\"
+    find '${REMOTE_MAP_DIR}' -maxdepth 1 -type f -name '*.pcd' -printf '%f %s bytes\\n' | sort
+    if test -n \"\${first_rgb_pcd}\"; then
+      echo \"rgb_pcd_header=\$(basename -- \"\${first_rgb_pcd}\")\"
+      sed -n '1,12p' \"\${first_rgb_pcd}\"
+    fi
+    test -s '${REMOTE_MAP_DIR}/rgb-preview-calibration.json'
+    test \"\${preview_stop_status}\" -eq 0
+    test \"\${preview_cleanup_status}\" -eq 0
+    test \"\${preview_restore_status}\" -eq 0
+    test \"\${preview_exit_code}\" = 0
+    test \"\${rgb_pcd_count}\" -ge 1
+  "
+  echo "RGB preview stopped and saved. Plain read-only LIO shadow was restored."
+  exit 0
+fi
+
+echo "[deploy] copy immutable configs"
+COPYFILE_DISABLE=1 tar --no-xattrs -C "${NAV_DIR}" -cf - \
+  source-lock.env \
+  compose.shadow.yml \
+  compose.mapping.yml \
+  driver.shadow.yaml \
+  g1_lio.yaml \
+  Dockerfile.fast-livo2-hotfix \
+  fast-livo2-runtime.patch \
+  fast-livo2-pcd-save.patch \
+  | ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" \
+      "mkdir -p '${REMOTE_DIR}' &&
+       tar -C '${REMOTE_DIR}' -xf - &&
+       chmod 0644 \
+         '${REMOTE_DIR}/source-lock.env' \
+         '${REMOTE_DIR}/compose.shadow.yml' \
+         '${REMOTE_DIR}/compose.mapping.yml' \
+         '${REMOTE_DIR}/driver.shadow.yaml' \
+         '${REMOTE_DIR}/g1_lio.yaml' \
+         '${REMOTE_DIR}/Dockerfile.fast-livo2-hotfix' \
+         '${REMOTE_DIR}/fast-livo2-runtime.patch' \
+         '${REMOTE_DIR}/fast-livo2-pcd-save.patch'"
+
+if [[ "${MODE}" == start_rgb_preview ]]; then
+  echo "[deploy] copy immutable RGB preview assets"
+  COPYFILE_DISABLE=1 tar --no-xattrs -cf - \
+    -C "${NAV_DIR}" \
+      source-lock.rgb.env \
+      compose.rgb-preview.yml \
+      Dockerfile.fast-livo2-rgb-hotfix \
+      fast-livo2-rgb-qos.patch \
+    -C "${RGB_PREVIEW_TEMP_DIR}" \
+      rgb-preview-calibration.json \
+      g1_livo.rgb-preview.yaml \
+    | ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" \
+        "tar -C '${REMOTE_DIR}' -xf - &&
+         chmod 0644 \
+           '${REMOTE_DIR}/source-lock.rgb.env' \
+           '${REMOTE_DIR}/compose.rgb-preview.yml' \
+           '${REMOTE_DIR}/Dockerfile.fast-livo2-rgb-hotfix' \
+           '${REMOTE_DIR}/fast-livo2-rgb-qos.patch' \
+           '${REMOTE_DIR}/rgb-preview-calibration.json' \
+           '${REMOTE_DIR}/g1_livo.rgb-preview.yaml'"
+fi
+
+if [[ "${MODE}" == start_mapping ]]; then
+  echo "[mapping] start map_name=${MAP_NAME}"
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set -e
+    mkdir -p '${REMOTE_MAP_DIR}'
+    test -z \"\$(find '${REMOTE_MAP_DIR}' -mindepth 1 -maxdepth 1 -print -quit)\"
+    test -w '${REMOTE_MAP_DIR}'
+    map_uid=\"\$(stat -c '%u' '${REMOTE_MAP_DIR}')\"
+    map_gid=\"\$(stat -c '%g' '${REMOTE_MAP_DIR}')\"
+    test \"\${map_uid}\" -ge 0
+    test \"\${map_gid}\" -ge 0
+    cd '${REMOTE_DIR}'
+    ROS_NAMESPACE='${ROS_NAMESPACE_VALUE}' \
+    NETWORK_INTERFACE='${NETWORK_INTERFACE_VALUE}' \
+    G1_MAP_NAME='${MAP_NAME}' \
+    G1_MAP_DIR='${REMOTE_MAP_DIR}' \
+    G1_PCD_SAVE_INTERVAL='${PCD_SAVE_INTERVAL_VALUE}' \
+    G1_MAP_UID=\"\${map_uid}\" \
+    G1_MAP_GID=\"\${map_gid}\" \
+      docker compose --env-file source-lock.env \
+        -f compose.shadow.yml -f compose.mapping.yml \
+        --profile lio-shadow \
+        up -d --no-build --force-recreate --wait --wait-timeout 90
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.mode\"}}')\" = mapping
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.map_name\"}}')\" = '${MAP_NAME}'
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.pcd_save_interval\"}}')\" = '${PCD_SAVE_INTERVAL_VALUE}'
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.map_owner\"}}')\" = \"\${map_uid}:\${map_gid}\"
+    test -z \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{.Config.User}}')\"
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{json .HostConfig.GroupAdd}}')\" = \"[\\\"\${map_gid}\\\"]\"
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{range .Mounts}}{{if eq .Destination \"/opt/fast_livo_ws/src/fast_livo/Log/pcd\"}}{{.Source}}{{end}}{{end}}')\" = '${REMOTE_MAP_DIR}'
+    docker exec phanthy-fast-livo2-shadow /bin/bash -lc \
+      \"id -G | tr ' ' '\\n' | grep -qx '\${map_gid}'\"
+    docker exec phanthy-fast-livo2-shadow test -w /opt/fast_livo_ws/src/fast_livo/Log/pcd
+    docker inspect phanthy-navigation-sensors-shadow phanthy-fast-livo2-shadow \
+      --format '{{.Name}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} user={{json .Config.User}} group_add={{json .HostConfig.GroupAdd}} read_only={{.HostConfig.ReadonlyRootfs}} privileged={{.HostConfig.Privileged}} capdrop={{json .HostConfig.CapDrop}} devices={{json .HostConfig.Devices}}'
+  "
+  echo "Mapping is active for ${MAP_NAME}. Manually drive the robot, then run:"
+  echo "G1_MAP_NAME=${MAP_NAME} CONFIRM_G1_SHADOW_WRITE=YES $0 stop_mapping ${SSH_TARGET} ${ROS_NAMESPACE_VALUE} ${NETWORK_INTERFACE_VALUE}"
+  exit 0
+fi
+
+if [[ "${MODE}" == start_rgb_preview ]]; then
+  echo "[rgb-preview] build/reuse isolated RGB image and start map_name=${MAP_NAME}"
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set -e
+    cd '${REMOTE_DIR}'
+    printf '%s  %s\n' '${FAST_LIVO2_RGB_QOS_PATCH_SHA256}' fast-livo2-rgb-qos.patch | sha256sum -c -
+    grep -Fxq '# preview_only: true' g1_livo.rgb-preview.yaml
+
+    installed_rgb_patch=\"\$(docker image inspect '${FAST_LIVO_RGB_IMAGE}' --format '{{index .Config.Labels \"org.opencontainers.image.fast-livo2-rgb-qos-patch\"}}' 2>/dev/null || true)\"
+    if test \"\${installed_rgb_patch}\" = '${FAST_LIVO2_RGB_QOS_PATCH_SHA256}'; then
+      echo 'RGB preview image already matches source lock; reuse it'
+    else
+      docker build \
+        --platform linux/arm64 \
+        --pull=false \
+        --network=none \
+        --build-arg FAST_LIVO2_RGB_BASE_IMAGE='${FAST_LIVO_RGB_BASE_IMAGE}' \
+        --build-arg FAST_LIVO2_COMMIT='${FAST_LIVO2_COMMIT}' \
+        --build-arg FAST_LIVO2_RGB_QOS_PATCH_SHA256='${FAST_LIVO2_RGB_QOS_PATCH_SHA256}' \
+        -t '${FAST_LIVO_RGB_IMAGE}' \
+        -f Dockerfile.fast-livo2-rgb-hotfix \
+        .
+    fi
+    test \"\$(docker image inspect '${FAST_LIVO_RGB_IMAGE}' --format '{{.Architecture}}')\" = arm64
+    test \"\$(docker image inspect '${FAST_LIVO_RGB_IMAGE}' --format '{{index .Config.Labels \"org.opencontainers.image.revision\"}}')\" = '${FAST_LIVO2_COMMIT}'
+    test \"\$(docker image inspect '${FAST_LIVO_RGB_IMAGE}' --format '{{index .Config.Labels \"org.opencontainers.image.fast-livo2-runtime-patch\"}}')\" = '${FAST_LIVO2_RUNTIME_PATCH_SHA256}'
+    test \"\$(docker image inspect '${FAST_LIVO_RGB_IMAGE}' --format '{{index .Config.Labels \"org.opencontainers.image.fast-livo2-pcd-save-patch\"}}')\" = '${FAST_LIVO2_PCD_SAVE_PATCH_SHA256}'
+    test \"\$(docker image inspect '${FAST_LIVO_RGB_IMAGE}' --format '{{index .Config.Labels \"org.opencontainers.image.fast-livo2-rgb-qos-patch\"}}')\" = '${FAST_LIVO2_RGB_QOS_PATCH_SHA256}'
+
+    mkdir -p '${REMOTE_MAP_DIR}'
+    test -z \"\$(find '${REMOTE_MAP_DIR}' -mindepth 1 -maxdepth 1 -print -quit)\"
+    cp rgb-preview-calibration.json '${REMOTE_MAP_DIR}/rgb-preview-calibration.json'
+    chmod 0444 '${REMOTE_MAP_DIR}/rgb-preview-calibration.json'
+    map_uid=\"\$(stat -c '%u' '${REMOTE_MAP_DIR}')\"
+    map_gid=\"\$(stat -c '%g' '${REMOTE_MAP_DIR}')\"
+    test \"\${map_uid}\" -ge 0
+    test \"\${map_gid}\" -ge 0
+
+    ROS_NAMESPACE='${ROS_NAMESPACE_VALUE}' \
+    NETWORK_INTERFACE='${NETWORK_INTERFACE_VALUE}' \
+    G1_MAP_NAME='${MAP_NAME}' \
+    G1_MAP_DIR='${REMOTE_MAP_DIR}' \
+    G1_PCD_SAVE_INTERVAL='${PCD_SAVE_INTERVAL_VALUE}' \
+    G1_MAP_UID=\"\${map_uid}\" \
+    G1_MAP_GID=\"\${map_gid}\" \
+    G1_RGB_CONFIG_PATH='${REMOTE_DIR}/g1_livo.rgb-preview.yaml' \
+    G1_RGB_TIME_EVIDENCE='${RGB_TIME_EVIDENCE_VALUE}' \
+    G1_RGB_MOTION_POLICY='${RGB_MOTION_POLICY_VALUE}' \
+      docker compose --env-file source-lock.env --env-file source-lock.rgb.env \
+        -f compose.shadow.yml -f compose.mapping.yml -f compose.rgb-preview.yml \
+        --profile lio-shadow \
+        up -d --no-build --force-recreate --wait --wait-timeout 90
+
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{.Config.Image}}')\" = '${FAST_LIVO_RGB_IMAGE}'
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.mode\"}}')\" = rgb_preview
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.map_name\"}}')\" = '${MAP_NAME}'
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.pcd_save_interval\"}}')\" = '${PCD_SAVE_INTERVAL_VALUE}'
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.rgb_evidence\"}}')\" = nominal_public_urdf
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.rgb_time_evidence\"}}')\" = '${RGB_TIME_EVIDENCE_VALUE}'
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.rgb_motion_policy\"}}')\" = '${RGB_MOTION_POLICY_VALUE}'
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{range .Mounts}}{{if eq .Destination \"/opt/fast_livo_ws/src/fast_livo/Log/pcd\"}}{{.Source}}{{end}}{{end}}')\" = '${REMOTE_MAP_DIR}'
+    test \"\$(docker inspect phanthy-fast-livo2-shadow --format '{{json .HostConfig.GroupAdd}}')\" = \"[\\\"\${map_gid}\\\"]\"
+    docker exec phanthy-fast-livo2-shadow /bin/bash -lc \
+      \"id -G | tr ' ' '\\n' | grep -qx '\${map_gid}'\"
+    docker exec phanthy-fast-livo2-shadow test -w /opt/fast_livo_ws/src/fast_livo/Log/pcd
+    docker inspect phanthy-navigation-sensors-shadow phanthy-fast-livo2-shadow \
+      --format '{{.Name}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} user={{json .Config.User}} group_add={{json .HostConfig.GroupAdd}} read_only={{.HostConfig.ReadonlyRootfs}} privileged={{.HostConfig.Privileged}} capdrop={{json .HostConfig.CapDrop}} devices={{json .HostConfig.Devices}}'
+  "
+  echo "RGB preview is active for ${MAP_NAME}; evidence=nominal_public_urdf, time_evidence=${RGB_TIME_EVIDENCE_VALUE}, motion_policy=${RGB_MOTION_POLICY_VALUE}."
+  if [[ "${RGB_MOTION_POLICY_VALUE}" == slow_manual_preview ]]; then
+    echo "Keep the robot stationary for the first 20 seconds, then drive slowly and avoid fast turns while building this nominal RGB preview map."
+  else
+    echo "Keep the robot stationary and inspect /${ROS_NAMESPACE_VALUE}/navigation/cloud_registered_rgb in RViz."
+  fi
+  echo "Stop command: G1_MAP_NAME=${MAP_NAME} CONFIRM_G1_SHADOW_WRITE=YES $0 stop_rgb_preview ${SSH_TARGET} ${ROS_NAMESPACE_VALUE} ${NETWORK_INTERFACE_VALUE}"
+  exit 0
+fi
+
+if [[ "${MODE}" == resume ]]; then
+  echo "[deploy] reuse previously loaded arm64 images"
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set -e
+    test \"\$(docker image inspect '${G1_DRIVER_IMAGE}' --format '{{.Architecture}}')\" = arm64
+    test \"\$(docker image inspect '${FAST_LIVO_IMAGE}' --format '{{.Architecture}}')\" = arm64
+  "
+elif [[ "${MODE}" == fast-up ]]; then
+  echo "[deploy] reuse driver image and stream patched FAST-LIVO2 image"
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" \
+    "test \"\$(docker image inspect '${G1_DRIVER_IMAGE}' --format '{{.Architecture}}')\" = arm64"
+  "${LOCAL_DOCKER[@]}" image save --platform linux/arm64 "${FAST_LIVO_IMAGE}" \
+    | gzip -1 \
+    | ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" 'gzip -dc | docker load'
+elif [[ "${MODE}" == fast-build-up ]]; then
+  echo "[deploy] build patched FAST-LIVO2 from validated remote base (no image transfer)"
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+    set -e
+    cd '${REMOTE_DIR}'
+    printf '%s  %s\n' \
+      '${FAST_LIVO2_RUNTIME_PATCH_SHA256}' \
+      fast-livo2-runtime.patch | sha256sum -c -
+    printf '%s  %s\n' \
+      '${FAST_LIVO2_PCD_SAVE_PATCH_SHA256}' \
+      fast-livo2-pcd-save.patch | sha256sum -c -
+    docker build \
+      --platform linux/arm64 \
+      --pull=false \
+      --network=none \
+      --build-arg FAST_LIVO2_BASE_IMAGE='${FAST_LIVO_BASE_IMAGE}' \
+      --build-arg FAST_LIVO2_COMMIT='${FAST_LIVO2_COMMIT}' \
+      --build-arg FAST_LIVO2_RUNTIME_PATCH_SHA256='${FAST_LIVO2_RUNTIME_PATCH_SHA256}' \
+      --build-arg FAST_LIVO2_PCD_SAVE_PATCH_SHA256='${FAST_LIVO2_PCD_SAVE_PATCH_SHA256}' \
+      -t '${FAST_LIVO_IMAGE}' \
+      -f Dockerfile.fast-livo2-hotfix \
+      .
+    test \"\$(docker image inspect '${FAST_LIVO_IMAGE}' --format '{{.Architecture}}')\" = arm64
+    test \"\$(docker image inspect '${FAST_LIVO_IMAGE}' --format '{{index .Config.Labels \"org.opencontainers.image.fast-livo2-runtime-patch\"}}')\" = '${FAST_LIVO2_RUNTIME_PATCH_SHA256}'
+    test \"\$(docker image inspect '${FAST_LIVO_IMAGE}' --format '{{index .Config.Labels \"org.opencontainers.image.fast-livo2-pcd-save-patch\"}}')\" = '${FAST_LIVO2_PCD_SAVE_PATCH_SHA256}'
+  "
+elif [[ "${MODE}" == sensor-up ]]; then
+  echo "[deploy] reuse FAST-LIVO2 image and stream patched sensor image"
+  ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" \
+    "test \"\$(docker image inspect '${FAST_LIVO_IMAGE}' --format '{{.Architecture}}')\" = arm64"
+  "${LOCAL_DOCKER[@]}" image save --platform linux/arm64 "${G1_DRIVER_IMAGE}" \
+    | gzip -1 \
+    | ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" 'gzip -dc | docker load'
+else
+  echo "[deploy] stream arm64 images"
+  "${LOCAL_DOCKER[@]}" image save --platform linux/arm64 \
+    "${G1_DRIVER_IMAGE}" "${FAST_LIVO_IMAGE}" \
+    | gzip -1 \
+    | ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" 'gzip -dc | docker load'
+fi
+
+echo "[deploy] start read-only shadow sidecars"
+ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+  set -e
+  cd '${REMOTE_DIR}'
+  ROS_NAMESPACE='${ROS_NAMESPACE_VALUE}' \
+  NETWORK_INTERFACE='${NETWORK_INTERFACE_VALUE}' \
+    docker compose --env-file source-lock.env \
+      -f compose.shadow.yml --profile lio-shadow \
+      up -d --no-build --force-recreate --wait --wait-timeout 90
+  docker inspect \
+    phanthy-navigation-sensors-shadow \
+    phanthy-fast-livo2-shadow \
+    --format '{{.Name}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} read_only={{.HostConfig.ReadonlyRootfs}} privileged={{.HostConfig.Privileged}} capdrop={{json .HostConfig.CapDrop}} devices={{json .HostConfig.Devices}} pid={{.HostConfig.PidMode}}'
+"
+
+echo "LIO shadow is running. Existing embodied-unitree-g1 was not replaced."
+echo "Stop command: CONFIRM_G1_SHADOW_WRITE=YES $0 down ${SSH_TARGET} ${ROS_NAMESPACE_VALUE} ${NETWORK_INTERFACE_VALUE}"

--- a/unitree/g1/traditional_navigation/derive-g1-rgb-preview-calibration.py
+++ b/unitree/g1/traditional_navigation/derive-g1-rgb-preview-calibration.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Derive a static-preview LiDAR-to-color transform from public G1 mounts.
+
+This deliberately emits ``nominal_public_urdf`` evidence.  It is suitable for
+an isolated, stationary RViz alignment check, but it is not a measured sensor
+calibration and must not pass the production RGB-LIVO gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any
+
+import numpy as np
+
+
+UNITREE_G1_DESCRIPTION = (
+    "https://github.com/unitreerobotics/unitree_ros/tree/master/robots/g1_description"
+)
+REALSENSE_D435_DESCRIPTION = (
+    "https://github.com/realsenseai/realsense-ros/blob/ros2-development/"
+    "realsense2_description/urdf/_d435.urdf.xacro"
+)
+
+# These three official descriptions carry the same sensor mounts.  Keep the
+# allow-list explicit so a new or deprecated machine revision cannot silently
+# inherit the Shanghai candidate.
+PUBLIC_MOUNTS = {
+    4: "g1_23dof_rev_1_0",
+    5: "g1_29dof_rev_1_0",
+    11: "g1_29dof_mode_11",
+}
+D435_XYZ = (0.0576235, 0.01753, 0.42987)
+D435_RPY = (0.0, 0.8307767239493009, 0.0)
+MID360_XYZ = (0.0002835, 0.00003, 0.428434)
+MID360_RPY = (math.pi, 0.05112069379091391, 0.0)
+BRIDGE_RPY = (math.pi, 0.0, 0.0)
+OPTICAL_RPY = (-math.pi / 2.0, 0.0, -math.pi / 2.0)
+
+
+def rpy_matrix(rpy: tuple[float, float, float]) -> np.ndarray:
+    roll, pitch, yaw = rpy
+    rx = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, math.cos(roll), -math.sin(roll)],
+            [0.0, math.sin(roll), math.cos(roll)],
+        ]
+    )
+    ry = np.array(
+        [
+            [math.cos(pitch), 0.0, math.sin(pitch)],
+            [0.0, 1.0, 0.0],
+            [-math.sin(pitch), 0.0, math.cos(pitch)],
+        ]
+    )
+    rz = np.array(
+        [
+            [math.cos(yaw), -math.sin(yaw), 0.0],
+            [math.sin(yaw), math.cos(yaw), 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    return rz @ ry @ rx
+
+
+def transform(rotation: np.ndarray, translation) -> np.ndarray:
+    result = np.eye(4)
+    result[:3, :3] = rotation
+    result[:3, 3] = np.asarray(translation, dtype=float)
+    return result
+
+
+def derive_lidar_to_color(probe: dict[str, Any]) -> tuple[list[float], list[float], str]:
+    mode_machine = int(probe["mode_machine"])
+    if mode_machine not in PUBLIC_MOUNTS:
+        raise ValueError(f"unsupported mode_machine for nominal preview: {mode_machine}")
+
+    d435i = probe["d435i"]
+    internal = d435i["depth_to_color_optical"]
+    rotation_values = internal["rotation_column_major"]
+    translation_values = internal["translation_m"]
+    if len(rotation_values) != 9 or len(translation_values) != 3:
+        raise ValueError("invalid RealSense depth-to-color extrinsic dimensions")
+
+    # get_extrinsics_to(depth, color) maps depth-optical coordinates to
+    # color-optical coordinates.  Its flat rotation array is column-major.
+    color_from_depth = transform(
+        np.asarray(rotation_values, dtype=float).reshape((3, 3), order="F"),
+        translation_values,
+    )
+    d435_from_depth_optical = transform(rpy_matrix(OPTICAL_RPY), (0.0, 0.0, 0.0))
+    d435_from_color_optical = d435_from_depth_optical @ np.linalg.inv(
+        color_from_depth
+    )
+
+    torso_from_d435 = transform(rpy_matrix(D435_RPY), D435_XYZ)
+    torso_from_mid360_raw = transform(rpy_matrix(MID360_RPY), MID360_XYZ)
+
+    # The navigation bridge publishes corrected = Rx(pi) * raw.  Convert the
+    # public raw MID360 link into the exact corrected livox_frame consumed by
+    # FAST-LIVO2, avoiding a second upside-down rotation.
+    raw_from_corrected = transform(rpy_matrix(BRIDGE_RPY).T, (0.0, 0.0, 0.0))
+    torso_from_corrected_lidar = torso_from_mid360_raw @ raw_from_corrected
+    torso_from_color_optical = torso_from_d435 @ d435_from_color_optical
+    color_from_corrected_lidar = (
+        np.linalg.inv(torso_from_color_optical) @ torso_from_corrected_lidar
+    )
+
+    rotation = color_from_corrected_lidar[:3, :3]
+    if not np.allclose(rotation.T @ rotation, np.eye(3), atol=5e-6):
+        raise ValueError("derived LiDAR-to-color rotation is not orthonormal")
+    if not math.isclose(float(np.linalg.det(rotation)), 1.0, abs_tol=5e-6):
+        raise ValueError("derived LiDAR-to-color rotation determinant is not +1")
+
+    return (
+        rotation.reshape(9).tolist(),
+        color_from_corrected_lidar[:3, 3].tolist(),
+        PUBLIC_MOUNTS[mode_machine],
+    )
+
+
+def canonical_id(value: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def validate_time_probe(
+    time_probe: dict[str, Any], live_probe: dict[str, Any]
+) -> dict[str, Any]:
+    if time_probe.get("schema_version") != 1 or time_probe.get("probe_type") != (
+        "g1_realsense_callback_latency"
+    ):
+        raise ValueError("unsupported RGB time-offset probe schema/type")
+    payload = {key: value for key, value in time_probe.items() if key != "probe_id"}
+    if time_probe.get("probe_id") != canonical_id(payload):
+        raise ValueError("RGB time-offset probe_id does not match canonical SHA256")
+    if str(time_probe.get("boot_id", "")) != str(live_probe.get("boot_id", "")):
+        raise ValueError("RGB time-offset probe boot_id does not match the live G1 boot")
+
+    timed_d435i = time_probe.get("d435i")
+    measurement = time_probe.get("measurement")
+    if not isinstance(timed_d435i, dict) or not isinstance(measurement, dict):
+        raise ValueError("RGB time-offset probe is incomplete")
+    live_d435i = live_probe["d435i"]
+    if str(timed_d435i.get("serial", "")) != str(live_d435i["serial"]):
+        raise ValueError("RGB time-offset probe D435I serial does not match live probe")
+    timed_color = timed_d435i.get("color")
+    if not isinstance(timed_color, dict):
+        raise ValueError("RGB time-offset probe color profile is missing")
+    live_color = live_d435i["color"]
+    timed_profile = tuple(int(timed_color.get(key, 0)) for key in ("width", "height", "fps"))
+    live_profile = tuple(int(live_color[key]) for key in ("width", "height", "fps"))
+    if timed_profile != live_profile:
+        raise ValueError(
+            f"RGB time-offset probe profile {timed_profile} does not match live {live_profile}"
+        )
+    if measurement.get("timestamp_domain") != "global_time":
+        raise ValueError("RGB time-offset probe must use RealSense global_time")
+    if int(measurement.get("sample_count", 0)) < 30:
+        raise ValueError("RGB time-offset probe requires at least 30 samples")
+
+    offset_s = float(measurement.get("recommended_img_time_offset_s"))
+    residual_ms = float(measurement.get("p95_abs_residual_ms"))
+    if not math.isfinite(offset_s) or abs(offset_s) > 0.5:
+        raise ValueError("RGB time-offset recommendation is outside +/-0.5 s")
+    if not math.isfinite(residual_ms) or not 0.0 <= residual_ms <= 20.0:
+        raise ValueError("RGB callback latency residual p95 exceeds 20 ms")
+    latency = measurement.get("callback_latency_ms")
+    if not isinstance(latency, dict) or not math.isfinite(float(latency.get("median"))):
+        raise ValueError("RGB callback latency median is missing")
+    return {
+        "probe_id": time_probe["probe_id"],
+        "method": str(measurement.get("method", "")),
+        "offset_s": offset_s,
+        "p95_residual_ms": residual_ms,
+        "callback_latency_median_ms": float(latency["median"]),
+        "sample_count": int(measurement["sample_count"]),
+    }
+
+
+def build_snapshot(
+    probe: dict[str, Any], time_probe: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    rotation, translation, model = derive_lidar_to_color(probe)
+    d435i = probe["d435i"]
+    color = d435i["color"]
+    global_time = d435i.get("global_time", [])
+    if not global_time or not all(item.get("enabled") for item in global_time):
+        raise ValueError("RealSense global_time_enabled is not active on every sensor")
+
+    if time_probe is None:
+        time_alignment = {
+            "status": "preview_only",
+            "timestamp_source": "callback_arrival_preview",
+            "img_time_offset_s": 0.0,
+            "p95_abs_skew_ms": None,
+        }
+        time_warning = "unverified camera-LiDAR time alignment"
+    else:
+        correction = validate_time_probe(time_probe, probe)
+        time_alignment = {
+            "status": "preview_only",
+            "timestamp_source": "callback_arrival_preview",
+            "img_time_offset_s": correction["offset_s"],
+            # This probe bounds callback-latency jitter, not true camera-to-
+            # LiDAR skew.  Keep the production skew field unverified.
+            "p95_abs_skew_ms": None,
+            "preview_time_correction": {
+                "method": correction["method"],
+                "time_probe_id": correction["probe_id"],
+                "sample_count": correction["sample_count"],
+                "callback_latency_median_ms": correction[
+                    "callback_latency_median_ms"
+                ],
+                "p95_abs_residual_ms": correction["p95_residual_ms"],
+            },
+        }
+        time_warning = (
+            "callback latency corrected from RealSense GLOBAL_TIME, but "
+            "camera-LiDAR skew is not independently verified"
+        )
+
+    data = {
+        "schema_version": 1,
+        "device_id": "g1-live-probe",
+        "unitree": {
+            "mode_machine": int(probe["mode_machine"]),
+            "model": model,
+        },
+        "d435i": {
+            "identity": {
+                "manufacturer": "Intel RealSense",
+                "model": d435i["model"],
+                "serial": d435i["serial"],
+            },
+            "profiles": {"color": color},
+            "factory_extrinsics": {
+                "depth_to_color_optical": d435i["depth_to_color_optical"]
+            },
+        },
+        "ground_truth": {
+            "transforms": {
+                "lidar_to_camera": {
+                    "status": "nominal_public_urdf",
+                    "source_frame": "livox_frame",
+                    "target_frame": "camera_color_optical_frame",
+                    "rotation_row_major": rotation,
+                    "translation_m": translation,
+                }
+            },
+            "time_alignment": {
+                "d435i_color_to_mid360": time_alignment
+            },
+        },
+    }
+    return {
+        "schema_version": 1,
+        "calibration_id": canonical_id(data),
+        "captured_at_epoch_ns": int(probe["captured_at_epoch_ns"]),
+        "data": data,
+        "provenance": {
+            "evidence_tier": "nominal_public_urdf",
+            "unitree_description": UNITREE_G1_DESCRIPTION,
+            "realsense_description": REALSENSE_D435_DESCRIPTION,
+            "warning": (
+                "STATIC RGB PREVIEW ONLY; not a measured robot-specific extrinsic "
+                f"and {time_warning}"
+            ),
+        },
+    }
+
+
+def write_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, prefix=path.name + ".", delete=False
+    ) as handle:
+        handle.write(content)
+        handle.flush()
+        os.fsync(handle.fileno())
+        temporary = Path(handle.name)
+    os.replace(temporary, path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("probe", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--time-offset-probe", type=Path)
+    args = parser.parse_args()
+
+    try:
+        with args.probe.open(encoding="utf-8") as handle:
+            probe = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        byte_count = args.probe.stat().st_size if args.probe.exists() else -1
+        print(
+            f"invalid live probe JSON: path={args.probe} bytes={byte_count} error={error}",
+            file=sys.stderr,
+        )
+        return 1
+    if not isinstance(probe, dict):
+        print("invalid live probe JSON: root must be an object", file=sys.stderr)
+        return 1
+    time_probe = None
+    if args.time_offset_probe is not None:
+        try:
+            with args.time_offset_probe.open(encoding="utf-8") as handle:
+                time_probe = json.load(handle)
+        except (OSError, json.JSONDecodeError) as error:
+            print(f"invalid RGB time-offset probe: {error}", file=sys.stderr)
+            return 1
+        if not isinstance(time_probe, dict):
+            print("invalid RGB time-offset probe: root must be an object", file=sys.stderr)
+            return 1
+    try:
+        snapshot = build_snapshot(probe, time_probe)
+    except (KeyError, TypeError, ValueError) as error:
+        print(f"invalid RGB preview calibration input: {error}", file=sys.stderr)
+        return 1
+    write_atomic(
+        args.output,
+        json.dumps(snapshot, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
+    transform_data = snapshot["data"]["ground_truth"]["transforms"][
+        "lidar_to_camera"
+    ]
+    print(
+        "rgb_livo_preview_calibration=nominal "
+        f"mode_machine={snapshot['data']['unitree']['mode_machine']} "
+        f"model={snapshot['data']['unitree']['model']} "
+        f"serial={snapshot['data']['d435i']['identity']['serial']} "
+        f"translation_m={transform_data['translation_m']}"
+    )
+    alignment = snapshot["data"]["ground_truth"]["time_alignment"][
+        "d435i_color_to_mid360"
+    ]
+    correction = alignment.get("preview_time_correction")
+    if isinstance(correction, dict):
+        print(
+            "rgb_time_alignment=callback_latency_corrected_preview "
+            f"img_time_offset_s={alignment['img_time_offset_s']:.9f} "
+            f"p95_residual_ms={correction['p95_abs_residual_ms']:.3f}"
+        )
+    print(f"output={args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unitree/g1/traditional_navigation/driver.shadow.yaml
+++ b/unitree/g1/traditional_navigation/driver.shadow.yaml
@@ -1,0 +1,21 @@
+ros_namespace: ""
+
+plugins:
+  navigation_sensors:
+    enabled: true
+    raw_cloud_topic: rt/utlidar/cloud_livox_mid360
+    raw_imu_topic: rt/utlidar/imu_livox_mid360
+    publish_raw_cloud: false
+    publish_fast_livo_cloud: true
+    raw_lidar_frame: livox_raw_frame
+    lidar_frame: livox_frame
+    imu_frame: livox_frame
+    # Fixed MID360 mounting transform. Apply it to LiDAR and its internal IMU
+    # together; never replace it with dashboard-style dynamic gravity alignment.
+    sensor_rotation_matrix: [1.0, 0.0, 0.0,
+                             0.0, -1.0, 0.0,
+                             0.0, 0.0, -1.0]
+    clock_warmup_samples: 32
+    clock_window_samples: 400
+    clock_reset_threshold_ms: 1000
+    clock_reset_confirm_samples: 8

--- a/unitree/g1/traditional_navigation/fast-livo2-pcd-save.patch
+++ b/unitree/g1/traditional_navigation/fast-livo2-pcd-save.patch
@@ -1,0 +1,179 @@
+--- a/src/LIVMapper.cpp
++++ b/src/LIVMapper.cpp
+@@ -13,6 +13,87 @@
+ #include "LIVMapper.h"
+ #include <vikit/camera_loader.h>
+ #include <boost/filesystem.hpp>
++#include <cmath>
++#include <fstream>
++
++namespace
++{
++bool writeIntensityPCDBinary(const std::string &path, const PointCloudXYZI &cloud, std::size_t &written_points)
++{
++  written_points = 0;
++  for (const auto &point : cloud.points)
++  {
++    if (std::isfinite(point.x) && std::isfinite(point.y) && std::isfinite(point.z))
++    {
++      ++written_points;
++    }
++  }
++  if (written_points == 0)
++  {
++    return false;
++  }
++
++  const std::string temporary_path = path + ".tmp";
++  std::ofstream output(temporary_path, std::ios::binary | std::ios::trunc);
++  if (!output)
++  {
++    return false;
++  }
++
++  output << "# .PCD v0.7 - Point Cloud Data file format\n"
++         << "VERSION 0.7\n"
++         << "FIELDS x y z intensity\n"
++         << "SIZE 4 4 4 4\n"
++         << "TYPE F F F F\n"
++         << "COUNT 1 1 1 1\n"
++         << "WIDTH " << written_points << "\n"
++         << "HEIGHT 1\n"
++         << "VIEWPOINT 0 0 0 1 0 0 0\n"
++         << "POINTS " << written_points << "\n"
++         << "DATA binary\n";
++
++  constexpr std::size_t kChunkPoints = 8192;
++  std::vector<float> buffer;
++  buffer.reserve(kChunkPoints * 4);
++  for (const auto &point : cloud.points)
++  {
++    if (!std::isfinite(point.x) || !std::isfinite(point.y) || !std::isfinite(point.z))
++    {
++      continue;
++    }
++    buffer.push_back(point.x);
++    buffer.push_back(point.y);
++    buffer.push_back(point.z);
++    buffer.push_back(std::isfinite(point.intensity) ? point.intensity : 0.0F);
++    if (buffer.size() == kChunkPoints * 4)
++    {
++      output.write(reinterpret_cast<const char *>(buffer.data()),
++                   static_cast<std::streamsize>(buffer.size() * sizeof(float)));
++      buffer.clear();
++    }
++  }
++  if (!buffer.empty())
++  {
++    output.write(reinterpret_cast<const char *>(buffer.data()),
++                 static_cast<std::streamsize>(buffer.size() * sizeof(float)));
++  }
++  output.close();
++  if (!output)
++  {
++    boost::filesystem::remove(temporary_path);
++    return false;
++  }
++
++  boost::system::error_code error;
++  boost::filesystem::rename(temporary_path, path, error);
++  if (error)
++  {
++    boost::filesystem::remove(temporary_path);
++    return false;
++  }
++  return true;
++}
++}
+ 
+ using namespace Sophus;
+ LIVMapper::LIVMapper(rclcpp::Node::SharedPtr &node, std::string node_name, const rclcpp::NodeOptions & options)
+@@ -653,12 +734,17 @@
+ 
+ void LIVMapper::savePCD() 
+ {
+-  if (pcd_save_en && (pcl_wait_save->points.size() > 0 || pcl_wait_save_intensity->points.size() > 0) && pcd_save_interval < 0) 
++  if (pcd_save_en && (pcl_wait_save->points.size() > 0 || pcl_wait_save_intensity->points.size() > 0))
+   {
+-    std::string raw_points_dir = std::string(ROOT_DIR) + "Log/pcd/all_raw_points.pcd";
++    const std::string raw_points_name = pcd_save_interval < 0 ? "all_raw_points.pcd" : "tail_raw_points.pcd";
++    std::string raw_points_dir = std::string(ROOT_DIR) + "Log/pcd/" + raw_points_name;
+     std::string downsampled_points_dir = std::string(ROOT_DIR) + "Log/pcd/all_downsampled_points.pcd";
+     pcl::PCDWriter pcd_writer;
+ 
++    RCLCPP_WARN(this->node->get_logger(),
++      "PCD finalization started: rgb_points=%zu intensity_points=%zu interval=%d",
++      pcl_wait_save->points.size(), pcl_wait_save_intensity->points.size(), pcd_save_interval);
++
+     if (img_en)
+     {
+       pcl::PointCloud<pcl::PointXYZRGB>::Ptr downsampled_cloud(new pcl::PointCloud<pcl::PointXYZRGB>);
+@@ -693,10 +779,15 @@
+       }
+     }
+     else
+-    {      
+-      pcd_writer.writeBinary(raw_points_dir, *pcl_wait_save_intensity);
+-      std::cout << GREEN << "Raw point cloud data saved to: " << raw_points_dir 
+-                << " with point count: " << pcl_wait_save_intensity->points.size() << RESET << std::endl;
++    {
++      std::size_t written_points = 0;
++      if (!writeIntensityPCDBinary(raw_points_dir, *pcl_wait_save_intensity, written_points))
++      {
++        RCLCPP_ERROR(this->node->get_logger(), "PCD finalization failed: %s", raw_points_dir.c_str());
++        return;
++      }
++      RCLCPP_WARN(this->node->get_logger(), "PCD finalization completed: path=%s points=%zu",
++        raw_points_dir.c_str(), written_points);
+     }
+   }
+ }
+@@ -1401,19 +1492,36 @@
+       string all_points_dir(string(string(ROOT_DIR) + "Log/pcd/") + ss_time.str() + string(".pcd"));
+ 
+       pcl::PCDWriter pcd_writer;
++      bool saved = true;
+ 
+       cout << "current scan saved to " << all_points_dir << endl;
+       if (pcl_wait_save->points.size() > 0)
+       {
+-        pcd_writer.writeBinary(all_points_dir, *pcl_wait_save); // pcl::io::savePCDFileASCII(all_points_dir, *pcl_wait_save);
+-        PointCloudXYZRGB().swap(*pcl_wait_save);
++        saved = pcd_writer.writeBinary(all_points_dir, *pcl_wait_save) == 0;
++        if (saved)
++        {
++          PointCloudXYZRGB().swap(*pcl_wait_save);
++        }
+       }
+       if(pcl_wait_save_intensity->points.size() > 0)
+       {
+-        pcd_writer.writeBinary(all_points_dir, *pcl_wait_save_intensity);
+-        PointCloudXYZI().swap(*pcl_wait_save_intensity);
++        std::size_t written_points = 0;
++        saved = writeIntensityPCDBinary(all_points_dir, *pcl_wait_save_intensity, written_points);
++        if (saved)
++        {
++          PointCloudXYZI().swap(*pcl_wait_save_intensity);
++          RCLCPP_WARN(this->node->get_logger(), "PCD checkpoint completed: path=%s points=%zu",
++            all_points_dir.c_str(), written_points);
++        }
++      }
++      if (saved)
++      {
++        scan_wait_num = 0;
++      }
++      else
++      {
++        RCLCPP_ERROR(this->node->get_logger(), "PCD checkpoint failed: %s", all_points_dir.c_str());
+       }
+-      scan_wait_num = 0;
+     }
+     
+     if(LidarMeasures.lio_vio_flg == LIO || LidarMeasures.lio_vio_flg == LO)
+@@ -1525,4 +1633,4 @@
+   msg_body_pose.header.frame_id = "camera_init";
+   path.poses.push_back(msg_body_pose);
+   pubPath->publish(path);
+-}
+\ No newline at end of file
++}

--- a/unitree/g1/traditional_navigation/fast-livo2-rgb-qos.patch
+++ b/unitree/g1/traditional_navigation/fast-livo2-rgb-qos.patch
@@ -1,0 +1,198 @@
+--- a/src/LIVMapper.cpp
++++ b/src/LIVMapper.cpp
+@@ -18,6 +18,10 @@
+ 
+ namespace
+ {
++constexpr std::size_t kMaxBufferedLidarFrames = 8;
++constexpr std::size_t kMaxBufferedImuSamples = 400;
++constexpr std::size_t kMaxBufferedImages = 4;
++
+ bool writeIntensityPCDBinary(const std::string &path, const PointCloudXYZI &cloud, std::size_t &written_points)
+ {
+   written_points = 0;
+@@ -397,18 +401,21 @@ void LIVMapper::initializeSubscribersAndPublishers(rclcpp::Node::SharedPtr &node,
+   // indefinitely when a transient load spike occurs.
+   constexpr size_t kPointCloudQueueDepth = 8;
+   constexpr size_t kImuQueueDepth = 400;
++  constexpr size_t kImageQueueDepth = 4;
+   if (p_pre->lidar_type == AVIA) {
+     sub_pcl = this->node->create_subscription<livox_ros_driver2::msg::CustomMsg>(lid_topic, kPointCloudQueueDepth, std::bind(&LIVMapper::livox_pcl_cbk, this, std::placeholders::_1));
+   } else {
+     sub_pcl = this->node->create_subscription<sensor_msgs::msg::PointCloud2>(lid_topic, kPointCloudQueueDepth, std::bind(&LIVMapper::standard_pcl_cbk, this, std::placeholders::_1));
+   }
+   sub_imu = this->node->create_subscription<sensor_msgs::msg::Imu>(imu_topic, kImuQueueDepth, std::bind(&LIVMapper::imu_cbk, this, std::placeholders::_1));
++  rclcpp::SensorDataQoS image_qos;
++  image_qos.keep_last(kImageQueueDepth);
+   if (enable_image_processing) {
+     sub_img_compressed = this->node->create_subscription<sensor_msgs::msg::CompressedImage>(
+-      img_topic, 200000, std::bind(&LIVMapper::jpeg_callback, this, std::placeholders::_1));
++      img_topic, image_qos, std::bind(&LIVMapper::jpeg_callback, this, std::placeholders::_1));
+   } else {
+     sub_img = this->node->create_subscription<sensor_msgs::msg::Image>(
+-      img_topic, 200000, std::bind(&LIVMapper::img_cbk, this, std::placeholders::_1));
++      img_topic, image_qos, std::bind(&LIVMapper::img_cbk, this, std::placeholders::_1));
+   }
+   pubLaserCloudFullRes = this->node->create_publisher<sensor_msgs::msg::PointCloud2>("/cloud_registered", 100);
+   pubNormal = this->node->create_publisher<visualization_msgs::msg::MarkerArray>("/visualization_marker", 100);
+@@ -457,7 +464,14 @@ void LIVMapper::jpeg_callback(const sensor_msgs::msg::CompressedImage::SharedPtr
+         mtx_buffer.lock();
+         img_buffer.push_back(image);
+         img_time_buffer.push_back(msg_header_time);
++        if (img_buffer.size() > kMaxBufferedImages) {
++            img_buffer.pop_front();
++            img_time_buffer.pop_front();
++            RCLCPP_WARN_THROTTLE(
++              node->get_logger(), *node->get_clock(), 1000,
++              "Image application buffer full; dropping oldest frame");
++        }
+         last_timestamp_img = msg_header_time;
+         mtx_buffer.unlock();
+         // Notify processing thread
+         sig_buffer.notify_all();
+@@ -553,7 +567,10 @@ void LIVMapper::handleVIO() 
+     vio_manager->plot_flag = false;
+   }
+ 
+-  vio_manager->processFrame(LidarMeasures.measures.back().img, _pv_list, voxelmap_manager->voxel_map_, LidarMeasures.last_lio_update_time - _first_lidar_time);
++  // This image is built only for the nominal, stationary RGB preview. Keep
++  // the validated LIO state and retain only the current camera frame needed
++  // to project/colorize the current cloud; do not grow a visual feature map.
++  vio_manager->prepareFrameForColorization(LidarMeasures.measures.back().img);
+ 
+   if (imu_prop_enable) 
+   {
+@@ -971,11 +988,20 @@ void LIVMapper::standard_pcl_cbk(const sensor_msgs::msg::PointCloud2::ConstShared
+   {
+     RCLCPP_ERROR(this->node->get_logger(),"lidar loop back, clear buffer");
+     lid_raw_data_buffer.clear();
++    lid_header_time_buffer.clear();
+   }
+   PointCloudXYZI::Ptr ptr(new PointCloudXYZI());
+   p_pre->process(msg, ptr);
+   lid_raw_data_buffer.push_back(ptr);
+   lid_header_time_buffer.push_back(cur_head_time);
++  if (lid_raw_data_buffer.size() > kMaxBufferedLidarFrames)
++  {
++    lid_raw_data_buffer.pop_front();
++    lid_header_time_buffer.pop_front();
++    RCLCPP_WARN_THROTTLE(
++      this->node->get_logger(), *this->node->get_clock(), 1000,
++      "LiDAR application buffer full; dropping oldest frame");
++  }
+   last_timestamp_lidar = cur_head_time;
+ 
+   mtx_buffer.unlock();
+@@ -1000,19 +1026,28 @@ void LIVMapper::livox_pcl_cbk(const livox_ros_driver2::msg::CustomMsg::ConstShare
+   {
+     RCLCPP_ERROR(this->node->get_logger(), "lidar loop back, clear buffer");
+     lid_raw_data_buffer.clear();
++    lid_header_time_buffer.clear();
+   }
+   RCLCPP_INFO(this->node->get_logger(), "get point cloud at time: %.6f", stamp2Sec(msg->header.stamp));
+   PointCloudXYZI::Ptr ptr(new PointCloudXYZI());
+   p_pre->process(msg, ptr);
+ 
+   if (!ptr || ptr->empty()) {
+     RCLCPP_ERROR(this->node->get_logger(), "Received an empty point cloud");
+     mtx_buffer.unlock();
+     return;
+   }
+ 
+   lid_raw_data_buffer.push_back(ptr);
+   lid_header_time_buffer.push_back(cur_head_time);
++  if (lid_raw_data_buffer.size() > kMaxBufferedLidarFrames)
++  {
++    lid_raw_data_buffer.pop_front();
++    lid_header_time_buffer.pop_front();
++    RCLCPP_WARN_THROTTLE(
++      this->node->get_logger(), *this->node->get_clock(), 1000,
++      "LiDAR application buffer full; dropping oldest frame");
++  }
+   last_timestamp_lidar = cur_head_time;
+ 
+   mtx_buffer.unlock();
+@@ -1064,13 +1097,24 @@ void LIVMapper::imu_cbk(const sensor_msgs::msg::Imu::ConstSharedPtr &msg_in)
+   last_timestamp_imu = timestamp;
+ 
+   imu_buffer.push_back(msg);
++  if (imu_buffer.size() > kMaxBufferedImuSamples)
++  {
++    imu_buffer.pop_front();
++    RCLCPP_WARN_THROTTLE(
++      this->node->get_logger(), *this->node->get_clock(), 1000,
++      "IMU application buffer full; dropping oldest sample");
++  }
+   mtx_buffer.unlock();
+   if (imu_prop_enable)
+   {
+     mtx_buffer_imu_prop.lock();
+     if (imu_prop_enable && !p_imu->imu_need_init) { prop_imu_buffer.push_back(*msg); }
++    if (prop_imu_buffer.size() > kMaxBufferedImuSamples)
++    {
++      prop_imu_buffer.pop_front();
++    }
+     newest_imu = *msg;
+     new_imu = true;
+     mtx_buffer_imu_prop.unlock();
+   }
+   sig_buffer.notify_all();
+@@ -1117,9 +1161,17 @@ void LIVMapper::img_cbk(const sensor_msgs::msg::Image::ConstSharedPtr &msg_in)
+   cv::Mat img_cur = getImageFromMsg(msg);
+   img_buffer.push_back(img_cur);
+   img_time_buffer.push_back(img_time_correct);
++  if (img_buffer.size() > kMaxBufferedImages)
++  {
++    img_buffer.pop_front();
++    img_time_buffer.pop_front();
++    RCLCPP_WARN_THROTTLE(
++      this->node->get_logger(), *this->node->get_clock(), 1000,
++      "Image application buffer full; dropping oldest frame");
++  }
+ 
+   // ROS_INFO("Correct Image time: %.6f", img_time_correct);
+ 
+   last_timestamp_img = img_time_correct;
+   // cv::imshow("img", img);
+   // cv::waitKey(1);
+--- a/include/vio.h
++++ b/include/vio.h
+@@ -143,6 +143,7 @@ public:
+   ~VIOManager();
+   void updateStateInverse(cv::Mat img, int level);
+   void updateState(cv::Mat img, int level);
++  void prepareFrameForColorization(cv::Mat &img);
+   void processFrame(cv::Mat &img, vector<pointWithVar> &pg, const unordered_map<VOXEL_LOCATION, VoxelOctoTree *> &feat_map, double img_time);
+   void retrieveFromVisualSparseMap(cv::Mat img, vector<pointWithVar> &pg, const unordered_map<VOXEL_LOCATION, VoxelOctoTree *> &plane_map);
+   void generateVisualMapPoints(cv::Mat img, vector<pointWithVar> &pg);
+--- a/src/vio.cpp
++++ b/src/vio.cpp
+@@ -1790,6 +1790,28 @@ void VIOManager::dumpDataForColmap()
+   cnt++;
+ }
+ 
++void VIOManager::prepareFrameForColorization(cv::Mat &img)
++{
++  if (img.empty())
++  {
++    img_rgb.release();
++    img_cp.release();
++    new_frame_.reset();
++    return;
++  }
++  if (width != img.cols || height != img.rows)
++  {
++    cv::resize(img, img, cv::Size(img.cols * image_resize_factor, img.rows * image_resize_factor), 0, 0, CV_INTER_LINEAR);
++  }
++
++  img_rgb = img.clone();
++  img_cp = img.clone();
++  if (img.channels() == 3) cv::cvtColor(img, img, CV_BGR2GRAY);
++
++  new_frame_.reset(new Frame(cam, img));
++  updateFrameState(*state);
++}
++
+ void VIOManager::processFrame(cv::Mat &img, vector<pointWithVar> &pg, const unordered_map<VOXEL_LOCATION, VoxelOctoTree *> &feat_map, double img_time)
+ {
+   if (width != img.cols || height != img.rows)

--- a/unitree/g1/traditional_navigation/fast-livo2-runtime.patch
+++ b/unitree/g1/traditional_navigation/fast-livo2-runtime.patch
@@ -1,0 +1,65 @@
+diff --git a/src/LIVMapper.cpp b/src/LIVMapper.cpp
+--- a/src/LIVMapper.cpp
++++ b/src/LIVMapper.cpp
+@@ -309,11 +309,16 @@ void LIVMapper::initializeSubscribersAndPublishers(rclcpp::Node::SharedPtr &node,
+ {
+   image_transport::ImageTransport it(this->node);
++  // This node services subscriptions and mapping in one spin_some loop. Huge
++  // reader histories preserve stale samples and can make the estimator lag
++  // indefinitely when a transient load spike occurs.
++  constexpr size_t kPointCloudQueueDepth = 8;
++  constexpr size_t kImuQueueDepth = 400;
+   if (p_pre->lidar_type == AVIA) {
+-    sub_pcl = this->node->create_subscription<livox_ros_driver2::msg::CustomMsg>(lid_topic, 200000, std::bind(&LIVMapper::livox_pcl_cbk, this, std::placeholders::_1));
++    sub_pcl = this->node->create_subscription<livox_ros_driver2::msg::CustomMsg>(lid_topic, kPointCloudQueueDepth, std::bind(&LIVMapper::livox_pcl_cbk, this, std::placeholders::_1));
+   } else {
+-    sub_pcl = this->node->create_subscription<sensor_msgs::msg::PointCloud2>(lid_topic, 200000, std::bind(&LIVMapper::standard_pcl_cbk, this, std::placeholders::_1));
++    sub_pcl = this->node->create_subscription<sensor_msgs::msg::PointCloud2>(lid_topic, kPointCloudQueueDepth, std::bind(&LIVMapper::standard_pcl_cbk, this, std::placeholders::_1));
+   }
+-  sub_imu = this->node->create_subscription<sensor_msgs::msg::Imu>(imu_topic, 200000, std::bind(&LIVMapper::imu_cbk, this, std::placeholders::_1));
++  sub_imu = this->node->create_subscription<sensor_msgs::msg::Imu>(imu_topic, kImuQueueDepth, std::bind(&LIVMapper::imu_cbk, this, std::placeholders::_1));
+   if (enable_image_processing) {
+     sub_img_compressed = this->node->create_subscription<sensor_msgs::msg::CompressedImage>(
+       img_topic, 200000, std::bind(&LIVMapper::jpeg_callback, this, std::placeholders::_1));
+@@ -929,14 +934,16 @@ void LIVMapper::imu_cbk(const sensor_msgs::msg::Imu::ConstSharedPtr &msg_in)
+   if (!imu_en) return;
+ 
+   if (last_timestamp_lidar < 0.0) return;
+-  RCLCPP_INFO(this->node->get_logger(), "get imu at time: %.6f", stamp2Sec(msg_in->header.stamp));
+   sensor_msgs::msg::Imu::SharedPtr msg(new sensor_msgs::msg::Imu(*msg_in));
+   msg->header.stamp = sec2Stamp(stamp2Sec(msg->header.stamp) - imu_time_offset);
+   double timestamp = stamp2Sec(msg->header.stamp);
+ 
+   if (fabs(last_timestamp_lidar - timestamp) > 0.5 && (!ros_driver_fix_en))
+   {
+-    RCLCPP_WARN(this->node->get_logger(), "IMU and LiDAR not synced! delta time: %lf .\n", last_timestamp_lidar - timestamp);
++    RCLCPP_WARN_THROTTLE(
++      this->node->get_logger(), *this->node->get_clock(), 1000,
++      "IMU and LiDAR not synced! delta time: %lf .",
++      last_timestamp_lidar - timestamp);
+   }
+ 
+   if (ros_driver_fix_en) timestamp += std::round(last_timestamp_lidar - timestamp);
+@@ -962,15 +969,17 @@ void LIVMapper::imu_cbk(const sensor_msgs::msg::Imu::ConstSharedPtr &msg_in)
+   if (last_timestamp_imu > 0.0 && timestamp > last_timestamp_imu + 0.2)
+   {
+-    RCLCPP_WARN(this->node->get_logger(), "imu time stamp Jumps %0.4lf seconds \n", timestamp - last_timestamp_imu);
+-    mtx_buffer.unlock();
+-    sig_buffer.notify_all();
+-    return;
++    // Returning here without advancing last_timestamp_imu wedges the stream:
++    // every subsequent valid sample is still more than 0.2 s ahead. Keep the
++    // gap visible, but accept the first post-gap sample as the new baseline.
++    RCLCPP_WARN_THROTTLE(
++      this->node->get_logger(), *this->node->get_clock(), 1000,
++      "IMU gap is %0.4lf seconds; accepting current sample to resynchronize",
++      timestamp - last_timestamp_imu);
+   }
+ 
+   last_timestamp_imu = timestamp;
+ 
+   imu_buffer.push_back(msg);
+-  cout<<"got imu: "<<timestamp<<" imu size "<<imu_buffer.size()<<endl;
+   mtx_buffer.unlock();
+   if (imu_prop_enable)
+   {

--- a/unitree/g1/traditional_navigation/g1_lio.yaml
+++ b/unitree/g1/traditional_navigation/g1_lio.yaml
@@ -1,0 +1,116 @@
+/**:
+  ros__parameters:
+    common:
+      # Compose remaps these stable upstream names into /<g1>/navigation/*.
+      img_topic: "/left_camera/image"
+      lid_topic: "/livox/lidar"
+      imu_topic: "/livox/imu"
+      img_en: 0
+      lidar_en: 1
+      ros_driver_bug_fix: false
+      enable_image_processing: false
+
+    # This ROS2 port constructs VIO unconditionally, even when img_en=0, and
+    # aborts if camera.model is absent. These inert values only satisfy that
+    # startup contract; they are not a D435i calibration and must never be used
+    # to enable visual fusion.
+    camera:
+      model: Pinhole
+      width: 640
+      height: 480
+      scale: 1.0
+      fx: 525.0
+      fy: 525.0
+      cx: 319.5
+      cy: 239.5
+      d0: 0.0
+      d1: 0.0
+      d2: 0.0
+      d3: 0.0
+
+    extrin_calib:
+      # MID360's IMU is internal/co-located. The bridge applies the same fixed
+      # Rx(pi) mounting correction to both LiDAR and IMU, so their relative
+      # transform remains identity here. Beijing G1 dual-IMU static evidence
+      # matched after Rx(pi) within 1.34 degrees; Shanghai still needs a repeat.
+      extrinsic_T: [0.0, 0.0, 0.0]
+      extrinsic_R: [1.0, 0.0, 0.0,
+                    0.0, 1.0, 0.0,
+                    0.0, 0.0, 1.0]
+      # Camera calibration is intentionally inert while img_en=0.
+      Rcl: [1.0, 0.0, 0.0,
+            0.0, 1.0, 0.0,
+            0.0, 0.0, 1.0]
+      Pcl: [0.0, 0.0, 0.0]
+
+    time_offset:
+      imu_time_offset: 0.0
+      img_time_offset: 0.0
+      exposure_time_init: 0.0
+
+    preprocess:
+      point_filter_num: 1
+      # The PR example's 1 mm leaf overflows PCL's voxel index on G1 and
+      # silently falls back to an unfiltered cloud. Keep enough MID360 detail
+      # while leaving headroom for the 10 Hz estimator loop.
+      filter_size_surf: 0.1
+      lidar_type: 7
+      scan_line: 4
+      blind: 0.5
+
+    vio:
+      max_iterations: 5
+      outlier_threshold: 1000
+      img_point_cov: 100
+      patch_size: 8
+      patch_pyrimid_level: 4
+      normal_en: true
+      raycast_en: false
+      inverse_composition_en: false
+      exposure_estimate_en: false
+      inv_expo_cov: 0.1
+
+    imu:
+      imu_en: true
+      imu_int_frame: 30
+      # Initial MID360 shadow values; N3 requires a stationary noise record.
+      acc_cov: 0.8
+      gyr_cov: 0.5
+      b_acc_cov: 0.001
+      b_gyr_cov: 0.001
+
+    lio:
+      max_iterations: 5
+      dept_err: 0.02
+      beam_err: 0.15
+      min_eigen_value: 0.005
+      voxel_size: 0.5
+      max_layer: 2
+      max_points_num: 50
+      layer_init_num: [5, 5, 5, 5, 5]
+
+    local_map:
+      map_sliding_en: false
+      half_map_size: 100
+      sliding_thresh: 8.0
+
+    uav:
+      imu_rate_odom: false
+      gravity_align_en: true
+
+    publish:
+      dense_map_en: false
+      pub_effect_point_en: false
+      pub_plane_en: false
+      pub_scan_num: 1
+      blind_rgb_points: 0.0
+
+    evo:
+      seq_name: "g1_lio_shadow"
+      pose_output_en: false
+
+    pcd_save:
+      pcd_save_en: false
+      colmap_output_en: false
+      filter_size_pcd: 0.15
+      interval: -1

--- a/unitree/g1/traditional_navigation/merge-g1-rgb-pcd.py
+++ b/unitree/g1/traditional_navigation/merge-g1-rgb-pcd.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Merge atomic FAST-LIVO2 RGB checkpoint PCDs after an unclean shutdown."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import re
+import struct
+import sys
+from typing import BinaryIO
+
+
+SCHEMA_VERSION = 1
+POINT_STRUCT = struct.Struct("<fffI")
+TIMESTAMP_PCD = re.compile(r"^[0-9]+\.[0-9]+\.pcd$")
+EXPECTED_FIELDS = ["x", "y", "z", "rgb"]
+EXPECTED_SIZE = ["4", "4", "4", "4"]
+EXPECTED_TYPE = ["F", "F", "F", "U"]
+EXPECTED_COUNT = ["1", "1", "1", "1"]
+
+
+class RecoveryError(ValueError):
+    """Raised when a checkpoint or recovered artifact is unsafe to consume."""
+
+
+def _read_header(handle: BinaryIO, path: Path) -> tuple[dict[str, list[str]], int]:
+    fields: dict[str, list[str]] = {}
+    while True:
+        line = handle.readline()
+        if not line:
+            raise RecoveryError(f"missing DATA binary header: {path}")
+        try:
+            text = line.decode("ascii").strip()
+        except UnicodeDecodeError as exc:
+            raise RecoveryError(f"non-ASCII PCD header: {path}") from exc
+        if not text or text.startswith("#"):
+            continue
+        parts = text.split()
+        fields[parts[0]] = parts[1:]
+        if parts[0] == "DATA":
+            break
+    return fields, handle.tell()
+
+
+def _one_int(fields: dict[str, list[str]], name: str, path: Path) -> int:
+    values = fields.get(name)
+    if values is None or len(values) != 1:
+        raise RecoveryError(f"invalid {name} header: {path}")
+    try:
+        value = int(values[0])
+    except ValueError as exc:
+        raise RecoveryError(f"non-integer {name} header: {path}") from exc
+    if value < 1:
+        raise RecoveryError(f"{name} must be positive: {path}")
+    return value
+
+
+def inspect_rgb_pcd(path: Path) -> dict[str, int]:
+    with path.open("rb") as handle:
+        fields, payload_offset = _read_header(handle, path)
+    expected = {
+        "FIELDS": EXPECTED_FIELDS,
+        "SIZE": EXPECTED_SIZE,
+        "TYPE": EXPECTED_TYPE,
+        "COUNT": EXPECTED_COUNT,
+        "HEIGHT": ["1"],
+        "DATA": ["binary"],
+    }
+    for name, values in expected.items():
+        if fields.get(name) != values:
+            raise RecoveryError(
+                f"unexpected {name} header in {path}: {fields.get(name)!r}"
+            )
+    width = _one_int(fields, "WIDTH", path)
+    points = _one_int(fields, "POINTS", path)
+    if width != points:
+        raise RecoveryError(f"WIDTH/POINTS mismatch in {path}")
+    expected_size = payload_offset + points * POINT_STRUCT.size
+    actual_size = path.stat().st_size
+    if actual_size != expected_size:
+        raise RecoveryError(
+            f"payload size mismatch in {path}: expected={expected_size} actual={actual_size}"
+        )
+    return {
+        "points": points,
+        "payload_offset": payload_offset,
+        "bytes": actual_size,
+    }
+
+
+def _output_header(points: int) -> bytes:
+    return (
+        "# .PCD v0.7 - Point Cloud Data file format\n"
+        "VERSION 0.7\n"
+        "FIELDS x y z rgb\n"
+        "SIZE 4 4 4 4\n"
+        "TYPE F F F U\n"
+        "COUNT 1 1 1 1\n"
+        f"WIDTH {points}\n"
+        "HEIGHT 1\n"
+        "VIEWPOINT 0 0 0 1 0 0 0\n"
+        f"POINTS {points}\n"
+        "DATA binary\n"
+    ).encode("ascii")
+
+
+def _atomic_json(path: Path, payload: dict[str, object]) -> None:
+    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    try:
+        with temporary.open("x", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _is_nonempty_all_zero(path: Path) -> bool:
+    if path.stat().st_size < 1:
+        return False
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            if any(chunk):
+                return False
+    return True
+
+
+def merge_checkpoints(
+    input_dir: Path,
+    output: Path,
+    manifest: Path,
+    reason: str,
+    skip_zero_filled_checkpoints: bool = False,
+) -> dict[str, object]:
+    input_dir = input_dir.resolve()
+    output = output.resolve()
+    manifest = manifest.resolve()
+    if not input_dir.is_dir():
+        raise RecoveryError(f"input directory does not exist: {input_dir}")
+    if output.parent != input_dir or manifest.parent != input_dir:
+        raise RecoveryError("output and manifest must stay inside the input directory")
+    sources = sorted(
+        (
+            path
+            for path in input_dir.iterdir()
+            if path.is_file() and TIMESTAMP_PCD.fullmatch(path.name)
+        ),
+        key=lambda path: tuple(int(part) for part in path.stem.split(".")),
+    )
+    if not sources:
+        raise RecoveryError(f"no timestamp RGB checkpoint PCDs in {input_dir}")
+
+    inspected: list[tuple[Path, dict[str, int]]] = []
+    skipped: list[dict[str, object]] = []
+    for path in sources:
+        try:
+            inspected.append((path, inspect_rgb_pcd(path)))
+        except RecoveryError:
+            if not skip_zero_filled_checkpoints or not _is_nonempty_all_zero(path):
+                raise
+            skipped.append(
+                {
+                    "name": path.name,
+                    "bytes": path.stat().st_size,
+                    "reason": "all_zero_after_unclean_shutdown",
+                }
+            )
+    if not inspected:
+        raise RecoveryError("no valid RGB checkpoint PCDs remain after recovery filtering")
+
+    total_points = sum(int(info["points"]) for _, info in inspected)
+    source_bytes = sum(int(info["bytes"]) for _, info in inspected)
+    header = _output_header(total_points)
+    temporary = output.with_name(f".{output.name}.tmp.{os.getpid()}")
+    digest = hashlib.sha256()
+    bounds = {
+        "x": [math.inf, -math.inf],
+        "y": [math.inf, -math.inf],
+        "z": [math.inf, -math.inf],
+    }
+    nonzero_rgb_points = 0
+    written_points = 0
+
+    try:
+        with temporary.open("xb") as destination:
+            destination.write(header)
+            digest.update(header)
+            for path, info in inspected:
+                with path.open("rb") as source:
+                    source.seek(int(info["payload_offset"]))
+                    remaining = int(info["points"]) * POINT_STRUCT.size
+                    while remaining:
+                        chunk = source.read(min(1024 * 1024, remaining))
+                        if not chunk:
+                            raise RecoveryError(f"short payload read: {path}")
+                        if len(chunk) % POINT_STRUCT.size:
+                            raise RecoveryError(f"unaligned payload chunk: {path}")
+                        for x, y, z, rgb in POINT_STRUCT.iter_unpack(chunk):
+                            if not (math.isfinite(x) and math.isfinite(y) and math.isfinite(z)):
+                                raise RecoveryError(f"non-finite point in {path}")
+                            bounds["x"][0] = min(bounds["x"][0], x)
+                            bounds["x"][1] = max(bounds["x"][1], x)
+                            bounds["y"][0] = min(bounds["y"][0], y)
+                            bounds["y"][1] = max(bounds["y"][1], y)
+                            bounds["z"][0] = min(bounds["z"][0], z)
+                            bounds["z"][1] = max(bounds["z"][1], z)
+                            nonzero_rgb_points += int(rgb != 0)
+                        destination.write(chunk)
+                        digest.update(chunk)
+                        written_points += len(chunk) // POINT_STRUCT.size
+                        remaining -= len(chunk)
+            destination.flush()
+            os.fsync(destination.fileno())
+        if written_points != total_points:
+            raise RecoveryError(
+                f"point count changed during merge: expected={total_points} actual={written_points}"
+            )
+        os.replace(temporary, output)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+    result: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "recovered_after_unclean_shutdown",
+        "reason": reason,
+        "source_directory": str(input_dir),
+        "candidate_source_count": len(sources),
+        "sources": [
+            {
+                "name": path.name,
+                "points": int(info["points"]),
+                "bytes": int(info["bytes"]),
+            }
+            for path, info in inspected
+        ],
+        "source_count": len(inspected),
+        "source_bytes": source_bytes,
+        "skipped_source_count": len(skipped),
+        "skipped_source_bytes": sum(int(item["bytes"]) for item in skipped),
+        "skipped_sources": skipped,
+        "output": output.name,
+        "output_bytes": output.stat().st_size,
+        "output_points": total_points,
+        "output_sha256": f"sha256:{digest.hexdigest()}",
+        "nonzero_rgb_points": nonzero_rgb_points,
+        "bounds_m": {
+            axis: [round(values[0], 6), round(values[1], 6)]
+            for axis, values in bounds.items()
+        },
+        "clean_shutdown": False,
+        "unsaved_tail_recovered": False,
+    }
+    _atomic_json(manifest, result)
+    return result
+
+
+def validate_recovery(output: Path, manifest: Path) -> dict[str, object]:
+    with manifest.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise RecoveryError("unsupported recovery manifest schema")
+    if payload.get("status") != "recovered_after_unclean_shutdown":
+        raise RecoveryError("manifest is not an unclean-shutdown recovery")
+    if payload.get("clean_shutdown") is not False:
+        raise RecoveryError("manifest incorrectly claims a clean shutdown")
+    skipped = payload.get("skipped_sources")
+    if not isinstance(skipped, list):
+        raise RecoveryError("manifest skipped source list is missing")
+    if payload.get("skipped_source_count") != len(skipped):
+        raise RecoveryError("manifest skipped source count mismatch")
+    for item in skipped:
+        if (
+            not isinstance(item, dict)
+            or not isinstance(item.get("name"), str)
+            or TIMESTAMP_PCD.fullmatch(item["name"]) is None
+            or not isinstance(item.get("bytes"), int)
+            or item["bytes"] < 1
+            or item.get("reason") != "all_zero_after_unclean_shutdown"
+        ):
+            raise RecoveryError("manifest contains an invalid skipped source")
+    if payload.get("output") != output.name:
+        raise RecoveryError("manifest output name mismatch")
+    info = inspect_rgb_pcd(output)
+    if payload.get("output_points") != info["points"]:
+        raise RecoveryError("manifest output point count mismatch")
+    digest = hashlib.sha256()
+    with output.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    if payload.get("output_sha256") != f"sha256:{digest.hexdigest()}":
+        raise RecoveryError("recovered PCD checksum mismatch")
+    return payload
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-dir", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument(
+        "--reason",
+        default="fast_livo2_exit_255_after_host_reboot",
+    )
+    parser.add_argument("--skip-zero-filled-checkpoints", action="store_true")
+    parser.add_argument("--validate", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        if args.validate:
+            result = validate_recovery(args.output, args.manifest)
+            action = "validate"
+        else:
+            if args.input_dir is None:
+                raise RecoveryError("--input-dir is required unless --validate is used")
+            result = merge_checkpoints(
+                args.input_dir,
+                args.output,
+                args.manifest,
+                args.reason,
+                args.skip_zero_filled_checkpoints,
+            )
+            action = "merge"
+    except (OSError, RecoveryError, json.JSONDecodeError) as exc:
+        print(f"rgb_pcd_recovery=FAIL error={exc}", file=sys.stderr)
+        return 1
+    bounds = result["bounds_m"]
+    print(
+        "rgb_pcd_recovery=PASS"
+        f" action={action}"
+        f" sources={result['source_count']}"
+        f" skipped_zero_filled={result['skipped_source_count']}"
+        f" points={result['output_points']}"
+        f" bytes={result['output_bytes']}"
+        f" nonzero_rgb={result['nonzero_rgb_points']}"
+        f" x_m={bounds['x']}"
+        f" y_m={bounds['y']}"
+        f" z_m={bounds['z']}"
+        f" clean_shutdown={str(result['clean_shutdown']).lower()}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unitree/g1/traditional_navigation/probe-g1-rgb-profile.py
+++ b/unitree/g1/traditional_navigation/probe-g1-rgb-profile.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Read the live G1 model and D435i factory profile without starting a stream."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import threading
+import time
+
+
+def main() -> int:
+    network_interface = sys.argv[1] if len(sys.argv) > 1 else "eth0"
+    expected_width = int(sys.argv[2]) if len(sys.argv) > 2 else 1920
+    expected_height = int(sys.argv[3]) if len(sys.argv) > 3 else 1080
+    expected_fps = int(sys.argv[4]) if len(sys.argv) > 4 else 15
+
+    import pyrealsense2 as rs
+
+    from unitree_sdk2py.core.channel import ChannelFactoryInitialize, ChannelSubscriber
+    from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowState_
+
+    ChannelFactoryInitialize(0, network_interface)
+    lowstate: dict[str, int] = {}
+    received = threading.Event()
+
+    def on_lowstate(message) -> None:
+        lowstate["mode_machine"] = int(message.mode_machine)
+        lowstate["mode_pr"] = int(message.mode_pr)
+        received.set()
+
+    subscriber = ChannelSubscriber("rt/lowstate", LowState_)
+    subscriber.Init(on_lowstate, 10)
+    if not received.wait(8):
+        raise RuntimeError("timed out waiting for rt/lowstate")
+
+    context = rs.context()
+    devices = context.query_devices()
+    if len(devices) != 1:
+        raise RuntimeError(f"expected exactly one RealSense device, found {len(devices)}")
+    device = devices[0]
+    profiles = [
+        profile
+        for sensor in device.query_sensors()
+        for profile in sensor.get_stream_profiles()
+    ]
+
+    def video_profile(stream, width, height, fps, pixel_format):
+        return next(
+            profile
+            for profile in profiles
+            if profile.stream_type() == stream
+            and profile.as_video_stream_profile().width() == width
+            and profile.as_video_stream_profile().height() == height
+            and profile.fps() == fps
+            and profile.format() == pixel_format
+        )
+
+    color = video_profile(
+        rs.stream.color,
+        expected_width,
+        expected_height,
+        expected_fps,
+        rs.format.bgr8,
+    )
+    depth = video_profile(rs.stream.depth, 640, 480, 15, rs.format.z16)
+    intrinsics = color.as_video_stream_profile().get_intrinsics()
+    depth_to_color = depth.get_extrinsics_to(color)
+    global_time = [
+        {
+            "sensor": sensor.get_info(rs.camera_info.name),
+            "enabled": bool(sensor.get_option(rs.option.global_time_enabled)),
+        }
+        for sensor in device.query_sensors()
+        if sensor.supports(rs.option.global_time_enabled)
+    ]
+
+    print(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "captured_at_epoch_ns": time.time_ns(),
+                "boot_id": Path("/proc/sys/kernel/random/boot_id")
+                .read_text(encoding="utf-8")
+                .strip(),
+                "mode_machine": lowstate["mode_machine"],
+                "mode_pr": lowstate["mode_pr"],
+                "network_interface": network_interface,
+                "d435i": {
+                    "serial": device.get_info(rs.camera_info.serial_number),
+                    "model": device.get_info(rs.camera_info.name),
+                    "color": {
+                        "width": intrinsics.width,
+                        "height": intrinsics.height,
+                        "fps": color.fps(),
+                        "format": "bgr8",
+                        "intrinsics": {
+                            "fx": intrinsics.fx,
+                            "fy": intrinsics.fy,
+                            "ppx": intrinsics.ppx,
+                            "ppy": intrinsics.ppy,
+                            "distortion_model": str(intrinsics.model).removeprefix(
+                                "distortion."
+                            ),
+                            "coeffs": list(intrinsics.coeffs),
+                        },
+                    },
+                    "depth_to_color_optical": {
+                        # librealsense exposes this matrix in column-major order.
+                        "rotation_column_major": list(depth_to_color.rotation),
+                        "translation_m": list(depth_to_color.translation),
+                    },
+                    "global_time": global_time,
+                },
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        ),
+        # stdout is a pipe through ssh/docker exec.  Flush before native DDS and
+        # librealsense destructors run so a fast interpreter teardown cannot
+        # leave the caller with a successful-but-empty probe file.
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unitree/g1/traditional_navigation/probe-g1-rgb-time-offset.py
+++ b/unitree/g1/traditional_navigation/probe-g1-rgb-time-offset.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Measure the G1 D435I callback-arrival offset from RealSense GLOBAL_TIME.
+
+The released G1 Driver timestamps RGB messages when the librealsense callback
+arrives.  This probe opens the same color profile exclusively, compares host
+delivery time with each frame's GLOBAL_TIME timestamp, and emits the fixed
+offset that FAST-LIVO2 should add to those callback-arrival ROS headers.
+
+It does not measure camera-to-LiDAR spatial extrinsics or prove end-to-end
+cross-sensor synchronization.  The result is intentionally preview evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+import statistics
+import sys
+import time
+from typing import Any
+
+
+PROBE_TYPE = "g1_realsense_callback_latency"
+MAX_OFFSET_ABS_S = 0.5
+MAX_P95_RESIDUAL_MS = 20.0
+MIN_SAMPLES = 30
+
+
+def percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        raise ValueError("cannot calculate a percentile from an empty sample")
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def canonical_id(data: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        data,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def build_result(
+    *,
+    serial: str,
+    boot_id: str,
+    width: int,
+    height: int,
+    fps: int,
+    timestamp_domain: str,
+    latencies_ms: list[float],
+    exposures_us: list[float],
+) -> dict[str, Any]:
+    if len(latencies_ms) < MIN_SAMPLES:
+        raise ValueError(f"need at least {MIN_SAMPLES} latency samples")
+    median_ms = statistics.median(latencies_ms)
+    residuals_ms = [abs(value - median_ms) for value in latencies_ms]
+    data: dict[str, Any] = {
+        "schema_version": 1,
+        "probe_type": PROBE_TYPE,
+        "captured_at_epoch_ns": time.time_ns(),
+        "boot_id": boot_id,
+        "d435i": {
+            "serial": serial,
+            "color": {
+                "width": width,
+                "height": height,
+                "fps": fps,
+                "format": "bgr8",
+            },
+        },
+        "measurement": {
+            "method": "realsense_global_time_to_host_delivery_proxy",
+            "timestamp_domain": timestamp_domain,
+            "sample_count": len(latencies_ms),
+            "callback_latency_ms": {
+                "min": min(latencies_ms),
+                "median": median_ms,
+                "p95": percentile(latencies_ms, 0.95),
+                "max": max(latencies_ms),
+            },
+            "recommended_img_time_offset_s": -median_ms / 1000.0,
+            "p95_abs_residual_ms": percentile(residuals_ms, 0.95),
+            "exposure_us": {
+                "median": statistics.median(exposures_us),
+                "p95": percentile(exposures_us, 0.95),
+            }
+            if exposures_us
+            else None,
+        },
+    }
+    return {**data, "probe_id": canonical_id(data)}
+
+
+def validate_result(result: Any) -> dict[str, Any]:
+    if not isinstance(result, dict):
+        raise ValueError("time-offset probe root must be an object")
+    if result.get("schema_version") != 1 or result.get("probe_type") != PROBE_TYPE:
+        raise ValueError("unsupported time-offset probe schema/type")
+
+    payload = {key: value for key, value in result.items() if key != "probe_id"}
+    if result.get("probe_id") != canonical_id(payload):
+        raise ValueError("time-offset probe_id does not match canonical SHA256")
+
+    boot_id = str(result.get("boot_id", "")).strip()
+    d435i = result.get("d435i")
+    measurement = result.get("measurement")
+    if not boot_id or not isinstance(d435i, dict) or not isinstance(measurement, dict):
+        raise ValueError("time-offset probe identity/measurement is incomplete")
+    serial = str(d435i.get("serial", "")).strip()
+    color = d435i.get("color")
+    if not serial or not isinstance(color, dict):
+        raise ValueError("time-offset probe D435I identity/profile is incomplete")
+    profile = (int(color.get("width", 0)), int(color.get("height", 0)), int(color.get("fps", 0)))
+    if any(value <= 0 for value in profile):
+        raise ValueError("time-offset probe color profile is invalid")
+
+    if measurement.get("timestamp_domain") != "global_time":
+        raise ValueError("RealSense frame timestamp domain must be global_time")
+    sample_count = int(measurement.get("sample_count", 0))
+    if sample_count < MIN_SAMPLES:
+        raise ValueError(f"time-offset probe requires at least {MIN_SAMPLES} samples")
+    offset_s = float(measurement.get("recommended_img_time_offset_s"))
+    residual_ms = float(measurement.get("p95_abs_residual_ms"))
+    if not math.isfinite(offset_s) or abs(offset_s) > MAX_OFFSET_ABS_S:
+        raise ValueError("recommended img_time_offset is outside +/-0.5 s")
+    if not math.isfinite(residual_ms) or not 0.0 <= residual_ms <= MAX_P95_RESIDUAL_MS:
+        raise ValueError("callback latency residual p95 exceeds 20 ms")
+
+    return {
+        "probe_id": result["probe_id"],
+        "boot_id": boot_id,
+        "serial": serial,
+        "profile": profile,
+        "offset_s": offset_s,
+        "p95_residual_ms": residual_ms,
+        "sample_count": sample_count,
+    }
+
+
+def capture(args: argparse.Namespace) -> dict[str, Any]:
+    import pyrealsense2 as rs
+
+    context = rs.context()
+    devices = context.query_devices()
+    if len(devices) != 1:
+        raise RuntimeError(f"expected exactly one RealSense device, found {len(devices)}")
+    device = devices[0]
+    serial = device.get_info(rs.camera_info.serial_number)
+
+    color_sensor = next(
+        sensor
+        for sensor in device.query_sensors()
+        if sensor.get_info(rs.camera_info.name) == "RGB Camera"
+    )
+    if not color_sensor.supports(rs.option.global_time_enabled):
+        raise RuntimeError("D435I RGB sensor does not support global_time_enabled")
+    color_sensor.set_option(rs.option.global_time_enabled, 1.0)
+
+    pipeline = rs.pipeline(context)
+    config = rs.config()
+    config.enable_device(serial)
+    config.enable_stream(
+        rs.stream.color,
+        args.width,
+        args.height,
+        rs.format.bgr8,
+        args.fps,
+    )
+
+    latencies_ms: list[float] = []
+    exposures_us: list[float] = []
+    timestamp_domains: set[str] = set()
+    pipeline.start(config)
+    try:
+        total = args.warmup + args.samples
+        for index in range(total):
+            frameset = pipeline.wait_for_frames(5000)
+            arrival_epoch_ns = time.time_ns()
+            color_frame = frameset.get_color_frame()
+            if not color_frame:
+                raise RuntimeError("frameset did not contain a color frame")
+            if index < args.warmup:
+                continue
+
+            domain = str(color_frame.get_frame_timestamp_domain()).split(".")[-1]
+            timestamp_domains.add(domain)
+            capture_epoch_ns = int(round(float(color_frame.get_timestamp()) * 1_000_000.0))
+            latency_ms = (arrival_epoch_ns - capture_epoch_ns) / 1_000_000.0
+            if not -5.0 <= latency_ms <= 500.0:
+                raise RuntimeError(
+                    "RealSense GLOBAL_TIME is not comparable with host CLOCK_REALTIME: "
+                    f"latency_ms={latency_ms:.3f}"
+                )
+            latencies_ms.append(latency_ms)
+            try:
+                if color_frame.supports_frame_metadata(
+                    rs.frame_metadata_value.actual_exposure
+                ):
+                    exposures_us.append(
+                        float(
+                            color_frame.get_frame_metadata(
+                                rs.frame_metadata_value.actual_exposure
+                            )
+                        )
+                    )
+            except RuntimeError:
+                pass
+    finally:
+        pipeline.stop()
+
+    if timestamp_domains != {"global_time"}:
+        raise RuntimeError(
+            "unexpected RealSense timestamp domains: " + ",".join(sorted(timestamp_domains))
+        )
+    return build_result(
+        serial=serial,
+        boot_id=Path("/proc/sys/kernel/random/boot_id").read_text(encoding="utf-8").strip(),
+        width=args.width,
+        height=args.height,
+        fps=args.fps,
+        timestamp_domain="global_time",
+        latencies_ms=latencies_ms,
+        exposures_us=exposures_us,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--validate", type=Path)
+    parser.add_argument("--width", type=int, default=1920)
+    parser.add_argument("--height", type=int, default=1080)
+    parser.add_argument("--fps", type=int, default=15)
+    parser.add_argument("--samples", type=int, default=120)
+    parser.add_argument("--warmup", type=int, default=30)
+    args = parser.parse_args()
+
+    try:
+        if args.validate is not None:
+            with args.validate.open(encoding="utf-8") as handle:
+                result = json.load(handle)
+            summary = validate_result(result)
+            print(
+                "rgb_time_probe=PASS "
+                f"serial={summary['serial']} "
+                f"offset_s={summary['offset_s']:.9f} "
+                f"p95_residual_ms={summary['p95_residual_ms']:.3f} "
+                f"samples={summary['sample_count']}"
+            )
+            return 0
+        if args.samples < MIN_SAMPLES:
+            raise ValueError(f"--samples must be at least {MIN_SAMPLES}")
+        if args.warmup < 1:
+            raise ValueError("--warmup must be positive")
+        result = capture(args)
+        validate_result(result)
+        print(json.dumps(result, ensure_ascii=False, sort_keys=True), flush=True)
+        return 0
+    except (
+        OSError,
+        RuntimeError,
+        StopIteration,
+        TypeError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as error:
+        print(f"rgb_time_probe=FAIL error={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unitree/g1/traditional_navigation/probe-g1-rgb-time-offset.sh
+++ b/unitree/g1/traditional_navigation/probe-g1-rgb-time-offset.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly PROBE_SCRIPT="${SCRIPT_DIR}/probe-g1-rgb-time-offset.py"
+readonly SSH_TARGET="${1:-}"
+readonly SAMPLE_COUNT="${2:-120}"
+readonly OUTPUT_PATH="${G1_RGB_TIME_PROBE_OUTPUT:-/private/tmp/g1-rgb-time-offset.json}"
+readonly DRIVER_CONTAINER="embodied-unitree-g1"
+readonly SSH_OPTS=(
+  -o ClearAllForwardings=yes
+  -o ControlMaster=no
+  -o ControlPath=none
+  -o BatchMode=yes
+  -o ConnectTimeout=8
+)
+
+usage() {
+  echo "Usage: CONFIRM_G1_SHADOW_WRITE=YES $0 <ssh-target> [sample-count]" >&2
+  echo "Output: G1_RGB_TIME_PROBE_OUTPUT=/private/tmp/g1-rgb-time-offset.json" >&2
+}
+
+if (( $# < 1 || $# > 2 )); then
+  usage
+  exit 2
+fi
+[[ "${SSH_TARGET}" =~ ^[a-zA-Z0-9_.@-]+$ ]] || {
+  echo "invalid ssh target: ${SSH_TARGET}" >&2
+  exit 2
+}
+if ! [[ "${SAMPLE_COUNT}" =~ ^[1-9][0-9]{1,2}$ ]] || \
+   (( SAMPLE_COUNT < 30 || SAMPLE_COUNT > 600 )); then
+  echo "sample-count must be an integer from 30 to 600" >&2
+  exit 2
+fi
+test -f "${PROBE_SCRIPT}" || {
+  echo "missing probe: ${PROBE_SCRIPT}" >&2
+  exit 1
+}
+test -d "$(dirname -- "${OUTPUT_PATH}")" || {
+  echo "output directory does not exist: $(dirname -- "${OUTPUT_PATH}")" >&2
+  exit 1
+}
+if [[ "${CONFIRM_G1_SHADOW_WRITE:-}" != "YES" ]]; then
+  echo "Refusing robot write. This probe temporarily stops and restores ${DRIVER_CONTAINER}." >&2
+  exit 2
+fi
+
+temporary_output="$(mktemp /private/tmp/g1-rgb-time-offset.XXXXXX)"
+cleanup() {
+  rm -f -- "${temporary_output}"
+}
+trap cleanup EXIT
+
+echo "[time-sync] temporarily release D435I, sample GLOBAL_TIME, then restore Driver" >&2
+ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+  set -euo pipefail
+  driver='${DRIVER_CONTAINER}'
+  current_mode=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.mode\"}}' 2>/dev/null || true)\"
+  if test \"\${current_mode}\" = mapping || test \"\${current_mode}\" = rgb_preview; then
+    echo \"refusing time probe while controlled write mode is active: \${current_mode}\" >&2
+    exit 1
+  fi
+  test \"\$(docker inspect \"\${driver}\" --format '{{.State.Running}}')\" = true
+  driver_image=\"\$(docker inspect \"\${driver}\" --format '{{.Config.Image}}')\"
+  test -n \"\${driver_image}\"
+  realsense_present=0
+  for vendor_file in /sys/bus/usb/devices/*/idVendor; do
+    device_dir=\"\${vendor_file%/idVendor}\"
+    if test -r \"\${vendor_file}\" && \
+       test -r \"\${device_dir}/idProduct\" && \
+       test \"\$(cat \"\${vendor_file}\")\" = 8086 && \
+       test \"\$(cat \"\${device_dir}/idProduct\")\" = 0b3a; then
+      realsense_present=1
+      break
+    fi
+  done
+  test \"\${realsense_present}\" = 1 || {
+    echo \"Intel RealSense D435I USB device 8086:0b3a is not present\" >&2
+    exit 1
+  }
+
+  driver_stopped=0
+  restore_driver() {
+    if test \"\${driver_stopped}\" = 1; then
+      docker start \"\${driver}\" >/dev/null
+      driver_stopped=0
+    fi
+  }
+  trap restore_driver EXIT INT TERM
+
+  driver_stopped=1
+  docker stop -t 20 \"\${driver}\" >/dev/null
+  docker run --rm -i \
+    --privileged \
+    --network host \
+    --ipc host \
+    -v /dev:/dev \
+    --entrypoint python3 \
+    \"\${driver_image}\" - \
+      --width 1920 --height 1080 --fps 15 \
+      --samples '${SAMPLE_COUNT}' --warmup 30
+  restore_driver
+  trap - EXIT INT TERM
+  test \"\$(docker inspect \"\${driver}\" --format '{{.State.Running}}')\" = true
+" < "${PROBE_SCRIPT}" > "${temporary_output}"
+
+summary="$(python3 "${PROBE_SCRIPT}" --validate "${temporary_output}")"
+install -m 0600 "${temporary_output}" "${OUTPUT_PATH}"
+printf '%s\n' "${summary}"
+printf 'output=%s\n' "${OUTPUT_PATH}"
+printf 'next_env=G1_RGB_TIME_PROBE=%q\n' "${OUTPUT_PATH}"

--- a/unitree/g1/traditional_navigation/recover-g1-rgb-preview.sh
+++ b/unitree/g1/traditional_navigation/recover-g1-rgb-preview.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly MERGE_SCRIPT="${SCRIPT_DIR}/merge-g1-rgb-pcd.py"
+readonly DEPLOY_SCRIPT="${SCRIPT_DIR}/deploy-g1-navigation-shadow.sh"
+readonly SSH_TARGET="${1:-}"
+readonly ROS_NAMESPACE_VALUE="${2:-ubuntu}"
+readonly NETWORK_INTERFACE_VALUE="${3:-eth0}"
+readonly MAP_NAME="${G1_MAP_NAME:-}"
+readonly REMOTE_MAP_ROOT="/home/unitree/phanthy-navigation-maps"
+readonly REMOTE_MAP_DIR="${REMOTE_MAP_ROOT}/${MAP_NAME}"
+readonly RECOVERED_PCD="${REMOTE_MAP_DIR}/all_rgb_points.recovered.pcd"
+readonly RECOVERY_MANIFEST="${REMOTE_MAP_DIR}/rgb-recovery-manifest.json"
+readonly SSH_OPTS=(
+  -o ClearAllForwardings=yes
+  -o ControlMaster=no
+  -o ControlPath=none
+  -o BatchMode=yes
+  -o ConnectTimeout=8
+)
+
+usage() {
+  echo "Usage: G1_MAP_NAME=<map> CONFIRM_G1_SHADOW_WRITE=YES $0 <ssh-target> [ros-namespace] [network-interface]" >&2
+}
+
+if (( $# < 1 || $# > 3 )); then
+  usage
+  exit 2
+fi
+[[ "${SSH_TARGET}" =~ ^[a-zA-Z0-9_.@-]+$ ]] || {
+  echo "invalid ssh target: ${SSH_TARGET}" >&2
+  exit 2
+}
+[[ "${MAP_NAME}" =~ ^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$ ]] || {
+  echo "G1_MAP_NAME must match [a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}" >&2
+  exit 2
+}
+[[ "${ROS_NAMESPACE_VALUE}" =~ ^[a-zA-Z0-9_/-]+$ ]] || {
+  echo "invalid ROS namespace: ${ROS_NAMESPACE_VALUE}" >&2
+  exit 2
+}
+[[ "${NETWORK_INTERFACE_VALUE}" =~ ^[a-zA-Z0-9_.:-]+$ ]] || {
+  echo "invalid network interface: ${NETWORK_INTERFACE_VALUE}" >&2
+  exit 2
+}
+if [[ "${CONFIRM_G1_SHADOW_WRITE:-}" != "YES" ]]; then
+  echo "Refusing robot write. Recovery creates an aggregate PCD and restores ordinary LIO." >&2
+  exit 2
+fi
+test -f "${MERGE_SCRIPT}" || {
+  echo "missing merge utility: ${MERGE_SCRIPT}" >&2
+  exit 1
+}
+test -x "${DEPLOY_SCRIPT}" || {
+  echo "missing deploy utility: ${DEPLOY_SCRIPT}" >&2
+  exit 1
+}
+
+echo "[preflight] validate interrupted RGB preview identity"
+ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "
+  set -euo pipefail
+  test \"\$(docker inspect embodied-unitree-g1 --format '{{.State.Running}}')\" = true
+  actual_running=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{.State.Running}}')\"
+  actual_exit=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{.State.ExitCode}}')\"
+  actual_mode=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.mode\"}}')\"
+  actual_map=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{index .Config.Labels \"com.phanthy.navigation.map_name\"}}')\"
+  actual_dir=\"\$(docker inspect phanthy-fast-livo2-shadow --format '{{range .Mounts}}{{if eq .Destination \"/opt/fast_livo_ws/src/fast_livo/Log/pcd\"}}{{.Source}}{{end}}{{end}}')\"
+  if ! { test \"\${actual_running}\" = false && \
+         test \"\${actual_exit}\" = 255 && \
+         test \"\${actual_mode}\" = rgb_preview && \
+         test \"\${actual_map}\" = '${MAP_NAME}' && \
+         test \"\${actual_dir}\" = '${REMOTE_MAP_DIR}'; }; then
+    echo \"refusing RGB recovery identity mismatch: requested_map=${MAP_NAME} running=\${actual_running} exit=\${actual_exit} mode=\${actual_mode} actual_map=\${actual_map} actual_dir=\${actual_dir}\" >&2
+    exit 1
+  fi
+  test -s '${REMOTE_MAP_DIR}/rgb-preview-calibration.json'
+  test -s '${REMOTE_MAP_DIR}/lidar_poses.txt'
+  source_count=\"\$(find '${REMOTE_MAP_DIR}' -maxdepth 1 -type f \
+    -regextype posix-extended -regex '.*/[0-9]+\.[0-9]+\.pcd' -size +0c | wc -l)\"
+  test \"\${source_count}\" -ge 1
+  echo \"map_name=${MAP_NAME} state=interrupted_rgb_preview exit=\${actual_exit} source_count=\${source_count}\"
+"
+
+echo "[recover] atomically merge RGB checkpoint PCDs"
+ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" \
+  "python3 - \
+    --input-dir '${REMOTE_MAP_DIR}' \
+    --output '${RECOVERED_PCD}' \
+    --manifest '${RECOVERY_MANIFEST}' \
+    --skip-zero-filled-checkpoints" \
+  < "${MERGE_SCRIPT}"
+
+echo "[recover] restore ordinary read-only LIO"
+CONFIRM_G1_SHADOW_WRITE=YES \
+  "${DEPLOY_SCRIPT}" resume \
+  "${SSH_TARGET}" "${ROS_NAMESPACE_VALUE}" "${NETWORK_INTERFACE_VALUE}"
+
+echo "[verify] recovered RGB artifact"
+ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" \
+  "python3 - \
+    --validate \
+    --output '${RECOVERED_PCD}' \
+    --manifest '${RECOVERY_MANIFEST}'" \
+  < "${MERGE_SCRIPT}"
+
+echo "RGB preview recovered after unclean shutdown."
+echo "Recovered map: ${RECOVERED_PCD}"
+echo "Manifest: ${RECOVERY_MANIFEST}"

--- a/unitree/g1/traditional_navigation/render-g1-livo-config.py
+++ b/unitree/g1/traditional_navigation/render-g1-livo-config.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Render a runnable FAST-LIVO2 RGB config from a verified G1 calibration.
+
+The input is the sensor-collector calibration snapshot.  This renderer is
+deliberately fail-closed: factory camera intrinsics alone are insufficient.
+The snapshot must also carry a verified LiDAR-to-color transform and measured
+camera/LiDAR time alignment for the exact runtime color profile.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import tempfile
+from typing import Any
+
+
+ALLOWED_EVIDENCE_STATUS = {"calibrated", "measured", "verified"}
+ALLOWED_TIMESTAMP_SOURCES = {
+    "realsense_global_time",
+    "realsense_hardware_clock",
+}
+NOMINAL_PREVIEW_EXTRINSIC_STATUS = "nominal_public_urdf"
+NOMINAL_PREVIEW_ALIGNMENT_STATUS = "preview_only"
+NOMINAL_PREVIEW_TIMESTAMP_SOURCE = "callback_arrival_preview"
+
+
+def _mapping(value: Any, path: str, blockers: list[str]) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    blockers.append(f"{path} 缺失或不是 object")
+    return {}
+
+
+def _finite_number(value: Any, path: str, blockers: list[str]) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        blockers.append(f"{path} 必须是有限数值")
+        return 0.0
+    if not math.isfinite(result):
+        blockers.append(f"{path} 必须是有限数值")
+        return 0.0
+    return result
+
+
+def _number_list(value: Any, size: int, path: str, blockers: list[str]) -> list[float]:
+    if not isinstance(value, list) or len(value) != size:
+        blockers.append(f"{path} 必须包含 {size} 个数值")
+        return [0.0] * size
+    return [_finite_number(item, f"{path}[{index}]", blockers) for index, item in enumerate(value)]
+
+
+def _validate_rotation(rotation: list[float], blockers: list[str]) -> None:
+    rows = [rotation[0:3], rotation[3:6], rotation[6:9]]
+    tolerance = 5e-3
+    for index, row in enumerate(rows):
+        norm = math.sqrt(sum(value * value for value in row))
+        if abs(norm - 1.0) > tolerance:
+            blockers.append(f"LiDAR→相机旋转矩阵第 {index + 1} 行未归一化")
+    for left in range(3):
+        for right in range(left + 1, 3):
+            dot = sum(rows[left][axis] * rows[right][axis] for axis in range(3))
+            if abs(dot) > tolerance:
+                blockers.append("LiDAR→相机旋转矩阵不正交")
+                return
+    determinant = (
+        rotation[0] * (rotation[4] * rotation[8] - rotation[5] * rotation[7])
+        - rotation[1] * (rotation[3] * rotation[8] - rotation[5] * rotation[6])
+        + rotation[2] * (rotation[3] * rotation[7] - rotation[4] * rotation[6])
+    )
+    if abs(determinant - 1.0) > tolerance:
+        blockers.append("LiDAR→相机旋转矩阵 determinant 必须接近 +1")
+
+
+def validate_snapshot(
+    snapshot: dict[str, Any],
+    expected_width: int,
+    expected_height: int,
+    expected_fps: int,
+    allow_nominal_preview: bool = False,
+) -> tuple[dict[str, Any], list[str]]:
+    blockers: list[str] = []
+    data = _mapping(snapshot.get("data"), "data", blockers)
+
+    encoded = json.dumps(
+        data,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    actual_calibration_id = "sha256:" + hashlib.sha256(encoded).hexdigest()
+    declared_calibration_id = str(snapshot.get("calibration_id", ""))
+    if declared_calibration_id != actual_calibration_id:
+        blockers.append("calibration_id 与 data 的规范化 SHA256 不一致")
+
+    d435i = _mapping(data.get("d435i"), "data.d435i", blockers)
+    identity = _mapping(d435i.get("identity"), "data.d435i.identity", blockers)
+    serial = str(identity.get("serial", "")).strip()
+    if not serial:
+        blockers.append("D435i serial 缺失")
+
+    profiles = _mapping(d435i.get("profiles"), "data.d435i.profiles", blockers)
+    color = _mapping(profiles.get("color"), "data.d435i.profiles.color", blockers)
+    width = int(_finite_number(color.get("width"), "color.width", blockers))
+    height = int(_finite_number(color.get("height"), "color.height", blockers))
+    fps = int(_finite_number(color.get("fps"), "color.fps", blockers))
+    if (width, height, fps) != (expected_width, expected_height, expected_fps):
+        blockers.append(
+            "D435i 标定 profile "
+            f"{width}x{height}@{fps} 与运行 profile "
+            f"{expected_width}x{expected_height}@{expected_fps} 不一致"
+        )
+
+    intrinsics = _mapping(color.get("intrinsics"), "color.intrinsics", blockers)
+    fx = _finite_number(intrinsics.get("fx"), "color.intrinsics.fx", blockers)
+    fy = _finite_number(intrinsics.get("fy"), "color.intrinsics.fy", blockers)
+    cx = _finite_number(
+        intrinsics.get("cx", intrinsics.get("ppx")),
+        "color.intrinsics.cx/ppx",
+        blockers,
+    )
+    cy = _finite_number(
+        intrinsics.get("cy", intrinsics.get("ppy")),
+        "color.intrinsics.cy/ppy",
+        blockers,
+    )
+    if fx <= 0 or fy <= 0:
+        blockers.append("D435i fx/fy 必须为正数")
+    if not 0 <= cx < max(width, 1) or not 0 <= cy < max(height, 1):
+        blockers.append("D435i cx/cy 必须位于标定图像范围内")
+    coefficients = _number_list(
+        intrinsics.get("coeffs"), 5, "color.intrinsics.coeffs", blockers
+    )
+    distortion_model = str(intrinsics.get("distortion_model", "")).lower()
+    if distortion_model == "inverse_brown_conrady" and any(
+        abs(value) > 1e-9 for value in coefficients
+    ):
+        blockers.append("非零 inverse_brown_conrady 系数不能直接写入 FAST-LIVO2 Pinhole 模型")
+    elif distortion_model not in {"brown_conrady", "inverse_brown_conrady", "none"}:
+        blockers.append(f"不支持的 D435i 畸变模型: {distortion_model or 'missing'}")
+
+    ground_truth_value = data.get("ground_truth")
+    ground_truth = ground_truth_value if isinstance(ground_truth_value, dict) else {}
+    if not ground_truth:
+        blockers.append("data.ground_truth 缺失，尚无 RGB-LiDAR 联合标定")
+    transforms_value = ground_truth.get("transforms")
+    transforms = transforms_value if isinstance(transforms_value, dict) else {}
+    lidar_to_camera_value = transforms.get("lidar_to_camera")
+    lidar_to_camera = (
+        lidar_to_camera_value if isinstance(lidar_to_camera_value, dict) else {}
+    )
+    transform_status = str(lidar_to_camera.get("status", ""))
+    nominal_preview = (
+        allow_nominal_preview
+        and transform_status == NOMINAL_PREVIEW_EXTRINSIC_STATUS
+    )
+    if transform_status not in ALLOWED_EVIDENCE_STATUS and not nominal_preview:
+        blockers.append("LiDAR→D435i 外参状态必须是 calibrated/measured/verified")
+    rotation_value = lidar_to_camera.get("rotation_row_major")
+    rotation = _number_list(
+        rotation_value,
+        9,
+        "lidar_to_camera.rotation_row_major",
+        blockers,
+    )
+    translation_value = lidar_to_camera.get("translation_m")
+    translation = _number_list(
+        translation_value,
+        3,
+        "lidar_to_camera.translation_m",
+        blockers,
+    )
+    if isinstance(rotation_value, list) and len(rotation_value) == 9:
+        _validate_rotation(rotation, blockers)
+    if isinstance(translation_value, list) and len(translation_value) == 3:
+        translation_norm = math.sqrt(sum(value * value for value in translation))
+        if not 0.01 <= translation_norm <= 2.0:
+            blockers.append("LiDAR→D435i 平移模长必须在 0.01–2.0 m 内")
+
+    alignments_value = ground_truth.get("time_alignment")
+    alignments = alignments_value if isinstance(alignments_value, dict) else {}
+    alignment_value = alignments.get("d435i_color_to_mid360")
+    alignment = alignment_value if isinstance(alignment_value, dict) else {}
+    alignment_status = str(alignment.get("status", ""))
+    preview_alignment = (
+        nominal_preview
+        and alignment_status == NOMINAL_PREVIEW_ALIGNMENT_STATUS
+    )
+    if alignment_status not in ALLOWED_EVIDENCE_STATUS and not preview_alignment:
+        blockers.append("D435i↔MID360 时间对齐状态必须是 calibrated/measured/verified")
+    timestamp_source = str(alignment.get("timestamp_source", ""))
+    preview_timestamp = (
+        preview_alignment and timestamp_source == NOMINAL_PREVIEW_TIMESTAMP_SOURCE
+    )
+    if timestamp_source not in ALLOWED_TIMESTAMP_SOURCES and not preview_timestamp:
+        blockers.append("相机时间戳必须来自 realsense hardware/global time，不能用回调到达时间")
+    if "img_time_offset_s" in alignment:
+        image_time_offset = _finite_number(
+            alignment.get("img_time_offset_s"), "time_alignment.img_time_offset_s", blockers
+        )
+        if abs(image_time_offset) > 0.5:
+            blockers.append("img_time_offset_s 绝对值必须不超过 0.5 s")
+    else:
+        image_time_offset = 0.0
+        blockers.append("缺少实测 img_time_offset_s")
+    if preview_alignment and alignment.get("p95_abs_skew_ms") is None:
+        p95_skew_ms = -1.0
+    elif "p95_abs_skew_ms" in alignment:
+        p95_skew_ms = _finite_number(
+            alignment.get("p95_abs_skew_ms"), "time_alignment.p95_abs_skew_ms", blockers
+        )
+        if not 0 <= p95_skew_ms <= 20.0:
+            blockers.append("D435i↔MID360 绝对 skew p95 必须不超过 20 ms")
+    else:
+        p95_skew_ms = 0.0
+        blockers.append("缺少 D435i↔MID360 skew p95 证据")
+
+    values = {
+        "calibration_id": actual_calibration_id,
+        "serial": serial,
+        "width": width,
+        "height": height,
+        "fps": fps,
+        "fx": fx,
+        "fy": fy,
+        "cx": cx,
+        "cy": cy,
+        "distortion": coefficients[:4],
+        "rotation": rotation,
+        "translation": translation,
+        "image_time_offset": image_time_offset,
+        "timestamp_source": timestamp_source,
+        "p95_skew_ms": p95_skew_ms,
+        "evidence_status": transform_status,
+        "preview_only": nominal_preview,
+    }
+    return values, blockers
+
+
+def _yaml_float(value: float) -> str:
+    """Render a finite YAML number with an unambiguous floating-point type."""
+    rendered = format(value, ".12g")
+    if "." not in rendered and "e" not in rendered.lower():
+        rendered += ".0"
+    return rendered
+
+
+def _yaml_list(values: list[float]) -> str:
+    return "[" + ", ".join(_yaml_float(value) for value in values) + "]"
+
+
+def render_yaml(values: dict[str, Any]) -> str:
+    distortion = values["distortion"]
+    p95_skew = (
+        f"{values['p95_skew_ms']:.3f}"
+        if values["p95_skew_ms"] >= 0
+        else "unverified"
+    )
+    return f"""# Generated by render-g1-livo-config.py; do not edit by hand.
+# calibration_id: {values['calibration_id']}
+# d435i_serial: {values['serial']}
+# color_profile: {values['width']}x{values['height']}@{values['fps']}
+# evidence_tier: {values['evidence_status']}
+# timestamp_source: {values['timestamp_source']}; p95_skew_ms: {p95_skew}
+# preview_only: {str(values['preview_only']).lower()}
+/**:
+  ros__parameters:
+    common:
+      img_topic: "/left_camera/image"
+      lid_topic: "/livox/lidar"
+      imu_topic: "/livox/imu"
+      img_en: 1
+      lidar_en: 1
+      ros_driver_bug_fix: false
+      enable_image_processing: true
+
+    camera:
+      model: Pinhole
+      width: {values['width']}
+      height: {values['height']}
+      scale: 1.0
+      fx: {_yaml_float(values['fx'])}
+      fy: {_yaml_float(values['fy'])}
+      cx: {_yaml_float(values['cx'])}
+      cy: {_yaml_float(values['cy'])}
+      d0: {_yaml_float(distortion[0])}
+      d1: {_yaml_float(distortion[1])}
+      d2: {_yaml_float(distortion[2])}
+      d3: {_yaml_float(distortion[3])}
+
+    extrin_calib:
+      extrinsic_T: [0.0, 0.0, 0.0]
+      extrinsic_R: [1.0, 0.0, 0.0,
+                    0.0, 1.0, 0.0,
+                    0.0, 0.0, 1.0]
+      Rcl: {_yaml_list(values['rotation'])}
+      Pcl: {_yaml_list(values['translation'])}
+
+    time_offset:
+      imu_time_offset: 0.0
+      img_time_offset: {_yaml_float(values['image_time_offset'])}
+      exposure_time_init: 0.0
+
+    preprocess:
+      point_filter_num: 1
+      filter_size_surf: 0.1
+      lidar_type: 7
+      scan_line: 4
+      blind: 0.5
+
+    vio:
+      max_iterations: 5
+      outlier_threshold: 1000
+      img_point_cov: 100
+      patch_size: 8
+      patch_pyrimid_level: 4
+      normal_en: true
+      raycast_en: false
+      inverse_composition_en: false
+      exposure_estimate_en: false
+      inv_expo_cov: 0.1
+
+    imu:
+      imu_en: true
+      imu_int_frame: 30
+      acc_cov: 0.8
+      gyr_cov: 0.5
+      b_acc_cov: 0.001
+      b_gyr_cov: 0.001
+
+    lio:
+      max_iterations: 5
+      dept_err: 0.02
+      beam_err: 0.15
+      min_eigen_value: 0.005
+      voxel_size: 0.5
+      max_layer: 2
+      max_points_num: 50
+      layer_init_num: [5, 5, 5, 5, 5]
+
+    local_map:
+      map_sliding_en: false
+      half_map_size: 100
+      sliding_thresh: 8.0
+
+    uav:
+      imu_rate_odom: false
+      gravity_align_en: true
+
+    publish:
+      dense_map_en: true
+      pub_effect_point_en: false
+      pub_plane_en: false
+      pub_scan_num: 1
+      blind_rgb_points: 0.0
+
+    evo:
+      seq_name: "g1_rgb_livo_shadow"
+      pose_output_en: false
+
+    image_save:
+      img_save_en: false
+      interval: 1
+
+    pcd_save:
+      pcd_save_en: false
+      colmap_output_en: false
+      filter_size_pcd: 0.02
+      interval: -1
+"""
+
+
+def write_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, prefix=path.name + ".", delete=False
+    ) as handle:
+        handle.write(content)
+        handle.flush()
+        os.fsync(handle.fileno())
+        temporary = Path(handle.name)
+    os.replace(temporary, path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("calibration", type=Path)
+    parser.add_argument("output", type=Path, nargs="?")
+    parser.add_argument("--expected-width", type=int, default=1920)
+    parser.add_argument("--expected-height", type=int, default=1080)
+    parser.add_argument("--expected-fps", type=int, default=15)
+    parser.add_argument(
+        "--allow-nominal-preview",
+        action="store_true",
+        help="render a static-only config from explicitly nominal public URDF evidence",
+    )
+    args = parser.parse_args()
+
+    with args.calibration.open(encoding="utf-8") as handle:
+        snapshot = json.load(handle)
+    if not isinstance(snapshot, dict):
+        raise SystemExit("calibration snapshot must be a JSON object")
+
+    values, blockers = validate_snapshot(
+        snapshot,
+        args.expected_width,
+        args.expected_height,
+        args.expected_fps,
+        args.allow_nominal_preview,
+    )
+    if blockers:
+        for blocker in blockers:
+            print(f"BLOCKER: {blocker}")
+        print(f"rgb_livo_calibration=blocked blocker_count={len(blockers)}")
+        return 1
+
+    state = "preview" if values["preview_only"] else "ready"
+    print(
+        f"rgb_livo_calibration={state} "
+        f"calibration_id={values['calibration_id']} "
+        f"serial={values['serial']} "
+        f"profile={values['width']}x{values['height']}@{values['fps']}"
+    )
+    if args.output is not None:
+        write_atomic(args.output, render_yaml(values))
+        print(f"output={args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unitree/g1/traditional_navigation/source-lock.env
+++ b/unitree/g1/traditional_navigation/source-lock.env
@@ -1,0 +1,22 @@
+# N2 FAST-LIVO2 shadow source lock. All revisions are immutable full Git SHAs.
+G1_DRIVER_IMAGE=phanthy-g1-driver:navigation-sensors-rx180
+
+FAST_LIVO2_REPO=https://github.com/Rhymer-Lcy/FAST-LIVO2-ROS2-MID360-Fisheye.git
+FAST_LIVO2_COMMIT=1fcd0d05cadaeb25ca59fd87cda95aaaee41e3ea
+FAST_LIVO2_BASE_IMAGE_TAG=1fcd0d0-n2qos1
+FAST_LIVO2_BASE_RUNTIME_PATCH_SHA256=f7fadc376f0f8ea45aa5c3ac0c11ad12a882d0c8dca356f75a61e7590dcdcb01
+FAST_LIVO2_RUNTIME_PATCH_SHA256=534b15ab7559d572b1be56611ab1b5f5d73809f91727de5e853cd04612f4fc3b
+FAST_LIVO2_PCD_SAVE_PATCH_SHA256=b3afa3e64b5743898c829fe34891f828027eb372324d05a8c94357f9cacd6ec4
+FAST_LIVO2_IMAGE_TAG=1fcd0d0-n3save1
+
+RPG_VIKIT_REPO=https://github.com/Rhymer-Lcy/rpg_vikit_ros2_fisheye.git
+RPG_VIKIT_COMMIT=0b5548d9adab58128f3a59a507e96a83acfa8fdf
+
+LIVOX_ROS_DRIVER2_REPO=https://github.com/Livox-SDK/livox_ros_driver2.git
+LIVOX_ROS_DRIVER2_COMMIT=13eb05e4e6dd7a765b934d0c5fd6236676a57b49
+
+LIVOX_SDK2_REPO=https://github.com/Livox-SDK/Livox-SDK2.git
+LIVOX_SDK2_COMMIT=f5d9375f84efe2b15bc0a052d3e18482ed13adf4
+
+SOPHUS_REPO=https://github.com/strasdat/Sophus.git
+SOPHUS_COMMIT=de0f8d3d92bf776271e16de56d1803940ebccab9

--- a/unitree/g1/traditional_navigation/source-lock.rgb.env
+++ b/unitree/g1/traditional_navigation/source-lock.rgb.env
@@ -1,0 +1,4 @@
+# Optional RGB-LIVO derivative. It is never selected by compose.shadow.yml.
+FAST_LIVO2_RGB_BASE_IMAGE=phanthy-fast-livo2:g1-1fcd0d0-n3save1
+FAST_LIVO2_RGB_IMAGE=phanthy-fast-livo2:g1-1fcd0d0-n3rgbpreview2
+FAST_LIVO2_RGB_QOS_PATCH_SHA256=63bc12a9e537cb63e1ce11b34ae1ad9e617ad62bc4151282dec2a524f03cfbf9

--- a/unitree/g1/traditional_navigation/tests/fake-navigation-command.sh
+++ b/unitree/g1/traditional_navigation/tests/fake-navigation-command.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly COMMAND_NAME="$(basename -- "$0")"
+
+case "${COMMAND_NAME}" in
+  docker)
+    if [[ " $* " == *" context inspect "* ]]; then
+      exit 0
+    fi
+    if [[ " $* " == *" image inspect "* ]]; then
+      if [[ " $* " == *"{{.Architecture}}"* ]]; then
+        echo "arm64"
+      else
+        echo "fake-image-inspect"
+      fi
+      exit 0
+    fi
+    echo "unexpected fake docker invocation: $*" >&2
+    exit 1
+    ;;
+  ssh)
+    test -n "${G1_FAKE_LOG:-}" || {
+      echo "G1_FAKE_LOG is required" >&2
+      exit 1
+    }
+    readonly REMOTE_COMMAND="${!#}"
+    bash -n -c "${REMOTE_COMMAND}"
+    printf '%s\n' "$*" >>"${G1_FAKE_LOG}"
+    if [[ "${REMOTE_COMMAND}" == *"docker run --rm -i"* && \
+          "${REMOTE_COMMAND}" == *"--samples"* ]]; then
+      cat >/dev/null
+      printf '%s\n' '{"schema_version":1,"probe_type":"g1_realsense_callback_latency","captured_at_epoch_ns":1785847200000000000,"boot_id":"test-boot-id","d435i":{"serial":"346522072810","color":{"width":1920,"height":1080,"fps":15,"format":"bgr8"}},"measurement":{"method":"realsense_global_time_to_host_delivery_proxy","timestamp_domain":"global_time","sample_count":120,"callback_latency_ms":{"min":28.0,"median":32.5,"p95":35.0,"max":38.0},"recommended_img_time_offset_s":-0.0325,"p95_abs_residual_ms":4.5,"exposure_us":{"median":8000.0,"p95":9000.0}},"probe_id":"sha256:c07dcefd97a9a3b61b7fec9771c685b9bf39934f86106cf560ca686bd240ce7f"}'
+      exit 0
+    fi
+    if [[ "${REMOTE_COMMAND}" == *"docker exec -i embodied-unitree-g1 python3 -"* ]]; then
+      cat >/dev/null
+      if [[ "${G1_FAKE_EMPTY_PROBE_ONCE:-}" == 1 && \
+            ! -e "${G1_FAKE_LOG}.probe-once" ]]; then
+        : > "${G1_FAKE_LOG}.probe-once"
+        exit 0
+      fi
+      printf '%s\n' '{"boot_id":"test-boot-id","captured_at_epoch_ns":1785847200000000000,"d435i":{"color":{"format":"bgr8","fps":15,"height":1080,"intrinsics":{"coeffs":[0.0,0.0,0.0,0.0,0.0],"distortion_model":"inverse_brown_conrady","fx":1368.246826171875,"fy":1372.2265625,"ppx":981.5875854492188,"ppy":552.4080810546875},"width":1920},"depth_to_color_optical":{"rotation_column_major":[0.9999568462371826,-0.008939534425735474,0.002532962244004011,0.008926372043788433,0.9999468326568604,0.005160734057426453,-0.002578962128609419,-0.005137901287525892,0.9999834895133972],"translation_m":[0.015179511159658432,0.0015000001294538379,0.001500000013038516]},"global_time":[{"enabled":true,"sensor":"Stereo Module"},{"enabled":true,"sensor":"RGB Camera"},{"enabled":true,"sensor":"Motion Module"}],"model":"Intel RealSense D435I","serial":"346522072810"},"mode_machine":4,"mode_pr":0,"network_interface":"eth0","schema_version":1}'
+      exit 0
+    fi
+    if [[ "${REMOTE_COMMAND}" == *"python3 -"* && \
+          "${REMOTE_COMMAND}" == *"all_rgb_points.recovered.pcd"* ]]; then
+      cat >/dev/null
+      if [[ "${REMOTE_COMMAND}" == *"--validate"* ]]; then
+        action="validate"
+      else
+        action="merge"
+      fi
+      echo "rgb_pcd_recovery=PASS action=${action} sources=34 skipped_zero_filled=10 points=1050000 bytes=16800182 nonzero_rgb=1050000 x_m=[-3.0, 4.0] y_m=[-2.0, 3.0] z_m=[-1.0, 2.0] clean_shutdown=false"
+      exit 0
+    fi
+    if [[ "${REMOTE_COMMAND}" == *"tar -C"* || "${REMOTE_COMMAND}" == *"docker load"* ]]; then
+      # Deployment streams archives/images over SSH. Drain the producer so the
+      # fake does not close the pipe early and turn a valid test into tar EPIPE.
+      cat >/dev/null
+    fi
+    echo "fake_ssh=ok"
+    ;;
+  *)
+    echo "fake command must be invoked as docker or ssh: ${COMMAND_NAME}" >&2
+    exit 1
+    ;;
+esac

--- a/unitree/g1/traditional_navigation/tests/imu_gap_publisher.py
+++ b/unitree/g1/traditional_navigation/tests/imu_gap_publisher.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Publish a static MID360/IMU stream with one deliberate IMU gap."""
+
+from __future__ import annotations
+
+from array import array
+import json
+import struct
+import time
+
+import rclpy
+from nav_msgs.msg import Odometry
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import Imu, PointCloud2, PointField
+
+
+IMU_PERIOD_SEC = 0.005
+CLOUD_PERIOD_SEC = 0.1
+GAP_START_SEC = 4.0
+GAP_END_SEC = 4.35
+TEST_DURATION_SEC = 10.0
+
+
+RELIABLE_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=400,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+
+def _static_scene() -> list[tuple[float, float, float, float, int, int]]:
+    points: list[tuple[float, float, float, float, int, int]] = []
+    for x_index in range(24):
+        for y_index in range(20):
+            points.append(
+                (
+                    1.0 + x_index * 0.2,
+                    -2.0 + y_index * 0.2,
+                    -1.0,
+                    20.0,
+                    0x10,
+                    (x_index + y_index) % 4,
+                )
+            )
+    for y_index in range(20):
+        for z_index in range(14):
+            points.append(
+                (
+                    5.0,
+                    -2.0 + y_index * 0.2,
+                    -1.0 + z_index * 0.15,
+                    40.0,
+                    0x10,
+                    (y_index + z_index) % 4,
+                )
+            )
+    for x_index in range(20):
+        for z_index in range(14):
+            points.append(
+                (
+                    1.0 + x_index * 0.2,
+                    3.0,
+                    -1.0 + z_index * 0.15,
+                    60.0,
+                    0x10,
+                    (x_index + z_index) % 4,
+                )
+            )
+    return points
+
+
+class ImuGapPublisher(Node):
+    def __init__(self) -> None:
+        super().__init__("fast_livo_imu_gap_smoke")
+        self._cloud_publisher = self.create_publisher(
+            PointCloud2, "/gap_test/lidar", RELIABLE_QOS
+        )
+        self._imu_publisher = self.create_publisher(
+            Imu, "/gap_test/imu", RELIABLE_QOS
+        )
+        self._odom_subscription = self.create_subscription(
+            Odometry, "/gap_test/odom", self._on_odom, 100
+        )
+        self._points = _static_scene()
+        self._test_start: float | None = None
+        self._odom_before_gap = 0
+        self._odom_after_gap = 0
+        self._odom_total = 0
+
+    def _on_odom(self, _message: Odometry) -> None:
+        self._odom_total += 1
+        if self._test_start is None:
+            return
+        elapsed = time.monotonic() - self._test_start
+        if elapsed < GAP_START_SEC:
+            self._odom_before_gap += 1
+        elif elapsed > GAP_END_SEC + 0.5:
+            self._odom_after_gap += 1
+
+    @staticmethod
+    def _set_stamp(message, stamp) -> None:
+        message.header.stamp = stamp.to_msg()
+        message.header.frame_id = "livox_frame"
+
+    def _publish_imu(self) -> None:
+        message = Imu()
+        self._set_stamp(message, self.get_clock().now())
+        message.orientation.w = 1.0
+        message.orientation_covariance[0] = -1.0
+        message.linear_acceleration.z = 1.0
+        self._imu_publisher.publish(message)
+
+    def _publish_cloud(self) -> None:
+        now = self.get_clock().now()
+        header_ns = now.nanoseconds
+        payload = bytearray(len(self._points) * 32)
+        denominator = max(1, len(self._points) - 1)
+        for index, (x, y, z, intensity, tag, line) in enumerate(self._points):
+            point_stamp_ns = header_ns + round(index / denominator * 80_000_000)
+            struct.pack_into(
+                "<fff4xfBB2xd",
+                payload,
+                index * 32,
+                x,
+                y,
+                z,
+                intensity,
+                tag,
+                line,
+                float(point_stamp_ns),
+            )
+
+        message = PointCloud2()
+        self._set_stamp(message, now)
+        message.height = 1
+        message.width = len(self._points)
+        message.fields = [
+            PointField(name="x", offset=0, datatype=PointField.FLOAT32, count=1),
+            PointField(name="y", offset=4, datatype=PointField.FLOAT32, count=1),
+            PointField(name="z", offset=8, datatype=PointField.FLOAT32, count=1),
+            PointField(
+                name="intensity", offset=16, datatype=PointField.FLOAT32, count=1
+            ),
+            PointField(name="tag", offset=20, datatype=PointField.UINT8, count=1),
+            PointField(name="line", offset=21, datatype=PointField.UINT8, count=1),
+            PointField(
+                name="timestamp", offset=24, datatype=PointField.FLOAT64, count=1
+            ),
+        ]
+        message.is_bigendian = False
+        message.point_step = 32
+        message.row_step = message.point_step * message.width
+        message.data = array("B", payload)
+        message.is_dense = True
+        self._cloud_publisher.publish(message)
+
+    def wait_for_estimator(self, timeout_sec: float = 15.0) -> None:
+        deadline = time.monotonic() + timeout_sec
+        while time.monotonic() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.05)
+            if (
+                self.count_subscribers("/gap_test/lidar") >= 1
+                and self.count_subscribers("/gap_test/imu") >= 1
+            ):
+                return
+        raise RuntimeError("FAST-LIVO2 subscriptions were not discovered")
+
+    def run(self) -> dict[str, int | float | bool]:
+        self.wait_for_estimator()
+        self._test_start = time.monotonic()
+        next_imu = self._test_start
+        next_cloud = self._test_start
+        gap_announced = False
+
+        while True:
+            now = time.monotonic()
+            elapsed = now - self._test_start
+            if elapsed >= TEST_DURATION_SEC:
+                break
+
+            if now >= next_cloud:
+                self._publish_cloud()
+                next_cloud = max(next_cloud + CLOUD_PERIOD_SEC, now)
+
+            if GAP_START_SEC <= elapsed < GAP_END_SEC:
+                next_imu = now + IMU_PERIOD_SEC
+                gap_announced = True
+            elif now >= next_imu:
+                self._publish_imu()
+                next_imu = max(next_imu + IMU_PERIOD_SEC, now)
+
+            rclpy.spin_once(self, timeout_sec=0.001)
+
+        for _ in range(20):
+            rclpy.spin_once(self, timeout_sec=0.01)
+
+        passed = (
+            gap_announced
+            and self._odom_before_gap >= 3
+            and self._odom_after_gap >= 3
+        )
+        return {
+            "passed": passed,
+            "intentional_gap_sec": round(GAP_END_SEC - GAP_START_SEC, 3),
+            "odom_before_gap": self._odom_before_gap,
+            "odom_after_gap": self._odom_after_gap,
+            "odom_total": self._odom_total,
+        }
+
+
+def main() -> int:
+    rclpy.init()
+    node = ImuGapPublisher()
+    try:
+        result = node.run()
+        print(json.dumps(result, sort_keys=True), flush=True)
+        return 0 if result["passed"] else 1
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unitree/g1/traditional_navigation/tests/run-imu-gap-smoke.sh
+++ b/unitree/g1/traditional_navigation/tests/run-imu-gap-smoke.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly NAV_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+readonly DOCKER_CONTEXT="${LOCAL_DOCKER_CONTEXT:-desktop-linux}"
+readonly FAST_LIVO_IMAGE="${1:-phanthy-fast-livo2:g1-1fcd0d0-n2gap1}"
+readonly CONTAINER_NAME="fast-livo-imu-gap-smoke-$$"
+
+cleanup() {
+  docker --context "${DOCKER_CONTEXT}" stop --time 10 "${CONTAINER_NAME}" \
+    >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker --context "${DOCKER_CONTEXT}" image inspect --platform linux/arm64 \
+  "${FAST_LIVO_IMAGE}" >/dev/null
+
+docker --context "${DOCKER_CONTEXT}" run -d --rm \
+  --name "${CONTAINER_NAME}" \
+  --network host \
+  --ipc host \
+  --read-only \
+  --security-opt no-new-privileges:true \
+  --cap-drop ALL \
+  --tmpfs /tmp:rw,size=256m,mode=1777 \
+  --tmpfs /opt/fast_livo_ws/src/fast_livo/Log:rw,size=256m,mode=1777 \
+  -e ROS_DOMAIN_ID=92 \
+  -e ROS_LOG_DIR=/tmp/ros-log \
+  -v "${NAV_DIR}/g1_lio.yaml:/config/g1_lio.yaml:ro" \
+  "${FAST_LIVO_IMAGE}" \
+  /bin/bash -lc '
+    source /opt/ros/humble/setup.bash
+    source /opt/fast_livo_ws/install/setup.bash
+    exec /opt/fast_livo_ws/install/fast_livo/lib/fast_livo/fastlivo_mapping \
+      --ros-args --params-file /config/g1_lio.yaml --log-level warn \
+      -r /livox/lidar:=/gap_test/lidar \
+      -r /livox/imu:=/gap_test/imu \
+      -r /aft_mapped_to_init:=/gap_test/odom \
+      -r /cloud_registered:=/gap_test/cloud_registered' >/dev/null
+
+set +e
+docker --context "${DOCKER_CONTEXT}" run --rm \
+  --network host \
+  --ipc host \
+  --read-only \
+  --security-opt no-new-privileges:true \
+  --cap-drop ALL \
+  --tmpfs /tmp:rw,size=128m,mode=1777 \
+  -e ROS_DOMAIN_ID=92 \
+  -e ROS_LOG_DIR=/tmp/ros-log \
+  -v "${SCRIPT_DIR}/imu_gap_publisher.py:/test/imu_gap_publisher.py:ro" \
+  "${FAST_LIVO_IMAGE}" \
+  /bin/bash -lc '
+    source /opt/ros/humble/setup.bash
+    source /opt/fast_livo_ws/install/setup.bash
+    exec python3 /test/imu_gap_publisher.py'
+readonly PUBLISHER_STATUS="$?"
+set -e
+
+readonly GAP_WARNING_COUNT="$(
+  docker --context "${DOCKER_CONTEXT}" logs "${CONTAINER_NAME}" 2>&1 \
+    | grep -c "accepting current sample to resynchronize" || true
+)"
+readonly LEGACY_REJECTION_COUNT="$(
+  docker --context "${DOCKER_CONTEXT}" logs "${CONTAINER_NAME}" 2>&1 \
+    | grep -c "imu time stamp Jumps" || true
+)"
+
+if [[ "${PUBLISHER_STATUS}" -ne 0 ]]; then
+  docker --context "${DOCKER_CONTEXT}" logs --tail 160 "${CONTAINER_NAME}" >&2
+fi
+
+test "${PUBLISHER_STATUS}" -eq 0
+test "${GAP_WARNING_COUNT}" -ge 1
+test "${LEGACY_REJECTION_COUNT}" -eq 0
+echo "gap_warnings=${GAP_WARNING_COUNT} legacy_rejections=${LEGACY_REJECTION_COUNT}"

--- a/unitree/g1/traditional_navigation/tests/run-pcd-save-smoke.sh
+++ b/unitree/g1/traditional_navigation/tests/run-pcd-save-smoke.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly NAV_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
+readonly DOCKER_CONTEXT="${LOCAL_DOCKER_CONTEXT:-desktop-linux}"
+
+set -a
+# shellcheck disable=SC1091
+source "${NAV_DIR}/source-lock.env"
+set +a
+
+readonly FAST_LIVO_IMAGE="${1:-phanthy-fast-livo2:g1-${FAST_LIVO2_IMAGE_TAG}}"
+readonly CONTAINER_NAME="fast-livo-pcd-save-smoke-$$"
+readonly OUTPUT_DIR="$(mktemp -d /private/tmp/g1-pcd-save-smoke.XXXXXX)"
+
+cleanup() {
+  docker --context "${DOCKER_CONTEXT}" rm -f "${CONTAINER_NAME}" \
+    >/dev/null 2>&1 || true
+  rm -rf -- "${OUTPUT_DIR}"
+}
+trap cleanup EXIT
+
+pcd_count() {
+  find "${OUTPUT_DIR}" -maxdepth 1 -type f -name '*.pcd' -size +0c \
+    | wc -l | tr -d ' '
+}
+
+docker --context "${DOCKER_CONTEXT}" image inspect --platform linux/arm64 \
+  "${FAST_LIVO_IMAGE}" >/dev/null
+
+docker --context "${DOCKER_CONTEXT}" run -d \
+  --name "${CONTAINER_NAME}" \
+  --platform linux/arm64 \
+  --network host \
+  --ipc host \
+  --read-only \
+  --security-opt no-new-privileges:true \
+  --cap-drop ALL \
+  --memory 6g \
+  --tmpfs /tmp:rw,size=256m,mode=1777 \
+  --tmpfs /opt/fast_livo_ws/src/fast_livo/Log:rw,size=512m,mode=1777 \
+  -e ROS_DOMAIN_ID=94 \
+  -e ROS_LOG_DIR=/tmp/ros-log \
+  -v "${NAV_DIR}/g1_lio.yaml:/config/g1_lio.yaml:ro" \
+  -v "${OUTPUT_DIR}:/opt/fast_livo_ws/src/fast_livo/Log/pcd:rw" \
+  "${FAST_LIVO_IMAGE}" \
+  /bin/bash -lc '
+    source /opt/ros/humble/setup.bash
+    source /opt/fast_livo_ws/install/setup.bash
+    exec /opt/fast_livo_ws/install/fast_livo/lib/fast_livo/fastlivo_mapping \
+      --ros-args --params-file /config/g1_lio.yaml --log-level warn \
+      -p pcd_save.pcd_save_en:=true \
+      -p pcd_save.interval:=20 \
+      -p pcd_save.type:=0 \
+      -r /livox/lidar:=/gap_test/lidar \
+      -r /livox/imu:=/gap_test/imu \
+      -r /aft_mapped_to_init:=/gap_test/odom \
+      -r /cloud_registered:=/gap_test/cloud_registered' >/dev/null
+
+sleep 2
+
+docker --context "${DOCKER_CONTEXT}" run --rm \
+  --platform linux/arm64 \
+  --network host \
+  --ipc host \
+  --read-only \
+  --security-opt no-new-privileges:true \
+  --cap-drop ALL \
+  --tmpfs /tmp:rw,size=128m,mode=1777 \
+  -e ROS_DOMAIN_ID=94 \
+  -e ROS_LOG_DIR=/tmp/ros-log \
+  -v "${SCRIPT_DIR}/imu_gap_publisher.py:/test/imu_gap_publisher.py:ro" \
+  "${FAST_LIVO_IMAGE}" \
+  /bin/bash -lc '
+    source /opt/ros/humble/setup.bash
+    source /opt/fast_livo_ws/install/setup.bash
+    exec python3 /test/imu_gap_publisher.py' >/dev/null
+
+readonly CHECKPOINT_COUNT="$(pcd_count)"
+test "${CHECKPOINT_COUNT}" -ge 1
+
+docker --context "${DOCKER_CONTEXT}" stop \
+  --signal SIGINT --time 30 "${CONTAINER_NAME}" >/dev/null
+
+readonly EXIT_CODE="$(
+  docker --context "${DOCKER_CONTEXT}" inspect "${CONTAINER_NAME}" \
+    --format '{{.State.ExitCode}}'
+)"
+readonly FINAL_COUNT="$(pcd_count)"
+
+test "${EXIT_CODE}" -eq 0
+test "${FINAL_COUNT}" -ge "${CHECKPOINT_COUNT}"
+test -z "$(find "${OUTPUT_DIR}" -maxdepth 1 -type f -name '*.tmp' -print -quit)"
+
+while IFS= read -r pcd_file; do
+  head -c 512 "${pcd_file}" | grep -a '^POINTS [1-9][0-9]*$' >/dev/null
+  head -c 512 "${pcd_file}" | grep -a '^DATA binary$' >/dev/null
+done < <(find "${OUTPUT_DIR}" -maxdepth 1 -type f -name '*.pcd' -size +0c | sort)
+
+readonly FIRST_PCD="$(
+  find "${OUTPUT_DIR}" -maxdepth 1 -type f -name '*.pcd' -size +0c \
+    | sort | sed -n '1p'
+)"
+set +e
+PARSER_OUTPUT="$(
+  docker --context "${DOCKER_CONTEXT}" run --rm \
+    --platform linux/arm64 \
+    --network none \
+    --read-only \
+    --tmpfs /tmp:rw,size=64m,mode=1777 \
+    -e ROS_DOMAIN_ID=95 \
+    -v "${FIRST_PCD}:/test/map.pcd:ro" \
+    "${FAST_LIVO_IMAGE}" \
+    /bin/bash -lc '
+      source /opt/ros/humble/setup.bash
+      source /opt/fast_livo_ws/install/setup.bash
+      timeout 3 ros2 run pcl_ros pcd_to_pointcloud --ros-args \
+        -p file_name:=/test/map.pcd -p interval:=1.0' 2>&1
+)"
+PARSER_EXIT_CODE="$?"
+set -e
+if [[ "${PARSER_EXIT_CODE}" -ne 124 ]]; then
+  printf '%s\n' "${PARSER_OUTPUT}" >&2
+  exit 1
+fi
+grep -F 'Publishing data with' <<<"${PARSER_OUTPUT}" >/dev/null
+
+docker --context "${DOCKER_CONTEXT}" logs "${CONTAINER_NAME}" 2>&1 \
+  | grep -F 'PCD checkpoint completed' >/dev/null
+docker --context "${DOCKER_CONTEXT}" logs "${CONTAINER_NAME}" 2>&1 \
+  | grep -F 'PCD finalization completed' >/dev/null
+
+echo "pcd_save_smoke=PASS checkpoints=${CHECKPOINT_COUNT} final_files=${FINAL_COUNT} exit=${EXIT_CODE}"

--- a/unitree/g1/traditional_navigation/tests/test-navigation-shells.sh
+++ b/unitree/g1/traditional_navigation/tests/test-navigation-shells.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly TEST_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly NAV_DIR="$(cd -- "${TEST_DIR}/.." && pwd -P)"
+readonly DEPLOY_SCRIPT="${NAV_DIR}/deploy-g1-navigation-shadow.sh"
+readonly ACCEPT_SCRIPT="${NAV_DIR}/accept-g1-navigation-shadow.sh"
+readonly TIME_PROBE_SCRIPT="${NAV_DIR}/probe-g1-rgb-time-offset.sh"
+readonly RECOVER_SCRIPT="${NAV_DIR}/recover-g1-rgb-preview.sh"
+readonly RGB_CONFIG_TEST="${TEST_DIR}/test_rgb_livo_config.py"
+readonly RGB_PCD_RECOVERY_TEST="${TEST_DIR}/test_rgb_pcd_recovery.py"
+readonly FAKE_COMMAND="${TEST_DIR}/fake-navigation-command.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+expect_status() {
+  expected="$1"
+  shift
+  set +e
+  "$@" >/dev/null 2>&1
+  actual="$?"
+  set -e
+  test "${actual}" -eq "${expected}" || {
+    fail "expected status ${expected}, got ${actual}: $*"
+  }
+}
+
+bash -n "${DEPLOY_SCRIPT}"
+bash -n "${ACCEPT_SCRIPT}"
+bash -n "${TIME_PROBE_SCRIPT}"
+bash -n "${RECOVER_SCRIPT}"
+bash -n "${FAKE_COMMAND}"
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v \
+  "${RGB_CONFIG_TEST}" "${RGB_PCD_RECOVERY_TEST}"
+rgb_patch_expected="$(sed -n 's/^FAST_LIVO2_RGB_QOS_PATCH_SHA256=//p' "${NAV_DIR}/source-lock.rgb.env")"
+rgb_patch_actual="$(shasum -a 256 "${NAV_DIR}/fast-livo2-rgb-qos.patch" | awk '{print $1}')"
+test "${rgb_patch_expected}" = "${rgb_patch_actual}" || fail "RGB QoS patch checksum drifted"
+grep -Fq 'FAST_LIVO2_RGB_BASE_IMAGE=phanthy-fast-livo2:g1-1fcd0d0-n3save1' \
+  "${NAV_DIR}/source-lock.rgb.env"
+grep -Fq 'FAST_LIVO2_RGB_IMAGE=phanthy-fast-livo2:g1-1fcd0d0-n3rgbpreview2' \
+  "${NAV_DIR}/source-lock.rgb.env"
+grep -Fq 'rclcpp::SensorDataQoS image_qos' "${NAV_DIR}/fast-livo2-rgb-qos.patch"
+grep -Fq 'kMaxBufferedLidarFrames = 8' "${NAV_DIR}/fast-livo2-rgb-qos.patch"
+grep -Fq 'kMaxBufferedImuSamples = 400' "${NAV_DIR}/fast-livo2-rgb-qos.patch"
+grep -Fq 'kMaxBufferedImages = 4' "${NAV_DIR}/fast-livo2-rgb-qos.patch"
+grep -Fq 'lid_header_time_buffer.pop_front()' "${NAV_DIR}/fast-livo2-rgb-qos.patch"
+grep -Fq 'prepareFrameForColorization' "${NAV_DIR}/fast-livo2-rgb-qos.patch"
+grep -Fq 'do not grow a visual feature map' "${NAV_DIR}/fast-livo2-rgb-qos.patch"
+grep -Fq 'rgb_pipeline: lio_colorize_only' "${NAV_DIR}/compose.rgb-preview.yml"
+
+expect_status 2 "${DEPLOY_SCRIPT}"
+expect_status 2 "${DEPLOY_SCRIPT}" preflight "bad target" ubuntu eth0
+expect_status 2 env G1_MAP_NAME=../bad "${DEPLOY_SCRIPT}" start_mapping g1-sh-wifi ubuntu eth0
+expect_status 2 env G1_MAP_NAME=sh_n3_smoke G1_PCD_SAVE_INTERVAL=0 \
+  "${DEPLOY_SCRIPT}" start_mapping g1-sh-wifi ubuntu eth0
+expect_status 2 env G1_MAP_NAME=../bad \
+  "${DEPLOY_SCRIPT}" start_rgb_preview g1-sh-wifi ubuntu eth0
+expect_status 2 env G1_MAP_NAME=sh_rgb_static G1_PCD_SAVE_INTERVAL=0 \
+  "${DEPLOY_SCRIPT}" start_rgb_preview g1-sh-wifi ubuntu eth0
+expect_status 2 "${TIME_PROBE_SCRIPT}" g1-sh-wifi
+expect_status 2 env CONFIRM_G1_SHADOW_WRITE=YES \
+  "${TIME_PROBE_SCRIPT}" g1-sh-wifi 29
+expect_status 2 "${RECOVER_SCRIPT}"
+expect_status 2 env G1_MAP_NAME=../bad CONFIRM_G1_SHADOW_WRITE=YES \
+  "${RECOVER_SCRIPT}" g1-sh-wifi
+expect_status 2 env G1_MAP_NAME=sh_rgb_interrupted \
+  "${RECOVER_SCRIPT}" g1-sh-wifi
+expect_status 2 "${ACCEPT_SCRIPT}" map g1-sh-wifi ubuntu eth0
+
+readonly TEST_ROOT="$(mktemp -d /private/tmp/g1-navigation-shells.XXXXXX)"
+trap 'rm -rf -- "${TEST_ROOT}"' EXIT
+mkdir -p "${TEST_ROOT}/bin"
+ln -s "${FAKE_COMMAND}" "${TEST_ROOT}/bin/docker"
+ln -s "${FAKE_COMMAND}" "${TEST_ROOT}/bin/ssh"
+readonly FAKE_PATH="${TEST_ROOT}/bin:${PATH}"
+
+readonly TIME_PROBE_LOG="${TEST_ROOT}/time-probe.log"
+readonly TIME_PROBE_OUTPUT="${TEST_ROOT}/time-probe.json"
+readonly TIME_PROBE_STDOUT="${TEST_ROOT}/time-probe.output"
+PATH="${FAKE_PATH}" G1_FAKE_LOG="${TIME_PROBE_LOG}" \
+G1_RGB_TIME_PROBE_OUTPUT="${TIME_PROBE_OUTPUT}" CONFIRM_G1_SHADOW_WRITE=YES \
+  "${TIME_PROBE_SCRIPT}" g1-sh-wifi 120 >"${TIME_PROBE_STDOUT}"
+grep -Fq 'rgb_time_probe=PASS' "${TIME_PROBE_STDOUT}"
+grep -Fq 'offset_s=-0.032500000' "${TIME_PROBE_STDOUT}"
+grep -Fq 'docker stop -t 20' "${TIME_PROBE_LOG}"
+grep -Fq 'docker start' "${TIME_PROBE_LOG}"
+python3 "${NAV_DIR}/probe-g1-rgb-time-offset.py" \
+  --validate "${TIME_PROBE_OUTPUT}" >/dev/null
+
+readonly RECOVER_LOG="${TEST_ROOT}/recover.log"
+readonly RECOVER_OUTPUT="${TEST_ROOT}/recover.output"
+PATH="${FAKE_PATH}" G1_FAKE_LOG="${RECOVER_LOG}" \
+G1_MAP_NAME=sh_rgb_interrupted CONFIRM_G1_SHADOW_WRITE=YES \
+  "${RECOVER_SCRIPT}" g1-sh-wifi ubuntu eth0 >"${RECOVER_OUTPUT}"
+grep -Fq 'rgb_pcd_recovery=PASS action=merge' "${RECOVER_OUTPUT}"
+grep -Fq 'rgb_pcd_recovery=PASS action=validate' "${RECOVER_OUTPUT}"
+grep -Fq 'skipped_zero_filled=10' "${RECOVER_OUTPUT}"
+grep -Fq 'clean_shutdown=false' "${RECOVER_OUTPUT}"
+grep -Fq 'test "${actual_exit}" = 255' "${RECOVER_LOG}"
+grep -Fq 'refusing RGB recovery identity mismatch' "${RECOVER_LOG}"
+grep -Fq 'all_rgb_points.recovered.pcd' "${RECOVER_LOG}"
+grep -Fq -- '--skip-zero-filled-checkpoints' "${RECOVER_LOG}"
+grep -Fq 'up -d --no-build --force-recreate --wait' "${RECOVER_LOG}"
+
+readonly PREFLIGHT_LOG="${TEST_ROOT}/preflight.log"
+(
+  cd /private/tmp
+  PATH="${FAKE_PATH}" G1_FAKE_LOG="${PREFLIGHT_LOG}" \
+    "${DEPLOY_SCRIPT}" preflight g1-sh-wifi ubuntu eth0
+)
+grep -Fq "PREFLIGHT OK: no robot state changed" <(
+  cd /private/tmp
+  PATH="${FAKE_PATH}" G1_FAKE_LOG="${TEST_ROOT}/preflight-repeat.log" \
+    "${DEPLOY_SCRIPT}" preflight g1-sh-wifi ubuntu eth0
+)
+if grep -Eq 'mkdir -p|docker (compose|build|load).*(up|down|build|load)' "${PREFLIGHT_LOG}"; then
+  fail "preflight emitted a robot write command"
+fi
+
+set +e
+start_output="$(
+  PATH="${FAKE_PATH}" G1_FAKE_LOG="${TEST_ROOT}/start-denied.log" \
+  G1_MAP_NAME=sh_n3_smoke \
+    "${DEPLOY_SCRIPT}" start_mapping g1-sh-wifi ubuntu eth0 2>&1
+)"
+start_status="$?"
+set -e
+test "${start_status}" -eq 2 || fail "start_mapping without confirmation was not denied"
+grep -Fq "Refusing robot write" <<<"${start_output}"
+
+readonly START_LOG="${TEST_ROOT}/start.log"
+PATH="${FAKE_PATH}" G1_FAKE_LOG="${START_LOG}" \
+G1_MAP_NAME=sh_n3_smoke G1_PCD_SAVE_INTERVAL=20 CONFIRM_G1_SHADOW_WRITE=YES \
+  "${DEPLOY_SCRIPT}" start_mapping g1-sh-wifi ubuntu eth0 >/dev/null
+grep -Fq "stat -c '%u'" "${START_LOG}"
+grep -Fq 'G1_MAP_UID="${map_uid}"' "${START_LOG}"
+grep -Fq 'G1_MAP_GID="${map_gid}"' "${START_LOG}"
+grep -Fq '{{json .HostConfig.GroupAdd}}' "${START_LOG}"
+grep -Fq 'test -z "$(docker inspect phanthy-fast-livo2-shadow' "${START_LOG}"
+grep -Fq 'test -w /opt/fast_livo_ws/src/fast_livo/Log/pcd' "${START_LOG}"
+grep -Fq 'group_add:' "${NAV_DIR}/compose.mapping.yml"
+grep -Fq -- '- "${G1_MAP_GID:-1000}"' "${NAV_DIR}/compose.mapping.yml"
+if grep -Eq '^    user:' "${NAV_DIR}/compose.mapping.yml"; then
+  fail "mapping override changes the validated FAST-LIVO2 user"
+fi
+
+readonly STOP_LOG="${TEST_ROOT}/stop.log"
+PATH="${FAKE_PATH}" G1_FAKE_LOG="${STOP_LOG}" \
+G1_MAP_NAME=sh_n3_smoke CONFIRM_G1_SHADOW_WRITE=YES \
+  "${DEPLOY_SCRIPT}" stop_mapping g1-sh-wifi ubuntu eth0 >/dev/null
+
+grep -Fq 'total += $1' "${STOP_LOG}"
+grep -Fq 'stop fast-livo2' "${STOP_LOG}"
+grep -Fq 'mapping_exit_code=' "${STOP_LOG}"
+grep -Fq 'test "${mapping_exit_code}" = 0' "${STOP_LOG}"
+grep -Fq 'mapping_restore_status=0' "${STOP_LOG}"
+grep -Fq 'test "${mapping_restore_status}" -eq 0' "${STOP_LOG}"
+grep -Fq 'refusing stop_mapping identity mismatch' "${STOP_LOG}"
+identity_guard_line="$(grep -n 'refusing stop_mapping identity mismatch' "${STOP_LOG}" | head -n 1 | cut -d: -f1)"
+stop_line="$(grep -n 'stop fast-livo2' "${STOP_LOG}" | head -n 1 | cut -d: -f1)"
+restore_line="$(grep -n 'up -d --no-build --wait' "${STOP_LOG}" | tail -n 1 | cut -d: -f1)"
+report_line="$(grep -n 'pcd_count=' "${STOP_LOG}" | tail -n 1 | cut -d: -f1)"
+test "${identity_guard_line}" -lt "${stop_line}" || fail "mapping identity guard occurs after stop"
+test -n "${restore_line}" || fail "ordinary shadow restore command missing"
+test -n "${report_line}" || fail "PCD report command missing"
+test "${restore_line}" -lt "${report_line}" || fail "map reporting occurs before shadow restore"
+if grep -Fq 'docker logs' "${DEPLOY_SCRIPT}"; then
+  fail "deployment script reads Docker logs on the G1"
+fi
+
+set +e
+rgb_start_output="$(
+  PATH="${FAKE_PATH}" G1_FAKE_LOG="${TEST_ROOT}/rgb-start-denied.log" \
+  G1_MAP_NAME=sh_rgb_static \
+    "${DEPLOY_SCRIPT}" start_rgb_preview g1-sh-wifi ubuntu eth0 2>&1
+)"
+rgb_start_status="$?"
+set -e
+test "${rgb_start_status}" -eq 2 || fail "start_rgb_preview without confirmation was not denied"
+grep -Fq "Refusing robot write" <<<"${rgb_start_output}"
+
+readonly RGB_START_LOG="${TEST_ROOT}/rgb-start.log"
+readonly RGB_START_OUTPUT="${TEST_ROOT}/rgb-start.output"
+PATH="${FAKE_PATH}" G1_FAKE_LOG="${RGB_START_LOG}" \
+G1_FAKE_EMPTY_PROBE_ONCE=1 G1_MAP_NAME=sh_rgb_static G1_PCD_SAVE_INTERVAL=20 \
+G1_RGB_TIME_PROBE="${TIME_PROBE_OUTPUT}" CONFIRM_G1_SHADOW_WRITE=YES \
+  "${DEPLOY_SCRIPT}" start_rgb_preview g1-sh-wifi ubuntu eth0 \
+  >"${RGB_START_OUTPUT}" 2>&1
+test "$(grep -Fc 'docker exec -i embodied-unitree-g1 python3 -' "${RGB_START_LOG}")" -eq 2 \
+  || fail "RGB probe did not retry after a successful-but-empty response"
+grep -Fq 'RGB probe attempt=1 invalid ssh_status=0 derive_status=1 bytes=0' \
+  "${RGB_START_OUTPUT}"
+grep -Fq 'docker build' "${RGB_START_LOG}"
+grep -Fq 'compose.rgb-preview.yml' "${RGB_START_LOG}"
+grep -Fq 'nominal_public_urdf' "${RGB_START_LOG}"
+grep -Fq 'measured_callback_latency' "${RGB_START_LOG}"
+grep -Fq 'slow_manual_preview' "${RGB_START_LOG}"
+grep -Fq 'img_time_offset_s=-0.032500000' "${RGB_START_OUTPUT}"
+grep -Fq '/navigation/cloud_registered_rgb' "${NAV_DIR}/compose.rgb-preview.yml"
+grep -Fq '/camera/rgb' "${NAV_DIR}/compose.rgb-preview.yml"
+grep -Fq 'healthcheck:' "${NAV_DIR}/compose.rgb-preview.yml"
+grep -Fq "awk '/^[1-9][0-9]*\$\$/" "${NAV_DIR}/compose.rgb-preview.yml"
+
+readonly RGB_STOP_LOG="${TEST_ROOT}/rgb-stop.log"
+PATH="${FAKE_PATH}" G1_FAKE_LOG="${RGB_STOP_LOG}" \
+G1_MAP_NAME=sh_rgb_static CONFIRM_G1_SHADOW_WRITE=YES \
+  "${DEPLOY_SCRIPT}" stop_rgb_preview g1-sh-wifi ubuntu eth0 >/dev/null
+grep -Fq 'refusing stop_rgb_preview identity mismatch' "${RGB_STOP_LOG}"
+grep -Fq 'stop fast-livo2' "${RGB_STOP_LOG}"
+grep -Fq 'preview_restore_status=0' "${RGB_STOP_LOG}"
+grep -Fq '^FIELDS x y z rgb' "${RGB_STOP_LOG}"
+rgb_identity_line="$(grep -n 'refusing stop_rgb_preview identity mismatch' "${RGB_STOP_LOG}" | head -n 1 | cut -d: -f1)"
+rgb_stop_line="$(grep -n 'stop fast-livo2' "${RGB_STOP_LOG}" | head -n 1 | cut -d: -f1)"
+rgb_restore_line="$(grep -n 'up -d --no-build --wait' "${RGB_STOP_LOG}" | tail -n 1 | cut -d: -f1)"
+rgb_report_line="$(grep -n 'rgb_pcd_count=' "${RGB_STOP_LOG}" | tail -n 1 | cut -d: -f1)"
+test "${rgb_identity_line}" -lt "${rgb_stop_line}" || fail "RGB preview identity guard occurs after stop"
+test "${rgb_restore_line}" -lt "${rgb_report_line}" || fail "RGB preview reports artifacts before LIO restore"
+
+readonly ACCEPT_PREFLIGHT_LOG="${TEST_ROOT}/accept-preflight.log"
+PATH="${FAKE_PATH}" G1_FAKE_LOG="${ACCEPT_PREFLIGHT_LOG}" \
+  "${ACCEPT_SCRIPT}" preflight g1-sh-wifi ubuntu eth0 >/dev/null
+if grep -Eq 'mkdir -p|docker (compose|build|load).*(up|down|build|load)' "${ACCEPT_PREFLIGHT_LOG}"; then
+  fail "acceptance preflight emitted a robot write command"
+fi
+
+PATH="${FAKE_PATH}" G1_FAKE_LOG="${TEST_ROOT}/accept-lio.log" \
+  "${ACCEPT_SCRIPT}" lio g1-sh-wifi ubuntu eth0 >/dev/null
+readonly ACCEPT_RGB_LOG="${TEST_ROOT}/accept-rgb.log"
+expect_status 1 env PATH="${FAKE_PATH}" G1_FAKE_LOG="${ACCEPT_RGB_LOG}" \
+  "${ACCEPT_SCRIPT}" rgb g1-sh-wifi ubuntu eth0
+grep -Fq '8086:0b3a' "${ACCEPT_RGB_LOG}"
+grep -Fq '/ubuntu/camera/rgb' "${ACCEPT_RGB_LOG}"
+grep -Fq '/home/unitree/.sensor-collector/calibration.json' "${ACCEPT_RGB_LOG}"
+if grep -Eq 'mkdir -p|docker (compose|build|load).*(up|down|build|load)' "${ACCEPT_RGB_LOG}"; then
+  fail "RGB acceptance emitted a robot write command"
+fi
+G1_MAP_NAME=sh_n3_smoke PATH="${FAKE_PATH}" G1_FAKE_LOG="${TEST_ROOT}/accept-map.log" \
+  "${ACCEPT_SCRIPT}" map g1-sh-wifi ubuntu eth0 >/dev/null
+grep -Fq '/tmp/nav_result.json' "${TEST_ROOT}/accept-map.log"
+grep -Fq "^POINTS [1-9][0-9]*" "${TEST_ROOT}/accept-map.log"
+
+echo "navigation_shell_tests=PASS"

--- a/unitree/g1/traditional_navigation/tests/test_rgb_livo_config.py
+++ b/unitree/g1/traditional_navigation/tests/test_rgb_livo_config.py
@@ -1,0 +1,525 @@
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+NAV_DIR = Path(__file__).resolve().parents[1]
+RENDERER = NAV_DIR / "render-g1-livo-config.py"
+DERIVER = NAV_DIR / "derive-g1-rgb-preview-calibration.py"
+TIME_PROBE = NAV_DIR / "probe-g1-rgb-time-offset.py"
+
+
+def callback_time_probe(boot_id: str = "test-boot-id") -> dict:
+    data = {
+        "schema_version": 1,
+        "probe_type": "g1_realsense_callback_latency",
+        "captured_at_epoch_ns": 1,
+        "boot_id": boot_id,
+        "d435i": {
+            "serial": "346522072810",
+            "color": {
+                "width": 1920,
+                "height": 1080,
+                "fps": 15,
+                "format": "bgr8",
+            },
+        },
+        "measurement": {
+            "method": "realsense_global_time_to_host_delivery_proxy",
+            "timestamp_domain": "global_time",
+            "sample_count": 120,
+            "callback_latency_ms": {
+                "min": 28.0,
+                "median": 32.5,
+                "p95": 35.0,
+                "max": 38.0,
+            },
+            "recommended_img_time_offset_s": -0.0325,
+            "p95_abs_residual_ms": 4.5,
+            "exposure_us": {"median": 8000.0, "p95": 9000.0},
+        },
+    }
+    encoded = json.dumps(
+        data,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return {
+        **data,
+        "probe_id": "sha256:" + hashlib.sha256(encoded).hexdigest(),
+    }
+
+
+def calibration_snapshot() -> dict:
+    data = {
+        "schema_version": 1,
+        "device_id": "sh-g1",
+        "d435i": {
+            "identity": {
+                "manufacturer": "Intel RealSense",
+                "model": "Intel RealSense D435I",
+                "serial": "346522072810",
+            },
+            "profiles": {
+                "color": {
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": 15,
+                    "format": "bgr8",
+                    "intrinsics": {
+                        "fx": 1368.0,
+                        "fy": 1372.0,
+                        "ppx": 981.0,
+                        "ppy": 552.0,
+                        "distortion_model": "inverse_brown_conrady",
+                        "coeffs": [0.0, 0.0, 0.0, 0.0, 0.0],
+                    },
+                }
+            },
+        },
+        "ground_truth": {
+            "transforms": {
+                "lidar_to_camera": {
+                    "status": "calibrated",
+                    "rotation_row_major": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0,
+                    ],
+                    "translation_m": [0.1, 0.0, 0.0],
+                }
+            },
+            "time_alignment": {
+                "d435i_color_to_mid360": {
+                    "status": "verified",
+                    "timestamp_source": "realsense_hardware_clock",
+                    "img_time_offset_s": 0.012,
+                    "p95_abs_skew_ms": 14.0,
+                }
+            },
+        },
+    }
+    encoded = json.dumps(
+        data,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return {
+        "schema_version": 1,
+        "calibration_id": "sha256:" + hashlib.sha256(encoded).hexdigest(),
+        "captured_at_epoch_ns": 1,
+        "data": data,
+        "provenance": {},
+    }
+
+
+class RenderG1LivoConfigTests(unittest.TestCase):
+    def run_renderer(self, snapshot: dict, output: Path) -> subprocess.CompletedProcess[str]:
+        calibration = output.with_suffix(".json")
+        calibration.write_text(json.dumps(snapshot), encoding="utf-8")
+        return subprocess.run(
+            [sys.executable, str(RENDERER), str(calibration), str(output)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_deriver_rejects_empty_probe_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            probe = root_path / "empty-probe.json"
+            output = root_path / "preview.json"
+            probe.write_text("", encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, str(DERIVER), str(probe), str(output)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("invalid live probe JSON", result.stderr)
+            self.assertIn("bytes=0", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+            self.assertFalse(output.exists())
+
+    def test_callback_time_probe_cli_validates_hash_and_jitter(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            probe_path = Path(root) / "time-probe.json"
+            probe_path.write_text(json.dumps(callback_time_probe()), encoding="utf-8")
+            valid = subprocess.run(
+                [sys.executable, str(TIME_PROBE), "--validate", str(probe_path)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(valid.returncode, 0, valid.stdout + valid.stderr)
+            self.assertIn("offset_s=-0.032500000", valid.stdout)
+            self.assertIn("p95_residual_ms=4.500", valid.stdout)
+
+            tampered = callback_time_probe()
+            tampered["measurement"]["p95_abs_residual_ms"] = 21.0
+            probe_path.write_text(json.dumps(tampered), encoding="utf-8")
+            rejected = subprocess.run(
+                [sys.executable, str(TIME_PROBE), "--validate", str(probe_path)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(rejected.returncode, 1)
+            self.assertIn("canonical SHA256", rejected.stderr)
+
+            unstable = callback_time_probe()
+            unstable["measurement"]["p95_abs_residual_ms"] = 21.0
+            payload = {key: value for key, value in unstable.items() if key != "probe_id"}
+            encoded = json.dumps(
+                payload,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            unstable["probe_id"] = "sha256:" + hashlib.sha256(encoded).hexdigest()
+            probe_path.write_text(json.dumps(unstable), encoding="utf-8")
+            jitter_rejected = subprocess.run(
+                [sys.executable, str(TIME_PROBE), "--validate", str(probe_path)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(jitter_rejected.returncode, 1)
+            self.assertIn("residual p95 exceeds 20 ms", jitter_rejected.stderr)
+
+    def test_renders_only_complete_calibration(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            output = Path(root) / "g1_livo.yaml"
+            result = self.run_renderer(calibration_snapshot(), output)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            rendered = output.read_text(encoding="utf-8")
+            self.assertIn("img_en: 1", rendered)
+            self.assertIn("enable_image_processing: true", rendered)
+            self.assertIn("width: 1920", rendered)
+            self.assertIn(
+                "Rcl: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]",
+                rendered,
+            )
+            self.assertIn("Pcl: [0.1, 0.0, 0.0]", rendered)
+            self.assertIn("img_time_offset: 0.012", rendered)
+            self.assertIn("d0: 0.0", rendered)
+            self.assertIn("filter_size_pcd: 0.02", rendered)
+
+    def test_rejects_unknown_lidar_camera_extrinsic(self) -> None:
+        snapshot = calibration_snapshot()
+        transform = snapshot["data"]["ground_truth"]["transforms"]["lidar_to_camera"]
+        transform["status"] = "unknown_requires_target_calibration"
+        transform["rotation_row_major"] = None
+        transform["translation_m"] = None
+        encoded = json.dumps(
+            snapshot["data"],
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        snapshot["calibration_id"] = "sha256:" + hashlib.sha256(encoded).hexdigest()
+        with tempfile.TemporaryDirectory() as root:
+            output = Path(root) / "g1_livo.yaml"
+            result = self.run_renderer(snapshot, output)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("LiDAR→D435i 外参状态", result.stdout)
+            self.assertFalse(output.exists())
+
+    def test_rejects_runtime_profile_mismatch(self) -> None:
+        snapshot = calibration_snapshot()
+        snapshot["data"]["d435i"]["profiles"]["color"].update(
+            {"width": 1280, "height": 720, "fps": 30}
+        )
+        encoded = json.dumps(
+            snapshot["data"],
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        snapshot["calibration_id"] = "sha256:" + hashlib.sha256(encoded).hexdigest()
+        with tempfile.TemporaryDirectory() as root:
+            output = Path(root) / "g1_livo.yaml"
+            result = self.run_renderer(snapshot, output)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("与运行 profile 1920x1080@15 不一致", result.stdout)
+            self.assertFalse(output.exists())
+
+    def test_rejects_tampered_calibration_id(self) -> None:
+        snapshot = calibration_snapshot()
+        snapshot["calibration_id"] = "sha256:" + "0" * 64
+        with tempfile.TemporaryDirectory() as root:
+            output = Path(root) / "g1_livo.yaml"
+            result = self.run_renderer(snapshot, output)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("calibration_id", result.stdout)
+            self.assertFalse(output.exists())
+
+    def test_nominal_mode4_preview_requires_explicit_flag(self) -> None:
+        probe = {
+            "schema_version": 1,
+            "captured_at_epoch_ns": 1,
+            "boot_id": "test-boot-id",
+            "mode_machine": 4,
+            "mode_pr": 0,
+            "network_interface": "eth0",
+            "d435i": {
+                "serial": "346522072810",
+                "model": "Intel RealSense D435I",
+                "color": {
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": 15,
+                    "format": "bgr8",
+                    "intrinsics": {
+                        "fx": 1368.246826171875,
+                        "fy": 1372.2265625,
+                        "ppx": 981.5875854492188,
+                        "ppy": 552.4080810546875,
+                        "distortion_model": "inverse_brown_conrady",
+                        "coeffs": [0.0, 0.0, 0.0, 0.0, 0.0],
+                    },
+                },
+                "depth_to_color_optical": {
+                    "rotation_column_major": [
+                        0.9999568462371826,
+                        -0.008939534425735474,
+                        0.002532962244004011,
+                        0.008926372043788433,
+                        0.9999468326568604,
+                        0.005160734057426453,
+                        -0.002578962128609419,
+                        -0.005137901287525892,
+                        0.9999834895133972,
+                    ],
+                    "translation_m": [
+                        0.015179511159658432,
+                        0.0015000001294538379,
+                        0.001500000013038516,
+                    ],
+                },
+                "global_time": [
+                    {"sensor": "Stereo Module", "enabled": True},
+                    {"sensor": "RGB Camera", "enabled": True},
+                    {"sensor": "Motion Module", "enabled": True},
+                ],
+            },
+        }
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            probe_path = root_path / "probe.json"
+            snapshot_path = root_path / "preview.json"
+            output = root_path / "g1_livo.preview.yaml"
+            probe_path.write_text(json.dumps(probe), encoding="utf-8")
+            derived = subprocess.run(
+                [sys.executable, str(DERIVER), str(probe_path), str(snapshot_path)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(derived.returncode, 0, derived.stdout + derived.stderr)
+            snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+            transform = snapshot["data"]["ground_truth"]["transforms"][
+                "lidar_to_camera"
+            ]
+            self.assertEqual(snapshot["data"]["unitree"]["model"], "g1_23dof_rev_1_0")
+            self.assertEqual(transform["status"], "nominal_public_urdf")
+            expected_rotation = [
+                -0.008109593435824423,
+                -0.9999568462371825,
+                -0.004534937467106068,
+                -0.7066513125489848,
+                0.008939534425735472,
+                -0.7075054689844624,
+                0.7075154854731978,
+                -0.0025329622440039496,
+                -0.7066933212441079,
+            ]
+            expected_translation = [
+                0.033162348481982296,
+                0.044845789024666904,
+                -0.03583561107829775,
+            ]
+            for actual, expected in zip(
+                transform["rotation_row_major"], expected_rotation
+            ):
+                self.assertAlmostEqual(actual, expected, places=9)
+            for actual, expected in zip(transform["translation_m"], expected_translation):
+                self.assertAlmostEqual(actual, expected, places=9)
+
+            denied = subprocess.run(
+                [sys.executable, str(RENDERER), str(snapshot_path), str(output)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(denied.returncode, 1)
+            self.assertFalse(output.exists())
+
+            allowed = subprocess.run(
+                [
+                    sys.executable,
+                    str(RENDERER),
+                    str(snapshot_path),
+                    str(output),
+                    "--allow-nominal-preview",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(allowed.returncode, 0, allowed.stdout + allowed.stderr)
+            rendered = output.read_text(encoding="utf-8")
+            self.assertIn("# evidence_tier: nominal_public_urdf", rendered)
+            self.assertIn("# preview_only: true", rendered)
+            self.assertIn("p95_skew_ms: unverified", rendered)
+            self.assertIn("img_time_offset: 0.0", rendered)
+            self.assertIn("Rcl: [-0.00810959343582", rendered)
+
+            time_probe_path = root_path / "time-probe.json"
+            timed_snapshot_path = root_path / "timed-preview.json"
+            timed_output = root_path / "g1_livo.timed-preview.yaml"
+            time_probe_path.write_text(
+                json.dumps(callback_time_probe()), encoding="utf-8"
+            )
+            timed_derived = subprocess.run(
+                [
+                    sys.executable,
+                    str(DERIVER),
+                    str(probe_path),
+                    str(timed_snapshot_path),
+                    "--time-offset-probe",
+                    str(time_probe_path),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(
+                timed_derived.returncode,
+                0,
+                timed_derived.stdout + timed_derived.stderr,
+            )
+            self.assertIn("img_time_offset_s=-0.032500000", timed_derived.stdout)
+            timed_snapshot = json.loads(timed_snapshot_path.read_text(encoding="utf-8"))
+            timed_alignment = timed_snapshot["data"]["ground_truth"][
+                "time_alignment"
+            ]["d435i_color_to_mid360"]
+            self.assertEqual(timed_alignment["img_time_offset_s"], -0.0325)
+            self.assertIsNone(timed_alignment["p95_abs_skew_ms"])
+            self.assertEqual(
+                timed_alignment["preview_time_correction"]["p95_abs_residual_ms"],
+                4.5,
+            )
+            timed_render = subprocess.run(
+                [
+                    sys.executable,
+                    str(RENDERER),
+                    str(timed_snapshot_path),
+                    str(timed_output),
+                    "--allow-nominal-preview",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(
+                timed_render.returncode,
+                0,
+                timed_render.stdout + timed_render.stderr,
+            )
+            self.assertIn(
+                "img_time_offset: -0.0325",
+                timed_output.read_text(encoding="utf-8"),
+            )
+
+    def test_nominal_preview_rejects_stale_time_probe_boot(self) -> None:
+        live_probe = {
+            "schema_version": 1,
+            "captured_at_epoch_ns": 1,
+            "boot_id": "current-boot",
+            "mode_machine": 4,
+            "d435i": {
+                "serial": "346522072810",
+                "model": "Intel RealSense D435I",
+                "color": {"width": 1920, "height": 1080, "fps": 15},
+                "depth_to_color_optical": {
+                    "rotation_column_major": [
+                        1.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0,
+                    ],
+                    "translation_m": [0.01, 0.0, 0.0],
+                },
+                "global_time": [{"sensor": "RGB Camera", "enabled": True}],
+            },
+        }
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            live_path = root_path / "live.json"
+            time_path = root_path / "time.json"
+            output = root_path / "preview.json"
+            live_path.write_text(json.dumps(live_probe), encoding="utf-8")
+            time_path.write_text(json.dumps(callback_time_probe()), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(DERIVER),
+                    str(live_path),
+                    str(output),
+                    "--time-offset-probe",
+                    str(time_path),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("boot_id", result.stderr)
+            self.assertFalse(output.exists())
+
+    def test_nominal_preview_rejects_unmatched_machine_revision(self) -> None:
+        probe = {
+            "mode_machine": 2,
+            "d435i": {
+                "depth_to_color_optical": {
+                    "rotation_column_major": [1.0] * 9,
+                    "translation_m": [0.0, 0.0, 0.0],
+                }
+            },
+        }
+        with tempfile.TemporaryDirectory() as root:
+            probe_path = Path(root) / "probe.json"
+            output = Path(root) / "preview.json"
+            probe_path.write_text(json.dumps(probe), encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, str(DERIVER), str(probe_path), str(output)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unsupported mode_machine", result.stderr)
+            self.assertFalse(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/traditional_navigation/tests/test_rgb_pcd_recovery.py
+++ b/unitree/g1/traditional_navigation/tests/test_rgb_pcd_recovery.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import struct
+import tempfile
+import unittest
+
+
+NAV_DIR = Path(__file__).resolve().parent.parent
+MODULE_PATH = NAV_DIR / "merge-g1-rgb-pcd.py"
+SPEC = importlib.util.spec_from_file_location("merge_g1_rgb_pcd", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def write_rgb_pcd(path: Path, points: list[tuple[float, float, float, int]]) -> None:
+    header = (
+        "# .PCD v0.7 - Point Cloud Data file format\n"
+        "VERSION 0.7\n"
+        "FIELDS x y z rgb\n"
+        "SIZE 4 4 4 4\n"
+        "TYPE F F F U\n"
+        "COUNT 1 1 1 1\n"
+        f"WIDTH {len(points)}\n"
+        "HEIGHT 1\n"
+        "VIEWPOINT 0 0 0 1 0 0 0\n"
+        f"POINTS {len(points)}\n"
+        "DATA binary\n"
+    ).encode("ascii")
+    with path.open("wb") as handle:
+        handle.write(header)
+        for point in points:
+            handle.write(struct.pack("<fffI", *point))
+
+
+class RgbPcdRecoveryTests(unittest.TestCase):
+    def test_merges_timestamp_checkpoints_and_writes_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            write_rgb_pcd(
+                root / "1785871908.100000.pcd",
+                [(0.0, 1.0, 2.0, 0x00112233), (2.0, 3.0, 4.0, 0x00445566)],
+            )
+            write_rgb_pcd(
+                root / "1785871909.200000.pcd",
+                [(-1.0, 5.0, 0.5, 0x00778899)],
+            )
+            write_rgb_pcd(root / "all_rgb_points.recovered.pcd", [(99.0, 99.0, 99.0, 1)])
+            output = root / "all_rgb_points.recovered.pcd"
+            manifest = root / "rgb-recovery-manifest.json"
+
+            result = MODULE.merge_checkpoints(root, output, manifest, "test_reboot")
+
+            self.assertEqual(result["source_count"], 2)
+            self.assertEqual(result["output_points"], 3)
+            self.assertEqual(result["nonzero_rgb_points"], 3)
+            self.assertEqual(result["bounds_m"]["x"], [-1.0, 2.0])
+            self.assertFalse(result["clean_shutdown"])
+            self.assertFalse(result["unsaved_tail_recovered"])
+            self.assertEqual(MODULE.inspect_rgb_pcd(output)["points"], 3)
+            validated = MODULE.validate_recovery(output, manifest)
+            self.assertEqual(validated["output_sha256"], result["output_sha256"])
+            with manifest.open(encoding="utf-8") as handle:
+                self.assertEqual(json.load(handle)["reason"], "test_reboot")
+
+    def test_explicitly_skips_only_nonempty_all_zero_checkpoints(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            write_rgb_pcd(
+                root / "1785871908.100000.pcd",
+                [(0.0, 1.0, 2.0, 0x00112233)],
+            )
+            zero_filled = root / "1785871909.200000.pcd"
+            zero_filled.write_bytes(bytes(4096))
+            output = root / "all_rgb_points.recovered.pcd"
+            manifest = root / "rgb-recovery-manifest.json"
+
+            with self.assertRaisesRegex(MODULE.RecoveryError, "missing DATA"):
+                MODULE.merge_checkpoints(root, output, manifest, "test_reboot")
+
+            result = MODULE.merge_checkpoints(
+                root,
+                output,
+                manifest,
+                "test_reboot",
+                skip_zero_filled_checkpoints=True,
+            )
+
+            self.assertEqual(result["candidate_source_count"], 2)
+            self.assertEqual(result["source_count"], 1)
+            self.assertEqual(result["skipped_source_count"], 1)
+            self.assertEqual(result["skipped_source_bytes"], 4096)
+            self.assertEqual(
+                result["skipped_sources"],
+                [
+                    {
+                        "name": zero_filled.name,
+                        "bytes": 4096,
+                        "reason": "all_zero_after_unclean_shutdown",
+                    }
+                ],
+            )
+            MODULE.validate_recovery(output, manifest)
+
+    def test_rejects_truncated_checkpoint_without_replacing_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "1785871908.100000.pcd"
+            write_rgb_pcd(source, [(0.0, 1.0, 2.0, 0x00112233)])
+            source.write_bytes(source.read_bytes()[:-1])
+            output = root / "all_rgb_points.recovered.pcd"
+            output.write_bytes(b"preserve-me")
+
+            with self.assertRaisesRegex(MODULE.RecoveryError, "payload size mismatch"):
+                MODULE.merge_checkpoints(
+                    root,
+                    output,
+                    root / "rgb-recovery-manifest.json",
+                    "test_reboot",
+                )
+
+            self.assertEqual(output.read_bytes(), b"preserve-me")
+
+    def test_rejects_non_rgb_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "1785871908.100000.pcd"
+            write_rgb_pcd(source, [(0.0, 1.0, 2.0, 0x00112233)])
+            source.write_bytes(source.read_bytes().replace(b"FIELDS x y z rgb", b"FIELDS x y z foo"))
+
+            with self.assertRaisesRegex(MODULE.RecoveryError, "unexpected FIELDS"):
+                MODULE.merge_checkpoints(
+                    root,
+                    root / "all_rgb_points.recovered.pcd",
+                    root / "rgb-recovery-manifest.json",
+                    "test_reboot",
+                    skip_zero_filled_checkpoints=True,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/traditional_navigation/上海G1验收记录模板.md
+++ b/unitree/g1/traditional_navigation/上海G1验收记录模板.md
@@ -1,0 +1,98 @@
+# 上海 G1 传统导航验收记录
+
+日期：
+现场人员：
+机器人入口：`g1-sh-wifi` / 其他：
+ROS namespace：`ubuntu`
+DDS 网卡：`eth0`
+代码 commit：
+地图名：
+
+## 1. 开机与只读 preflight
+
+执行：
+
+```bash
+./accept-g1-navigation-shadow.sh preflight g1-sh-wifi ubuntu eth0
+```
+
+- 时间 / boot ID / uptime：
+- NTP：
+- 主 driver 镜像、启动时间、重启/OOM：
+- shadow 是否存在及安全属性：
+- 结论：通过 / 不通过
+
+## 2. LIO 短时活性
+
+执行：
+
+```bash
+./accept-g1-navigation-shadow.sh lio g1-sh-wifi ubuntu eth0
+```
+
+- `lidar_fast_livo` 平均频率：
+- `imu` 平均频率：
+- `odom` 平均频率：
+- `cloud_registered` 平均频率：
+- clock reset / rejected / stamp clamped：
+- FAST-LIVO 点云丢包：
+- 10 分钟 gap recovery / legacy rejection / sync warning：
+- CPU / 内存：
+- 静止漂移观察：
+- 结论：通过 / 不通过
+
+## 3. 人工驾驶建图
+
+开始命令与输出：
+
+```bash
+G1_MAP_NAME=<map_name> CONFIRM_G1_SHADOW_WRITE=YES \
+  ./deploy-g1-navigation-shadow.sh start_mapping g1-sh-wifi ubuntu eth0
+```
+
+- mapping label / map name / bind mount：
+- 起始位置：
+- 驾驶路线与时长：
+- 闭环区域 / 遮挡 / 动态障碍：
+- 异常日志：
+
+停止命令与输出：
+
+```bash
+G1_MAP_NAME=<map_name> CONFIRM_G1_SHADOW_WRITE=YES \
+  ./deploy-g1-navigation-shadow.sh stop_mapping g1-sh-wifi ubuntu eth0
+```
+
+- 优雅停止耗时：
+- 普通只读 shadow 是否自动恢复：
+- PCD 文件数 / 总大小：
+
+## 4. 地图产物只读验收
+
+执行：
+
+```bash
+G1_MAP_NAME=<map_name> \
+  ./accept-g1-navigation-shadow.sh map g1-sh-wifi ubuntu eth0
+```
+
+- PCD 文件名：
+- `POINTS`：
+- `DATA` 编码：
+- 包围盒 / 几何截图：
+- `/tmp/nav_result.json`：存在且内容为 / 不存在 / 错误码：
+- 期望地图文件是否与后续重定位参数完全一致：
+- 结论：通过 / 不通过
+
+## 5. 未验证项与回滚
+
+- 未验证：地图加载 / scan-to-map 全局重定位 / EGO shadow / ground-controller / 真实运动。
+- 回滚命令：
+
+```bash
+CONFIRM_G1_SHADOW_WRITE=YES \
+  ./deploy-g1-navigation-shadow.sh down g1-sh-wifi ubuntu eth0
+```
+
+- 回滚后主 driver 状态：
+- 后续问题与证据路径：

--- a/unitree/g1/传统导航接口冻结.md
+++ b/unitree/g1/传统导航接口冻结.md
@@ -1,0 +1,167 @@
+# G1 传统导航环境与接口冻结
+
+日期：2026-08-04  
+对应任务：飞书 t100285「运行 EGO-Planner + FAST-LIVO2 完成传统导航闭环」  
+当前阶段：N1 完成；北京 G1 N2 约 19 分 30 秒短验收通过（未补足正式 30 分钟门禁）；固定倒装旋转与 IMU 断流热修镜像均已完成真机正常数据流复核；断流触发后的恢复行为由本地确定性注入覆盖；下一步进入 N3 显式建图
+
+## 结论
+
+现有 G1 驱动不能直接作为 FAST-LIVO2 的传感器入口。北京 G1 实测表明，MID360 原始 DDS 稳定，但现有展示链路丢失了原始 Header、字段描述和坐标语义；同时雷达/IMU 的传感器时钟比 Jetson 系统时钟落后约 183.68 天，D435i 又使用系统当前时间。若不先统一时基，视觉、雷达和 IMU 融合会在同步阶段失败。
+
+本方案冻结为：定位侧直订 Unitree 原始 DDS；驱动提供一个默认关闭的标准 ROS2 桥，保留原始 `ring/time`、校正 Header 时钟，并对点云和雷达内置 IMU 同时施加固定 `Rx(pi)` 倒装旋转；FAST-LIVO2 遇到单次前向 IMU 断流时接受断流后的首个样本并推进时间基线，避免进入永久拒收；N2 通过纯传感器 sidecar 运行该桥，不进入 driver 主入口或初始化运动能力；FAST-LIVO2 和 EGO-Planner 以独立容器运行；运动执行默认不武装，N2/N4 只允许 shadow 输出。
+
+验证优先级为：有合适 G1 时优先真机；暂无合适机器人时，远端算力环境只用于源码编译、单测和录包回放初验，不改变算法最终运行在 G1 的架构，也不替代真机验收。
+
+## 现场事实
+
+| 项目 | 北京 G1 只读实测 | 设计影响 |
+|---|---|---|
+| 系统 | Jetson Orin NX，L4T R35.3.1；驱动容器 Ubuntu 22.04 + ROS2 Humble | FAST-LIVO2 官方主线仍是 ROS1；N2 使用隔离、锁版本的 ROS2/MID360 适配分支 |
+| MID360 点云 | `rt/utlidar/cloud_livox_mid360`，约 9.8–10 Hz，约 2 万点/帧，`point_step=22` | 必须保留全部原始字节和字段 |
+| 点字段 | `x/y/z/intensity/ring/time`；`time` 覆盖约 101 ms 扫描周期 | `time` 是逐点去畸变输入，不得删除或改写 |
+| MID360 IMU | `rt/utlidar/imu_livox_mid360`，约 197–200 Hz | 与点云共用同一个校正器 |
+| MID360 安装轴向 | 雷达 IMU 静止加速度约 `[-0.5205, 0.0213, -0.8561] g`；同刻机身 IMU 归一化约 `[-0.5030, -0.0079, 0.8642]` | 对雷达点云和 IMU 同时应用 `Rx(pi)` 后夹角仅 `1.34°`；不能只改 FAST-LIVO2 的 LiDAR 外参 |
+| 原始时钟 | 雷达/IMU约为 2026-02-01；主机为 2026-08-04，相差约 15,869,770 秒 | 用到达时刻估计共同常量偏移，并持续报告残差/重置 |
+| 现有展示点云 | `/ubuntu/lidar/cloud`；晚加入订阅者持续出现丢消息 | 不作为估计器入口 |
+| D435i | 彩色/深度约 6–7 Hz；用主机当前时间；暂无 `CameraInfo`/外参/TF | N2 先跑 LIO；视觉仅在 N3 前完成硬同步与标定后开启 |
+| 资源 | 诊断期间驱动容器约占 4.8 CPU 核，整机 CPU 常见 40%–60% | shadow 配置应关闭重复点云处理和非必要地图插件，再测预算 |
+
+上海 G1 的设备时钟偏移、外参、实际频率和 CPU 预算均未确认，不能把北京数值当作上海验收结果。
+
+## 进程边界
+
+| 组件 | 运行时 | 职责 | 默认状态 |
+|---|---|---|---|
+| `embodied-unitree-g1` | ROS2 Humble / FastDDS，Domain 42 | 现有设备与安全执行器 | 主入口导航桥关闭，不被 N2 替换 |
+| `navigation-sensor-shadow` | G1/Jetson，Unitree DDS Domain 0 + ROS2 Domain 42 | 原始 MID360 DDS → 冻结 ROS2 接口 | 只读 sidecar；无 MCP/运动/设备权限 |
+| `fast-livo2` | G1/Jetson 本机 ROS2 Humble，独立 GPL 镜像 | LIO/LIVO、建图、里程计、注册点云 | shadow；先 `img_en=0` |
+| `ego-planner` | ROS2 Humble / CycloneDDS | 局部轨迹生成与重规划 | shadow |
+| `ground-controller` | ROS2 Humble | 将三维 B-spline 限制为 G1 平面速度指令 | 未武装 |
+
+FAST-LIVO2 为 GPL-2.0，EGO-Planner ROS2 分支为 GPL-3.0。源码不并入当前驱动目录；镜像、修改和分发在独立边界维护，商用发布前必须完成许可证审查。
+
+## 冻结接口
+
+### MCP 卡片契约
+
+传统导航不新建第二张导航卡片，对外继续使用 `controlled_spatial`。工具名、描述、字段和 `x-action-params` 以 `controlled_spatial_contract.py` 为唯一正本，原生 SLAM 后端与 FAST-LIVO2/EGO 后端共用同一契约，不让 agent 感知底层替换。
+
+| 卡片 action | 传统导航后端语义 | 放行阶段 |
+|---|---|---|
+| `start_mapping` / `stop_mapping` | 显式以 `map_name` 开始建图；停止时优雅结束 FAST-LIVO2，校验并登记地图产物 | N3 |
+| `tag_place` / `untag_place` / `list_tags` | 以当前 `map -> base_link` 位姿增删查 POI，保留 `name/description/x/y/yaw` | N3 |
+| `list_maps` / `delete_map` / `load_map` | 地图元数据与产物同步管理；`load_map` 必须走真实全局配准，不允许以 LIO 重启伪装重定位 | N3 |
+| `navigate_to_tag` / `navigate_to_pose` | 向 EGO 提交目标后立即返回 `navigating`；`speed` 默认 0.5 m/s 且限制在 0.2–0.8 m/s | N4 shadow / N5 运动 |
+| `wait_navigation_done` | 必须紧跟上述两个非阻塞 action；默认 `stall_timeout=90`，只在到达、超时或错误时返回 | N4/N5 |
+| `pause_nav` / `resume_nav` / `stop_nav` | 操作同一导航状态机；`stop_nav` 必须取消目标并输出零速 | N4 shadow / N5 运动 |
+
+`mode=1` 表示遇障停止，`mode=0` 表示绕障。传统后端在绕障能力完成 N5 验收前必须对 `mode=0` 明确返回不支持，不得静默改写成 `mode=1`。N2/N3 shadow 只实现传感器、定位和地图能力，不因卡片契约已冻结就提前武装运动。
+
+### 原始输入
+
+| 话题 | 类型 | 频率 | 约束 |
+|---|---|---:|---|
+| `rt/utlidar/cloud_livox_mid360` | Unitree DDS `sensor_msgs/PointCloud2_` | 10 Hz | 原始 `data`、字段、`point_step`、逐点 `time` 原样保留 |
+| `rt/utlidar/imu_livox_mid360` | Unitree DDS `sensor_msgs/Imu_` | 200 Hz | 读取原始角速度/线加速度；桥接输出统一做固定安装旋转，零四元数标记为 orientation unavailable |
+| D435i 原始彩色 | 待 N3 冻结 | 目标 15 Hz | 必须增加原始 Image、CameraInfo、硬件时戳与外参 |
+
+### 标准化输出
+
+命名空间默认取主机名；北京示例为 `ubuntu`。
+
+| 话题 | ROS2 类型 | QoS | 使用者 |
+|---|---|---|---|
+| `/<ns>/navigation/lidar` | `sensor_msgs/PointCloud2` | best effort，depth 2 | 可选原始记录/诊断；N2 默认关闭 |
+| `/<ns>/navigation/lidar_fast_livo` | `sensor_msgs/PointCloud2` | reliable，depth 2 | 锁版本 ROS2/MID360 FAST-LIVO2 |
+| `/<ns>/navigation/imu` | `sensor_msgs/Imu` | reliable，depth 200 | FAST-LIVO2 bridge / 诊断 |
+| `/<ns>/navigation/sensor_diagnostics` | `std_msgs/String` JSON | reliable | 上线门禁 |
+| `/<ns>/navigation/odom` | `nav_msgs/Odometry` | sensor data | EGO、控制器 |
+| `/<ns>/navigation/cloud_registered` | `sensor_msgs/PointCloud2` | sensor data | EGO 障碍物输入 |
+| `/<ns>/navigation/goal` | `geometry_msgs/PoseStamped` | reliable | 任务入口 |
+| `/<ns>/navigation/cmd_vel_shadow` | `geometry_msgs/TwistStamped` | best effort | shadow 记录，不连接运控 |
+| `/<ns>/navigation/cmd_vel` | `geometry_msgs/TwistStamped` | best effort | 仅 N5 明确武装后连接 SmartMotion |
+
+### TF
+
+冻结树为：`map -> odom -> base_link -> livox_frame`，相机开启后补 `base_link -> camera_link -> camera_color_optical_frame`。桥接层只做一次固定安装旋转，不做随姿态变化的重力对齐；点云和雷达 IMU 一起变换后，FAST-LIVO2 内部 LiDAR-to-IMU 外参保持单位阵，避免同一旋转应用两次。`base_link -> livox_frame` 的平移和最终静态 TF 仍须实测入档。
+
+### 时钟策略
+
+1. 雷达和 IMU 共用一个 `host_arrival - sensor_stamp` 滚动最小值估计器。
+2. 初始至少收集 32 个样本才发布；校准期样本丢弃。
+3. 单个大延迟回调只记拒绝，不改变全局偏移；连续 8 个超过 1 秒的异常才判定时钟重置并重新预热。
+4. 原始话题只校正 Header，逐点 `time` 保持相对扫描起点的原始纳秒偏移；适配话题另生成 `timestamp = corrected_header_ns + time`，不反向污染原始话题。
+5. 诊断必须暴露偏移、到达残差、重置次数和各流丢包数。
+
+## 配置和阶段门禁
+
+当前仓库仅增加默认关闭项：
+
+```yaml
+plugins:
+  navigation_sensors:
+    enabled: false
+    publish_raw_cloud: false
+    publish_fast_livo_cloud: true
+    raw_lidar_frame: livox_raw_frame
+    lidar_frame: livox_frame
+    imu_frame: livox_frame
+    sensor_rotation_matrix: [1.0, 0.0, 0.0,
+                             0.0, -1.0, 0.0,
+                             0.0, 0.0, -1.0]
+```
+
+N2 不修改现有 driver 的配置，而由独立 `navigation_sensor_bridge_main.py` 读取 `driver.shadow.yaml`，只构造传感器桥；它没有 MCP 端口、运动插件、`/dev` 或 host PID 权限。估计器运行时只发布 `lidar_fast_livo`；原始标准话题仅在短时诊断时打开，两路同时发布的北京实测吞吐只有约 4.8 Hz。
+
+短时功能验证可让 sidecar 与现有 driver 并行，且不替换 `embodied-unitree-g1`。正式 CPU/内存预算验收仍需把旧 `lidar`、`controlled_spatial` 和 `controlled_spatial_map` 的重复处理计入结果，或由现场人员在受控窗口停用重复链路并保留回滚；部署脚本不自动停止现有服务。
+
+锁定的 ROS2 分支即使 `img_en=0` 也会无条件构造 VIO 并要求 `camera.model`。`g1_lio.yaml` 因此包含一组只用于通过启动契约的惰性 Pinhole 占位值；它不是 D435i 标定，不得用它开启视觉融合。
+
+| 阶段 | 放行条件 | 禁止项 |
+|---|---|---|
+| N1 接口冻结 | 单元测试通过；标准消息字段/时钟策略确定 | 部署、运动 |
+| N2 FAST-LIVO2 shadow | IMU约 200 Hz、点云约 10 Hz；时间残差稳定；连续 30 分钟无 clock reset | 相机融合、运动 |
+| N3 建图/重定位 | 标定文件入档；地图可保存加载；重定位为真实全局配准而非状态伪造 | 未确认地图直接导航 |
+| N4 EGO shadow | 里程计/障碍点云/目标输入齐全；轨迹持续重规划；G1 平面约束通过 | 连接运控 |
+| N5 运动与安全 | 用户现场授权；遥控急停；最大速度/角速度/超时门禁；每条命令有限时长 | continuous 无超时指令 |
+| N6 上海闭环 | 在上海 G1 重新完成全部频率、时钟、资源、地图、重规划和停障验收 | 用北京结果代替上海结果 |
+
+## 上游基线
+
+- FAST-LIVO2：<https://github.com/hku-mars/FAST-LIVO2>
+- ROS2/MID360 候选实现：<https://github.com/hku-mars/FAST-LIVO2/pull/318>，N2 固定审查过的 commit，不跟随其 `main`
+- EGO-Planner ROS2：<https://github.com/ZJU-FAST-Lab/ego-planner-swarm/tree/ros2_version>
+- G1/Humble 离线地图定位候选：<https://github.com/deepglint/FAST_LIO_LOCALIZATION_HUMANOID/tree/humble>，审查固定 commit `df4772ec4797172430e7efe990711d09a529f4ad`
+
+官方主线的 Livox 输入是 `livox_ros_driver/CustomMsg`，不能直接消费 G1 的 PointCloud2。PR #318 尚未合并且没有上游 review，虽已实现 ROS2 Humble/MID360，但只能作为可回滚的 shadow 候选；上线镜像需固定 commit、保存源版本和构建清单。本桥同时保留原始标准话题，便于候选分支被替换时不重做设备层。
+
+锁定 FAST-LIVO2 只有 PCD 保存路径，没有地图加载、`/initialpose` 或 scan-to-map 重定位。Humanoid 候选确实提供离线地图 ICP 纠偏，但初始化仍依赖给定粗位姿与局部地图裁剪，且 `open3d_loc` 没有明确许可证、Open3D ARM 包未充分验证、默认话题和超大 QoS 深度也需修改。因此 N3 必须把“地图持久化”和“真实配准定位”分成两项验收，不能用 LIO 重启续跑伪装成重定位。
+
+地图持久化已冻结为显式 `compose.mapping.yml` override：N2 默认 `PCD_SAVE_EN=false`；mapping 必须指定专用空目录 `G1_MAP_DIR`，容器仍只读且仅 PCD 目录可持久写。初验使用 `interval=-1`，短时采图后由 SIGINT 触发 raw/降采样地图落盘。实测还发现 `ros2 run` Python 包装器成为 PID 1 时不会可靠转发停止信号，空数据容器等待 120 秒仍被强杀；改为直接执行安装后的 C++ 二进制后，实际参数 `true/-1/0` 可读回，空数据 mapping Compose 在约 7 秒内优雅停止。真实 G1 地图内容、退出时延与内存上限仍是 N3 门禁，不能由空数据测试代替。
+
+## 北京代理验证记录
+
+- 最终估计器输入路径使用 reliable/depth 2：桥内点云 9.94 Hz、IMU 199.65 Hz；独立 ROS2 消费者点云 9.85 Hz、IMU 195.55 Hz；clock reset 0，时钟残差 0.329 ms。
+- 消费者看到的点云时延 p50 114.362 ms、p95 127.835 ms、max 250.945 ms；IMU 时延 p50 1.369 ms、p95 9.846 ms、max 18.261 ms。点云的约 100 ms 是整帧扫描聚合的预期成本，不得单独平移 Header。
+- FAST-LIVO2 适配点云为 32 bytes/point：`x/y/z/intensity/tag/line/timestamp`；单帧约 20,000 点，`line=0–3`、`tag=0x10`，逐点相对时间约 5,120–100,000,000 ns。
+- Python ROS2 Humble 对大 `bytes` 的调试 setter 会逐字节校验，是早期适配路径只有约 8 Hz 的根因；改为 `array('B')` 快速路径后恢复上述频率。同时发布原始和适配两路大点云仍只有约 4.8 Hz，因此 N2 默认只开适配路径。
+- 以上为北京 G1 现有驱动容器内的纯内存探针结果，没有在机器人上写文件、改配置或部署镜像；不等于 N2 真机放行。
+- 同一台北京 G1 的雷达 IMU 与机身 IMU 静态对照确认固定倒装：雷达向量经 `Rx(pi)` 后与机身归一化重力方向余弦为 `0.999727`，夹角 `1.34°`。机身当时约有 30.7° 俯仰，不能把该姿态误写成传感器额外安装角。
+
+## N2 构建验证记录
+
+- 2026-08-04 在本机 Docker Desktop 对锁定的 5 个上游源码 commit 完成 `linux/arm64` 真实构建；FAST-LIVO2 主程序与 Livox SDK2、livox_ros_driver2、Sophus、Vikit 全部编译通过。
+- 镜像 `phanthy-fast-livo2:g1-1fcd0d0` 的 revision 为 `1fcd0d05cadaeb25ca59fd87cda95aaaee41e3ea`，镜像 ID 为 `sha256:3c8f9c2cbde6ea637f0875d8fc948576125adfa577559c1449c0a01326db4934`，逻辑大小 970,577,022 bytes。
+- 离线 smoke test 确认 ROS package、`fastlivo_mapping` 可执行文件和全部动态链接完整；无网络节点加载 `g1_lio.yaml` 后稳定存活 12 秒至测试超时。
+- 双容器真实 Compose 启动后 `sensor-bridge` 与 `fast-livo2` 均为 `healthy`；二者均为只读根文件系统、非特权、`cap_drop=ALL`、无设备映射和 host PID。测试容器已删除，保留镜像与构建缓存。
+- 首次双容器测试发现 FAST-LIVO2 的 reliable IMU 订阅与桥的 best-effort 发布不兼容；将 IMU 发布冻结为 reliable 后，日志告警消失，`ros2 topic info -v` 确认点云和 IMU 均为 1 个 reliable publisher 对 1 个 reliable subscriber。
+- 固定倒装修正版 `phanthy-g1-driver:navigation-sensors-rx180` 完成 `linux/arm64` 真实构建，ID 为 `sha256:e0ce5d75750e522fa10db304472feab322fbd3e0710cc38bf396c4fa2784f7f4`，逻辑大小 342,131,607 bytes。一次性容器导入、旋转样例和真实双容器 Compose healthcheck 均通过；基础镜像不可达的内网 APT 源已改为可配置且默认公开的 Ubuntu ARM 源。
+- 北京 G1 于 14:48:48–15:08:18 完成约 19 分 30 秒短验收：容器 healthy、重启/OOM 为 0，clock reset/rejected/stamp clamped 为 0；点云丢 3/11,829、适配点云丢 0、IMU 丢 426/237,145；77 次同步 warning 未出现 fatal。用户选择以 20 分钟形成阶段结论，因此正式 30 分钟门禁明确未执行。
+- 坐标修正版部署到北京 G1 后，导航 IMU 与机身 IMU 的重力方向余弦为 `0.999240`、夹角 `2.2339°`，导航 IMU 模长为 `1.000818 g`；点云、IMU、里程计和注册点云均恢复实时输出，确认 `Rx(pi)` 在真机链路生效。
+- 随后一次 `0.3053 s` 的前向 IMU 间隙暴露上游恢复缺陷：旧逻辑在超阈值时直接返回，却不推进 `last_timestamp_imu`，导致后续所有样本持续被判定为跳变，容器仍为 healthy 但里程计停止。该现象说明进程健康不能替代输出活性门禁。
+- 新的内容锁定补丁在本地 arm64 镜像 `phanthy-fast-livo2:g1-1fcd0d0-n2gap1` 中完成确定性注入验证：先稳定产生 38 条里程计，注入 `0.35 s` IMU 间隙后继续产生 52 条，总计 98 条；只出现 1 次恢复告警，旧式永久拒收告警为 0。镜像 ID 为 `sha256:ba214f2512b57f1339cde7ed0d17f62d67b76e99fbeb45f74fc1c0426eb894b9`，逻辑大小 976,429,055 bytes，补丁 SHA256 为 `534b15ab7559d572b1be56611ab1b5f5d73809f91727de5e853cd04612f4fc3b`。
+- 北京 G1 使用远端锁定基础镜像完成 hotfix 构建，仅发送 23.55 kB build context；真机镜像 ID 为 `sha256:9151c5b22fddb3533045a92588a3ca10670b17aea83b7b448e8ed8c8d471218f`。重建后两个 shadow 均为 healthy、重启 0、OOM 0，且保持只读、非特权、`cap_drop=ALL`；现有 `embodied-unitree-g1` 未替换。
+- 8 秒只读订阅复核得到 IMU `199.64 Hz`、里程计与注册点云 `9.96 Hz`；桥诊断为 clock reset/rejected/stamp clamped 均 0、残差 `0.011 ms`、FAST-LIVO 点云丢 0。启动后约 3 分 36 秒内旧式永久拒收告警为 0；出现 15 次既有同步 warning，但没有打断里程计。该窗口未自然出现大 IMU 间隙，因此不能把它写成“真机已触发并恢复”。
+- 未验证项：北京 G1 自然断流后的恢复样本、静止漂移与地图几何；正式 30 分钟 clock reset 门禁；上海 G1 复核；地图加载与真实配准定位。
+
+EGO 原始模型面向多旋翼，不能把其三维位置命令直接发送给 G1。`ground-controller` 必须锁定 z/roll/pitch，并执行速度、角速度、加速度、轨迹新鲜度和障碍安全限制。


### PR DESCRIPTION
## 背景

G1 传统导航需要一条不替换现有 Driver、不接入运控的 MID360 + IMU + FAST-LIVO2 shadow 链路，并为 `controlled_spatial` 提供可显式启停、可验收的建图产物。

## 主要变更

- 冻结 `controlled_spatial` 14-action 契约，对齐 `wait_navigation_done` 90 秒默认超时。
- 新增隔离的 MID360/IMU sensor bridge：统一 ROS 2 点云布局、修正传感器时钟域，并对倒装 MID360 的点云与 IMU 同时应用 `Rx(pi)`。
- 新增纯 LIO FAST-LIVO2 shadow Compose，隔离 odom/cloud/TF 话题，不向全局 TF 或任何运动接口写入。
- 修复前向 IMU gap 后上游持续拒收的时间基线问题。
- 增加显式 `start_mapping` / `stop_mapping` 生命周期：运行中原子 PCD checkpoint、正常退出尾段保存、地图身份校验与停止后自动恢复普通只读 shadow。
- 新增仓内部署/只读验收脚本、fake SSH/Docker shell 回归、PCD 保存 smoke 与现场验收模板。
- 保留显式隔离的 RGB preview/fail-closed 门禁与异常恢复资产；默认 LIO 配置固定 `img_en=0`，RGB 未进入当前交付。

## 安全与兼容边界

- `navigation_sensors` 默认关闭，只在显式 shadow 配置中启用。
- 两个 shadow sidecar 保持 `read_only` / 非特权 / `cap_drop=ALL` / 无设备映射 / `restart: no`。
- 不替换 `embodied-unitree-g1`，不暴露 `/cmd_vel`、SmartMotion 或 action-service 写面。
- 当前生产路线仅使用纯 LiDAR/LIO 点云；RGB 需完成当台 D435i–MID360 实测外参后才能复验。

## 已验证

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=unitree/g1 python3 -m unittest discover -s unitree/g1/tests -v` — 25/25 通过。
- `bash unitree/g1/traditional_navigation/tests/test-navigation-shells.sh` — PASS。
- RGB 配置/恢复 Python 单测 — 13/13 通过。
- 7 个 shell 入口 `bash -n` 通过。
- 普通 LIO、mapping、隔离 RGB preview 三套 Compose 解析通过。
- 上海 G1 已完成约 18 分钟 N2 shadow 真机窗口和 N3 人工驾驶 PCD 保存验收；现有 Driver 未被替换。

## 本 PR 不声称完成

- 分段 PCD 合并/去重/体素降采样后的唯一可加载地图制品。
- 地图加载、scan-to-map 全局重定位和 `load_map` 闭环。
- EGO-Planner、ground-controller 或任何真实自主运动输出。
- RGB 生产建图与已验外参。

## 建议审查顺序

1. `controlled_spatial_contract.py`
2. `navigation_time.py` / `navigation_pointcloud.py` / `navigation_sensor_bridge.py`
3. `traditional_navigation/compose.shadow.yml` / `compose.mapping.yml`
4. `fast-livo2-runtime.patch` / `fast-livo2-pcd-save.patch`
5. 部署、验收脚本与回归
