### PR TITLE
feat(engineai/t800): ship Odin2 vision and depth-node systemd units

### DIFF
--- a/engineai/t800/deploy/engineai-odin2-depth.service
+++ b/engineai/t800/deploy/engineai-odin2-depth.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=EngineAI T800 Odin2 calibrated pointcloud-to-depth node
+Wants=network-online.target
+After=network-online.target engineai-odin2.service
+Wants=engineai-odin2.service
+
+[Service]
+Type=simple
+User=ubuntu
+Environment=HOME=/home/ubuntu
+Environment=ROS_DOMAIN_ID=69
+Environment=RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+ExecStart=/bin/bash -lc 'source /opt/ros/humble/setup.bash && source /home/ubuntu/odin-depth-ws/install/setup.bash && exec ros2 run odin_ros_driver pcd2depth_ros2_node --ros-args -p calib_file_path:=/home/ubuntu/odin-depth-ws/calib.yaml -p cloud_raw_topic:=/manifold/ODIN2/device0/cloud/raw -p color_raw_topic:=/manifold/ODIN2/device0/camera0/raw -p depth_image_topic:=/manifold/ODIN2/device0/depth -p depth_cloud_topic:=/manifold/ODIN2/device0/depth_cloud'
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/engineai/t800/deploy/engineai-odin2.service
+++ b/engineai/t800/deploy/engineai-odin2.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=EngineAI T800 Odin2 ROS2 vision driver
+Wants=network-online.target
+After=network-online.target
+ConditionPathExists=/opt/ros/humble/share/odin_ros_driver_rev1/launch/driver.launch.py
+ConditionPathExists=/home/ubuntu/odin/src/ros_driver/config/control_command.yaml
+
+[Service]
+Type=simple
+User=ubuntu
+Group=ubuntu
+WorkingDirectory=/home/ubuntu/odin
+Environment=HOME=/home/ubuntu
+Environment=ROS_DOMAIN_ID=69
+Environment=ROS_LOCALHOST_ONLY=0
+Environment=RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+ExecStartPre=/usr/bin/ping -c 1 -W 2 192.168.100.251
+ExecStart=/usr/bin/bash -lc 'source /opt/ros/humble/setup.bash && exec ros2 launch odin_ros_driver_rev1 driver.launch.py start_rviz:=false'
+Restart=on-failure
+RestartSec=5
+KillSignal=SIGINT
+TimeoutStopSec=20
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## 概述

补充 T800 Odin2 视觉栈的 systemd 部署单元。此前四张卡片（`pointcloud`/`camera`/`depth`/`mic`）与环境修复已随 #157 合入 main；本 PR 补齐机器人上实际运行、但尚未入库的两个部署文件。

## 内容

### `deploy/engineai-odin2.service`

- Odin2 ROS2 视觉驱动常驻服务（Domain 69、CycloneDDS、headless，`start_rviz:=false`）
- 启动前 ping `192.168.100.251`（Odin2 设备）确保硬件在线；失败自动重启

### `deploy/engineai-odin2-depth.service`

- 官方 `pcd2depth_ros2_node` 常驻服务，发布标定深度图 `/manifold/ODIN2/device0/depth`（`sensor_msgs/Image`、32FC1）——depth 卡的输入源
- 与 Odin2 主驱动的关系使用 `Wants=`（而非 `Requires=`）：开机时主驱动瞬时失败不会让深度节点永久失活——`Restart=on-failure` 不覆盖依赖失败（真机已实测踩坑：该服务开机 dead 导致 depth 卡无输入，需手动重启）

## 验证

- 真机验证：两个 unit 已部署在 T800 应用计算单元（`/etc/systemd/system/`），全链路正常——Domain 69 深度源 ~10 Hz → driver 转换 → Domain 42 `/ubuntu/vision/depth` 640×480 16UC1 ~5.4 Hz
- `engineai-odin2-depth.service` 以 `Wants=` 版本重启验证 active、输出持续正常
- 本仓库测试 63 项全部通过
