### PR TITLE
feat(ext_mic): remote mic auto-probe, health check & sidebar config

### DIFF
--- a/x-humanoid/tianyi2.0/config.yaml
+++ b/x-humanoid/tianyi2.0/config.yaml
@@ -69,13 +69,10 @@ plugins:
   ext_mic:
     enabled: true
     network_sources:
-      - name: "DJI Wireless Mic"
-        url: "tcp://192.168.41.1:9800/pcm16k"
-        # audio_sender auto-start: SSH to the host where the mic is plugged in
-        ssh_host: "192.168.41.1"
+      - ssh_host: "192.168.41.1"
         ssh_user: "ubuntu"
         ssh_password: "123"
-        card: 1
+        port: 9800
         sender_path: "/home/ubuntu/audio_sender.py"
   light:
     enabled: true

--- a/x-humanoid/tianyi2.0/ext_devices.py
+++ b/x-humanoid/tianyi2.0/ext_devices.py
@@ -1062,24 +1062,18 @@ class ExtMicPlugin:
                 "ssh_host": {
                     "type": "string",
                     "description": "Remote host address",
+                    "default": "192.168.41.1",
                 },
                 "ssh_user": {
                     "type": "string",
                     "description": "SSH username",
+                    "default": "ubuntu",
                 },
                 "ssh_pass": {
                     "type": "string",
+                    "format": "password",
                     "description": "SSH password",
-                },
-                "ssh_port": {
-                    "type": "string",
-                    "description": "Audio service port",
-                    "default": "9800",
-                },
-                "ssh_script": {
-                    "type": "string",
-                    "description": "audio_sender.py path on remote",
-                    "default": "/home/ubuntu/audio_sender.py",
+                    "default": "123",
                 },
             },
         }
@@ -1274,9 +1268,9 @@ class ExtMicPlugin:
                     probed = self._probe_remote(
                         ssh_host=ssh_host,
                         ssh_user=args.get("ssh_user", "ubuntu"),
-                        ssh_pass=args.get("ssh_pass", ""),
-                        port=int(args.get("ssh_port", "9800") or "9800"),
-                        script=args.get("ssh_script", "/home/ubuntu/audio_sender.py"),
+                        ssh_pass=args.get("ssh_pass", "123"),
+                        port=9800,
+                        script="/home/ubuntu/audio_sender.py",
                     )
                     return {"configured": True, "remote_devices": probed}
                 return {"configured": True}

--- a/x-humanoid/tianyi2.0/ext_devices.py
+++ b/x-humanoid/tianyi2.0/ext_devices.py
@@ -139,6 +139,46 @@ def _enumerate_ext_mics() -> list[dict]:
     return devices
 
 
+def _parse_arecord_output(output: str) -> list[dict]:
+    """Parse arecord -l output into device list, excluding internal devices."""
+    devices = []
+    EXCLUDE = ["realsense", "nvidia", "tegra", "hdmi", "ape"]
+    for line in output.splitlines():
+        m = re.match(r'card (\d+): (\w+) \[(.+?)\], device (\d+):', line)
+        if m:
+            card_idx, card_id, desc, dev_idx = m.groups()
+            if any(x in desc.lower() or x in card_id.lower() for x in EXCLUDE):
+                continue
+            devices.append({
+                "card": int(card_idx),
+                "device": int(dev_idx),
+                "name": desc,
+                "alsa_id": f"hw:{card_idx},{dev_idx}",
+            })
+    return devices
+
+
+def _parse_hw_params(output: str) -> dict:
+    """Parse arecord --dump-hw-params output for format/rate/channels."""
+    info = {"format": "S16_LE", "rate": 48000, "channels": 1}
+    for line in output.splitlines():
+        if line.strip().startswith('FORMAT:'):
+            fmts = line.split('FORMAT:')[1].strip().split()
+            if 'S24_3LE' in fmts:
+                info["format"] = "S24_3LE"
+            elif 'S16_LE' in fmts:
+                info["format"] = "S16_LE"
+        elif 'CHANNELS:' in line:
+            ch = line.split('CHANNELS:')[1].strip()
+            if '2' in ch:
+                info["channels"] = 2
+        elif 'RATE:' in line:
+            rates = [int(x) for x in re.findall(r'\d+', line.split('RATE:')[1])]
+            if rates:
+                info["rate"] = min(rates)
+    return info
+
+
 def _enumerate_ext_cameras() -> list[dict]:
     """List external V4L2 video capture devices (excluding RealSense)."""
     devices = []
@@ -402,7 +442,8 @@ class _ExtMicNode(Node):
 class _NetworkMicNode(Node):
     """Captures audio from a remote host via SSH + arecord and publishes AudioChunk."""
 
-    def __init__(self, url: str, device_name: str, namespace: str, instance_id: str, context=None):
+    def __init__(self, url: str, device_name: str, namespace: str, instance_id: str, context=None,
+                 ssh_user: str = "", ssh_pass: str = "", ssh_script: str = "", ssh_card: str = "1"):
         node_name = f"ext_mic_{instance_id.replace('-', '_')}"
         super().__init__(node_name, context=context)
         self._url = url  # "ssh://user:pass@host/hw:card,dev" or "tcp://host:port"
@@ -413,6 +454,11 @@ class _NetworkMicNode(Node):
         self._thread: Optional[threading.Thread] = None
         self._running = False
         self.state = "idle"
+        # SSH management config for remote audio_sender health check / restart
+        self._ssh_user = ssh_user
+        self._ssh_pass = ssh_pass
+        self._ssh_script = ssh_script
+        self._ssh_card = ssh_card
 
     def start(self) -> dict:
         if self.state == "running":
@@ -584,6 +630,9 @@ class _NetworkMicNode(Node):
         host, port = url_body.rsplit(":", 1)
         port = int(port)
 
+        # Health check: ensure remote audio_sender is alive and streaming
+        self._ensure_remote_ready(host, port)
+
         # S24_3LE stereo 48kHz params
         FRAME_SIZE = 6  # 3 bytes * 2 channels
         NATIVE_RATE = 48000
@@ -599,7 +648,7 @@ class _NetworkMicNode(Node):
                 sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
                 sock.settimeout(5.0)
                 sock.connect((host, port))
-                sock.settimeout(None)
+                sock.settimeout(10.0)  # detect stale connection (no data for 10s)
                 sock.setsockopt(_socket.IPPROTO_TCP, _socket.TCP_NODELAY, 1)
                 connect_failures = 0  # reset on successful connect
                 print(f"[ext_mic/tcp] connected to {host}:{port} (pre_converted={pre_converted})", flush=True)
@@ -609,7 +658,11 @@ class _NetworkMicNode(Node):
                 first_publish = True
 
                 while self._running:
-                    data = sock.recv(8192)
+                    try:
+                        data = sock.recv(8192)
+                    except _socket.timeout:
+                        print(f"[ext_mic/tcp] no data for 10s, reconnecting...", flush=True)
+                        break
                     if not data:
                         break
 
@@ -671,6 +724,68 @@ class _NetworkMicNode(Node):
                         pass
             if self._running:
                 time.sleep(2)
+                self._ensure_remote_ready(host, port)
+
+    def _ensure_remote_ready(self, host: str, port: int):
+        """Check remote audio_sender health; restart via SSH if unhealthy."""
+        import socket as _socket
+        import subprocess as _subprocess
+
+        # Step 1: probe — connect and try to read data within 3s
+        healthy = False
+        try:
+            sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+            sock.settimeout(3.0)
+            sock.connect((host, port))
+            sock.settimeout(3.0)
+            data = sock.recv(1024)
+            healthy = len(data) > 0
+            sock.close()
+        except Exception:
+            pass
+
+        if healthy:
+            return
+
+        # Step 2: unhealthy — SSH restart if config available
+        if not self._ssh_user or not self._ssh_script:
+            print(f"[ext_mic/tcp] remote unhealthy on {host}:{port} but no SSH config", flush=True)
+            return
+
+        print(f"[ext_mic/tcp] remote unhealthy, restarting via SSH...", flush=True)
+        restart_cmd = (
+            f"pkill -f '{self._ssh_script}' 2>/dev/null; sleep 1; "
+            f"nohup python3 {self._ssh_script} --port {port} --card {self._ssh_card} "
+            f"> /tmp/audio_sender.log 2>&1 &"
+        )
+        ssh_cmd = [
+            "sshpass", "-p", self._ssh_pass,
+            "ssh", "-o", "StrictHostKeyChecking=no", "-o", "ConnectTimeout=5",
+            f"{self._ssh_user}@{host}", restart_cmd,
+        ]
+        try:
+            _subprocess.run(ssh_cmd, capture_output=True, timeout=15)
+        except Exception as e:
+            print(f"[ext_mic/tcp] SSH restart failed: {e}", flush=True)
+            return
+
+        # Step 3: wait for ready — poll TCP until data received (max ~8s)
+        for i in range(4):
+            time.sleep(2)
+            try:
+                sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+                sock.settimeout(3.0)
+                sock.connect((host, port))
+                sock.settimeout(3.0)
+                data = sock.recv(1024)
+                sock.close()
+                if len(data) > 0:
+                    print(f"[ext_mic/tcp] remote ready after restart ({(i+1)*2}s)", flush=True)
+                    return
+            except Exception:
+                pass
+
+        print(f"[ext_mic/tcp] remote still not ready after restart, proceeding anyway", flush=True)
 
     def stop(self) -> dict:
         self._running = False
@@ -908,20 +1023,25 @@ TOOLS_EXT_CAMERA = [
 class ExtMicPlugin:
     PREFIX = "ext_mic"
 
-    def __init__(self, plugin_cfg: dict, namespace: str, executor):
+    def __init__(self, plugin_cfg: dict, namespace: str, executor, remote_devices: list = None):
         self._namespace = namespace
         self._executor = executor
         self._nodes: dict[str, _ExtMicNode] = {}
         self._instance_configs: dict[str, dict] = {}  # instance_id → saved config params
         self._available_devices = _enumerate_ext_mics()
-        # Add network sources from config
-        for ns in plugin_cfg.get("network_sources", []):
-            self._available_devices.append({
-                "index": ns["url"],
-                "alsa_id": ns["url"],
-                "name": ns.get("name", ns["url"]),
-                "network": True,
-            })
+        # Add dynamically probed remote devices (from main.py _probe_remote_mics)
+        if remote_devices:
+            self._available_devices.extend(remote_devices)
+        elif plugin_cfg.get("network_sources"):
+            # Fallback: static config (backward compat if probe not called)
+            for ns in plugin_cfg.get("network_sources", []):
+                url = ns.get("url", f"tcp://{ns.get('ssh_host', '')}:{ns.get('port', 9800)}/pcm16k")
+                self._available_devices.append({
+                    "index": url,
+                    "alsa_id": url,
+                    "name": ns.get("name", ns.get("ssh_host", "Remote Mic")),
+                    "network": True,
+                })
         log.info(f"[ext_mic] found {len(self._available_devices)} external mic device(s)")
         for d in self._available_devices:
             log.info(f"  [{d['index']}] {d['name']}")
@@ -935,9 +1055,31 @@ class ExtMicPlugin:
             "properties": {
                 "device_index": {
                     "type": "string",
-                    "description": "音频设备",
+                    "description": "Audio device",
                     "scope": "instance",
-                    "oneOf": device_options if device_options else [{"const": "", "title": "无可用设备"}],
+                    "oneOf": device_options if device_options else [{"const": "", "title": "No devices available"}],
+                },
+                "ssh_host": {
+                    "type": "string",
+                    "description": "Remote host address",
+                },
+                "ssh_user": {
+                    "type": "string",
+                    "description": "SSH username",
+                },
+                "ssh_pass": {
+                    "type": "string",
+                    "description": "SSH password",
+                },
+                "ssh_port": {
+                    "type": "string",
+                    "description": "Audio service port",
+                    "default": "9800",
+                },
+                "ssh_script": {
+                    "type": "string",
+                    "description": "audio_sender.py path on remote",
+                    "default": "/home/ubuntu/audio_sender.py",
                 },
             },
         }
@@ -951,6 +1093,92 @@ class ExtMicPlugin:
             self._nodes[key].stop()
             self._executor.remove_node(self._nodes[key])
             del self._nodes[key]
+
+    def _probe_remote(self, ssh_host: str, ssh_user: str, ssh_pass: str,
+                      port: int, script: str) -> list[dict]:
+        """SSH probe remote host: detect devices, deploy & start audio_sender, cache results."""
+        import subprocess as _sp
+        from pathlib import Path
+
+        def _ssh(cmd, timeout=10):
+            return _sp.run(
+                ["sshpass", "-p", ssh_pass, "ssh",
+                 "-o", "StrictHostKeyChecking=no", "-o", "ConnectTimeout=3",
+                 f"{ssh_user}@{ssh_host}", cmd],
+                capture_output=True, text=True, timeout=timeout)
+
+        # Remove old remote devices for this host
+        self._available_devices = [d for d in self._available_devices
+                                   if not (d.get("network") and d.get("_ssh_host") == ssh_host)]
+
+        # Probe devices
+        try:
+            result = _ssh("arecord -l")
+            devices = _parse_arecord_output(result.stdout + result.stderr)
+        except Exception as e:
+            log.warning(f"[ext_mic/probe] {ssh_host}: SSH failed: {e}")
+            return []
+
+        if not devices:
+            log.info(f"[ext_mic/probe] {ssh_host}: no capture devices")
+            return []
+
+        # Probe hw params for each device
+        for dev in devices:
+            try:
+                hw = _ssh(f"arecord -D hw:{dev['card']},{dev['device']} --dump-hw-params -d 1 /dev/null 2>&1")
+                dev.update(_parse_hw_params(hw.stdout + hw.stderr))
+            except Exception:
+                dev.setdefault("format", "S16_LE")
+                dev.setdefault("rate", 16000)
+                dev.setdefault("channels", 1)
+
+        # Deploy audio_sender.py if missing
+        try:
+            check = _ssh(f"test -f {script} && echo EXISTS")
+            if "EXISTS" not in (check.stdout or ""):
+                local_src = str(Path(__file__).parent / "audio_sender.py")
+                _sp.run(["sshpass", "-p", ssh_pass, "scp",
+                         "-o", "StrictHostKeyChecking=no",
+                         local_src, f"{ssh_user}@{ssh_host}:{script}"],
+                        check=True, timeout=15)
+                log.info(f"[ext_mic/probe] {ssh_host}: deployed audio_sender.py")
+        except Exception as e:
+            log.warning(f"[ext_mic/probe] {ssh_host}: deploy failed: {e}")
+
+        # Start audio_sender if not running
+        primary_card = devices[0]["card"]
+        try:
+            check = _ssh("pgrep -f audio_sender.py")
+            if check.returncode != 0 or not check.stdout.strip():
+                _ssh(f"nohup python3 {script} --port {port} --card {primary_card} "
+                     f"> /tmp/audio_sender.log 2>&1 &")
+                time.sleep(1)
+                log.info(f"[ext_mic/probe] {ssh_host}: started audio_sender (card={primary_card}, port={port})")
+        except Exception:
+            pass
+
+        # Cache results and return summary
+        probed = []
+        for dev in devices:
+            fmt_desc = f"{dev.get('format', '?')}/{dev.get('rate', '?')}Hz/{dev.get('channels', '?')}ch"
+            entry = {
+                "index": f"tcp://{ssh_host}:{port}/pcm16k",
+                "alsa_id": f"tcp://{ssh_host}:{port}/pcm16k",
+                "name": f"{dev['name']} ({fmt_desc}) @ {ssh_host}",
+                "network": True,
+                "_ssh_host": ssh_host,
+                "_ssh_user": ssh_user,
+                "_ssh_pass": ssh_pass,
+                "_ssh_card": str(dev["card"]),
+                "_ssh_script": script,
+                "_port": port,
+            }
+            self._available_devices.append(entry)
+            probed.append({"name": entry["name"], "url": entry["alsa_id"]})
+
+        log.info(f"[ext_mic/probe] {ssh_host}: found {len(devices)} device(s)")
+        return probed
 
     def dispatch(self, action: str, args: dict) -> dict | None:
         instance_id = args.get("instance_id", "")
@@ -997,8 +1225,19 @@ class ExtMicPlugin:
                 pass  # keep as string (alsa_id like "hw:0,0" or "tcp://...")
             if instance_id not in self._nodes:
                 if isinstance(device_id, str) and (device_id.startswith("tcp://") or device_id.startswith("ssh://")):
+                    # Extract SSH params from available_devices for health check/restart
+                    ssh_params = {}
+                    for d in self._available_devices:
+                        if d.get("alsa_id") == device_id or d.get("index") == device_id:
+                            ssh_params = {
+                                "ssh_user": d.get("_ssh_user", ""),
+                                "ssh_pass": d.get("_ssh_pass", ""),
+                                "ssh_script": d.get("_ssh_script", ""),
+                                "ssh_card": d.get("_ssh_card", "1"),
+                            }
+                            break
                     node = _NetworkMicNode(device_id, device_name, self._namespace, instance_id,
-                                           context=self._executor.context)
+                                           context=self._executor.context, **ssh_params)
                 else:
                     node = _ExtMicNode(device_id, device_name, self._namespace, instance_id,
                                        context=self._executor.context)
@@ -1022,12 +1261,25 @@ class ExtMicPlugin:
             return {"state": "idle"}
 
         elif action == "config":
-            # Save instance config params for later use during start
             if instance_id:
+                # Instance config (per-card device selection)
                 self._instance_configs[instance_id] = {
                     k: v for k, v in args.items() if k not in ('action', 'instance_id')
                 }
-            return {"configured": True, "instance_id": instance_id}
+                return {"configured": True, "instance_id": instance_id}
+            else:
+                # Shared config (sidebar SSH settings) — trigger remote probe
+                ssh_host = args.get("ssh_host", "").strip()
+                if ssh_host:
+                    probed = self._probe_remote(
+                        ssh_host=ssh_host,
+                        ssh_user=args.get("ssh_user", "ubuntu"),
+                        ssh_pass=args.get("ssh_pass", ""),
+                        port=int(args.get("ssh_port", "9800") or "9800"),
+                        script=args.get("ssh_script", "/home/ubuntu/audio_sender.py"),
+                    )
+                    return {"configured": True, "remote_devices": probed}
+                return {"configured": True}
 
         return None
 

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -88,74 +88,109 @@ def _ensure_lyre_audio_mode():
         print(f"[lyre] WARNING: could not switch to {target} mode: {e}")
 
 
-def _ensure_audio_sender(cfg: dict):
-    """Ensure audio_sender.py TCP server is running on remote hosts for network mic sources."""
+def _probe_remote_mics(cfg: dict) -> list[dict]:
+    """SSH probe remote hosts for audio devices, deploy & start audio_sender, return device list."""
     ext_mic_cfg = cfg.get("plugins", {}).get("ext_mic", {})
     if not ext_mic_cfg.get("enabled", False):
-        return
-    sources = ext_mic_cfg.get("network_sources", [])
+        return []
 
-    for src in sources:
-        url = src.get("url", "")
-        if not url.startswith("tcp://"):
-            continue
+    results = []
+    for src in ext_mic_cfg.get("network_sources", []):
         ssh_host = src.get("ssh_host")
         if not ssh_host:
             continue
-
         ssh_user = src.get("ssh_user", "ubuntu")
         ssh_pass = src.get("ssh_password", "")
-        card = src.get("card", 1)
+        port = src.get("port", 9800)
         sender_path = src.get("sender_path", "/home/ubuntu/audio_sender.py")
-        port = url.rsplit(":", 1)[-1].split("/")[0] if ":" in url else "9800"
-        name = src.get("name", ssh_host)
 
-        def _ssh(cmd: str, timeout: int = 10) -> subprocess.CompletedProcess:
+        def _ssh(cmd: str, timeout: int = 10, _host=ssh_host, _user=ssh_user, _pass=ssh_pass):
             return subprocess.run(
-                ["sshpass", "-p", ssh_pass, "ssh",
-                 "-o", "StrictHostKeyChecking=no", "-o", f"ConnectTimeout=3",
-                 f"{ssh_user}@{ssh_host}", cmd],
+                ["sshpass", "-p", _pass, "ssh",
+                 "-o", "StrictHostKeyChecking=no", "-o", "ConnectTimeout=3",
+                 f"{_user}@{_host}", cmd],
                 capture_output=True, text=True, timeout=timeout)
 
-        # Check if already running
+        # Step 1: Probe remote audio devices
         try:
-            result = _ssh("pgrep -f audio_sender.py")
-            if result.returncode == 0 and result.stdout.strip():
-                pid = result.stdout.strip().splitlines()[0]
-                print(f"[audio_sender] {name}: already running on {ssh_host} (pid={pid})")
-                continue
+            result = _ssh("arecord -l")
+            devices = _parse_arecord_output(result.stdout + result.stderr)
         except Exception as e:
-            print(f"[audio_sender] {name}: WARNING: SSH check failed: {e}")
+            print(f"[ext_mic/probe] {ssh_host}: SSH probe failed: {e}")
             continue
 
-        # Deploy audio_sender.py if not present
+        if not devices:
+            print(f"[ext_mic/probe] {ssh_host}: no capture devices found")
+            continue
+
+        # Step 1.5: Probe hw params for each device
+        for dev in devices:
+            try:
+                hw_result = _ssh(
+                    f"arecord -D hw:{dev['card']},{dev['device']} --dump-hw-params -d 1 /dev/null 2>&1")
+                hw_info = _parse_hw_params(hw_result.stdout + hw_result.stderr)
+                dev.update(hw_info)
+            except Exception:
+                dev.setdefault("format", "S16_LE")
+                dev.setdefault("rate", 16000)
+                dev.setdefault("channels", 1)
+
+        # Step 2: Deploy audio_sender.py if missing
         try:
-            result = _ssh(f"test -f {sender_path} && echo EXISTS")
-            if "EXISTS" not in (result.stdout or ""):
+            check = _ssh(f"test -f {sender_path} && echo EXISTS")
+            if "EXISTS" not in (check.stdout or ""):
                 local_src = str(Path(__file__).parent / "audio_sender.py")
                 subprocess.run(
                     ["sshpass", "-p", ssh_pass, "scp",
                      "-o", "StrictHostKeyChecking=no",
                      local_src, f"{ssh_user}@{ssh_host}:{sender_path}"],
                     check=True, timeout=15)
-                print(f"[audio_sender] {name}: deployed to {ssh_host}:{sender_path}")
+                print(f"[ext_mic/probe] {ssh_host}: deployed audio_sender.py")
         except Exception as e:
-            print(f"[audio_sender] {name}: WARNING: deploy failed: {e}")
-            continue
+            print(f"[ext_mic/probe] {ssh_host}: deploy failed: {e}")
 
-        # Start in background
+        # Step 3: Start audio_sender if not running (use first detected card)
+        primary_card = devices[0]["card"]
         try:
-            _ssh(f"nohup python3 {sender_path} --port {port} --card {card} "
-                 f"> /tmp/audio_sender.log 2>&1 &")
-            time.sleep(1)
-            result = _ssh("pgrep -f audio_sender.py")
-            if result.returncode == 0 and result.stdout.strip():
-                pid = result.stdout.strip().splitlines()[0]
-                print(f"[audio_sender] {name}: started on {ssh_host} (pid={pid}, port={port}, card={card})")
+            check = _ssh("pgrep -f audio_sender.py")
+            if check.returncode != 0 or not check.stdout.strip():
+                _ssh(f"nohup python3 {sender_path} --port {port} --card {primary_card} "
+                     f"> /tmp/audio_sender.log 2>&1 &")
+                time.sleep(1)
+                verify = _ssh("pgrep -f audio_sender.py")
+                if verify.returncode == 0 and verify.stdout.strip():
+                    pid = verify.stdout.strip().splitlines()[0]
+                    print(f"[ext_mic/probe] {ssh_host}: started audio_sender (pid={pid}, card={primary_card}, port={port})")
+                else:
+                    print(f"[ext_mic/probe] {ssh_host}: WARNING: audio_sender did not start")
             else:
-                print(f"[audio_sender] {name}: WARNING: did not start, check {ssh_host}:/tmp/audio_sender.log")
+                pid = check.stdout.strip().splitlines()[0]
+                print(f"[ext_mic/probe] {ssh_host}: audio_sender already running (pid={pid})")
         except Exception as e:
-            print(f"[audio_sender] {name}: WARNING: start failed: {e}")
+            print(f"[ext_mic/probe] {ssh_host}: start failed: {e}")
+
+        # Step 4: Build device list entries (name includes format info)
+        for dev in devices:
+            fmt_desc = f"{dev.get('format', '?')}/{dev.get('rate', '?')}Hz/{dev.get('channels', '?')}ch"
+            results.append({
+                "index": f"tcp://{ssh_host}:{port}/pcm16k",
+                "alsa_id": f"tcp://{ssh_host}:{port}/pcm16k",
+                "name": f"{dev['name']} ({fmt_desc}) @ {ssh_host}",
+                "network": True,
+                "_ssh_host": ssh_host,
+                "_ssh_user": ssh_user,
+                "_ssh_pass": ssh_pass,
+                "_ssh_card": str(dev["card"]),
+                "_ssh_script": sender_path,
+                "_port": port,
+            })
+
+        print(f"[ext_mic/probe] {ssh_host}: found {len(devices)} device(s)")
+
+    return results
+
+
+from ext_devices import _parse_arecord_output, _parse_hw_params
 
 
 def _resolve_namespace(cfg: dict) -> str:
@@ -215,7 +250,8 @@ class DualDomainROS2:
 # ── Bundle ────────────────────────────────────────────────────────────────────
 
 class TianyiDeviceBundle:
-    def __init__(self, cfg: dict, namespace: str, ros2: DualDomainROS2, slamtec_client):
+    def __init__(self, cfg: dict, namespace: str, ros2: DualDomainROS2, slamtec_client,
+                 remote_mics: list = None):
         self._cfg = cfg
         self._plugins: list = []
         plugins_cfg = cfg.get("plugins", {})
@@ -348,7 +384,8 @@ class TianyiDeviceBundle:
 
         if plugins_cfg.get("ext_mic", {}).get("enabled", False):
             from ext_devices import ExtMicPlugin
-            self._plugins.append(ExtMicPlugin(plugins_cfg["ext_mic"], namespace, ros2.executor_core))
+            self._plugins.append(ExtMicPlugin(plugins_cfg["ext_mic"], namespace, ros2.executor_core,
+                                              remote_devices=remote_mics or []))
             print("[bundle] ExtMicPlugin loaded")
 
         if plugins_cfg.get("light", {}).get("enabled", False):
@@ -576,15 +613,15 @@ def main():
     # Ensure host lyre service is in audio mode (ASR + TTS, no built-in dialogue)
     _ensure_lyre_audio_mode()
 
-    # Ensure TCP audio sender is running on host for DJI wireless mic
-    _ensure_audio_sender(cfg)
+    # Ensure TCP audio sender is running on host for network mics (also probes remote devices)
+    remote_mics = _probe_remote_mics(cfg)
 
     # Dual-domain ROS2
     ros2 = DualDomainROS2()
     ros2.start_spin()
     print("[bundle] Dual-domain ROS2 initialized (domain 0 + domain 42)")
 
-    _bundle = TianyiDeviceBundle(cfg, namespace, ros2, slamtec_client)
+    _bundle = TianyiDeviceBundle(cfg, namespace, ros2, slamtec_client, remote_mics=remote_mics)
     _bundle.start_all()
 
     _start_registration(mcp_port, cfg.get("name", "Tianyi 2.0 Pro"), "driver")


### PR DESCRIPTION
## Summary
- Sidebar shared config for remote mic SSH info (host/user/pass with defaults)
- On config save, driver SSH-probes remote host: detects audio devices, deploys audio_sender.py, starts service
- Health check on start and reconnect: auto-restarts unresponsive audio_sender via SSH
- 10s socket timeout detects ALSA-stuck connections
- Startup probe from config.yaml as fallback
- Device names show detected format/rate/channels info

## Test plan
- [ ] Open dashboard sidebar, ext_mic config → verify 3 fields with defaults
- [ ] Save config → driver logs show probe + device detection
- [ ] Start ext_mic on canvas → audio streams normally
- [ ] Kill audio_sender on remote → ext_mic auto-restarts it
- [ ] Container restart with auto-start enabled → full recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)