### PR TITLE
feat(g1): add joint health card

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Each driver is a standalone [MCP](https://modelcontextprotocol.io) HTTP server t
 
 | Driver | Hardware | Port | Description |
 |--------|----------|------|-------------|
-| `unitree/g1` | Unitree G1 Humanoid | 15701 | Locomotion, arm control, mic, speaker, LED, state monitoring |
+| `unitree/g1` | Unitree G1 Humanoid | 15701 | Locomotion, arm control, mic, speaker, LED, state and joint-health monitoring |
 | `engineai/t800` | EngineAI T800 Development Edition | 15708 | ROS2/Native SDK, full state, dance/gesture sequences, virtual gamepad, locomotion and low-level joint control |
 | `phanthy/remote_control` | Remote Control Bridge | 15710 | Remote control relay |
 
@@ -78,6 +78,10 @@ Quick overview:
 - Each driver implements MCP JSON-RPC 2.0 over HTTP (`initialize`, `tools/list`, `tools/call`)
 - Tool naming convention: `{device}_{action}` (e.g., `loco_move`, `mic_start`)
 - Driver port range: **15700–15799**
+
+### G1 Joint Health Card
+
+`joint_health` subscribes to G1 `rt/lowstate` and diagnoses per-joint temperature, temperature rise, sustained high torque, and telemetry timeouts. It publishes to `/<namespace>/health/joints` and supports `snapshot`, `list_alerts`, and `reset_baseline`. The card is read-only and never stops or commands the robot; its thresholds are configurable in `unitree/g1/config.yaml`.
 
 ### Topic Inference via `info` Action
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,7 +10,7 @@
 
 | 驱动 | 硬件 | 端口 | 说明 |
 |------|------|------|------|
-| `unitree/g1` | Unitree G1 人形机器人 | 15701 | 运动控制、机械臂、麦克风、扬声器、LED、状态监控 |
+| `unitree/g1` | Unitree G1 人形机器人 | 15701 | 运动控制、机械臂、麦克风、扬声器、LED、状态与关节健康监控 |
 | `engineai/t800` | 众擎 T800 开发版 | 15708 | ROS2/Native SDK、全身状态、舞蹈/手势序列、虚拟手柄、运动与高低层控制 |
 | `phanthy/remote_control` | 远程控制桥接 | 15710 | 远程控制中继 |
 
@@ -80,6 +80,10 @@ python main.py
 - 驱动端口范围：**15700–15799**
 
 参见 [CONTRIBUTING.md](CONTRIBUTING.md) 了解开发环境搭建和 PR 指南。
+
+### G1 关节健康卡片
+
+`joint_health` 订阅 G1 的 `rt/lowstate`，提供逐关节温度、温升速率、持续高扭矩和数据超时诊断，并发布到 `/<namespace>/health/joints`。卡片支持 `snapshot`、`list_alerts` 和 `reset_baseline` 操作。它只提供诊断，不会停止或控制机器人；温度、扭矩、连续样本数和超时阈值可在 `unitree/g1/config.yaml` 中配置。
 
 ---
 

--- a/unitree/g1/Dockerfile
+++ b/unitree/g1/Dockerfile
@@ -47,6 +47,7 @@ COPY unitree_sdk2py/ /work/unitree_sdk2py/
 COPY resource/       /work/resource/
 COPY main.py   /work/main.py
 COPY device.py /work/device.py
+COPY joint_health.py /work/joint_health.py
 COPY rpc_proxy.py /work/rpc_proxy.py
 COPY ext_devices.py /work/ext_devices.py
 COPY safety_harness.py /work/safety_harness.py

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -16,6 +16,19 @@ plugins:
     enabled: true
   state:
     enabled: true
+  joint_health:
+    enabled: true
+    warning_temp_c: 70
+    critical_temp_c: 85
+    warning_temp_rise_c_per_min: 12
+    critical_temp_rise_c_per_min: 20
+    temperature_history_sec: 30
+    warning_torque_nm: 45
+    critical_torque_nm: 70
+    torque_consecutive_samples: 10
+    stale_timeout_sec: 1.0
+    sample_interval_sec: 0.1
+    publish_interval_sec: 0.5
   camera:
     enabled: true
   lidar:

--- a/unitree/g1/joint_health.py
+++ b/unitree/g1/joint_health.py
@@ -1,0 +1,384 @@
+"""Unitree G1 joint health sensor card.
+
+The analyzer is deliberately independent from ROS2/DDS so its safety-related
+classification can be tested without robot hardware.  The plugin layer only
+adapts ``rt/lowstate`` samples to the analyzer and publishes JSON snapshots.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import threading
+import time
+from collections import deque
+
+
+G1_MOTOR_NAMES = (
+    "left_hip_pitch_joint", "left_hip_roll_joint", "left_hip_yaw_joint",
+    "left_knee_joint", "left_ankle_pitch_joint", "left_ankle_roll_joint",
+    "right_hip_pitch_joint", "right_hip_roll_joint", "right_hip_yaw_joint",
+    "right_knee_joint", "right_ankle_pitch_joint", "right_ankle_roll_joint",
+    "waist_yaw_joint", "waist_roll_joint", "waist_pitch_joint",
+    "left_shoulder_pitch_joint", "left_shoulder_roll_joint",
+    "left_shoulder_yaw_joint", "left_elbow_joint", "left_wrist_roll_joint",
+    "left_wrist_pitch_joint", "left_wrist_yaw_joint",
+    "right_shoulder_pitch_joint", "right_shoulder_roll_joint",
+    "right_shoulder_yaw_joint", "right_elbow_joint", "right_wrist_roll_joint",
+    "right_wrist_pitch_joint", "right_wrist_yaw_joint",
+    "reserved_motor_29", "reserved_motor_30", "reserved_motor_31",
+    "reserved_motor_32", "reserved_motor_33", "reserved_motor_34",
+)
+
+_LEVEL_RANK = {"normal": 0, "warning": 1, "critical": 2}
+
+
+def _finite(value, default=0.0) -> float:
+    try:
+        result = float(value)
+        return result if math.isfinite(result) else default
+    except (TypeError, ValueError):
+        return default
+
+
+class JointHealthAnalyzer:
+    """Classify G1 motor telemetry using conservative configurable limits."""
+
+    def __init__(self, config: dict | None = None):
+        cfg = config or {}
+        self.warning_temp_c = float(cfg.get("warning_temp_c", 70.0))
+        self.critical_temp_c = float(cfg.get("critical_temp_c", 85.0))
+        self.warning_temp_rise_c_per_min = float(
+            cfg.get("warning_temp_rise_c_per_min", 12.0)
+        )
+        self.critical_temp_rise_c_per_min = float(
+            cfg.get("critical_temp_rise_c_per_min", 20.0)
+        )
+        self.warning_torque_nm = float(cfg.get("warning_torque_nm", 45.0))
+        self.critical_torque_nm = float(cfg.get("critical_torque_nm", 70.0))
+        self.torque_consecutive_samples = max(
+            1, int(cfg.get("torque_consecutive_samples", 10))
+        )
+        self.stale_timeout_sec = float(cfg.get("stale_timeout_sec", 1.0))
+        self.publish_interval_sec = float(cfg.get("publish_interval_sec", 0.5))
+        self.sample_interval_sec = float(cfg.get("sample_interval_sec", 0.1))
+        self._history_window_sec = max(
+            5.0, float(cfg.get("temperature_history_sec", 30.0))
+        )
+        self._lock = threading.Lock()
+        self._latest: list[dict] = []
+        self._last_update: float | None = None
+        self._temp_history = [deque() for _ in G1_MOTOR_NAMES]
+        self._torque_counts = [0 for _ in G1_MOTOR_NAMES]
+
+        if self.warning_temp_c >= self.critical_temp_c:
+            raise ValueError("warning_temp_c must be lower than critical_temp_c")
+        if self.warning_temp_rise_c_per_min >= self.critical_temp_rise_c_per_min:
+            raise ValueError(
+                "warning_temp_rise_c_per_min must be lower than "
+                "critical_temp_rise_c_per_min"
+            )
+        if self.warning_torque_nm >= self.critical_torque_nm:
+            raise ValueError("warning_torque_nm must be lower than critical_torque_nm")
+
+    @staticmethod
+    def _read(motor, field, default=0.0):
+        if isinstance(motor, dict):
+            return motor.get(field, default)
+        return getattr(motor, field, default)
+
+    def update(self, motors, now: float | None = None) -> dict:
+        now = time.monotonic() if now is None else float(now)
+        latest = []
+        with self._lock:
+            for idx, motor in enumerate(list(motors)[:len(G1_MOTOR_NAMES)]):
+                temperatures = self._read(motor, "temperature", []) or []
+                valid_temperatures = [
+                    _finite(value) for value in temperatures
+                    if -40.0 <= _finite(value, -999.0) <= 200.0
+                ]
+                temperature = max(valid_temperatures) if valid_temperatures else None
+                torque = _finite(self._read(motor, "tau_est", 0.0))
+
+                if temperature is not None:
+                    history = self._temp_history[idx]
+                    history.append((now, temperature))
+                    cutoff = now - self._history_window_sec
+                    while len(history) > 1 and history[0][0] < cutoff:
+                        history.popleft()
+                    elapsed = now - history[0][0]
+                    rise_rate = (
+                        (temperature - history[0][1]) * 60.0 / elapsed
+                        if elapsed >= 5.0 else 0.0
+                    )
+                else:
+                    rise_rate = 0.0
+
+                abs_torque = abs(torque)
+                if abs_torque >= self.warning_torque_nm:
+                    self._torque_counts[idx] += 1
+                else:
+                    self._torque_counts[idx] = 0
+
+                latest.append({
+                    "idx": idx,
+                    "joint": G1_MOTOR_NAMES[idx],
+                    "temperature_c": temperature,
+                    "temperature_rise_c_per_min": round(rise_rate, 2),
+                    "torque_nm": round(torque, 3),
+                    "velocity_rad_s": round(
+                        _finite(self._read(motor, "dq", 0.0)), 4
+                    ),
+                    "position_rad": round(
+                        _finite(self._read(motor, "q", 0.0)), 4
+                    ),
+                    "motorstate_raw": int(self._read(motor, "motorstate", 0)),
+                    "over_torque_samples": self._torque_counts[idx],
+                })
+            self._latest = latest
+            self._last_update = now
+        return self.snapshot(now)
+
+    def reset_baseline(self, now: float | None = None) -> dict:
+        now = time.monotonic() if now is None else float(now)
+        with self._lock:
+            for idx, item in enumerate(self._latest):
+                temperature = item["temperature_c"]
+                self._temp_history[idx].clear()
+                if temperature is not None:
+                    self._temp_history[idx].append((now, temperature))
+                self._torque_counts[idx] = 0
+                item["over_torque_samples"] = 0
+                item["temperature_rise_c_per_min"] = 0.0
+        return self.snapshot(now)
+
+    def _alerts_for(self, motor: dict) -> list[dict]:
+        alerts = []
+
+        def add(level: str, reason: str, value, threshold):
+            alerts.append({
+                "level": level,
+                "reason": reason,
+                "joint": motor["joint"],
+                "motor_idx": motor["idx"],
+                "value": value,
+                "threshold": threshold,
+            })
+
+        temperature = motor["temperature_c"]
+        if temperature is None:
+            add("warning", "temperature_unavailable", None, None)
+        elif temperature >= self.critical_temp_c:
+            add("critical", "temperature_high", temperature, self.critical_temp_c)
+        elif temperature >= self.warning_temp_c:
+            add("warning", "temperature_high", temperature, self.warning_temp_c)
+
+        rise_rate = motor["temperature_rise_c_per_min"]
+        if rise_rate >= self.critical_temp_rise_c_per_min:
+            add(
+                "critical", "temperature_rising_fast", rise_rate,
+                self.critical_temp_rise_c_per_min,
+            )
+        elif rise_rate >= self.warning_temp_rise_c_per_min:
+            add(
+                "warning", "temperature_rising_fast", rise_rate,
+                self.warning_temp_rise_c_per_min,
+            )
+
+        if motor["over_torque_samples"] >= self.torque_consecutive_samples:
+            abs_torque = abs(motor["torque_nm"])
+            if abs_torque >= self.critical_torque_nm:
+                add("critical", "sustained_high_torque", abs_torque, self.critical_torque_nm)
+            else:
+                add("warning", "sustained_high_torque", abs_torque, self.warning_torque_nm)
+        return alerts
+
+    def snapshot(self, now: float | None = None) -> dict:
+        now = time.monotonic() if now is None else float(now)
+        with self._lock:
+            latest = [dict(item) for item in self._latest]
+            last_update = self._last_update
+
+        if last_update is None:
+            return {
+                "state": "waiting",
+                "health_level": "warning",
+                "reason": "no_lowstate_data",
+                "summary": {"healthy": 0, "warning": 0, "critical": 0},
+                "alerts": [],
+                "motors": [],
+                "last_update_ago_ms": None,
+            }
+
+        age_sec = max(0.0, now - last_update)
+        alerts = []
+        motor_levels = []
+        for motor in latest:
+            motor_alerts = self._alerts_for(motor)
+            alerts.extend(motor_alerts)
+            motor["health_level"] = max(
+                (alert["level"] for alert in motor_alerts),
+                key=lambda level: _LEVEL_RANK[level],
+                default="normal",
+            )
+            motor_levels.append(motor["health_level"])
+
+        state = "running"
+        if age_sec > self.stale_timeout_sec:
+            state = "stale"
+            alerts.insert(0, {
+                "level": "critical",
+                "reason": "lowstate_timeout",
+                "joint": None,
+                "motor_idx": None,
+                "value": round(age_sec, 3),
+                "threshold": self.stale_timeout_sec,
+            })
+
+        counts = {
+            level: sum(1 for item_level in motor_levels if item_level == level)
+            for level in ("normal", "warning", "critical")
+        }
+        health_level = max(
+            (alert["level"] for alert in alerts),
+            key=lambda level: _LEVEL_RANK[level],
+            default="normal",
+        )
+        return {
+            "state": state,
+            "health_level": health_level,
+            "summary": {
+                "healthy": counts["normal"],
+                "warning": counts["warning"],
+                "critical": counts["critical"],
+            },
+            "alerts": alerts,
+            "motors": latest,
+            "last_update_ago_ms": round(age_sec * 1000),
+        }
+
+
+class JointHealthPlugin:
+    PREFIX = "joint_health"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor):
+        self._topic = f"/{namespace}/health/joints"
+        self._analyzer = JointHealthAnalyzer(plugin_config)
+        self._node = self._make_node()
+        executor.add_node(self._node)
+
+    def _make_node(self):
+        from rclpy.node import Node
+        from rclpy.qos import (
+            DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy,
+        )
+        from std_msgs.msg import String
+        from unitree_sdk2py.core.channel import ChannelSubscriber
+        from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowState_
+
+        analyzer = self._analyzer
+        topic = self._topic
+        qos = QoSProfile(
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=10,
+            durability=DurabilityPolicy.VOLATILE,
+        )
+
+        class JointHealthNode(Node):
+            def __init__(self):
+                super().__init__("g1_joint_health")
+                self._publisher = self.create_publisher(String, topic, qos)
+                self._last_publish = 0.0
+                self._last_sample = 0.0
+                self._subscriber = None
+                try:
+                    # Keep a strong reference: otherwise the DDS reader may be
+                    # garbage-collected and silently stop delivering samples.
+                    self._subscriber = ChannelSubscriber("rt/lowstate", LowState_)
+                    self._subscriber.Init(self._on_lowstate, 10)
+                    self.get_logger().info(
+                        f"JointHealthNode subscribed rt/lowstate -> {topic}"
+                    )
+                except Exception as exc:
+                    self.get_logger().warning(
+                        f"JointHealthNode failed to subscribe rt/lowstate: {exc}"
+                    )
+
+            def _on_lowstate(self, msg):
+                now = time.monotonic()
+                if now - self._last_sample < analyzer.sample_interval_sec:
+                    return
+                self._last_sample = now
+                snapshot = analyzer.update(msg.motor_state, now)
+                if now - self._last_publish < analyzer.publish_interval_sec:
+                    return
+                self._last_publish = now
+                output = String()
+                output.data = json.dumps(snapshot, ensure_ascii=False)
+                self._publisher.publish(output)
+
+        return JointHealthNode()
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "joint_health",
+            "type": "sensor",
+            "multiInstance": False,
+            "description": (
+                "G1 joint health diagnostics: per-joint temperature, temperature "
+                "rise, sustained torque, and lowstate freshness. Read-only; does "
+                "not stop or command the robot."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["snapshot", "list_alerts", "reset_baseline"],
+                        "default": "snapshot",
+                        "description": "Diagnostic query to perform",
+                    },
+                },
+            },
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("joint_health", "snapshot"):
+            return self._analyzer.snapshot()
+        if action == "list_alerts":
+            snapshot = self._analyzer.snapshot()
+            return {
+                "state": snapshot["state"],
+                "health_level": snapshot["health_level"],
+                "alerts": snapshot["alerts"],
+                "last_update_ago_ms": snapshot["last_update_ago_ms"],
+            }
+        if action == "reset_baseline":
+            snapshot = self._analyzer.reset_baseline()
+            return {
+                "state": snapshot["state"],
+                "health_level": snapshot["health_level"],
+                "baseline_reset": True,
+                "last_update_ago_ms": snapshot["last_update_ago_ms"],
+            }
+        if action == "start":
+            return {"state": "running"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "info":
+            snapshot = self._analyzer.snapshot()
+            return {
+                "state": snapshot["state"],
+                "health_level": snapshot["health_level"],
+                "topic_out": [{"topic": self._topic, "format": "data/json"}],
+                "last_update_ago_ms": snapshot["last_update_ago_ms"],
+            }
+        return {"error": f"Unknown action: {action}"}

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -110,6 +110,13 @@ class G1DeviceBundle:
             self._plugins.append(StatePlugin(plugins_cfg["state"], namespace, executor))
             print("[bundle] StatePlugin loaded")
 
+        if plugins_cfg.get("joint_health", {}).get("enabled", False):
+            from joint_health import JointHealthPlugin
+            self._plugins.append(JointHealthPlugin(
+                plugins_cfg["joint_health"], namespace, executor
+            ))
+            print("[bundle] JointHealthPlugin loaded")
+
         if plugins_cfg.get("camera", {}).get("enabled", False):
             from device import RealSensePlugin
             self._plugins.append(RealSensePlugin(plugins_cfg["camera"], namespace, executor))

--- a/unitree/g1/tests/test_docker_context.py
+++ b/unitree/g1/tests/test_docker_context.py
@@ -1,0 +1,15 @@
+import pathlib
+import unittest
+
+
+G1_DIR = pathlib.Path(__file__).resolve().parents[1]
+
+
+class DockerContextTests(unittest.TestCase):
+    def test_joint_health_module_is_copied_into_image(self):
+        dockerfile = (G1_DIR / "Dockerfile").read_text()
+        self.assertIn("COPY joint_health.py /work/joint_health.py", dockerfile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_joint_health.py
+++ b/unitree/g1/tests/test_joint_health.py
@@ -1,0 +1,114 @@
+import pathlib
+import sys
+import unittest
+
+
+G1_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(G1_DIR))
+
+from joint_health import G1_MOTOR_NAMES, JointHealthAnalyzer, JointHealthPlugin
+
+
+def motor(temp=40, torque=0.0, q=0.0, dq=0.0):
+    return {
+        "temperature": [temp, temp - 1],
+        "tau_est": torque,
+        "q": q,
+        "dq": dq,
+        "motorstate": 0,
+    }
+
+
+def motors(**overrides):
+    result = [motor() for _ in G1_MOTOR_NAMES]
+    for idx, values in overrides.items():
+        result[int(idx)] = motor(**values)
+    return result
+
+
+class JointHealthAnalyzerTests(unittest.TestCase):
+    def test_waits_for_first_lowstate_sample(self):
+        snapshot = JointHealthAnalyzer().snapshot(now=10.0)
+        self.assertEqual("waiting", snapshot["state"])
+        self.assertEqual("no_lowstate_data", snapshot["reason"])
+
+    def test_healthy_snapshot_has_named_motors(self):
+        snapshot = JointHealthAnalyzer().update(motors(), now=10.0)
+        self.assertEqual("normal", snapshot["health_level"])
+        self.assertEqual(35, snapshot["summary"]["healthy"])
+        self.assertEqual("left_knee_joint", snapshot["motors"][3]["joint"])
+
+    def test_temperature_warning_and_critical(self):
+        analyzer = JointHealthAnalyzer()
+        snapshot = analyzer.update(
+            motors(**{"3": {"temp": 75}, "9": {"temp": 90}}), now=10.0
+        )
+        by_joint = {alert["joint"]: alert for alert in snapshot["alerts"]}
+        self.assertEqual("warning", by_joint["left_knee_joint"]["level"])
+        self.assertEqual("critical", by_joint["right_knee_joint"]["level"])
+        self.assertEqual("critical", snapshot["health_level"])
+
+    def test_temperature_rise_requires_five_seconds_of_history(self):
+        analyzer = JointHealthAnalyzer({
+            "warning_temp_rise_c_per_min": 10,
+            "critical_temp_rise_c_per_min": 20,
+        })
+        analyzer.update(motors(), now=0.0)
+        snapshot = analyzer.update(motors(**{"3": {"temp": 41.5}}), now=6.0)
+        alerts = [a for a in snapshot["alerts"] if a["joint"] == "left_knee_joint"]
+        self.assertEqual("warning", alerts[0]["level"])
+        self.assertEqual("temperature_rising_fast", alerts[0]["reason"])
+
+    def test_torque_must_be_sustained(self):
+        analyzer = JointHealthAnalyzer({"torque_consecutive_samples": 3})
+        analyzer.update(motors(**{"3": {"torque": 50}}), now=1.0)
+        analyzer.update(motors(**{"3": {"torque": 50}}), now=1.1)
+        snapshot = analyzer.update(motors(**{"3": {"torque": 50}}), now=1.2)
+        alerts = [a for a in snapshot["alerts"] if a["joint"] == "left_knee_joint"]
+        self.assertEqual("sustained_high_torque", alerts[0]["reason"])
+        self.assertEqual("warning", alerts[0]["level"])
+
+    def test_stale_lowstate_is_critical(self):
+        analyzer = JointHealthAnalyzer({"stale_timeout_sec": 0.5})
+        analyzer.update(motors(), now=1.0)
+        snapshot = analyzer.snapshot(now=2.0)
+        self.assertEqual("stale", snapshot["state"])
+        self.assertEqual("critical", snapshot["health_level"])
+        self.assertEqual("lowstate_timeout", snapshot["alerts"][0]["reason"])
+
+    def test_reset_baseline_clears_rate_and_torque_history(self):
+        analyzer = JointHealthAnalyzer({"torque_consecutive_samples": 2})
+        analyzer.update(motors(), now=0.0)
+        analyzer.update(motors(**{"3": {"temp": 45, "torque": 50}}), now=10.0)
+        snapshot = analyzer.reset_baseline(now=10.0)
+        knee = snapshot["motors"][3]
+        self.assertEqual(0, knee["over_torque_samples"])
+        self.assertEqual(0.0, knee["temperature_rise_c_per_min"])
+
+
+class JointHealthPluginContractTests(unittest.TestCase):
+    def setUp(self):
+        self.plugin = JointHealthPlugin.__new__(JointHealthPlugin)
+        self.plugin._topic = "/test_robot/health/joints"
+        self.plugin._analyzer = JointHealthAnalyzer()
+
+    def test_tool_declares_sensor_topic_and_actions(self):
+        tool = self.plugin.get_tool()
+        self.assertEqual("joint_health", tool["name"])
+        self.assertEqual("sensor", tool["type"])
+        self.assertEqual("data/json", tool["topic_out"][0]["format"])
+        self.assertEqual(
+            ["snapshot", "list_alerts", "reset_baseline"],
+            tool["inputSchema"]["properties"]["action"]["enum"],
+        )
+
+    def test_info_returns_authoritative_topic(self):
+        result = self.plugin.dispatch("info", {})
+        self.assertEqual("waiting", result["state"])
+        self.assertEqual(
+            "/test_robot/health/joints", result["topic_out"][0]["topic"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 功能说明

为 Unitree G1 新增 `joint_health` 关节健康诊断卡片。

卡片订阅 `rt/lowstate`，提供逐关节健康状态，并发布：

- Topic：`/<namespace>/health/joints`
- Format：`data/json`

## 诊断能力

- 关节温度告警
- 温升速率告警
- 持续高扭矩告警
- LowState 数据超时告警
- `normal / warning / critical` 健康等级
- 35 个电机的逐项状态和健康汇总

## 支持操作

- `snapshot`：读取完整健康快照
- `list_alerts`：只读取当前告警
- `reset_baseline`：重置温升和连续扭矩统计
- `info`：返回权威输出 Topic

该卡片只提供只读诊断，不会停止或控制机器人。

## 配置

在 `unitree/g1/config.yaml` 中增加：

- 温度 warning/critical 阈值
- 温升速率阈值
- 持续扭矩阈值
- 连续样本数量
- LowState 超时时间
- 分析和发布频率

## 测试情况

### 本地测试

- 10 项单元测试全部通过
- Python 语法检查通过
- YAML 解析通过
- `git diff --check` 通过
- Dockerfile 回归测试确认 `joint_health.py` 被复制到镜像

### G1 真机测试

使用提交 `ae5bcc7` 完成无缓存 Docker 镜像构建并部署：

- `JointHealthPlugin` 加载成功
- 成功订阅 `rt/lowstate`
- MCP 服务正常运行于 `localhost:15701`
- `snapshot` 返回 `state=running`
- 当前真机结果：
  - `health_level=normal`
  - `healthy=35`
  - `warning=0`
  - `critical=0`
  - `alerts=[]`
- Agent Core Canvas 可以发现并拖入 `joint_health`
- `/ubuntu/health/joints` 数据可以在监控模式正常显示和更新

## 安全边界

- 不下发任何运动指令
- 不接管急停或 Safety Harness
- 不根据含义尚未确认的 `motorstate` 位自动判定故障
- 第一版仅提供诊断和告警