### PR TITLE
feat: add G1 wireless controller cardFeature/g1 wireless controller

### DIFF
--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -16,6 +16,8 @@ plugins:
     enabled: true
   state:
     enabled: true
+  wireless_controller:
+    enabled: true
   camera:
     enabled: true
   lidar:

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -16,7 +16,10 @@ drivers/unitree/g1/device.py — Unitree G1 设备插件（重构版）。
   LocoPlugin         (actuator)  — 运动控制
   ArmActionPlugin    (actuator)  — 手臂动作
   StatePlugin        (sensor)    — DDS LowState → IMU/battery ROS2 topic
+  WirelessControllerPlugin (sensor) — DDS LowState wireless_remote → ROS2 topic
 """
+
+from __future__ import annotations
 
 import json
 import queue
@@ -1815,6 +1818,160 @@ class StatePlugin:
             if urdf_path.exists():
                 return {"urdf": urdf_path.read_text()}
             return {"error": "URDF model file not found"}
+        return None
+
+
+# ── WirelessControllerPlugin (sensor/status) ─────────────────────────────────
+
+class _WirelessControllerNode(Node):
+    """Subscribes to DDS lowstate wireless remote bytes and republishes JSON to ROS2."""
+
+    DDS_TOPIC = "rt/lowstate"
+    FRESH_TIMEOUT_SEC = 1.0
+    PUBLISH_INTERVAL_SEC = 0.1
+
+    def __init__(self, topic: str, fresh_timeout_sec: float = FRESH_TIMEOUT_SEC):
+        super().__init__("g1_wireless_controller")
+        self._topic = topic
+        self._pub = self.create_publisher(String, topic, _LOW_LAT_QOS)
+        self._fresh_timeout_sec = float(fresh_timeout_sec)
+        self._lock = threading.Lock()
+        self._last_state: dict | None = None
+        self._sample_count = 0
+        self._sub = None
+        self._timer = self.create_timer(self.PUBLISH_INTERVAL_SEC, self._publish_snapshot)
+
+        try:
+            from unitree_sdk2py.core.channel import ChannelSubscriber
+            from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowState_
+            self._sub = ChannelSubscriber(self.DDS_TOPIC, LowState_)
+            self._sub.Init(self._on_wireless_controller, 10)
+            self.get_logger().info(f"WirelessControllerNode subscribed {self.DDS_TOPIC} → {topic}")
+        except Exception as e:
+            self.get_logger().warn(f"WirelessControllerNode: failed to subscribe {self.DDS_TOPIC}: {e}")
+
+    def _format_state(self, msg, now: float | None = None) -> dict:
+        update_time = time.monotonic() if now is None else now
+        remote = list(msg.wireless_remote)
+        keys = int(remote[2]) | (int(remote[3]) << 8)
+
+        def unpack_float(offset: int) -> float:
+            return struct.unpack("f", bytes(remote[offset:offset + 4]))[0]
+
+        return {
+            "lx": float(unpack_float(4)),
+            "ly": float(unpack_float(20)),
+            "rx": float(unpack_float(8)),
+            "ry": float(unpack_float(12)),
+            "keys": keys,
+            "_updated_at": update_time,
+        }
+
+    def _public_state(self, state: dict | None, sample_count: int, now: float | None = None) -> dict:
+        current = time.monotonic() if now is None else now
+        base = {
+            "source_topic": self.DDS_TOPIC,
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+            "fresh_timeout_sec": self._fresh_timeout_sec,
+            "sample_count": sample_count,
+        }
+        if not state:
+            return {
+                **base,
+                "state": "no_data",
+                "connected": False,
+                "reason": "no_data",
+                "last_update_ago_ms": -1,
+            }
+
+        last_update_ago_ms = max(0, int((current - state["_updated_at"]) * 1000))
+        connected = last_update_ago_ms <= int(self._fresh_timeout_sec * 1000)
+        public = {k: v for k, v in state.items() if not k.startswith("_")}
+        return {
+            **base,
+            **public,
+            "state": "running" if connected else "stale",
+            "connected": connected,
+            "reason": "fresh" if connected else "stale",
+            "last_update_ago_ms": last_update_ago_ms,
+        }
+
+    def _on_wireless_controller(self, msg) -> None:
+        state = self._format_state(msg)
+        with self._lock:
+            self._last_state = state
+            self._sample_count += 1
+
+    def _publish_snapshot(self, now: float | None = None) -> None:
+        snapshot = self.snapshot(now=now)
+        out = String()
+        out.data = json.dumps(snapshot)
+        self._pub.publish(out)
+
+    def snapshot(self, now: float | None = None) -> dict:
+        with self._lock:
+            state = dict(self._last_state) if self._last_state else None
+            sample_count = self._sample_count
+        return self._public_state(state, sample_count, now=now)
+
+    def info(self) -> dict:
+        snapshot = self.snapshot()
+        return {
+            "state": snapshot["state"],
+            "source_topic": self.DDS_TOPIC,
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+            "fresh_timeout_sec": self._fresh_timeout_sec,
+            "connected": snapshot["connected"],
+            "reason": snapshot["reason"],
+            "sample_count": snapshot["sample_count"],
+            "last_update_ago_ms": snapshot["last_update_ago_ms"],
+        }
+
+
+class WirelessControllerPlugin:
+    PREFIX = "wireless_controller"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor):
+        self._topic = f"/{namespace}/state/wireless_controller"
+        fresh_timeout_sec = plugin_config.get("fresh_timeout_sec", _WirelessControllerNode.FRESH_TIMEOUT_SEC)
+        self._node = _WirelessControllerNode(self._topic, fresh_timeout_sec=fresh_timeout_sec)
+        executor.add_node(self._node)
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "wireless_controller",
+            "type": "sensor",
+            "multiInstance": False,
+            "description": (
+                "G1 wireless controller status — read-only DDS snapshot of lx/ly/rx/ry axes, "
+                "raw keys bitmap, and data freshness"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["snapshot", "info"],
+                        "description": "Optional read action; omitted calls return the current snapshot",
+                    },
+                },
+            },
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        pass  # DDS subscription starts in __init__
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action in ("wireless_controller", "snapshot", "start"):
+            return self._node.snapshot()
+        if action == "info":
+            return self._node.info()
+        if action == "stop":
+            return {"state": "idle", "topic_out": [{"topic": self._topic, "format": "data/json"}]}
         return None
 
 

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -1892,8 +1892,6 @@ class _WirelessControllerNode(Node):
     def _public_state(self, state: dict | None, sample_count: int, now: float | None = None) -> dict:
         current = time.monotonic() if now is None else now
         base = {
-            "source_topic": self.DDS_TOPIC,
-            "topic_out": [{"topic": self._topic, "format": "data/json"}],
             "fresh_timeout_sec": self._fresh_timeout_sec,
             "sample_count": sample_count,
             "deadzone": self.ACTIVE_DEADZONE,
@@ -1946,8 +1944,6 @@ class _WirelessControllerNode(Node):
         state = self.current_state()
         return {
             "state": state["state"],
-            "source_topic": self.DDS_TOPIC,
-            "topic_out": [{"topic": self._topic, "format": "data/json"}],
             "fresh_timeout_sec": self._fresh_timeout_sec,
             "deadzone": self.ACTIVE_DEADZONE,
             "connected": state["connected"],
@@ -1972,19 +1968,10 @@ class WirelessControllerPlugin:
             "type": "sensor",
             "multiInstance": False,
             "description": (
-                "G1 wireless controller input monitor — read whether physical controller stick "
-                "or button input is reaching the driver. This is read-only and never commands motion."
+                "G1 wireless controller input monitor — publishes physical controller stick "
+                "and button input reaching the driver. This sensor never commands motion."
             ),
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string",
-                        "enum": ["read", "info"],
-                        "description": "Optional action; omitted calls read the current controller input",
-                    },
-                },
-            },
+            "inputSchema": {"type": "object", "properties": {}},
             "topic_out": [{"topic": self._topic, "format": "data/json"}],
         }
 
@@ -1995,12 +1982,12 @@ class WirelessControllerPlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict | None:
-        if action in ("wireless_controller", "read", "start"):
+        if action in ("wireless_controller", "start"):
             return self._node.current_state()
         if action == "info":
             return self._node.info()
         if action == "stop":
-            return {"state": "idle", "topic_out": [{"topic": self._topic, "format": "data/json"}]}
+            return {"state": "idle"}
         return None
 
 

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -1829,6 +1829,7 @@ class _WirelessControllerNode(Node):
     DDS_TOPIC = "rt/lowstate"
     FRESH_TIMEOUT_SEC = 1.0
     PUBLISH_INTERVAL_SEC = 0.1
+    ACTIVE_DEADZONE = 0.1
 
     def __init__(self, topic: str, fresh_timeout_sec: float = FRESH_TIMEOUT_SEC):
         super().__init__("g1_wireless_controller")
@@ -1839,7 +1840,7 @@ class _WirelessControllerNode(Node):
         self._last_state: dict | None = None
         self._sample_count = 0
         self._sub = None
-        self._timer = self.create_timer(self.PUBLISH_INTERVAL_SEC, self._publish_snapshot)
+        self._timer = self.create_timer(self.PUBLISH_INTERVAL_SEC, self._publish_state)
 
         try:
             from unitree_sdk2py.core.channel import ChannelSubscriber
@@ -1867,6 +1868,27 @@ class _WirelessControllerNode(Node):
             "_updated_at": update_time,
         }
 
+    def _stick_state(self, x: float, y: float) -> dict:
+        magnitude = min(1.0, (x * x + y * y) ** 0.5)
+        active = magnitude >= self.ACTIVE_DEADZONE
+        if not active:
+            primary_axis = "neutral"
+            direction = "neutral"
+        elif abs(x) >= abs(y):
+            primary_axis = "x"
+            direction = "positive" if x > 0 else "negative"
+        else:
+            primary_axis = "y"
+            direction = "positive" if y > 0 else "negative"
+        return {
+            "x": round(x, 3),
+            "y": round(y, 3),
+            "active": active,
+            "primary_axis": primary_axis,
+            "direction": direction,
+            "magnitude": round(magnitude, 3),
+        }
+
     def _public_state(self, state: dict | None, sample_count: int, now: float | None = None) -> dict:
         current = time.monotonic() if now is None else now
         base = {
@@ -1874,6 +1896,7 @@ class _WirelessControllerNode(Node):
             "topic_out": [{"topic": self._topic, "format": "data/json"}],
             "fresh_timeout_sec": self._fresh_timeout_sec,
             "sample_count": sample_count,
+            "deadzone": self.ACTIVE_DEADZONE,
         }
         if not state:
             return {
@@ -1886,14 +1909,19 @@ class _WirelessControllerNode(Node):
 
         last_update_ago_ms = max(0, int((current - state["_updated_at"]) * 1000))
         connected = last_update_ago_ms <= int(self._fresh_timeout_sec * 1000)
-        public = {k: v for k, v in state.items() if not k.startswith("_")}
+        keys = int(state["keys"])
         return {
             **base,
-            **public,
             "state": "running" if connected else "stale",
             "connected": connected,
             "reason": "fresh" if connected else "stale",
             "last_update_ago_ms": last_update_ago_ms,
+            "left_stick": self._stick_state(float(state["lx"]), float(state["ly"])),
+            "right_stick": self._stick_state(float(state["rx"]), float(state["ry"])),
+            "buttons": {
+                "raw": keys,
+                "active": keys != 0,
+            },
         }
 
     def _on_wireless_controller(self, msg) -> None:
@@ -1902,29 +1930,30 @@ class _WirelessControllerNode(Node):
             self._last_state = state
             self._sample_count += 1
 
-    def _publish_snapshot(self, now: float | None = None) -> None:
-        snapshot = self.snapshot(now=now)
+    def _publish_state(self, now: float | None = None) -> None:
+        state = self.current_state(now=now)
         out = String()
-        out.data = json.dumps(snapshot)
+        out.data = json.dumps(state)
         self._pub.publish(out)
 
-    def snapshot(self, now: float | None = None) -> dict:
+    def current_state(self, now: float | None = None) -> dict:
         with self._lock:
             state = dict(self._last_state) if self._last_state else None
             sample_count = self._sample_count
         return self._public_state(state, sample_count, now=now)
 
     def info(self) -> dict:
-        snapshot = self.snapshot()
+        state = self.current_state()
         return {
-            "state": snapshot["state"],
+            "state": state["state"],
             "source_topic": self.DDS_TOPIC,
             "topic_out": [{"topic": self._topic, "format": "data/json"}],
             "fresh_timeout_sec": self._fresh_timeout_sec,
-            "connected": snapshot["connected"],
-            "reason": snapshot["reason"],
-            "sample_count": snapshot["sample_count"],
-            "last_update_ago_ms": snapshot["last_update_ago_ms"],
+            "deadzone": self.ACTIVE_DEADZONE,
+            "connected": state["connected"],
+            "reason": state["reason"],
+            "sample_count": state["sample_count"],
+            "last_update_ago_ms": state["last_update_ago_ms"],
         }
 
 
@@ -1943,16 +1972,16 @@ class WirelessControllerPlugin:
             "type": "sensor",
             "multiInstance": False,
             "description": (
-                "G1 wireless controller status — read-only DDS snapshot of lx/ly/rx/ry axes, "
-                "raw keys bitmap, and data freshness"
+                "G1 wireless controller input monitor — read whether physical controller stick "
+                "or button input is reaching the driver. This is read-only and never commands motion."
             ),
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["snapshot", "info"],
-                        "description": "Optional read action; omitted calls return the current snapshot",
+                        "enum": ["read", "info"],
+                        "description": "Optional action; omitted calls read the current controller input",
                     },
                 },
             },
@@ -1966,8 +1995,8 @@ class WirelessControllerPlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict | None:
-        if action in ("wireless_controller", "snapshot", "start"):
-            return self._node.snapshot()
+        if action in ("wireless_controller", "read", "start"):
+            return self._node.current_state()
         if action == "info":
             return self._node.info()
         if action == "stop":

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -110,6 +110,11 @@ class G1DeviceBundle:
             self._plugins.append(StatePlugin(plugins_cfg["state"], namespace, executor))
             print("[bundle] StatePlugin loaded")
 
+        if plugins_cfg.get("wireless_controller", {}).get("enabled", False):
+            from device import WirelessControllerPlugin
+            self._plugins.append(WirelessControllerPlugin(plugins_cfg["wireless_controller"], namespace, executor))
+            print("[bundle] WirelessControllerPlugin loaded")
+
         if plugins_cfg.get("camera", {}).get("enabled", False):
             from device import RealSensePlugin
             self._plugins.append(RealSensePlugin(plugins_cfg["camera"], namespace, executor))

--- a/unitree/g1/tests/__init__.py
+++ b/unitree/g1/tests/__init__.py
@@ -1,0 +1,2 @@
+"""G1 driver tests."""
+

--- a/unitree/g1/tests/test_wireless_controller.py
+++ b/unitree/g1/tests/test_wireless_controller.py
@@ -170,7 +170,8 @@ class WirelessControllerPluginTests(unittest.TestCase):
             [{"topic": "/test_g1/state/wireless_controller", "format": "data/json"}],
             tool["topic_out"],
         )
-        self.assertEqual(["snapshot", "info"], tool["inputSchema"]["properties"]["action"]["enum"])
+        self.assertEqual(["read", "info"], tool["inputSchema"]["properties"]["action"]["enum"])
+        self.assertIn("read-only", tool["description"])
 
     def test_subscribes_to_unitree_lowstate_dds(self):
         self.assertEqual(1, len(FakeChannelSubscriber.instances))
@@ -179,7 +180,7 @@ class WirelessControllerPluginTests(unittest.TestCase):
         self.assertIs(sub.message_type, LowState)
         self.assertEqual(10, sub.queue_len)
 
-    def test_publishes_json_and_returns_snapshot(self):
+    def test_publishes_json_and_returns_current_input_state(self):
         remote = [0] * 40
         remote[2] = 1
         remote[3] = 2
@@ -192,7 +193,7 @@ class WirelessControllerPluginTests(unittest.TestCase):
 
         node = self.executor.nodes[0]
         self.assertEqual([], node.publishers[0].messages)
-        self.plugin._node._publish_snapshot()
+        self.plugin._node._publish_state()
         published = json.loads(node.publishers[0].messages[-1].data)
         self.assertEqual("running", published["state"])
         self.assertTrue(published["connected"])
@@ -200,33 +201,41 @@ class WirelessControllerPluginTests(unittest.TestCase):
         self.assertEqual(1, published["sample_count"])
         self.assertEqual("rt/lowstate", published["source_topic"])
         self.assertEqual(0, published["last_update_ago_ms"])
-        self.assertAlmostEqual(0.1, published["lx"])
-        self.assertAlmostEqual(-0.2, published["ly"])
-        self.assertAlmostEqual(0.3, published["rx"])
-        self.assertAlmostEqual(-0.4, published["ry"])
-        self.assertEqual(513, published["keys"])
+        self.assertAlmostEqual(0.1, published["left_stick"]["x"])
+        self.assertAlmostEqual(-0.2, published["left_stick"]["y"])
+        self.assertTrue(published["left_stick"]["active"])
+        self.assertEqual("y", published["left_stick"]["primary_axis"])
+        self.assertEqual("negative", published["left_stick"]["direction"])
+        self.assertAlmostEqual(0.3, published["right_stick"]["x"])
+        self.assertAlmostEqual(-0.4, published["right_stick"]["y"])
+        self.assertTrue(published["right_stick"]["active"])
+        self.assertEqual(513, published["buttons"]["raw"])
+        self.assertTrue(published["buttons"]["active"])
 
-        snapshot = self.plugin.dispatch("wireless_controller", {})
-        self.assertEqual("running", snapshot["state"])
-        self.assertTrue(snapshot["connected"])
-        self.assertAlmostEqual(0.1, snapshot["lx"])
-        self.assertAlmostEqual(-0.2, snapshot["ly"])
-        self.assertAlmostEqual(0.3, snapshot["rx"])
-        self.assertAlmostEqual(-0.4, snapshot["ry"])
-        self.assertEqual(513, snapshot["keys"])
-        self.assertEqual(1, snapshot["sample_count"])
-        self.assertGreaterEqual(snapshot["last_update_ago_ms"], 0)
+        state = self.plugin.dispatch("wireless_controller", {})
+        self.assertEqual("running", state["state"])
+        self.assertTrue(state["connected"])
+        self.assertAlmostEqual(0.1, state["left_stick"]["x"])
+        self.assertAlmostEqual(-0.2, state["left_stick"]["y"])
+        self.assertAlmostEqual(0.3, state["right_stick"]["x"])
+        self.assertAlmostEqual(-0.4, state["right_stick"]["y"])
+        self.assertEqual(513, state["buttons"]["raw"])
+        self.assertEqual(1, state["sample_count"])
+        self.assertGreaterEqual(state["last_update_ago_ms"], 0)
 
-    def test_no_data_snapshot_is_explicit(self):
-        snapshot = self.plugin.dispatch("snapshot", {})
-        self.assertEqual("no_data", snapshot["state"])
-        self.assertFalse(snapshot["connected"])
-        self.assertEqual("no_data", snapshot["reason"])
-        self.assertEqual(0, snapshot["sample_count"])
-        self.assertEqual(-1, snapshot["last_update_ago_ms"])
+        read_state = self.plugin.dispatch("read", {})
+        self.assertEqual(state["buttons"], read_state["buttons"])
+
+    def test_no_data_state_is_explicit(self):
+        state = self.plugin.dispatch("read", {})
+        self.assertEqual("no_data", state["state"])
+        self.assertFalse(state["connected"])
+        self.assertEqual("no_data", state["reason"])
+        self.assertEqual(0, state["sample_count"])
+        self.assertEqual(-1, state["last_update_ago_ms"])
         self.assertEqual(
             [{"topic": "/test_g1/state/wireless_controller", "format": "data/json"}],
-            snapshot["topic_out"],
+            state["topic_out"],
         )
 
     def test_info_reports_source_and_freshness_without_axes(self):
@@ -241,12 +250,13 @@ class WirelessControllerPluginTests(unittest.TestCase):
             info["topic_out"],
         )
         self.assertEqual(1.0, info["fresh_timeout_sec"])
+        self.assertEqual(0.1, info["deadzone"])
         self.assertTrue(info["connected"])
         self.assertEqual(1, info["sample_count"])
-        self.assertNotIn("lx", info)
-        self.assertNotIn("keys", info)
+        self.assertNotIn("left_stick", info)
+        self.assertNotIn("buttons", info)
 
-    def test_stale_snapshot_is_published_by_timer(self):
+    def test_stale_state_is_published_by_timer(self):
         node = self.executor.nodes[0]
         stale_now = 102.0
         msg = types.SimpleNamespace(wireless_remote=[0] * 40)
@@ -254,14 +264,14 @@ class WirelessControllerPluginTests(unittest.TestCase):
         with self.plugin._node._lock:
             self.plugin._node._last_state["_updated_at"] = 100.0
 
-        snapshot = self.plugin._node.snapshot(now=stale_now)
-        self.assertEqual("stale", snapshot["state"])
-        self.assertFalse(snapshot["connected"])
-        self.assertEqual("stale", snapshot["reason"])
-        self.assertEqual(1, snapshot["sample_count"])
-        self.assertGreaterEqual(snapshot["last_update_ago_ms"], 1000)
+        state = self.plugin._node.current_state(now=stale_now)
+        self.assertEqual("stale", state["state"])
+        self.assertFalse(state["connected"])
+        self.assertEqual("stale", state["reason"])
+        self.assertEqual(1, state["sample_count"])
+        self.assertGreaterEqual(state["last_update_ago_ms"], 1000)
 
-        self.plugin._node._publish_snapshot(now=stale_now)
+        self.plugin._node._publish_state(now=stale_now)
         published = json.loads(node.publishers[0].messages[-1].data)
         self.assertEqual("stale", published["state"])
         self.assertFalse(published["connected"])

--- a/unitree/g1/tests/test_wireless_controller.py
+++ b/unitree/g1/tests/test_wireless_controller.py
@@ -170,8 +170,9 @@ class WirelessControllerPluginTests(unittest.TestCase):
             [{"topic": "/test_g1/state/wireless_controller", "format": "data/json"}],
             tool["topic_out"],
         )
-        self.assertEqual(["read", "info"], tool["inputSchema"]["properties"]["action"]["enum"])
-        self.assertIn("read-only", tool["description"])
+        self.assertEqual({}, tool["inputSchema"]["properties"])
+        self.assertNotIn("read", tool["description"].lower())
+        self.assertIn("never commands motion", tool["description"])
 
     def test_subscribes_to_unitree_lowstate_dds(self):
         self.assertEqual(1, len(FakeChannelSubscriber.instances))
@@ -199,7 +200,8 @@ class WirelessControllerPluginTests(unittest.TestCase):
         self.assertTrue(published["connected"])
         self.assertEqual("fresh", published["reason"])
         self.assertEqual(1, published["sample_count"])
-        self.assertEqual("rt/lowstate", published["source_topic"])
+        self.assertNotIn("source_topic", published)
+        self.assertNotIn("topic_out", published)
         self.assertEqual(0, published["last_update_ago_ms"])
         self.assertAlmostEqual(0.1, published["left_stick"]["x"])
         self.assertAlmostEqual(-0.2, published["left_stick"]["y"])
@@ -223,20 +225,17 @@ class WirelessControllerPluginTests(unittest.TestCase):
         self.assertEqual(1, state["sample_count"])
         self.assertGreaterEqual(state["last_update_ago_ms"], 0)
 
-        read_state = self.plugin.dispatch("read", {})
-        self.assertEqual(state["buttons"], read_state["buttons"])
+        self.assertIsNone(self.plugin.dispatch("read", {}))
 
     def test_no_data_state_is_explicit(self):
-        state = self.plugin.dispatch("read", {})
+        state = self.plugin.dispatch("wireless_controller", {})
         self.assertEqual("no_data", state["state"])
         self.assertFalse(state["connected"])
         self.assertEqual("no_data", state["reason"])
         self.assertEqual(0, state["sample_count"])
         self.assertEqual(-1, state["last_update_ago_ms"])
-        self.assertEqual(
-            [{"topic": "/test_g1/state/wireless_controller", "format": "data/json"}],
-            state["topic_out"],
-        )
+        self.assertNotIn("source_topic", state)
+        self.assertNotIn("topic_out", state)
 
     def test_info_reports_source_and_freshness_without_axes(self):
         msg = types.SimpleNamespace(wireless_remote=[0] * 40)
@@ -244,11 +243,8 @@ class WirelessControllerPluginTests(unittest.TestCase):
 
         info = self.plugin.dispatch("info", {})
         self.assertEqual("running", info["state"])
-        self.assertEqual("rt/lowstate", info["source_topic"])
-        self.assertEqual(
-            [{"topic": "/test_g1/state/wireless_controller", "format": "data/json"}],
-            info["topic_out"],
-        )
+        self.assertNotIn("source_topic", info)
+        self.assertNotIn("topic_out", info)
         self.assertEqual(1.0, info["fresh_timeout_sec"])
         self.assertEqual(0.1, info["deadzone"])
         self.assertTrue(info["connected"])

--- a/unitree/g1/tests/test_wireless_controller.py
+++ b/unitree/g1/tests/test_wireless_controller.py
@@ -1,0 +1,278 @@
+import importlib.util
+import json
+import struct
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def json_float(value):
+    return struct.pack("f", value)
+
+
+class Message:
+    pass
+
+
+class FakeString(Message):
+    def __init__(self):
+        self.data = ""
+
+
+class FakePublisher:
+    def __init__(self, topic):
+        self.topic = topic
+        self.messages = []
+
+    def publish(self, message):
+        self.messages.append(message)
+
+
+class FakeLogger:
+    def __init__(self):
+        self.infos = []
+        self.warnings = []
+
+    def info(self, message):
+        self.infos.append(message)
+
+    def warn(self, message):
+        self.warnings.append(message)
+
+
+class FakeNode:
+    def __init__(self, name):
+        self.name = name
+        self.publishers = []
+        self.timers = []
+        self.logger = FakeLogger()
+
+    def create_publisher(self, message_type, topic, qos):
+        publisher = FakePublisher(topic)
+        self.publishers.append(publisher)
+        return publisher
+
+    def create_timer(self, interval_sec, callback):
+        timer = types.SimpleNamespace(interval_sec=interval_sec, callback=callback)
+        self.timers.append(timer)
+        return timer
+
+    def get_logger(self):
+        return self.logger
+
+
+class FakeExecutor:
+    def __init__(self):
+        self.nodes = []
+
+    def add_node(self, node):
+        self.nodes.append(node)
+
+
+class FakeChannelSubscriber:
+    instances = []
+
+    def __init__(self, topic, message_type):
+        self.topic = topic
+        self.message_type = message_type
+        self.callback = None
+        self.queue_len = None
+        FakeChannelSubscriber.instances.append(self)
+
+    def Init(self, callback, queue_len):
+        self.callback = callback
+        self.queue_len = queue_len
+
+
+class LowState:
+    pass
+
+
+def install_stubs():
+    FakeChannelSubscriber.instances = []
+
+    rclpy = types.ModuleType("rclpy")
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_node.Node = FakeNode
+    rclpy_qos = types.ModuleType("rclpy.qos")
+    rclpy_qos.QoSProfile = lambda **kwargs: types.SimpleNamespace(**kwargs)
+    rclpy_qos.ReliabilityPolicy = types.SimpleNamespace(BEST_EFFORT=1)
+    rclpy_qos.HistoryPolicy = types.SimpleNamespace(KEEP_LAST=1)
+    rclpy_qos.DurabilityPolicy = types.SimpleNamespace(VOLATILE=1)
+    sys.modules["rclpy"] = rclpy
+    sys.modules["rclpy.node"] = rclpy_node
+    sys.modules["rclpy.qos"] = rclpy_qos
+
+    std_msgs = types.ModuleType("std_msgs.msg")
+    std_msgs.Header = type("Header", (Message,), {})
+    std_msgs.String = FakeString
+    sys.modules["std_msgs.msg"] = std_msgs
+
+    audio_msgs = types.ModuleType("audio_msgs.msg")
+    audio_msgs.AudioChunk = type("AudioChunk", (Message,), {})
+    sys.modules["audio_msgs.msg"] = audio_msgs
+
+    channel = types.ModuleType("unitree_sdk2py.core.channel")
+    channel.ChannelSubscriber = FakeChannelSubscriber
+    sys.modules["unitree_sdk2py"] = types.ModuleType("unitree_sdk2py")
+    sys.modules["unitree_sdk2py.core"] = types.ModuleType("unitree_sdk2py.core")
+    sys.modules["unitree_sdk2py.core.channel"] = channel
+
+    g1_audio = types.ModuleType("unitree_sdk2py.g1.audio.g1_audio_client")
+    g1_audio.AudioClient = object
+    sys.modules["unitree_sdk2py.g1"] = types.ModuleType("unitree_sdk2py.g1")
+    sys.modules["unitree_sdk2py.g1.audio"] = types.ModuleType("unitree_sdk2py.g1.audio")
+    sys.modules["unitree_sdk2py.g1.audio.g1_audio_client"] = g1_audio
+
+    dds = types.ModuleType("unitree_sdk2py.idl.unitree_hg.msg.dds_")
+    dds.LowState_ = LowState
+    sys.modules["unitree_sdk2py.idl"] = types.ModuleType("unitree_sdk2py.idl")
+    sys.modules["unitree_sdk2py.idl.unitree_hg"] = types.ModuleType("unitree_sdk2py.idl.unitree_hg")
+    sys.modules["unitree_sdk2py.idl.unitree_hg.msg"] = types.ModuleType("unitree_sdk2py.idl.unitree_hg.msg")
+    sys.modules["unitree_sdk2py.idl.unitree_hg.msg.dds_"] = dds
+
+    pointcloud_utils = types.ModuleType("pointcloud_utils")
+    pointcloud_utils.gravity_align_inplace = lambda *args, **kwargs: None
+    sys.modules["pointcloud_utils"] = pointcloud_utils
+
+    numpy = types.ModuleType("numpy")
+    numpy.ndarray = object
+    sys.modules.setdefault("numpy", numpy)
+
+
+def load_device():
+    install_stubs()
+    spec = importlib.util.spec_from_file_location("g1_device_wireless_test", ROOT / "device.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class WirelessControllerPluginTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.device = load_device()
+
+    def setUp(self):
+        FakeChannelSubscriber.instances = []
+        self.executor = FakeExecutor()
+        self.plugin = self.device.WirelessControllerPlugin({}, "test_g1", self.executor)
+
+    def test_tool_contract(self):
+        tool = self.plugin.get_tool()
+        self.assertEqual("wireless_controller", tool["name"])
+        self.assertEqual("sensor", tool["type"])
+        self.assertEqual(
+            [{"topic": "/test_g1/state/wireless_controller", "format": "data/json"}],
+            tool["topic_out"],
+        )
+        self.assertEqual(["snapshot", "info"], tool["inputSchema"]["properties"]["action"]["enum"])
+
+    def test_subscribes_to_unitree_lowstate_dds(self):
+        self.assertEqual(1, len(FakeChannelSubscriber.instances))
+        sub = FakeChannelSubscriber.instances[0]
+        self.assertEqual("rt/lowstate", sub.topic)
+        self.assertIs(sub.message_type, LowState)
+        self.assertEqual(10, sub.queue_len)
+
+    def test_publishes_json_and_returns_snapshot(self):
+        remote = [0] * 40
+        remote[2] = 1
+        remote[3] = 2
+        remote[4:8] = list(json_float(0.1))
+        remote[8:12] = list(json_float(0.3))
+        remote[12:16] = list(json_float(-0.4))
+        remote[20:24] = list(json_float(-0.2))
+        msg = types.SimpleNamespace(wireless_remote=remote)
+        FakeChannelSubscriber.instances[0].callback(msg)
+
+        node = self.executor.nodes[0]
+        self.assertEqual([], node.publishers[0].messages)
+        self.plugin._node._publish_snapshot()
+        published = json.loads(node.publishers[0].messages[-1].data)
+        self.assertEqual("running", published["state"])
+        self.assertTrue(published["connected"])
+        self.assertEqual("fresh", published["reason"])
+        self.assertEqual(1, published["sample_count"])
+        self.assertEqual("rt/lowstate", published["source_topic"])
+        self.assertEqual(0, published["last_update_ago_ms"])
+        self.assertAlmostEqual(0.1, published["lx"])
+        self.assertAlmostEqual(-0.2, published["ly"])
+        self.assertAlmostEqual(0.3, published["rx"])
+        self.assertAlmostEqual(-0.4, published["ry"])
+        self.assertEqual(513, published["keys"])
+
+        snapshot = self.plugin.dispatch("wireless_controller", {})
+        self.assertEqual("running", snapshot["state"])
+        self.assertTrue(snapshot["connected"])
+        self.assertAlmostEqual(0.1, snapshot["lx"])
+        self.assertAlmostEqual(-0.2, snapshot["ly"])
+        self.assertAlmostEqual(0.3, snapshot["rx"])
+        self.assertAlmostEqual(-0.4, snapshot["ry"])
+        self.assertEqual(513, snapshot["keys"])
+        self.assertEqual(1, snapshot["sample_count"])
+        self.assertGreaterEqual(snapshot["last_update_ago_ms"], 0)
+
+    def test_no_data_snapshot_is_explicit(self):
+        snapshot = self.plugin.dispatch("snapshot", {})
+        self.assertEqual("no_data", snapshot["state"])
+        self.assertFalse(snapshot["connected"])
+        self.assertEqual("no_data", snapshot["reason"])
+        self.assertEqual(0, snapshot["sample_count"])
+        self.assertEqual(-1, snapshot["last_update_ago_ms"])
+        self.assertEqual(
+            [{"topic": "/test_g1/state/wireless_controller", "format": "data/json"}],
+            snapshot["topic_out"],
+        )
+
+    def test_info_reports_source_and_freshness_without_axes(self):
+        msg = types.SimpleNamespace(wireless_remote=[0] * 40)
+        FakeChannelSubscriber.instances[0].callback(msg)
+
+        info = self.plugin.dispatch("info", {})
+        self.assertEqual("running", info["state"])
+        self.assertEqual("rt/lowstate", info["source_topic"])
+        self.assertEqual(
+            [{"topic": "/test_g1/state/wireless_controller", "format": "data/json"}],
+            info["topic_out"],
+        )
+        self.assertEqual(1.0, info["fresh_timeout_sec"])
+        self.assertTrue(info["connected"])
+        self.assertEqual(1, info["sample_count"])
+        self.assertNotIn("lx", info)
+        self.assertNotIn("keys", info)
+
+    def test_stale_snapshot_is_published_by_timer(self):
+        node = self.executor.nodes[0]
+        stale_now = 102.0
+        msg = types.SimpleNamespace(wireless_remote=[0] * 40)
+        self.plugin._node._on_wireless_controller(msg)
+        with self.plugin._node._lock:
+            self.plugin._node._last_state["_updated_at"] = 100.0
+
+        snapshot = self.plugin._node.snapshot(now=stale_now)
+        self.assertEqual("stale", snapshot["state"])
+        self.assertFalse(snapshot["connected"])
+        self.assertEqual("stale", snapshot["reason"])
+        self.assertEqual(1, snapshot["sample_count"])
+        self.assertGreaterEqual(snapshot["last_update_ago_ms"], 1000)
+
+        self.plugin._node._publish_snapshot(now=stale_now)
+        published = json.loads(node.publishers[0].messages[-1].data)
+        self.assertEqual("stale", published["state"])
+        self.assertFalse(published["connected"])
+
+    def test_config_and_main_register_plugin(self):
+        config_text = (ROOT / "config.yaml").read_text()
+        main_text = (ROOT / "main.py").read_text()
+        self.assertIn("wireless_controller:", config_text)
+        self.assertIn("WirelessControllerPlugin", main_text)
+        self.assertIn('plugins_cfg.get("wireless_controller"', main_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add read-only G1 wireless_controller card
- Decode raw controller state from rt/lowstate wireless_remote
- Publish JSON state to /ubuntu/state/wireless_controller at 10Hz
- Expose MCP snapshot/info with freshness, connected state, sample_count, and raw keys

## Validation
- python3 -m unittest discover -s unitree/g1/tests -p 'test_*.py' -v
- py_compile passed
- git diff --check passed
- Real G1 validation:
  - snapshot/info connected=true and sample_count grows
  - ROS2 topic publishes at ~10Hz
  - left/right stick changes observed
  - raw keys changed 0 -> 2048 -> 0