### PR TITLE
fix: SmartMotion IPC race causing premature nav 'arrived'

### DIFF
--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -82,15 +82,54 @@ class SmartMotionProxy:
         )
         self._proc.start()
         print(f"[SmartMotionProxy] subprocess started → pid={self._proc.pid}")
+        # Per-request result routing: avoid race when multiple threads call _call
+        self._pending: dict[str, queue.Queue] = {}  # req_id → per-request queue
+        self._dispatch_lock = threading.Lock()
+        self._dispatch_thread = threading.Thread(target=self._dispatch_results, daemon=True)
+        self._dispatch_thread.start()
+        self._req_counter = 0
+        self._req_lock = threading.Lock()
+
+    def _next_req_id(self) -> str:
+        with self._req_lock:
+            self._req_counter += 1
+            return f"req_{self._req_counter}"
+
+    def _dispatch_results(self):
+        """Background thread that routes results from subprocess to the correct caller."""
+        while True:
+            try:
+                item = self._result_queue.get(timeout=1.0)
+                req_id = item.pop("_req_id", None) if isinstance(item, dict) else None
+                if req_id and req_id in self._pending:
+                    self._pending[req_id].put(item)
+                else:
+                    # Fallback: shouldn't happen, but don't lose the result
+                    # Put it in any waiting queue (legacy behavior)
+                    with self._dispatch_lock:
+                        for q in self._pending.values():
+                            q.put(item)
+                            break
+            except queue.Empty:
+                continue
+            except Exception:
+                continue
 
     def _call(self, method: str, timeout: float = 15.0, **kwargs) -> dict:
-        """Send command to subprocess and wait for result."""
-        self._cmd_queue.put({"method": method, **kwargs})
+        """Send command to subprocess and wait for result (thread-safe)."""
+        req_id = self._next_req_id()
+        result_q = queue.Queue(maxsize=1)
+        with self._dispatch_lock:
+            self._pending[req_id] = result_q
         try:
-            result = self._result_queue.get(timeout=timeout)
+            self._cmd_queue.put({"method": method, "_req_id": req_id, **kwargs})
+            result = result_q.get(timeout=timeout)
             return result
         except queue.Empty:
             return {"error": f"SmartMotion subprocess timeout ({method})"}
+        finally:
+            with self._dispatch_lock:
+                self._pending.pop(req_id, None)
 
     def move(self, vx: float, vy: float, vyaw: float, duration: float = -1.0) -> dict:
         return self._call("move", vx=vx, vy=vy, vyaw=vyaw, duration=duration)
@@ -920,6 +959,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                 result = {"status": "shutdown"}
 
             if result is not None:
+                result["_req_id"] = cmd.get("_req_id")
                 result_queue.put(result)
         except queue.Empty:
             pass


### PR DESCRIPTION
## Summary
- SmartMotionProxy 的 `_result_queue` 是所有线程共享的，当 `_acp_wait_nav` 和 `dispatch` 同时调用 `_call()` 时，结果会交叉返回
- 导致 `navigate_to` 收到 `wait_nav_done` 的 "arrived" 结果 → LLM 以为已到达 → 提前开始讲解
- 修复：添加 per-request ID 路由，每个 `_call()` 有独立的 result queue

## Root Cause
```
Thread 1 (_acp_wait_nav): _call("wait_nav_done") → result_queue.get()
Thread 2 (dispatch):      _call("navigate_to")   → result_queue.get()
                                    ↑ picks up Thread 1's "arrived" result!
```

## Fix
- 每个 `_call()` 生成 unique `req_id`
- 命令带 `_req_id` 发送到子进程
- 子进程返回结果时附带 `_req_id`
- Dispatch thread 将结果路由到正确的调用者

## Test plan
- [ ] G1 导览全程，确认不再出现 P12-P15 "error: navigating"
- [ ] 确认讲解只在 nav 真正完成后开始

🤖 Generated with [Claude Code](https://claude.com/claude-code)