### PR TITLE
feat: ACP rollout — gestures, nav, R1 SmartMotion

### DIFF
--- a/README_dev.md
+++ b/README_dev.md
@@ -550,27 +550,36 @@ unitree-g1:                      # Service name (must be unique)
 
 ## Action Completion Protocol (ACP)
 
-When a tool performs a long-running physical action (TTS playback, navigation, arm movement), the LLM agent needs to know when the action finishes. ACP solves this at the **harness level** — the Agent Core transparently tracks async actions and exposes a `sync()` tool for the LLM to wait on.
+When a tool performs a long-running physical action (TTS playback, navigation, arm gesture), the LLM agent needs to know when it finishes. ACP solves this at the **harness level** — Agent Core transparently tracks async actions via an automatic barrier. The LLM is unaware of the async machinery.
 
 ### How It Works
 
 ```
-LLM calls speak("hello")
-  → Driver dispatch() returns {"status":"running", "action_id":"speak-a7f3c"}
-  → Agent Core registers pending action
-  → LLM sees the immediate result, can continue reasoning
+LLM calls speak("hello world")
+  → Driver dispatch() returns {"state":"speaking", "action_id":"tts_speak_a7f3c"}
+  → Agent Core registers pending action (from x-completion + action_id in result)
+  → LLM sees immediate result, continues reasoning
 
-...speech plays...
+LLM calls navigate_to_tag("P3")
+  → Agent Core BARRIER: waits until speak-a7f3c completes before dispatching
+  → ...TTS finishes, driver POSTs /api/acp/complete → pending cleared...
+  → BARRIER releases, navigate dispatched
+  → Driver returns {"state":"navigating", "action_id":"nav_b2e8d"}
+  → LLM continues reasoning (can pre-plan next speech)
 
-Driver worker finishes
-  → POST /api/acp/complete to Agent Core
-     body: {"action_id":"speak-a7f3c", "status":"completed"}
-  → Agent Core resolves the pending action
-  → Completion notification injected into LLM turn (via steering)
-
-LLM calls sync(["speak-a7f3c"])   (or waits for steering notification)
-  → Blocks until action completes → returns results
+LLM calls speak("welcome to P3")
+  → BARRIER: waits until nav_b2e8d completes
+  → ...navigation arrives, driver POSTs completion...
+  → speak dispatched
 ```
+
+**Key**: The barrier is automatic and transparent. No `sync()` tool needed. The LLM just calls tools normally — the harness ensures physical actions execute sequentially.
+
+### Barrier Scope
+
+The barrier blocks **actuator** and **processor** type tools while pending actions exist. It does NOT block:
+- **sensor** tools (camera, lidar, battery queries) — always instant
+- **resource** tools (list_tags, list_maps, get_status) — read-only
 
 ### Driver Implementation Guide
 
@@ -585,74 +594,153 @@ Add to your tool's `inputSchema`:
     "required": ["action"],
     "x-completion": {
         "actions": ["speak", "navigate_to_tag"],  # which actions are async
-        "timeout": 120                             # max wait seconds
+        "timeout": 120                             # max wait seconds (fallback)
     }
 }
 ```
+
+Only declare actions that are genuinely long-running (>3s). Short blocking calls (1-2s service calls) should remain synchronous.
 
 #### 2. Return `action_id` in async action responses
 
 When an async action is dispatched, include `action_id` in the return dict:
 
 ```python
+from uuid import uuid4
+
 def dispatch(self, action, args):
     if action == "speak":
-        action_id = f"speak-{uuid4().hex[:8]}"
-        self.queue.put((args["text"], action_id))
-        return {"status": "running", "action_id": action_id}
+        action_id = f"tts_speak_{uuid4().hex[:8]}"
+        threading.Thread(target=self._do_speak, args=(args["text"], action_id), daemon=True).start()
+        return {"state": "speaking", "action_id": action_id}
 ```
 
-The `action_id` must be unique and stable — it's the correlation key for completion.
+The `action_id` must be unique — it's the correlation key for completion.
 
 #### 3. POST completion to Agent Core
 
 When the action finishes, POST to Agent Core's ACP endpoint:
 
 ```python
-import urllib.request, ssl, json, os
-
-def _acp_callback(action_id: str, status: str, result: dict):
+def _acp_callback(self, action_id: str, status: str, result: dict):
     """POST action completion to Agent Core."""
-    agent_core_url = os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
-    ctx = ssl.create_default_context()
+    import urllib.request as _urllib
+    import ssl as _ssl
+    import json
+    import os as _os
+
+    agent_core_url = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+    ctx = _ssl.create_default_context()
     ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
+    ctx.verify_mode = _ssl.CERT_NONE
     payload = json.dumps({
         "action_id": action_id,
         "status": status,       # "completed" | "error" | "cancelled"
-        "result": result,       # optional result data
+        "result": result,       # task-specific data
+        "tool": self.PREFIX,    # tool name for logging
+        "ts": __import__('time').time(),
     }).encode()
-    req = urllib.request.Request(
-        f"{agent_core_url}/api/acp/complete",
-        data=payload,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    urllib.request.urlopen(req, timeout=3, context=ctx)
+    try:
+        req = _urllib.Request(
+            f"{agent_core_url}/api/acp/complete",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        _urllib.urlopen(req, timeout=5, context=ctx)
+    except Exception as e:
+        import sys
+        print(f"[ACP] callback failed for {action_id}: {e}", file=sys.stderr)
 ```
 
-Call this from your worker thread when the action finishes. `AGENT_CORE_URL` env var is already set in all driver containers (same one used for registration heartbeat).
+**Important**: Use `import os as _os` inside the callback function — nested functions and threads may not see module-level `os` in some contexts.
+
+Call this from your worker thread when the action finishes. `AGENT_CORE_URL` env var is set in all driver containers.
 
 #### 4. No SSE endpoint needed
 
-Unlike earlier designs, drivers do NOT need to implement an `/sse` endpoint. The completion notification is a simple HTTP POST — fire and forget.
+Drivers do NOT need to implement an `/sse` endpoint. The completion notification is a simple HTTP POST.
 
-### LLM-Side Usage (handled by Agent Core)
+### Advanced Patterns
 
-The LLM sees a `sync()` system tool:
+#### Dynamic Timeout (TTS)
 
+For text-to-speech, timeout should scale with text length:
+
+```python
+timeout = len(text) / 3.0 + 10  # ~3 chars/sec + buffer
 ```
-sync(action_ids="speak-a7f3c,nav-001", timeout=120)
-→ Blocks until all specified actions complete
-→ Returns {"status": "completed", "results": {...}}
+
+If actual playback duration is known (e.g. from a progress callback):
+
+```python
+timeout = reported_duration + 5.0  # actual duration + small buffer
 ```
 
-If no `action_ids` specified, waits for ALL pending actions.
+#### Race Condition Buffer (Event-Based Completion)
 
-Completion notifications also arrive as **steering messages** between tool calls, so the LLM can react to completions without explicitly calling `sync()`.
+When completion depends on an external event (e.g. ROS2 PlayEvent topic), the event may arrive BEFORE your pending wait is registered. Use a buffer:
+
+```python
+class TtsPlugin:
+    def __init__(self):
+        self._play_event_buffer: dict[str, int] = {}   # sid → event_code
+        self._pending_play: dict[str, threading.Event] = {}
+
+    def _on_play_event(self, msg):
+        """ROS2 callback — may fire before _pending_play[sid] exists."""
+        sid = msg.sid
+        event_code = msg.event_code
+        # Always buffer
+        self._play_event_buffer[sid] = event_code
+        # Also signal if pending exists
+        if sid in self._pending_play:
+            self._pending_play[sid].set()
+
+    def _wait_for_completion(self, sid, action_id, timeout):
+        # Check buffer first (event already arrived)
+        buffered = self._play_event_buffer.pop(sid, None)
+        if buffered is not None:
+            status = "completed" if buffered == 1 else "error"
+            self._acp_callback(action_id, status, {})
+            return
+        # Not buffered yet — register and wait
+        ev = threading.Event()
+        self._pending_play[sid] = ev
+        ev.wait(timeout=timeout)
+        self._pending_play.pop(sid, None)
+        buffered = self._play_event_buffer.pop(sid, None)
+        status = "completed" if buffered == 1 else "error"
+        self._acp_callback(action_id, status, {})
+```
+
+#### Stall Detection (Navigation)
+
+For navigation actions, detect when the robot stops moving but hasn't arrived:
+
+```python
+def _nav_poll_thread(self, action_id, target, stall_timeout=60):
+    last_pose = self._get_current_pose()
+    last_move_time = time.time()
+
+    while True:
+        time.sleep(1.0)
+        pose = self._get_current_pose()
+
+        if self._has_arrived(pose, target):
+            self._acp_callback(action_id, "completed", {"pose": pose})
+            return
+
+        if self._distance(pose, last_pose) > 0.05:  # moved
+            last_pose = pose
+            last_move_time = time.time()
+        elif time.time() - last_move_time > stall_timeout:
+            self._acp_callback(action_id, "error", {"error": "stall timeout"})
+            return
+```
 
 ### Backward Compatibility
 
 - Tools without `x-completion` → unchanged behavior (sync return)
-- Tools that don't return `action_id` → no pending registered, no waiting
-- Drivers that don't POST completion → sync() will timeout gracefully
+- Tools that don't return `action_id` → no pending registered, barrier passes through
+- Drivers that don't POST completion → barrier will timeout gracefully (uses `x-completion.timeout`)

--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -285,6 +285,38 @@ def _bearing_label(dx: float, dy: float) -> str:
         return "behind"
 
 
+# ── ACP Helper ───────────────────────────────────────────────────────────────
+
+def _acp_notify(action_id: str, status: str, result: dict, tool: str = "controlled_spatial"):
+    """POST action completion to Agent Core."""
+    import urllib.request as _urllib
+    import ssl as _ssl
+    import os as _os
+
+    agent_core_url = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+    ctx = _ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = _ssl.CERT_NONE
+    payload = json.dumps({
+        "action_id": action_id,
+        "status": status,
+        "result": result,
+        "tool": tool,
+        "ts": time.time(),
+    }).encode()
+    try:
+        req = _urllib.Request(
+            f"{agent_core_url}/api/acp/complete",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        _urllib.urlopen(req, timeout=5, context=ctx)
+    except Exception as e:
+        import sys
+        print(f"[ACP] callback failed for {action_id}: {e}", file=sys.stderr)
+
+
 # ── Plugin ───────────────────────────────────────────────────────────────────
 
 class ControlledSpatialPlugin:
@@ -371,6 +403,10 @@ class ControlledSpatialPlugin:
                     "stall_timeout": {"type": "number", "description": "Seconds without movement before declaring timeout (default 90)"},
                 },
                 "required": ["action"],
+                "x-completion": {
+                    "actions": ["navigate_to_tag", "navigate_to_pose"],
+                    "timeout": 180,
+                },
                 "x-action-params": {
                     "start_mapping": {"params": ["map_name"], "description": "Start SLAM mapping with given map name"},
                     "stop_mapping": {"params": [], "description": "Stop mapping and save the map"},
@@ -380,9 +416,9 @@ class ControlledSpatialPlugin:
                     "list_maps": {"params": [], "description": "List all saved maps"},
                     "delete_map": {"params": ["map_name"], "description": "Delete a map and its associated data"},
                     "load_map": {"params": ["map_name"], "description": "Load a map (robot must be at map origin)"},
-                    "navigate_to_tag": {"params": ["tag_name", "speed", "mode"], "description": "Navigate to a tagged place (non-blocking). mode: 1=stop-on-obstacle (default), 0=detour. MUST be followed by a separate wait_navigation_done call in the same turn to wait for arrival before proceeding."},
-                    "navigate_to_pose": {"params": ["x", "y", "yaw", "speed", "mode"], "description": "Navigate to coordinates (non-blocking). mode: 1=stop-on-obstacle (default), 0=detour. MUST be followed by a separate wait_navigation_done call in the same turn to wait for arrival before proceeding."},
-                    "wait_navigation_done": {"params": ["stall_timeout"], "description": "Block until the previous navigate_to_tag or navigate_to_pose completes. Returns on arrival, timeout, or error. Always call after navigate_to_tag/navigate_to_pose."},
+                    "navigate_to_tag": {"params": ["tag_name", "speed", "mode"], "description": "Navigate to a tagged place. System automatically waits for arrival via ACP barrier."},
+                    "navigate_to_pose": {"params": ["x", "y", "yaw", "speed", "mode"], "description": "Navigate to coordinates. System automatically waits for arrival via ACP barrier."},
+                    "wait_navigation_done": {"params": ["stall_timeout"], "description": "Manually block until navigation completes. Usually unnecessary — ACP barrier handles this automatically."},
                     "pause_nav": {"params": [], "description": "Pause navigation"},
                     "resume_nav": {"params": [], "description": "Resume navigation"},
                     "stop_nav": {"params": [], "description": "Stop and cancel navigation"},
@@ -464,6 +500,65 @@ class ControlledSpatialPlugin:
                 self._last_db_map_status = map_status
         except Exception as e:
             print(f"[ControlledSpatial] failed to update map view state: {e}", flush=True)
+
+    # ── ACP completion thread ────────────────────────────────────────────────
+
+    def _acp_wait_nav(self, action_id: str, target: str, stall_timeout: float = 90):
+        """Wait for navigation to complete, then fire ACP callback."""
+        t0 = time.time()
+        last_pose = self._get_pose()
+        last_move_time = time.time()
+
+        while True:
+            # Check DDS-driven arrival event
+            if self._nav_arrived.wait(timeout=1.0):
+                elapsed = round(time.time() - t0, 1)
+                if self._nav_error:
+                    error = self._nav_error
+                    self._nav_error = None
+                    _acp_notify(action_id, "error", {
+                        "target": target, "error": error, "elapsed": elapsed,
+                    })
+                else:
+                    pose = self._get_pose()
+                    _acp_notify(action_id, "completed", {
+                        "target": target, "pose": pose, "elapsed": elapsed,
+                    })
+                return
+
+            # Stall detection
+            current_pose = self._get_pose()
+            if current_pose and last_pose:
+                dx = current_pose["x"] - last_pose["x"]
+                dy = current_pose["y"] - last_pose["y"]
+                moved = math.sqrt(dx * dx + dy * dy)
+                if moved > 0.05:
+                    last_pose = current_pose
+                    last_move_time = time.time()
+            elif current_pose:
+                last_pose = current_pose
+                last_move_time = time.time()
+
+            if time.time() - last_move_time > stall_timeout:
+                # Pause nav to stop the robot
+                if self._smart_motion:
+                    self._smart_motion.pause_nav()
+                elif self._client:
+                    self._client.PauseNav()
+                _acp_notify(action_id, "error", {
+                    "target": target,
+                    "error": f"stall_timeout ({stall_timeout}s)",
+                    "elapsed": round(time.time() - t0, 1),
+                })
+                return
+
+            # Hard timeout
+            if time.time() - t0 > 180:
+                _acp_notify(action_id, "error", {
+                    "target": target, "error": "timeout_180s",
+                    "elapsed": 180,
+                })
+                return
 
     # ── Dispatch ─────────────────────────────────────────────────────────────
 
@@ -634,14 +729,22 @@ class ControlledSpatialPlugin:
                 mode = int(args.get("mode", 1))
                 if mode != 1:
                     mode = 1  # 强制停障模式，不允许绕障
-                # Non-blocking: sends NavigateTo RPC and returns immediately.
-                # LLM agent must call wait_navigation_done to wait for arrival.
                 self._nav_arrived.clear()
                 self._nav_error = None
-                return self._smart_motion.navigate_to(poi["x"], poi["y"], yaw, tag_name,
-                                                      speed=speed, mode=mode)
+                result = self._smart_motion.navigate_to(poi["x"], poi["y"], yaw, tag_name,
+                                                     speed=speed, mode=mode)
+                # ACP: spawn completion thread
+                from uuid import uuid4
+                action_id = f"g1_nav_{uuid4().hex[:8]}"
+                result["action_id"] = action_id
+                threading.Thread(
+                    target=self._acp_wait_nav,
+                    args=(action_id, tag_name, float(args.get("stall_timeout", 90))),
+                    daemon=True,
+                ).start()
+                return result
 
-            # Fallback: direct SLAM navigation (non-blocking, needs wait_navigation_done)
+            # Fallback: direct SLAM navigation
             q_z = math.sin(yaw / 2)
             q_w = math.cos(yaw / 2)
             speed = max(0.2, min(0.8, float(args.get("speed", 0.5))))
@@ -652,7 +755,16 @@ class ControlledSpatialPlugin:
             self._nav_error = None
             code, resp = self._client.NavigateTo(poi["x"], poi["y"], 0, 0, 0, q_z, q_w, speed=speed, mode=mode)
             if code == 0:
-                return {"status": "navigating", "target": tag_name, "pose": {"x": poi["x"], "y": poi["y"], "yaw": yaw}}
+                from uuid import uuid4
+                action_id = f"g1_nav_{uuid4().hex[:8]}"
+                threading.Thread(
+                    target=self._acp_wait_nav,
+                    args=(action_id, tag_name, float(args.get("stall_timeout", 90))),
+                    daemon=True,
+                ).start()
+                return {"status": "navigating", "target": tag_name,
+                        "pose": {"x": poi["x"], "y": poi["y"], "yaw": yaw},
+                        "action_id": action_id}
             return _rpc_error("NavigateTo", code, resp)
 
         elif action == "navigate_to_pose":
@@ -667,7 +779,16 @@ class ControlledSpatialPlugin:
                     mode = 1  # 强制停障模式，不允许绕障
                 self._nav_arrived.clear()
                 self._nav_error = None
-                return self._smart_motion.navigate_to(x, y, yaw, speed=speed, mode=mode)
+                result = self._smart_motion.navigate_to(x, y, yaw, speed=speed, mode=mode)
+                from uuid import uuid4
+                action_id = f"g1_nav_{uuid4().hex[:8]}"
+                result["action_id"] = action_id
+                threading.Thread(
+                    target=self._acp_wait_nav,
+                    args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90))),
+                    daemon=True,
+                ).start()
+                return result
 
             q_z = math.sin(yaw / 2)
             q_w = math.cos(yaw / 2)
@@ -677,7 +798,15 @@ class ControlledSpatialPlugin:
             self._nav_error = None
             code, resp = self._client.NavigateTo(x, y, 0, 0, 0, q_z, q_w, speed=speed, mode=mode)
             if code == 0:
-                return {"status": "navigating", "target_pose": {"x": x, "y": y, "yaw": yaw}}
+                from uuid import uuid4
+                action_id = f"g1_nav_{uuid4().hex[:8]}"
+                threading.Thread(
+                    target=self._acp_wait_nav,
+                    args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90))),
+                    daemon=True,
+                ).start()
+                return {"status": "navigating", "target_pose": {"x": x, "y": y, "yaw": yaw},
+                        "action_id": action_id}
             return _rpc_error("NavigateTo", code, resp)
 
         elif action == "wait_navigation_done":

--- a/unitree/r1/device.py
+++ b/unitree/r1/device.py
@@ -305,6 +305,9 @@ class _SpeakerNode(Node):
     PREFILL = 3       # buffer 3 chunks (~300ms) before starting playback
     MERGE_BYTES = 9600  # merge into ~300ms blocks before calling PlayStream
 
+    # EOF magic: 8 bytes (4 samples [1,-1,1,-1])，标记 utterance 结束
+    AUDIO_EOF_MAGIC = b'\x01\x00\xff\xff\x01\x00\xff\xff'
+
     def __init__(self, audio_client: AudioClient):
         super().__init__("r1_speaker")
         self._client = audio_client
@@ -317,6 +320,12 @@ class _SpeakerNode(Node):
         self._drain_thread: threading.Thread | None = None
         self._last_chunk_time = 0.0
         self._flush_timer = None
+        # 打断/暂停控制
+        self._lock = threading.Lock()
+        self._interrupt_flag = threading.Event()
+        self._pause_event = threading.Event()
+        self._pause_event.set()  # 初始为非暂停状态
+        self._muted = False  # interrupt 后静默，丢弃后续 chunks 直到 EOF
         # Clear stale PlayStream session from previous container run (MCU keeps state across reboot)
         self._client.PlayStop(APP_NAME)
         self.get_logger().info("SpeakerNode ready")
@@ -327,10 +336,11 @@ class _SpeakerNode(Node):
                 return self._topic
             self.stop_play()
         self._topic = topic
+        self._muted = False  # 新 start 时清除静默
         self._sub = self.create_subscription(
             AudioChunk, topic, self._on_chunk, _LOW_LAT_QOS,
         )
-        self.state = "playing"
+        self.state = "ready"
         self.get_logger().info(f"[speaker] subscribed to {topic}")
         return topic
 
@@ -343,9 +353,12 @@ class _SpeakerNode(Node):
             self.destroy_subscription(self._sub)
             self._sub = None
         self._draining.clear()
+        self._pause_event.set()
+        self._interrupt_flag.set()
         if self._drain_thread is not None:
             self._drain_thread.join(timeout=2)
             self._drain_thread = None
+        self._interrupt_flag.clear()
         while not self._buf.empty():
             try:
                 self._buf.get_nowait()
@@ -357,14 +370,81 @@ class _SpeakerNode(Node):
             self.get_logger().warn(f"PlayStop error: {e}")
         self.state = "idle"
 
+    def interrupt(self) -> dict:
+        """立即中止播放：清空 buffer，停止 SDK，保持 subscription。"""
+        with self._lock:
+            self._interrupt_flag.set()
+            while not self._buf.empty():
+                try:
+                    self._buf.get_nowait()
+                except queue.Empty:
+                    break
+            try:
+                self._client.PlayStop(APP_NAME)
+            except Exception as e:
+                self.get_logger().warn(f"[speaker] interrupt PlayStop error: {e}")
+            if self._drain_thread is not None and self._drain_thread.is_alive():
+                self._drain_thread.join(timeout=1)
+                self._drain_thread = None
+            self._interrupt_flag.clear()
+            self._pause_event.set()
+            self._draining.clear()
+            self._muted = True  # 静默：丢弃后续 TTS chunks 直到 EOF
+            self.state = "ready"
+        self.get_logger().info("[speaker] interrupted — buffer cleared, muted until EOF")
+        return {"state": "ready", "action": "interrupted"}
+
+    def pause(self) -> dict:
+        """暂停播放：停止 SDK，保留 buffer。"""
+        with self._lock:
+            if self.state not in ("playing", "ready"):
+                return {"state": self.state, "error": "not playing"}
+            self._pause_event.clear()
+            try:
+                self._client.PlayStop(APP_NAME)
+            except Exception as e:
+                self.get_logger().warn(f"[speaker] pause PlayStop error: {e}")
+            self.state = "paused"
+        self.get_logger().info(f"[speaker] paused — buffer size={self._buf.qsize()}")
+        return {"state": "paused", "buffer_chunks": self._buf.qsize()}
+
+    def resume(self) -> dict:
+        """恢复播放：从 buffer 中剩余内容继续。"""
+        with self._lock:
+            if self.state != "paused":
+                return {"state": self.state, "error": "not paused"}
+            self.state = "playing"
+            self._pause_event.set()
+            if self._drain_thread is None or not self._drain_thread.is_alive():
+                if not self._buf.empty():
+                    self._start_drain()
+        self.get_logger().info("[speaker] resumed")
+        return {"state": "playing"}
+
     def _on_chunk(self, msg: AudioChunk) -> None:
         pcm = bytes(msg.data)
+        now = time.monotonic()
         self._idx += 1
+
+        # 检测 EOF magic：utterance 结束标记
+        if len(pcm) == 8 and pcm == self.AUDIO_EOF_MAGIC:
+            if self._muted:
+                self._muted = False
+                self.get_logger().info("[speaker] unmuted — received EOF marker")
+            return
+
+        # Muted 状态：interrupt 后丢弃来自旧 utterance 的 chunks
+        if self._muted:
+            self._last_chunk_time = now
+            return
+
         self._buf.put(pcm)
-        self._last_chunk_time = time.monotonic()
-        if not self._draining.is_set() and self._buf.qsize() >= self.PREFILL:
+        self._last_chunk_time = now
+        if self.state == "ready":
+            self.state = "playing"
+        if not self._draining.is_set() and self.state == "playing" and self._buf.qsize() >= self.PREFILL:
             self._start_drain()
-        elif not self._draining.is_set() and self._flush_timer is None:
+        elif not self._draining.is_set() and self.state == "playing" and self._flush_timer is None:
             self._flush_timer = self.create_timer(0.2, self._check_flush)
 
     def _start_drain(self) -> None:
@@ -381,7 +461,7 @@ class _SpeakerNode(Node):
             self._flush_timer.cancel()
             self.destroy_timer(self._flush_timer)
             self._flush_timer = None
-        if not self._draining.is_set() and not self._buf.empty():
+        if not self._draining.is_set() and not self._buf.empty() and self.state == "playing":
             idle = time.monotonic() - self._last_chunk_time
             if idle >= 0.15:
                 self._start_drain()
@@ -391,6 +471,11 @@ class _SpeakerNode(Node):
         merged = b''
         empty_count = 0
         while self._draining.is_set():
+            if self._interrupt_flag.is_set():
+                return
+            if not self._pause_event.wait(timeout=0.1):
+                continue
+
             try:
                 pcm = self._buf.get(timeout=0.1)
                 merged += pcm
@@ -408,12 +493,17 @@ class _SpeakerNode(Node):
                 play_idx += 1
                 self._play_merged(merged, play_idx)
                 merged = b''
-        if merged:
+        if merged and not self._interrupt_flag.is_set():
             play_idx += 1
             self._play_merged(merged, play_idx)
         self._draining.clear()
+        if self.state == "playing":
+            self.state = "ready"
+        self.get_logger().info("[speaker] drain finished")
 
     def _play_merged(self, pcm: bytes, idx: int) -> None:
+        if self._interrupt_flag.is_set():
+            return
         duration = len(pcm) / 32000
         t0 = time.monotonic()
         try:
@@ -424,7 +514,7 @@ class _SpeakerNode(Node):
             self.get_logger().error(f"[speaker] PlayStream error: {e}")
         elapsed = time.monotonic() - t0
         remaining = duration - elapsed - 0.08
-        if remaining > 0:
+        if remaining > 0 and not self._interrupt_flag.is_set():
             time.sleep(remaining)
 
 
@@ -460,7 +550,7 @@ class SpeakerPlugin:
         }
 
     def start(self) -> None:
-        pass  # startup sound is played on first dispatch(start) when project starts
+        pass
 
     def _play_startup_sound(self) -> None:
         """Play startup PCM by directly calling PlayStream in small blocks with pacing."""
@@ -468,7 +558,7 @@ class SpeakerPlugin:
         pcm_path = pathlib.Path(__file__).parent / 'resource' / 'startup_beep.pcm'
         try:
             pcm = pcm_path.read_bytes()
-            block_size = 9600  # ~300ms per block
+            block_size = 9600
             for offset in range(0, len(pcm), block_size):
                 block = pcm[offset:offset + block_size]
                 code, _ = self._node._client.PlayStream(APP_NAME, "0", block)
@@ -491,18 +581,104 @@ class SpeakerPlugin:
             topic = args.get("input_topic", "")
             if not topic:
                 return {"error": "Missing input_topic"}
-            # Always stop first to ensure clean restart and startup sound plays
             self._node.stop_play()
-            # Play startup sound in background
             threading.Thread(target=self._play_startup_sound, daemon=True).start()
             topic = self._node.start_play(topic)
-            return {"state": "playing", "topic": topic}
+            return {"state": "ready", "topic": topic}
         elif action == "stop":
             self._node.stop_play()
             return {"state": "idle"}
         elif action == "info":
-            return {"state": self._node.state, "topic": self._node._topic}
+            return {
+                "state": self._node.state,
+                "topic": self._node._topic,
+                "buffer_chunks": self._node._buf.qsize(),
+            }
         return None
+
+
+# ── SmartMotionPlugin (actuator) ─────────────────────────────────────────
+
+class SmartMotionPlugin:
+    """统一打断/暂停控制卡片。协调 speaker + loco 的中止和暂停。"""
+    PREFIX = "smart_motion"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor,
+                 speaker_plugin=None, loco_plugin=None):
+        self._speaker = speaker_plugin
+        self._loco = loco_plugin
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "smart_motion",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "SmartMotion — 统一运动/输出控制，提供打断、暂停、恢复能力",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["interrupt_all", "interrupt_speak", "interrupt_motion",
+                                 "pause_speak", "resume_speak", "status"],
+                        "description": "Action to perform",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "interrupt_all":    {"params": [], "description": "中止所有输出（语音+动作同时停止）"},
+                    "interrupt_speak":  {"params": [], "description": "中止语音播放，清空待播队列"},
+                    "interrupt_motion": {"params": [], "description": "停止机器人当前运动"},
+                    "pause_speak":      {"params": [], "description": "暂停语音播放（保留未播内容，可恢复）"},
+                    "resume_speak":     {"params": [], "description": "恢复之前暂停的语音播放"},
+                    "status":           {"params": [], "description": "查询当前输出状态（语音/运动）"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "interrupt_all":
+            r1 = self._do_interrupt_speak()
+            r2 = self._do_interrupt_motion()
+            return {"speak": r1, "motion": r2}
+        elif action == "interrupt_speak":
+            return self._do_interrupt_speak()
+        elif action == "interrupt_motion":
+            return self._do_interrupt_motion()
+        elif action == "pause_speak":
+            if self._speaker:
+                return self._speaker._node.pause()
+            return {"error": "no speaker plugin"}
+        elif action == "resume_speak":
+            if self._speaker:
+                return self._speaker._node.resume()
+            return {"error": "no speaker plugin"}
+        elif action == "status":
+            return {
+                "speak": self._speaker.dispatch("info", {}) if self._speaker else None,
+                "motion": self._loco.dispatch("info", {}) if self._loco else None,
+            }
+        return None
+
+    def _do_interrupt_speak(self) -> dict | None:
+        if self._speaker:
+            return self._speaker._node.interrupt()
+        return {"error": "no speaker plugin"}
+
+    def _do_interrupt_motion(self) -> dict | None:
+        if self._loco:
+            return self._loco.dispatch("stop_move", {})
+        return {"error": "no loco plugin"}
 
 
 # ── LedPlugin (actuator) ─────────────────────────────────────────────────────

--- a/unitree/r1/main.py
+++ b/unitree/r1/main.py
@@ -110,6 +110,18 @@ class R1DeviceBundle:
             self._plugins.append(ExtCameraPlugin(plugins_cfg["ext_camera"], namespace, executor))
             print("[bundle] ExtCameraPlugin loaded")
 
+        # SmartMotion 统一打断控制（放在最后，需要引用其他 plugin）
+        if plugins_cfg.get("smart_motion", {}).get("enabled", True):
+            from device import SmartMotionPlugin
+            speaker_plugin = next((p for p in self._plugins if getattr(p, 'PREFIX', '') == 'speaker'), None)
+            loco_plugin = next((p for p in self._plugins if getattr(p, 'PREFIX', '') == 'loco'), None)
+            self._plugins.append(SmartMotionPlugin(
+                plugins_cfg.get("smart_motion", {}), namespace, executor,
+                speaker_plugin=speaker_plugin,
+                loco_plugin=loco_plugin,
+            ))
+            print(f"[bundle] SmartMotionPlugin loaded (speaker={'yes' if speaker_plugin else 'no'}, loco={'yes' if loco_plugin else 'no'})")
+
     def start_all(self) -> None:
         for i, p in enumerate(self._plugins):
             try:

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -3784,7 +3784,7 @@ class TtsPlugin:
                     "force": {"type": "boolean", "description": "是否强制播放(打断当前播放)", "default": False},
                 },
                 "required": ["action"],
-                "x-completion": {"actions": ["speak"], "timeout": 60},
+                "x-completion": {"actions": ["speak"], "timeout": 180},
                 "x-action-params": {
                     "speak": {"params": ["text", "force"], "description": "合成并播放文本"},
                     "interrupt": {"params": [], "description": "中止播放（不可恢复）"},
@@ -3812,6 +3812,9 @@ class TtsPlugin:
         except ImportError as e:
             print(f"[TtsPlugin] WARNING: msg import failed ({e})")
 
+    # PlayEvent event codes
+    _EVENT_NAMES = {0: "STARTED", 1: "COMPLETED", 2: "STOPPED", 3: "CANCELLED", 4: "FAILED"}
+
     def _on_play_event(self, msg):
         """PlayEvent callback: 播放完成/停止/失败时解锁对应的 pending."""
         # event: 0=STARTED, 1=COMPLETED, 2=STOPPED, 3=CANCELLED, 4=FAILED
@@ -3824,7 +3827,8 @@ class TtsPlugin:
             if sid in self._pending_play:
                 self._pending_play_status[sid] = event_code
                 self._pending_play[sid].set()
-            print(f"[TtsPlugin] PlayEvent: sid={sid} event={event_code}")
+            event_name = self._EVENT_NAMES.get(event_code, f"UNKNOWN({event_code})")
+            print(f"[TtsPlugin] PlayEvent: sid={sid} {event_name}")
 
     def _on_play_progress(self, msg):
         """PlayProgress callback: 获取播放总时长，用于精确超时计算。"""
@@ -3860,88 +3864,131 @@ class TtsPlugin:
         if not self._play_client:
             return {"error": "service client not initialized"}
         try:
-            from lyre_msgs.srv import PlayText
             import uuid as _uuid
-            req = PlayText.Request()
-            req.text = text
-            req.force = force
-            req.last = True
-            future = self._play_client.call_async(req)
             action_id = f"tts-{_uuid.uuid4().hex[:8]}"
 
-            # Background thread: wait for PlayEvent COMPLETED then ACP callback
-            def _wait_cb(fut, aid, spoken_text):
-                import time as _t
-                # Phase 1: 等 service response（获取 sid）
-                timeout_service = 10.0
-                start = _t.time()
-                while not fut.done() and _t.time() - start < timeout_service:
-                    _t.sleep(0.1)
-                # 获取 sid
-                sid = None
-                if fut.done():
-                    result = fut.result()
-                    if result:
-                        sid = getattr(result, 'sid', None)
+            # 分段：超过 280 字按标点切分，避免超长文本 PlayEvent 丢失
+            segments = self._split_text(text, max_chars=280)
 
-                # Phase 2: 等 PlayEvent 通知播放完成
-                status = "completed"
-                if sid:
-                    # 先检查 buffer：PlayEvent 可能在我们获取 sid 之前就到了
-                    buffered = self._play_event_buffer.pop(sid, None)
-                    if buffered is not None:
-                        # 已经完成了！
-                        status = "completed" if buffered == 1 else "error"
-                        print(f"[TtsPlugin] PlayEvent from buffer: sid={sid} event={buffered}")
-                    else:
-                        # 注册 pending，等 PlayEvent callback
-                        ev = threading.Event()
-                        self._pending_play[sid] = ev
-                        # 超时 = progress 报告的总时长 + 5s，fallback 字数/3 + 5
-                        import time as _t2
-                        _t2.sleep(0.5)  # 短等让 progress 有机会到达
-                        reported_duration = self._pending_play_duration.get(sid)
-                        if reported_duration and reported_duration > 0:
-                            play_timeout = reported_duration + 5.0
-                        else:
-                            play_timeout = len(spoken_text) / 3.0 + 5.0
-                        if not ev.wait(timeout=play_timeout):
-                            status = "error"
-                            print(f"[TtsPlugin] PlayEvent timeout: sid={sid}, waited {play_timeout:.0f}s (duration={reported_duration})")
-                        else:
-                            event_code = self._pending_play_status.get(sid, 1)
-                            status = "completed" if event_code == 1 else "error"
-                        # 清理
-                        self._pending_play.pop(sid, None)
-                        self._pending_play_status.pop(sid, None)
-                    self._pending_play_duration.pop(sid, None)
-                    self._play_event_buffer.pop(sid, None)
-                elif not sid:
-                    # 没拿到 sid，fallback 按字数估算
-                    fallback_s = len(spoken_text) / 4.0 + 3.0
-                    _t.sleep(fallback_s)
-                    print(f"[TtsPlugin] no sid from service, fallback sleep {fallback_s:.0f}s")
-
-                # ACP callback
-                try:
-                    import urllib.request, ssl, json as _json, os as _os
-                    url = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
-                    ctx = ssl.create_default_context()
-                    ctx.check_hostname = False
-                    ctx.verify_mode = ssl.CERT_NONE
-                    p = _json.dumps({"action_id": aid, "status": status,
-                                     "result": {"action": "speak", "sid": sid or "unknown"}}).encode()
-                    r = urllib.request.Request(f"{url}/api/acp/complete", data=p,
-                                              headers={"Content-Type": "application/json"}, method="POST")
-                    urllib.request.urlopen(r, timeout=3, context=ctx)
-                    print(f"[TtsPlugin] ACP {status}: {aid} (sid={sid})")
-                except Exception as e:
-                    print(f"[TtsPlugin] ACP callback failed: {e}")
-
-            threading.Thread(target=_wait_cb, args=(future, action_id, text), daemon=True).start()
-            return {"state": "speaking", "action_id": action_id, "text": text[:50]}
+            # Background thread: 逐段播放, 全部完成后 ACP callback
+            threading.Thread(
+                target=self._speak_segments,
+                args=(segments, force, action_id, text),
+                daemon=True,
+            ).start()
+            return {"state": "speaking", "action_id": action_id, "text": text[:50],
+                    "segments": len(segments)}
         except Exception as e:
             return {"error": str(e)}
+
+    @staticmethod
+    def _split_text(text: str, max_chars: int = 280) -> list[str]:
+        """按标点分段，每段不超过 max_chars 字。"""
+        import re as _re
+        sentences = _re.split(r'(?<=[。！？；\n])', text)
+        segments = []
+        current = ""
+        for sent in sentences:
+            if not sent:
+                continue
+            if len(current) + len(sent) > max_chars and current:
+                segments.append(current)
+                current = sent
+            else:
+                current += sent
+        if current:
+            segments.append(current)
+        return segments if segments else [text]
+
+    def _speak_segments(self, segments: list, force: bool, action_id: str, full_text: str):
+        """顺序播放多段文本，全部完成后 ACP callback。"""
+        import time as _t
+        from lyre_msgs.srv import PlayText
+
+        overall_status = "completed"
+
+        for i, seg_text in enumerate(segments):
+            is_last = (i == len(segments) - 1)
+            # 发送 PlayText service
+            req = PlayText.Request()
+            req.text = seg_text
+            req.force = force if i == 0 else False  # 只第一段 force
+            req.last = is_last
+            future = self._play_client.call_async(req)
+
+            # Phase 1: 等 service response（获取 sid）
+            timeout_service = 10.0
+            start = _t.time()
+            while not future.done() and _t.time() - start < timeout_service:
+                _t.sleep(0.1)
+
+            sid = None
+            if future.done():
+                result = future.result()
+                if result:
+                    sid = getattr(result, 'sid', None)
+
+            # Phase 2: 等 PlayEvent
+            if sid:
+                buffered = self._play_event_buffer.pop(sid, None)
+                if buffered is not None:
+                    seg_status = "completed" if buffered == 1 else "error"
+                    print(f"[TtsPlugin] seg {i+1}/{len(segments)} from buffer: sid={sid} event={buffered}")
+                else:
+                    ev = threading.Event()
+                    self._pending_play[sid] = ev
+                    _t.sleep(0.3)
+                    reported_duration = self._pending_play_duration.get(sid)
+                    if reported_duration and reported_duration > 0:
+                        play_timeout = reported_duration + 8.0
+                    else:
+                        # 更宽松: 2.5字/秒 + 10s buffer
+                        play_timeout = len(seg_text) / 2.5 + 10.0
+                    if not ev.wait(timeout=play_timeout):
+                        seg_status = "error"
+                        print(f"[TtsPlugin] PlayEvent timeout: seg {i+1}/{len(segments)} sid={sid}, waited {play_timeout:.0f}s (duration={reported_duration})")
+                    else:
+                        event_code = self._pending_play_status.get(sid, 1)
+                        # event_code: 1=COMPLETED, 2=STOPPED (也算完成), 3=CANCELLED, 4=FAILED
+                        seg_status = "completed" if event_code <= 2 else "error"
+                        if event_code > 2:
+                            event_name = self._EVENT_NAMES.get(event_code, f"UNKNOWN({event_code})")
+                            print(f"[TtsPlugin] seg {i+1}/{len(segments)} failed: {event_name} (code={event_code})")
+                        elif event_code == 2:
+                            print(f"[TtsPlugin] seg {i+1}/{len(segments)} STOPPED (treated as completed)")
+                    self._pending_play.pop(sid, None)
+                    self._pending_play_status.pop(sid, None)
+                self._pending_play_duration.pop(sid, None)
+                self._play_event_buffer.pop(sid, None)
+
+                if seg_status == "error" and not is_last:
+                    # 某段 error 但还有后续段，继续播下一段
+                    print(f"[TtsPlugin] seg {i+1} error, continuing to next segment")
+                    continue
+                elif seg_status == "error" and is_last:
+                    overall_status = "error"
+            elif not sid:
+                # 没拿到 sid，fallback 按字数估算
+                fallback_s = len(seg_text) / 2.5 + 5.0
+                _t.sleep(fallback_s)
+                print(f"[TtsPlugin] no sid from service seg {i+1}, fallback sleep {fallback_s:.0f}s")
+
+        # ACP callback
+        try:
+            import urllib.request, ssl, json as _json, os as _os
+            url = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            p = _json.dumps({"action_id": action_id, "status": overall_status,
+                             "result": {"action": "speak", "sid": sid or "unknown",
+                                        "segments": len(segments)}}).encode()
+            r = urllib.request.Request(f"{url}/api/acp/complete", data=p,
+                                      headers={"Content-Type": "application/json"}, method="POST")
+            urllib.request.urlopen(r, timeout=5, context=ctx)
+            print(f"[TtsPlugin] ACP {overall_status}: {action_id} ({len(segments)} segs, {len(full_text)} chars)")
+        except Exception as e:
+            print(f"[TtsPlugin] ACP callback failed: {e}")
 
     def _call_empty_service(self, client, action_name: str) -> dict:
         if not client:

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -187,6 +187,36 @@ _LEG_LEVELS = [
 ]
 
 
+def _acp_notify(action_id: str, status: str, result: dict, tool: str = ""):
+    """POST action completion to Agent Core (module-level ACP helper)."""
+    import urllib.request as _urllib
+    import ssl as _ssl
+    import os as _os
+
+    agent_core_url = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+    ctx = _ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = _ssl.CERT_NONE
+    payload = json.dumps({
+        "action_id": action_id,
+        "status": status,
+        "result": result,
+        "tool": tool,
+        "ts": time.time(),
+    }).encode()
+    try:
+        req = _urllib.Request(
+            f"{agent_core_url}/api/acp/complete",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        _urllib.urlopen(req, timeout=5, context=ctx)
+    except Exception as e:
+        import sys
+        print(f"[ACP] callback failed for {action_id}: {e}", file=sys.stderr)
+
+
 class _ActionSequence:
     """Run one cancellable actuator sequence at a time."""
 
@@ -196,7 +226,8 @@ class _ActionSequence:
         self._cancel_event: threading.Event | None = None
         self._thread: threading.Thread | None = None
 
-    def start(self, worker) -> None:
+    def start(self, worker, on_done=None) -> None:
+        """Start a worker sequence. on_done(cancelled: bool) called when finished."""
         self.cancel()
         cancel_event = threading.Event()
 
@@ -206,10 +237,16 @@ class _ActionSequence:
             except Exception as e:
                 print(f"[{self._name}] sequence failed: {e}")
             finally:
+                cancelled = cancel_event.is_set()
                 with self._lock:
                     if self._cancel_event is cancel_event:
                         self._cancel_event = None
                         self._thread = None
+                if on_done:
+                    try:
+                        on_done(cancelled)
+                    except Exception as e:
+                        print(f"[{self._name}] on_done callback failed: {e}")
 
         thread = threading.Thread(
             target=_run, name=f"{self._name}_sequence", daemon=True)
@@ -2013,10 +2050,11 @@ class HeadGesturePlugin:
                     },
                 },
                 "required": ["action"],
+                "x-completion": {
+                    "actions": ["scan", "shake"],
+                    "timeout": 30,
+                },
                 "x-action-params": {
-                    "nod": {"params": ["cycles", "nod_amplitude", "speed"], "description": "向下点头后回正，不经过抬头姿态"},
-                    "shake": {"params": ["cycles", "shake_amplitude", "speed"], "description": "在左右方向之间连续摇头后回正"},
-                    "scan": {"params": ["cycles", "scan_amplitude", "speed", "scan_hold"], "description": "依次观察左侧并停留、回中、观察右侧并停留、回中"},
                     "tilt": {"params": ["side", "tilt_amplitude", "speed", "hold"], "description": "向指定方向歪头、保持后回正"},
                     "reset": {"params": ["speed"], "description": "取消序列并将头部回正"},
                     "cancel": {"params": [], "description": "取消尚未发送的后续动作帧"},
@@ -2114,19 +2152,35 @@ class HeadGesturePlugin:
                     return
 
         baseline_seq, baseline = self._feedback_snapshot()
-        self._sequence.start(_worker)
+        # ACP: for long actions (scan, shake), return action_id and callback on done
+        action_id = None
+        on_done = None
+        if action in ("scan", "shake"):
+            from uuid import uuid4
+            action_id = f"head_gesture_{action}_{uuid4().hex[:8]}"
+
+            def on_done(cancelled):
+                if cancelled:
+                    _acp_notify(action_id, "cancelled", {"gesture": action}, "head_gesture")
+                else:
+                    _acp_notify(action_id, "completed", {"gesture": action, "cycles": cycles}, "head_gesture")
+
+        self._sequence.start(_worker, on_done=on_done)
         first_target = frames[0][:3]
         feedback = self._wait_for_head_feedback(
             first_target, baseline_seq, baseline)
         if feedback.get("state") == "error":
             self._sequence.cancel()
             return feedback
-        return {
+        result = {
             "state": "running", "gesture": action, "cycles": cycles,
             "amplitude": amplitude, "speed": speed,
             "feedback_verified": True,
             "feedback": feedback,
         }
+        if action_id:
+            result["action_id"] = action_id
+        return result
 
     def _on_head_status(self, msg):
         now = time.monotonic()
@@ -2819,6 +2873,10 @@ class ArmGesturePlugin:
                     },
                 },
                 "required": ["action"],
+                "x-completion": {
+                    "actions": ["salute", "welcome", "shake_hands"],
+                    "timeout": 30,
+                },
                 "x-action-params": {
                     "salute": {"params": ["salute_side", "speed"], "description": "抬起小臂、将手靠近额侧、停留后回正"},
                     "welcome": {"params": ["side", "cycles", "speed"], "description": "在身体侧上方抬起手掌并左右摆动后回正"},
@@ -2958,18 +3016,34 @@ class ArmGesturePlugin:
                     return
 
         baseline_seq, baseline = self._feedback_snapshot(side)
-        self._sequence.start(_worker)
+        # ACP: for long gestures, return action_id and callback on done
+        action_id = None
+        on_done = None
+        if action in ("salute", "welcome", "shake_hands"):
+            from uuid import uuid4
+            action_id = f"arm_gesture_{action}_{uuid4().hex[:8]}"
+
+            def on_done(cancelled):
+                if cancelled:
+                    _acp_notify(action_id, "cancelled", {"gesture": action, "side": side}, "arm_gesture")
+                else:
+                    _acp_notify(action_id, "completed", {"gesture": action, "side": side}, "arm_gesture")
+
+        self._sequence.start(_worker, on_done=on_done)
         feedback = self._wait_for_arm_feedback(
             side, frames[0][0], baseline_seq, baseline)
         if feedback.get("state") == "error":
             self._sequence.cancel()
             return feedback
-        return {
+        result = {
             "state": "running", "gesture": action, "side": side,
             "cycles": cycles, "speed": speed,
             "feedback_verified": True,
             "feedback": feedback,
         }
+        if action_id:
+            result["action_id"] = action_id
+        return result
 
     def _on_arm_status(self, msg):
         now = time.monotonic()
@@ -4126,6 +4200,10 @@ class VoicePlayActuatorPlugin:
 class NavPlugin:
     """底盘导航控制 — 自主导航/遥控/旋转/回桩"""
 
+    _ACP_ACTIONS = frozenset(("move_to", "rotate", "rotate_to", "go_home"))
+    _POLL_INTERVAL = 1.0
+    _STALL_TIMEOUT = 60.0
+
     def __init__(self, plugin_config: dict, namespace: str, ros2, slamtec_client):
         self._ns = namespace
         self._ros2 = ros2
@@ -4159,17 +4237,21 @@ class NavPlugin:
                     "vyaw": {"type": "number", "description": "旋转速度(rad/s), 正=逆时针"},
                 },
                 "required": ["action"],
+                "x-completion": {
+                    "actions": ["move_to", "rotate", "rotate_to", "go_home"],
+                    "timeout": 180,
+                },
                 "x-action-params": {
                     "move_to": {"params": ["x", "y", "speed"],
-                                "description": "自主导航到目标点(带避障)"},
+                                "description": "自主导航到目标点(带避障)，系统自动等待到达"},
                     "move_by": {"params": ["direction", "speed"],
                                 "description": "方向遥控移动(不避障, 持续500ms)"},
                     "rotate": {"params": ["angle"],
-                               "description": "原地旋转指定角度(度)"},
+                               "description": "原地旋转指定角度(度)，系统自动等待完成"},
                     "rotate_to": {"params": ["angle"],
-                                  "description": "原地旋转到绝对角度(度)"},
+                                  "description": "原地旋转到绝对角度(度)，系统自动等待完成"},
                     "go_home": {"params": [],
-                                "description": "自主导航回充电桩"},
+                                "description": "自主导航回充电桩，系统自动等待到达"},
                     "cancel": {"params": [],
                              "description": "取消当前导航动作"},
                     "get_pose": {"params": [],
@@ -4195,7 +4277,11 @@ class NavPlugin:
             y = args.get("y", 0)
             speed = args.get("speed")
             result = self._slamtec.move_to(x, y, speed_ratio=speed)
-            return {"state": "navigating", "target": {"x": x, "y": y}, "api_result": result}
+            action_id = self._start_poll(action, result, {"x": x, "y": y})
+            resp = {"state": "navigating", "target": {"x": x, "y": y}, "api_result": result}
+            if action_id:
+                resp["action_id"] = action_id
+            return resp
 
         elif action == "move_by":
             direction = args.get("direction", "forward")
@@ -4208,17 +4294,29 @@ class NavPlugin:
             angle_deg = args.get("angle", 0)
             angle_rad = _deg2rad(angle_deg)
             result = self._slamtec.rotate(angle_rad)
-            return {"state": "rotating", "angle": angle_deg, "api_result": result}
+            action_id = self._start_poll(action, result, {"angle": angle_deg})
+            resp = {"state": "rotating", "angle": angle_deg, "api_result": result}
+            if action_id:
+                resp["action_id"] = action_id
+            return resp
 
         elif action == "rotate_to":
             angle_deg = args.get("angle", 0)
             angle_rad = _deg2rad(angle_deg)
             result = self._slamtec.rotate_to(angle_rad)
-            return {"state": "rotating_to", "angle": angle_deg, "api_result": result}
+            action_id = self._start_poll(action, result, {"angle": angle_deg})
+            resp = {"state": "rotating_to", "angle": angle_deg, "api_result": result}
+            if action_id:
+                resp["action_id"] = action_id
+            return resp
 
         elif action == "go_home":
             result = self._slamtec.go_home()
-            return {"state": "going_home", "api_result": result}
+            action_id = self._start_poll(action, result, {})
+            resp = {"state": "going_home", "api_result": result}
+            if action_id:
+                resp["action_id"] = action_id
+            return resp
 
         elif action == "cancel":
             result = self._slamtec.cancel_current_action()
@@ -4238,6 +4336,92 @@ class NavPlugin:
         elif action in ("start", "info"):
             return {"state": "ready"}
         return {"error": f"unknown action: {action}"}
+
+    def _start_poll(self, action: str, api_result: dict, context: dict) -> str | None:
+        """Start ACP polling thread for a Slamtec action. Returns action_id or None."""
+        from uuid import uuid4
+        action_id = f"nav_{action}_{uuid4().hex[:8]}"
+        threading.Thread(
+            target=self._poll_loop,
+            args=(action_id, action, context),
+            daemon=True,
+        ).start()
+        return action_id
+
+    def _poll_loop(self, action_id: str, action: str, context: dict):
+        """Poll Slamtec for action completion, then fire ACP callback."""
+        t0 = time.time()
+        last_pose = None
+        last_move_time = time.time()
+
+        while True:
+            time.sleep(self._POLL_INTERVAL)
+            elapsed = time.time() - t0
+
+            # Check if action is still running
+            try:
+                current = self._slamtec.get_current_action()
+            except Exception:
+                current = {}
+
+            # Slamtec status: action_status 0=waiting, 1=running, 2=finished, 3=paused, 4=error
+            status = current.get("action_status") if current else None
+
+            if status == 2:  # finished
+                result_code = current.get("result", 0)
+                if result_code == 0:
+                    _acp_notify(action_id, "completed", {
+                        "action": action, "elapsed": round(elapsed, 1), **context,
+                    }, "nav")
+                else:
+                    _acp_notify(action_id, "error", {
+                        "action": action, "error": f"result_code={result_code}",
+                        "elapsed": round(elapsed, 1), **context,
+                    }, "nav")
+                return
+
+            if status == 4:  # error
+                _acp_notify(action_id, "error", {
+                    "action": action, "error": "action_error",
+                    "elapsed": round(elapsed, 1), **context,
+                }, "nav")
+                return
+
+            if status is None and elapsed > 3.0:
+                # No current action — may have completed between polls
+                _acp_notify(action_id, "completed", {
+                    "action": action, "elapsed": round(elapsed, 1), **context,
+                }, "nav")
+                return
+
+            # Stall detection (move_to/go_home only)
+            if action in ("move_to", "go_home"):
+                try:
+                    pose = self._slamtec.get_pose()
+                    if last_pose:
+                        dx = pose.get("x", 0) - last_pose.get("x", 0)
+                        dy = pose.get("y", 0) - last_pose.get("y", 0)
+                        if (dx * dx + dy * dy) > 0.01:  # moved > 0.1m
+                            last_pose = pose
+                            last_move_time = time.time()
+                        elif time.time() - last_move_time > self._STALL_TIMEOUT:
+                            _acp_notify(action_id, "error", {
+                                "action": action, "error": "stall_timeout",
+                                "elapsed": round(elapsed, 1), **context,
+                            }, "nav")
+                            return
+                    else:
+                        last_pose = pose
+                        last_move_time = time.time()
+                except Exception:
+                    pass
+
+            # Hard timeout
+            if elapsed > 180:
+                _acp_notify(action_id, "error", {
+                    "action": action, "error": "timeout", "elapsed": 180, **context,
+                }, "nav")
+                return
 
 
 # ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Extend ACP (Action Completion Protocol) to all long-duration tools across tianyi2.0 and G1
- Merge R1 Speaker interrupt + SmartMotion card
- Rewrite README_dev.md ACP documentation with latest patterns

## Changes

### Tianyi 2.0 (`x-humanoid/tianyi2.0/device.py`)
- Add module-level `_acp_notify()` helper (replaces inline callbacks)
- `_ActionSequence.start()` now accepts `on_done(cancelled: bool)` callback
- **HeadGesturePlugin**: x-completion for `scan`, `shake` (5-16s) — callback on sequence end
- **ArmGesturePlugin**: x-completion for `salute`, `welcome`, `shake_hands` (3-6s) — callback on sequence end
- **NavPlugin**: x-completion for `move_to`, `rotate`, `rotate_to`, `go_home` — polling thread with stall detection

### G1 (`unitree/g1/controlled_spatial.py`)
- Add `_acp_notify()` helper
- x-completion for `navigate_to_tag`, `navigate_to_pose`
- `_acp_wait_nav()` thread: waits on `_nav_arrived` event, stall detection, hard timeout
- Update action descriptions (remove "must call wait_navigation_done")

### R1 (`unitree/r1/device.py` + `main.py`)
- Cherry-pick from `feat/r1-speaker-smartmotion`: Speaker interrupt/pause/resume + SmartMotionPlugin

### Documentation (`README_dev.md`)
- Rewrite ACP section: barrier semantics (no more `sync()` tool)
- Add advanced patterns: race condition buffer, dynamic timeout, stall detection
- Clarify barrier scope: blocks actuator+processor, not sensor/resource

## Test plan
- [ ] Tianyi: deploy, run arm_gesture salute → verify action_id + ACP callback
- [ ] Tianyi: nav move_to → verify polling thread fires completion
- [ ] G1: deploy, navigate_to_tag → verify _acp_wait_nav fires callback
- [ ] R1: deploy, test SmartMotion interrupt_all

🤖 Generated with [Claude Code](https://claude.com/claude-code)