### PR TITLE
feat(g1): fix navigate ACP + async loco FSM/move

### DIFF
--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -506,11 +506,32 @@ class ControlledSpatialPlugin:
     def _acp_wait_nav(self, action_id: str, target: str, stall_timeout: float = 90):
         """Wait for navigation to complete, then fire ACP callback."""
         t0 = time.time()
+
+        # Primary: delegate to SmartMotion subprocess which has reliable
+        # pose-based arrival detection (dist < 0.3m from target).
+        # The main process DDS callback for ctrl_info.is_arrived is unreliable
+        # (SLAM service never publishes ctrl_info in practice).
+        if self._smart_motion:
+            result = self._smart_motion.wait_nav_done(stall_timeout=stall_timeout)
+            elapsed = round(time.time() - t0, 1)
+            status = result.get("status", "error")
+            if status == "arrived":
+                _acp_notify(action_id, "completed", {
+                    "target": target, "pose": result.get("pose"), "elapsed": elapsed,
+                })
+            else:
+                _acp_notify(action_id, "error", {
+                    "target": target,
+                    "error": result.get("error", status),
+                    "elapsed": elapsed,
+                })
+            return
+
+        # Fallback: no SmartMotion — poll local DDS callback + stall detection
         last_pose = self._get_pose()
         last_move_time = time.time()
 
         while True:
-            # Check DDS-driven arrival event
             if self._nav_arrived.wait(timeout=1.0):
                 elapsed = round(time.time() - t0, 1)
                 if self._nav_error:
@@ -526,7 +547,6 @@ class ControlledSpatialPlugin:
                     })
                 return
 
-            # Stall detection
             current_pose = self._get_pose()
             if current_pose and last_pose:
                 dx = current_pose["x"] - last_pose["x"]
@@ -540,10 +560,7 @@ class ControlledSpatialPlugin:
                 last_move_time = time.time()
 
             if time.time() - last_move_time > stall_timeout:
-                # Pause nav to stop the robot
-                if self._smart_motion:
-                    self._smart_motion.pause_nav()
-                elif self._client:
+                if self._client:
                     self._client.PauseNav()
                 _acp_notify(action_id, "error", {
                     "target": target,
@@ -552,7 +569,6 @@ class ControlledSpatialPlugin:
                 })
                 return
 
-            # Hard timeout
             if time.time() - t0 > 180:
                 _acp_notify(action_id, "error", {
                     "target": target, "error": "timeout_180s",

--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -348,6 +348,7 @@ class ControlledSpatialPlugin:
         self._map_status: str = "idle"  # idle | mapping | localized
         self._nav_arrived = threading.Event()
         self._nav_error: str | None = None
+        self._nav_action_id: str | None = None  # current navigate ACP action_id
         self._last_db_map_status: str | None = None
         self._lock = threading.Lock()
 
@@ -386,7 +387,6 @@ class ControlledSpatialPlugin:
                             "list_maps", "delete_map",
                             "load_map",
                             "navigate_to_tag", "navigate_to_pose",
-                            "wait_navigation_done",
                             "pause_nav", "resume_nav", "stop_nav",
                         ],
                         "description": "Action to perform",
@@ -418,7 +418,6 @@ class ControlledSpatialPlugin:
                     "load_map": {"params": ["map_name"], "description": "Load a map (robot must be at map origin)"},
                     "navigate_to_tag": {"params": ["tag_name", "speed", "mode"], "description": "Navigate to a tagged place. System automatically waits for arrival via ACP barrier."},
                     "navigate_to_pose": {"params": ["x", "y", "yaw", "speed", "mode"], "description": "Navigate to coordinates. System automatically waits for arrival via ACP barrier."},
-                    "wait_navigation_done": {"params": ["stall_timeout"], "description": "Manually block until navigation completes. Usually unnecessary — ACP barrier handles this automatically."},
                     "pause_nav": {"params": [], "description": "Pause navigation"},
                     "resume_nav": {"params": [], "description": "Resume navigation"},
                     "stop_nav": {"params": [], "description": "Stop and cancel navigation"},
@@ -505,6 +504,7 @@ class ControlledSpatialPlugin:
 
     def _acp_wait_nav(self, action_id: str, target: str, stall_timeout: float = 90):
         """Wait for navigation to complete, then fire ACP callback."""
+        self._nav_action_id = action_id
         t0 = time.time()
 
         # Primary: delegate to SmartMotion subprocess which has reliable
@@ -514,15 +514,25 @@ class ControlledSpatialPlugin:
         if self._smart_motion:
             result = self._smart_motion.wait_nav_done(stall_timeout=stall_timeout)
             elapsed = round(time.time() - t0, 1)
+            # Guard: if this nav was superseded, don't fire stale ACP
+            if self._nav_action_id != action_id:
+                print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping notify')
+                return
+            self._nav_action_id = None
             status = result.get("status", "error")
             if status == "arrived":
                 _acp_notify(action_id, "completed", {
                     "target": target, "pose": result.get("pose"), "elapsed": elapsed,
                 })
             else:
+                # Validate: if status is unexpected (e.g. "navigating" from queue race),
+                # treat as error with full result for debugging
+                error_msg = result.get("error", status)
+                if status not in ("error", "timeout", "stopped"):
+                    print(f'[ControlledSpatial] _acp_wait_nav unexpected status: {result}')
                 _acp_notify(action_id, "error", {
                     "target": target,
-                    "error": result.get("error", status),
+                    "error": error_msg,
                     "elapsed": elapsed,
                 })
             return
@@ -731,6 +741,10 @@ class ControlledSpatialPlugin:
             tag_name = args.get("tag_name", "")
             if not tag_name:
                 return {"error": "tag_name is required"}
+            # Cancel any in-flight navigation ACP
+            if self._nav_action_id:
+                _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
+                self._nav_action_id = None
             active_map = self._active_map
             if not active_map:
                 return {"error": "No active map. Load a map first."}
@@ -787,6 +801,10 @@ class ControlledSpatialPlugin:
             x = float(args.get("x", 0))
             y = float(args.get("y", 0))
             yaw = float(args.get("yaw", 0))
+            # Cancel any in-flight navigation ACP
+            if self._nav_action_id:
+                _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
+                self._nav_action_id = None
 
             if self._smart_motion:
                 speed = max(0.2, min(0.8, float(args.get("speed", 0.5))))

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -970,20 +970,30 @@ class LocoStatePlugin:
 # ── ACP notify helper (shared by LocoPlugin) ─────────────────────────────────
 
 import os as _os
-import requests as _requests
 
 _LOCO_AGENT_CORE_URL = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
 
 
 def _loco_acp_notify(action_id: str, status: str, result: dict, tool: str = "loco"):
     """POST ACP completion callback to Agent Core."""
+    import urllib.request as _urllib
+    import ssl as _ssl
+
+    ctx = _ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = _ssl.CERT_NONE
+    payload = json.dumps({
+        "action_id": action_id, "status": status,
+        "result": result, "tool": tool, "ts": time.time(),
+    }).encode()
     try:
-        _requests.post(
+        req = _urllib.Request(
             f"{_LOCO_AGENT_CORE_URL}/api/acp/complete",
-            json={"action_id": action_id, "status": status,
-                  "result": result, "tool": tool, "ts": time.time()},
-            timeout=5, verify=False,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
         )
+        _urllib.urlopen(req, timeout=5, context=ctx)
     except Exception as e:
         print(f"[Loco] ACP notify failed: {e}")
 

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -967,6 +967,27 @@ class LocoStatePlugin:
         return None
 
 
+# ── ACP notify helper (shared by LocoPlugin) ─────────────────────────────────
+
+import os as _os
+import requests as _requests
+
+_LOCO_AGENT_CORE_URL = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+
+
+def _loco_acp_notify(action_id: str, status: str, result: dict, tool: str = "loco"):
+    """POST ACP completion callback to Agent Core."""
+    try:
+        _requests.post(
+            f"{_LOCO_AGENT_CORE_URL}/api/acp/complete",
+            json={"action_id": action_id, "status": status,
+                  "result": result, "tool": tool, "ts": time.time()},
+            timeout=5, verify=False,
+        )
+    except Exception as e:
+        print(f"[Loco] ACP notify failed: {e}")
+
+
 # ── LocoPlugin (actuator) ────────────────────────────────────────────────────
 
 class LocoPlugin:
@@ -1018,6 +1039,10 @@ class LocoPlugin:
                     "turn":       {"type": "boolean", "description": "Turn while waving (default false)"},
                 },
                 "required": ["action"],
+                "x-completion": {
+                    "actions": ["move"],
+                    "timeout": 60,
+                },
                 "x-action-params": {
                     "move":             {"params": ["vx", "vy", "vyaw", "duration"], "description": "Move with specified velocities. duration>0 for timed move, 0 or negative for continuous until stop."},
                     "stop_move":        {"params": [],                                 "description": "Stop all movement immediately"},
@@ -1061,6 +1086,20 @@ class LocoPlugin:
                     },
                 },
                 "required": ["mode"],
+                "x-completion": {
+                    "actions": ["lie2standup", "standup2lie", "standup2squat", "squat2standup"],
+                    "timeout": 90,
+                },
+                "x-action-params": {
+                    "lie2standup":     {"params": [], "description": "安全起立 (ground/squat → standing)"},
+                    "standup2lie":     {"params": [], "description": "安全躺下 (standing → damping on ground)"},
+                    "standup2squat":   {"params": [], "description": "站到蹲 (standing → squat)"},
+                    "squat2standup":   {"params": [], "description": "蹲到站 (squat → standing)"},
+                    "damp":            {"params": [], "description": "阻尼模式 (ground only)"},
+                    "zero_torque":     {"params": [], "description": "零力矩 (ground only)"},
+                    "emergency_stop":  {"params": [], "description": "紧急阻尼 (any state)"},
+                    "get_current_mode": {"params": [], "description": "查询当前状态"},
+                },
             },
         }
 
@@ -1096,6 +1135,17 @@ class LocoPlugin:
         self._move_timer = None
         self._client.StopMove()
 
+    def _auto_stop_acp(self, action_id: str):
+        """Timer 回调：自动停止运动 + fire ACP callback."""
+        self._move_timer = None
+        self._client.StopMove()
+        _loco_acp_notify(action_id, "completed", {"reason": "duration_expired"}, tool="loco")
+
+    def _acp_wait_move(self, action_id: str, duration: float):
+        """Wait for SmartMotion timed move to complete, then fire ACP callback."""
+        time.sleep(duration + 0.5)  # SmartMotion auto-stops after duration; small buffer
+        _loco_acp_notify(action_id, "completed", {"reason": "duration_expired"}, tool="loco")
+
     def dispatch(self, action: str, args: dict) -> dict | None:
         if action == "start":
             return {"state": "ready"}
@@ -1115,7 +1165,18 @@ class LocoPlugin:
 
             # Route through SmartMotion safety harness
             if self._smart_motion:
-                return self._smart_motion.move(vx, vy, vyaw, duration)
+                result = self._smart_motion.move(vx, vy, vyaw, duration)
+                if duration > 0:
+                    from uuid import uuid4
+                    action_id = f"g1_move_{uuid4().hex[:8]}"
+                    result["action_id"] = action_id
+                    # SmartMotion handles auto-stop internally; spawn thread to wait and notify
+                    threading.Thread(
+                        target=self._acp_wait_move,
+                        args=(action_id, duration),
+                        daemon=True,
+                    ).start()
+                return result
 
             # Fallback: direct control (no safety harness)
             vx   = max(-1.0, min(1.0, vx))
@@ -1127,15 +1188,18 @@ class LocoPlugin:
                 self._move_timer = None
 
             if duration > 0:
+                from uuid import uuid4
+                action_id = f"g1_move_{uuid4().hex[:8]}"
                 # G1 SetVelocity duration has known bugs — use Timer fallback
                 ret = self._client.Move(vx, vy, vyaw, True)
-                self._move_timer = threading.Timer(duration, self._auto_stop)
+                self._move_timer = threading.Timer(duration, self._auto_stop_acp, args=[action_id])
                 self._move_timer.start()
+                return {"status": "moving", "action_id": action_id,
+                        "vx": vx, "vy": vy, "vyaw": vyaw, "duration": duration}
             else:
                 # Continuous move until explicit stop
                 ret = self._client.Move(vx, vy, vyaw, True)
-
-            return {"ret": ret, "vx": vx, "vy": vy, "vyaw": vyaw, "duration": duration}
+                return {"ret": ret, "vx": vx, "vy": vy, "vyaw": vyaw, "duration": duration}
         elif action == "stop_move":
             # Route through SmartMotion safety harness
             if self._smart_motion:
@@ -1152,8 +1216,11 @@ class LocoPlugin:
                     pass
             ret = self._client.StopMove()
             return {"ret": ret}
-        elif action == "switch_mode":
-            mode = args.get("mode", "")
+        elif action in ("switch_mode", "lie2standup", "standup2lie", "standup2squat",
+                        "squat2standup", "damp", "zero_torque", "emergency_stop", "get_current_mode"):
+            # x-action-params split: action is the mode directly
+            # Legacy: action == "switch_mode" with mode in args
+            mode = action if action != "switch_mode" else args.get("mode", "")
             code, current_fsm = self._client.GetFsmId()
 
             if code != 0:
@@ -1190,11 +1257,11 @@ class LocoPlugin:
                     if current_fsm == 0:
                         steps.append(("Damp", 1, "damp"))
                     steps.append(("Lie2StandUp", 500, "lie2standup"))
-                    return self._run_fsm_sequence(steps)
+                    return self._async_fsm(mode, steps)
                 # From low states (squat/prep): start(500)
                 if current_fsm in self._LOW_STATES:
                     steps = [("Start", 500, "start")]
-                    return self._run_fsm_sequence(steps)
+                    return self._async_fsm(mode, steps)
                 return {"error": f"Cannot stand up from FSM={current_fsm}"}
 
             elif mode == "standup2lie":
@@ -1205,10 +1272,10 @@ class LocoPlugin:
                     self._client.StopMove()
                     import time as _time; _time.sleep(1.0)
                     steps = [("StandUp2Squat", 2, "standup2squat"), ("Damp", 1, "damp")]
-                    return self._run_fsm_sequence(steps)
+                    return self._async_fsm(mode, steps)
                 if current_fsm in self._LOW_STATES:
                     steps = [("Damp", 1, "damp")]
-                    return self._run_fsm_sequence(steps)
+                    return self._async_fsm(mode, steps)
                 return {"error": f"Cannot lie down from FSM={current_fsm}. Use emergency_stop if needed."}
 
             elif mode == "standup2squat":
@@ -1218,7 +1285,7 @@ class LocoPlugin:
                     self._client.StopMove()
                     import time as _time; _time.sleep(1.0)
                     steps = [("StandUp2Squat", 2, "standup2squat")]
-                    return self._run_fsm_sequence(steps)
+                    return self._async_fsm(mode, steps)
                 return {"error": f"Cannot squat from FSM={current_fsm}. Use emergency_stop if needed."}
 
             elif mode == "squat2standup":
@@ -1226,7 +1293,7 @@ class LocoPlugin:
                     return {"info": "Robot is already standing", "fsm_id": current_fsm}
                 if current_fsm in self._LOW_STATES:
                     steps = [("Start", 500, "start")]
-                    return self._run_fsm_sequence(steps)
+                    return self._async_fsm(mode, steps)
                 if current_fsm in self._GROUND_STATES:
                     return {"error": f"Robot is on ground (FSM={current_fsm}). Use lie2standup instead."}
                 return {"error": f"Cannot stand from FSM={current_fsm}"}
@@ -1290,6 +1357,23 @@ class LocoPlugin:
         if result is None:
             return {"error": "RPC timeout during sequence execution"}
         return result
+
+    def _async_fsm(self, mode: str, steps: list) -> dict:
+        """Launch FSM sequence asynchronously, return action_id immediately."""
+        from uuid import uuid4
+        action_id = f"g1_fsm_{uuid4().hex[:8]}"
+        threading.Thread(
+            target=self._acp_fsm_sequence,
+            args=(action_id, mode, steps),
+            daemon=True,
+        ).start()
+        return {"status": "executing", "mode": mode, "action_id": action_id}
+
+    def _acp_fsm_sequence(self, action_id: str, mode: str, steps: list):
+        """Background thread: execute FSM sequence, then fire ACP callback."""
+        result = self._run_fsm_sequence(steps)
+        status = "error" if result.get("error") else "completed"
+        _loco_acp_notify(action_id, status, {"mode": mode, **result}, tool="switch_mode")
 
 
 # ── AsrPlugin (sensor) ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Navigate fix**: `_acp_wait_nav` now delegates to SmartMotion subprocess's `wait_nav_done()` which has reliable pose-based arrival detection (dist < 0.3m). Previously waited on `ctrl_info.is_arrived` which SLAM service never publishes, causing navigate to always timeout at 90-180s.
- **Loco FSM async**: `switch_mode` actions (lie2standup, standup2lie, standup2squat, squat2standup) now return `action_id` immediately and execute FSM sequences in background threads with ACP callback on completion.
- **Loco move async**: `move` with `duration > 0` now returns `action_id` immediately and fires ACP callback when duration expires.
- Added `x-completion` and `x-action-params` schemas to `switch_mode` and `loco` tools.

## Test plan
- [ ] Deploy to G1, load_map → navigate_to_tag → verify ACP callback fires on arrival (not timeout)
- [ ] Call switch_mode lie2standup → verify immediate return with action_id + ACP completed after ~10s
- [ ] Call loco move duration=3 → verify immediate return + ACP completed after 3s
- [ ] Verify barrier blocks subsequent actuator tools until ACP completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)