### PR TITLE
feat(g1): 新增 continuous_gait 与 bms_control 两张卡片

### DIFF
--- a/T800卡片开发上传流程.md
+++ b/T800卡片开发上传流程.md
@@ -1,0 +1,268 @@
+# 众擎 T800 driver/skill 合作开发上传流程
+
+> 本文档仿照 `x-humanoid/tianyi2.0` 的 `tianyi卡片开发上传流程.md` 编写，
+> 适用于众擎（EngineAI）T800 开发版驱动的所有合作开发。开发完成后上传到
+> 官方仓库 `https://github.com/4paradigm/phanthymotus-driver`。
+
+---
+
+## 推送流程
+
+### 1. Fork 主仓库
+
+打开 `https://github.com/4paradigm/phanthymotus-driver`，点击右上角 Fork 按钮。
+
+- 目标选你自己的 GitHub 账号
+- 默认 fork main 分支即可
+- 点击 Create fork
+
+### 2. 开发前检查：查重（必读）
+
+Fork 完成后，**开始开发前必须先完成查重，禁止跳过**。按以下顺序检查：
+
+#### 2.1 检查官方仓库已实现的卡片和 skills
+
+查看官方仓库 `https://github.com/4paradigm/phanthymotus-driver` 的
+`engineai/t800/` 下**已经实现**的卡片和 skills：
+
+- `README.md` 中的工具表 —— 当前已上线 **37 个工具**（joints、imu、battery、
+  motor_health、loco、motion_mode、joint_plan、gesture、led、tts、mic、
+  speaker、pointcloud、camera、depth 等）；
+- `device.py` 中的 Plugin 类与 `config.yaml` 中已启用的插件；
+- `skills/` 目录（如有）下已提交的 skill。
+
+#### 2.2 检查 PR 中已提交待审核的卡片
+
+打开官方仓库的 Pull requests 页面
+（`https://github.com/4paradigm/phanthymotus-driver/pulls`），查看 open PRs
+中**已提交但尚未合并**的卡片。别人正在开发或已提交待审核的能力不要重复做；
+如你的目标卡片与待审核 PR 冲突，可在该 PR 下留言协作，或改认其他任务。
+
+#### 2.3 根据官方开发手册找不重复的卡片或 skill
+
+打开众擎官方 ROS2 接口开发手册（飞书文档
+`https://dx3a2bminsq.feishu.cn/wiki/AdwAwlxmLigrJVkAoOkc2szcnDh`），对照
+2.1 已实现卡片和 2.2 待审核 PR，找出**还没有被覆盖**的接口，把它做成新的
+卡片或 skill。
+
+> 不要做重复能力：关节状态、IMU、电源、运动状态机、机体速度、关节规划、
+> 手势、LED、TTS、麦克风、扬声器、点云、双目相机、深度图等均已被覆盖。
+> 对已有卡片的能力边界不确定时，先确认清楚再动手。
+
+### 3. 在任务认领平台认领任务
+
+查重确认目标卡片不重复后，打开 `http://10.100.130.173:8080/`，认领自己的
+任务再开始开发。
+
+> 任务认领后才能开始编码。认领后如发现与已有卡片重复，需回平台说明并改认
+> 其他任务，不要私自开发重复能力。
+
+### 4. 克隆到本地
+
+```
+git clone https://github.com/<你的GitHub用户名>/phanthymotus-driver.git
+cd phanthymotus-driver
+```
+
+> 直接 clone main 分支即可。众擎 T800 相关的代码已合入 main，无需切换分支。
+
+### 5. 编辑卡片代码
+
+T800 驱动代码位于 `engineai/t800/`，核心文件：
+
+| 文件 | 作用 |
+|------|------|
+| `device.py` | 核心：所有卡片（Plugin）的实现逻辑 |
+| `config.yaml` | 插件开关配置（新增卡片需在此添加 `enabled: true`） |
+| `main.py` | 入口：加载插件、注册到 MCP、启动 HTTP 服务 |
+| `driver.yaml` | 镜像/服务描述（新增卡片无需改此文件） |
+
+新增卡片修改 device.py、config.yaml、main.py 这几个文件即可。**不要新建
+独立的 plugin 文件**，卡片一律以 Plugin 类形式整合进 `device.py`（参照
+`StatePlugin`、`MicPlugin`、`VisionPlugin` 的写法）。
+
+### 6. 提交代码并推送到自己的 fork
+
+```
+cd engineai
+git add t800
+git status --short
+git commit -m "feat: 新增xxx卡片 (xxx)"
+git push -u origin main
+```
+
+> 提交信息格式：`feat: 新增 xxx 卡片` 或 `feat: <卡片英文名> — <简短描述>`
+>
+> 推送到自己 fork 的 main 分支。如果提示输入用户名和密码，输入你的 GitHub
+> 用户名和 Personal Access Token。
+
+### 7. 确认推送成功
+
+访问 `https://github.com/<你的用户名>/phanthymotus-driver`，确认 main 分支上
+的 `engineai/t800/` 文件已更新。
+
+---
+
+## 测试流程
+
+> ⚠️ **当前手上没有 T800 真机。** 以下为通用测试框架（参照 tianyi 实测流程），
+> **真机到位后需要针对 T800 实机环境做调整**：应用单元 IP、SSH 账号、Agent Core
+> 地址、容器名、ROS Domain 69 / CycloneDDS 网络参数等，以
+> `engineai/t800/docs/T800真机部署实测.md` 的最终确认值为准。
+
+### 1. 在 T800 应用单元上拉取代码
+
+```
+ssh ubuntu@<T800应用单元IP>        # 待真机到位后确认
+git clone https://github.com/<你的用户名>/phanthymotus-driver.git
+```
+
+> clone 下来默认就是 main 分支。
+
+### 2. 构建本地镜像
+
+```
+cd ~/phanthymotus-driver
+bash build.sh engineai/t800
+```
+
+> 注意这段时间不能断联。构建完成后用 `docker images | grep t800` 查看实际
+> 镜像名（tag 形如 `release.<年月日>.<commit>`）。
+
+### 3. 停旧容器，启动自己的新容器
+
+首先停掉当前运行的驱动容器（端口 15708 不能冲突）：
+
+```
+sudo docker stop embodied-engineai-t800
+```
+
+启动自己的容器（容器名带自己的缩写，便于多人同时测试时区分）：
+
+```
+sudo docker run --rm -d \
+  --name t800-test-<你的名字缩写> \
+  --network host \
+  --ipc host \
+  --pid host \
+  --privileged \
+  -v /dev:/dev \
+  -v /opt/engineai/native_sdk:/opt/engineai/native_sdk \
+  -e NETWORK_INTERFACE=eth0 \
+  <实际镜像名>
+```
+
+> `--rm` 表示容器停止后自动删除，不留残留。`-d` 后台运行。
+>
+> 如果测试过程中多次重建镜像，需要先停掉旧容器再启动新的：
+> ```
+> sudo docker stop t800-test-<你的名字缩写>
+> sudo docker run --rm -d --name t800-test-<你的名字缩写> --network host --ipc host --pid host --privileged -v /dev:/dev -v /opt/engineai/native_sdk:/opt/engineai/native_sdk -e NETWORK_INTERFACE=eth0 <实际镜像名>
+> ```
+
+查看日志确认启动正常：
+
+```
+sudo docker logs -f t800-test-<你的名字缩写>
+```
+
+看到终端打印出所有插件的 MCP 工具定义即表示启动成功
+（`http://localhost:15708/health` 返回 `{"state": "running"}`）。
+
+### 4. 在画布上验证
+
+驱动启动后会自动注册到 Agent Core。
+
+浏览器打开 Agent Core（地址与 token 待真机到位后确认），进入**配置模式**，
+应该能看到 EngineAI T800 驱动下列出了新卡片。
+
+拖动卡片到画布中，切换到**监控模式**，检查数据是否正常显示。如果是执行器
+卡片，可以测试调用动作是否生效。
+
+### 5. 合并到主仓库
+
+！真机测试验证通过后！，把自己 fork 的 main 分支通过 Pull Request 合并到主
+仓库的 `main` 分支。
+
+> 未通过真机验证的能力不允许提 PR。提 PR 时在描述中注明：卡片名称、对应
+> 飞书文档章节、真机验证结果（画布截图或测试记录）。
+
+---
+
+## 开发 → 上线全流程速查
+
+```
+┌──────────────────────┐
+│  1. Fork 主仓库       │  fork main 分支到自己的 GitHub
+│  (在线操作)           │
+└──────────┬───────────┘
+           ▼
+┌──────────────────────┐
+│  2. 开发前查重（必读）  │  ① 官方仓库 t800 已实现卡片/skills
+│                      │  ② PR 中已提交待审核的卡片
+│                      │  ③ 官方开发手册比对，找未覆盖接口
+└──────────┬───────────┘
+           ▼
+┌──────────────────────┐
+│  3. 认领任务           │  http://10.100.130.173:8080/
+└──────────┬───────────┘
+           ▼
+┌──────────────────────┐
+│  4. 克隆到本地         │  git clone <自己的fork>
+│                      │  cd phanthymotus-driver
+└──────────┬───────────┘
+           ▼
+┌──────────────────────┐
+│  5. 写代码             │  编辑 engineai/t800/device.py
+│  (直接在自己fork的      │  / config.yaml / main.py
+│   main分支上改)        │  (不新建独立 py 文件)
+└──────────┬───────────┘
+           ▼
+┌──────────────────────┐
+│  6. 提交推送到自己fork  │  git add t800 → commit → push origin main
+└──────────┬───────────┘
+           ▼
+┌──────────────────────┐
+│  7. 实机拉取           │  git clone <自己的fork> 到 T800 应用单元
+└──────────┬───────────┘
+           ▼
+┌──────────────────────┐
+│  8. 构建镜像           │  bash build.sh engineai/t800
+└──────────┬───────────┘
+           ▼
+┌──────────────────────────────┐
+│  9. 起测试容器                 │  停原容器 → docker run --rm
+│     t800-test-<缩写>          │  --name t800-test-<缩写>
+└──────────┬───────────────────┘
+           ▼
+┌──────────────────────┐
+│  10. 画布验证          │  Dashboard 看新卡片 → 监控模式测数据
+└──────────┬───────────┘
+           ▼
+┌─────────────────────────────────────┐
+│  11. 真机验证通过后提 PR              │  自己 fork main
+│      目标: upstream main             │  → PR → upstream main
+└─────────────────────────────────────┘
+```
+
+> 步骤 7–10 的实机参数（IP、Agent Core 地址、镜像名等）待真机到位后按
+> `T800真机部署实测.md` 调整。
+
+---
+
+## 故障回滚
+
+如果新镜像有问题，随时回滚到原版：
+
+```
+sudo docker stop t800-test-<你的名字缩写>
+sudo docker rm -f embodied-engineai-t800
+
+# 重新部署原版镜像（镜像 tag 待真机部署确认后填写）
+sudo docker run -d --name embodied-engineai-t800 \
+  --network host --ipc host --pid host --privileged \
+  -v /dev:/dev \
+  -v /opt/engineai/native_sdk:/opt/engineai/native_sdk \
+  -e NETWORK_INTERFACE=eth0 \
+  <原版镜像名>
+```

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -28,6 +28,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `robot_snapshot` | sensor | 运动、关节、IMU、电源和电机健康聚合快照 |
 | `fault_summary` | sensor | 电机掉线/禁用/错误/过温及电源错误摘要 |
 | `stability` | sensor | 基于 IMU 的倾斜和跌倒风险估计 |
+| `system_health` | sensor | 驱动连接、电机故障、电池状态、机身稳定性的四级健康聚合诊断与处置建议 |
 | `joint_groups` | sensor | 腿、躯干、双臂、头部和全身关节名称/索引映射 |
 | `capabilities` | sensor | Driver 能力发现、原生状态和已知限制 |
 | `ros_graph` | sensor | 实时发现固件节点、topic、service 和尚未映射的新接口 |

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -76,6 +76,8 @@ plugins:
     rate_hz: 20.0
   safety:
     enabled: true
+  system_health:
+    enabled: true
   native_sdk:
     enabled: true
     mode: "external"       # external | process | systemd

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -1707,3 +1707,189 @@ class SafetyControlPlugin:
         msg.damping = [1.0] * len(T800_JOINT_NAMES)
         msg.parallel_parser_type = 0
         self._joint_pub.publish(msg)
+
+
+# ── SystemHealthPlugin (sensor) ──────────────────────────────────────────────
+
+class SystemHealthPlugin:
+    """Aggregated system health diagnostic — driver, motor, battery, stability."""
+
+    def __init__(self, config: dict, namespace: str, ros2, state: StatePlugin):
+        self._config = config
+        self._state = state
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "system_health",
+            "type": "sensor",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": "T800 系统健康聚合诊断，综合驱动连接、电机故障、电池状态、机身稳定性输出健康等级和处置建议",
+            "inputSchema": {"type": "object", "properties": {}},
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action == "start":
+            return {"state": "running"}
+        if action == "stop":
+            return {"state": "idle"}
+        return self._diagnose()
+
+    def _diagnose(self) -> dict:
+        driver_health = self._state._snapshot("driver_health")
+        fault_summary = self._state._derived_snapshot("fault_summary")
+        stability = self._state._derived_snapshot("stability")
+        battery = self._state._snapshot("battery")
+
+        # --- issues collection ---
+        issues: list[dict] = []
+
+        # Critical: motor
+        for entry in fault_summary.get("offline_joints", []):
+            issues.append({"severity": "critical", "category": "motor",
+                           "message": f"关节 {entry} 掉线"})
+        for entry in fault_summary.get("motor_errors", []):
+            issues.append({"severity": "critical", "category": "motor",
+                           "message": f"关节 {entry['joint_index']} 电机错误码 {entry['code']}"})
+        power_err = fault_summary.get("power_error_code", 0)
+        if power_err != 0:
+            issues.append({"severity": "critical", "category": "battery",
+                           "message": f"电源错误码 {power_err}"})
+        if fault_summary.get("disabled_joints"):
+            issues.append({"severity": "warning", "category": "motor",
+                           "message": f"关节 {fault_summary['disabled_joints']} 电机禁用"})
+
+        # Critical: stability
+        if stability.get("state") == "fall_risk":
+            tilt = float(stability.get("tilt_rad", 0.0))
+            issues.append({"severity": "critical", "category": "stability",
+                           "message": f"跌倒风险，倾斜 {tilt:.3f} rad"})
+
+        # Critical: battery
+        batt_pct = float(battery.get("percentage") or 100)
+        if batt_pct <= 10:
+            issues.append({"severity": "critical", "category": "battery",
+                           "message": f"电量极低 {int(batt_pct)}%"})
+
+        # Warning: motor
+        for entry in fault_summary.get("hot_motors", []):
+            issues.append({"severity": "warning", "category": "motor",
+                           "message": f"关节 {entry['joint_index']} 过温 {entry['temperature_c']:.1f}°C"})
+
+        # Warning: stability
+        if stability.get("state") == "tilted":
+            tilt = float(stability.get("tilt_rad", 0.0))
+            issues.append({"severity": "warning", "category": "stability",
+                           "message": f"机身倾斜 {tilt:.3f} rad"})
+
+        # Warning: battery
+        if 10 < batt_pct <= 30:
+            issues.append({"severity": "warning", "category": "battery",
+                           "message": f"电量偏低 {int(batt_pct)}%"})
+
+        # Warning: driver
+        stale_names = [
+            name for name, src in driver_health.get("sources", {}).items()
+            if src.get("stale", False)
+        ]
+        for name in stale_names:
+            issues.append({"severity": "warning", "category": "driver",
+                           "message": f"数据源 {name} 数据超时"})
+
+        # Sort: critical first
+        issues.sort(key=lambda i: 0 if i["severity"] == "critical" else 1)
+
+        # --- recommendations ---
+        rec_set: set[str] = set()
+        if fault_summary.get("offline_joints"):
+            rec_set.add("检查掉线关节连接线与供电")
+        if fault_summary.get("motor_errors"):
+            rec_set.add("排查电机故障码，必要时停机检修")
+        if fault_summary.get("disabled_joints"):
+            rec_set.add("检查电机禁用状态，确认是否为安全保护触发")
+        if fault_summary.get("hot_motors"):
+            rec_set.add("降低负载，等待电机降温")
+        if power_err != 0:
+            rec_set.add("检查电源系统")
+        if batt_pct <= 30:
+            rec_set.add("立即充电" if batt_pct <= 10 else "尽快充电")
+        if stability.get("state") == "fall_risk":
+            rec_set.add("立即停止运动，切换 passive 或人工扶持")
+        if stability.get("state") == "tilted":
+            rec_set.add("注意机身姿态，避免剧烈动作")
+        if stale_names:
+            rec_set.add("检查 ROS2 话题连接")
+        deduped_recs = list(rec_set)
+
+        # --- level ---
+        has_critical = any(i["severity"] == "critical" for i in issues)
+        has_warning = any(i["severity"] == "warning" for i in issues)
+
+        batt_stale = battery.get("stale", True)
+        if (driver_health.get("state") == "waiting"
+                or fault_summary.get("source_stale", True)
+                or stability.get("state") == "no_data"
+                or batt_stale):
+            level = "unknown"
+        elif has_critical:
+            level = "critical"
+        elif has_warning:
+            level = "warning"
+        else:
+            level = "ok"
+
+        # --- subsystems ---
+        motor_state = "ok"
+        if fault_summary.get("source_stale", True):
+            motor_state = "unknown"
+        elif any(i["severity"] == "critical" and i["category"] == "motor" for i in issues):
+            motor_state = "critical"
+        elif any(i["severity"] == "warning" and i["category"] == "motor" for i in issues):
+            motor_state = "warning"
+
+        batt_state = "ok"
+        if batt_stale:
+            batt_state = "unknown"
+        elif any(i["severity"] == "critical" and i["category"] == "battery" for i in issues):
+            batt_state = "critical"
+        elif any(i["severity"] == "warning" and i["category"] == "battery" for i in issues):
+            batt_state = "warning"
+
+        stab_state = stability.get("state", "unknown")
+        if stab_state == "no_data":
+            stab_state = "unknown"
+
+        return {
+            "level": level,
+            "subsystems": {
+                "driver": {"state": driver_health.get("state", "unknown"),
+                           "stale_sources": stale_names},
+                "motor": {
+                    "state": motor_state,
+                    "offline_count": len(fault_summary.get("offline_joints", [])),
+                    "error_count": len(fault_summary.get("motor_errors", [])),
+                    "hot_count": len(fault_summary.get("hot_motors", [])),
+                    "disabled_count": len(fault_summary.get("disabled_joints", [])),
+                },
+                "battery": {
+                    "state": batt_state,
+                    "percentage": int(batt_pct),
+                    "voltage_v": float(battery.get("voltage_v", 0) or 0),
+                    "current_a": float(battery.get("current_a", 0) or 0),
+                    "error_code": int(battery.get("error_code", 0) or 0),
+                },
+                "stability": {
+                    "state": stab_state,
+                    "tilt_rad": float(stability.get("tilt_rad", 0.0)),
+                },
+            },
+            "issues": issues,
+            "recommendations": deduped_recs,
+            "timestamp_ms": _now_ms(),
+        }

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -94,6 +94,7 @@ class T800DeviceBundle:
             NativeSdkPlugin,
             SafetyControlPlugin,
             StatePlugin,
+            SystemHealthPlugin,
             TtsPlugin,
         )
         from virtual_gamepad import VirtualGamepadPlugin
@@ -116,6 +117,7 @@ class T800DeviceBundle:
             ("motor_power", MotorPowerPlugin, (config, namespace, ros2)),
             ("native_node_control", NativeNodeControlPlugin, (config, namespace, ros2)),
             ("safety", SafetyControlPlugin, (config, namespace, ros2, state)),
+            ("system_health", SystemHealthPlugin, (config, namespace, ros2, state)),
         )
         instances = {}
         for key, cls, args in plugin_types:

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -27,27 +27,16 @@ plugins:
     command_topic: rt/lf/bmscmd
   arm:
     enabled: true
-  state:
+  arm_trajectory:
     enabled: true
-  gripper_state:
-    enabled: true
-    left_dds_topic: "rt/hand/left_state"
-    right_dds_topic: "rt/hand/right_state"
-    min_angle_rad: 0.0
-    max_angle_rad: 1.5
-    grasp_tau_threshold: 0.1
-    publish_hz: 20
-  gripper_control:
-    enabled: true
-    left_dds_topic: "rt/hand/left_cmd"
-    right_dds_topic: "rt/hand/right_cmd"
-    min_angle_rad: 0.0
-    max_angle_rad: 1.5
+    lowcmd_topic: "rt/lowcmd"
+    lowstate_topic: "rt/lowstate"
     motor_mode: 10
     default_kp: 20.0
     default_kd: 1.0
-    default_force_pct: 50
-    max_tau: 0.5
+    control_freq_hz: 50
+  state:
+    enabled: true
   head_control:
     enabled: true
     motor_index: 23           # 头部电机索引，待真机确认
@@ -60,6 +49,19 @@ plugins:
     lowstate_topic: "rt/lowstate"
     shake_amplitude_deg: 30.0
     shake_speed_hz: 1.5
+    shake_times: 3
+  waist_control:
+    enabled: true
+    motor_index: 12           # 腰部电机索引，待真机确认
+    min_angle_deg: -180.0     # 最小角度，待确认
+    max_angle_deg: 180.0      # 最大角度，待确认
+    motor_mode: 10            # 位置控制模式，待确认
+    default_kp: 20.0
+    default_kd: 1.0
+    lowcmd_topic: "rt/lowcmd"
+    lowstate_topic: "rt/lowstate"
+    shake_amplitude_deg: 45.0
+    shake_speed_hz: 1.0
     shake_times: 3
   camera:
     enabled: true

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -12,6 +12,8 @@ plugins:
     enabled: true
   loco:
     enabled: true
+  continuous_gait:
+    enabled: true
   arm:
     enabled: true
   state:

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -29,6 +29,25 @@ plugins:
     enabled: true
   state:
     enabled: true
+  gripper_state:
+    enabled: true
+    left_dds_topic: "rt/hand/left_state"
+    right_dds_topic: "rt/hand/right_state"
+    min_angle_rad: 0.0
+    max_angle_rad: 1.5
+    grasp_tau_threshold: 0.1
+    publish_hz: 20
+  gripper_control:
+    enabled: true
+    left_dds_topic: "rt/hand/left_cmd"
+    right_dds_topic: "rt/hand/right_cmd"
+    min_angle_rad: 0.0
+    max_angle_rad: 1.5
+    motor_mode: 10
+    default_kp: 20.0
+    default_kd: 1.0
+    default_force_pct: 50
+    max_tau: 0.5
   camera:
     enabled: true
   lidar:

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -14,6 +14,9 @@ plugins:
     enabled: true
   continuous_gait:
     enabled: true
+  bms_control:
+    enabled: true
+    command_topic: rt/lf/bmscmd
   arm:
     enabled: true
   state:

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -48,6 +48,19 @@ plugins:
     default_kd: 1.0
     default_force_pct: 50
     max_tau: 0.5
+  head_control:
+    enabled: true
+    motor_index: 23           # 头部电机索引，待真机确认
+    min_angle_deg: -90.0      # 最小角度（左）
+    max_angle_deg: 90.0       # 最大角度（右）
+    motor_mode: 10            # 位置控制模式，待确认
+    default_kp: 20.0
+    default_kd: 1.0
+    lowcmd_topic: "rt/lowcmd"
+    lowstate_topic: "rt/lowstate"
+    shake_amplitude_deg: 30.0
+    shake_speed_hz: 1.5
+    shake_times: 3
   camera:
     enabled: true
   lidar:

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -12,6 +12,14 @@ plugins:
     enabled: true
   loco:
     enabled: true
+  fall_recovery:
+    enabled: true
+    fall_angle_threshold_deg: 50
+    fall_confirm_duration: 0.5
+    foot_force_threshold: 10
+    recovery_timeout: 10
+    imu_topic: state/imu
+    foot_force_topic: loco/state
   continuous_gait:
     enabled: true
   bms_control:

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -15,6 +15,7 @@ drivers/unitree/g1/device.py — Unitree G1 设备插件（重构版）。
   LocoStatePlugin    (sensor)    — DDS SportModeState → ROS2 topic
   LocoPlugin         (actuator)  — 运动控制
   ArmActionPlugin    (actuator)  — 手臂动作
+  ArmTrajectoryPlugin (actuator) — 自定义手臂轨迹控制
   StatePlugin        (sensor)    — DDS LowState → IMU/battery ROS2 topic
 """
 
@@ -1842,6 +1843,340 @@ class ArmActionPlugin:
         return None
 
 
+# ── ArmTrajectoryPlugin (actuator) ────────────────────────────────────────────
+
+class ArmTrajectoryPlugin:
+    PREFIX = "arm_trajectory"
+
+    # 以下索引为推测值，必须真机确认
+    LEFT_ARM_MOTORS = {
+        "shoulder_pitch": 15,
+        "shoulder_roll": 16,
+        "shoulder_yaw": 17,
+        "elbow": 18,
+        "wrist_roll": 19,
+        "wrist_pitch": 20,
+        "wrist_yaw": 21,
+    }
+    # 以下索引为推测值，必须真机确认
+    # TODO: 真机确认：现有 config.yaml 中 head_control.motor_index=23 与此映射的 right_shoulder_roll 冲突，需同步核对。
+    RIGHT_ARM_MOTORS = {
+        "shoulder_pitch": 22,
+        "shoulder_roll": 23,
+        "shoulder_yaw": 24,
+        "elbow": 25,
+        "wrist_roll": 26,
+        "wrist_pitch": 27,
+        "wrist_yaw": 28,
+    }
+
+    def __init__(self, plugin_config: dict, namespace: str, executor):
+        self._lowcmd_topic = plugin_config.get("lowcmd_topic", "rt/lowcmd")
+        self._lowstate_topic = plugin_config.get("lowstate_topic", "rt/lowstate")
+        self._motor_mode = int(plugin_config.get("motor_mode", 10))  # TODO: 真机确认
+        self._default_kp = float(plugin_config.get("default_kp", 20.0))
+        self._default_kd = float(plugin_config.get("default_kd", 1.0))
+        self._control_freq_hz = float(plugin_config.get("control_freq_hz", 50))
+        self._publisher = None
+        self._trajectory_stop = threading.Event()
+        self._trajectory_thread = None
+        self._state_lock = threading.Lock()
+        self._current_angles_rad = {idx: None for idx in self._all_motor_indexes()}
+
+        try:
+            from unitree_sdk2py.core.channel import ChannelSubscriber
+            from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowState_
+            self._subscriber = ChannelSubscriber(self._lowstate_topic, LowState_)
+            self._subscriber.Init(self._on_lowstate, 10)
+        except Exception as e:
+            self._subscriber = None
+            print(f"[arm_trajectory] LowState subscription unavailable: {e}")
+
+    def get_tool(self) -> dict:
+        joint_schema = {
+            joint: {"type": "number", "description": f"{joint} target angle in degrees; omitted joints keep current command"}
+            for joint in self.LEFT_ARM_MOTORS
+        }
+        arm_schema = {
+            "type": "object",
+            "properties": joint_schema,
+            "description": "Arm joint target positions in degrees; omitted joints are not moved",
+        }
+        return {
+            "name": "arm_trajectory",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "G1 custom arm joint position and trajectory control over LowCmd, complementary to the predefined gesture arm tool",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["set_positions", "move_to", "execute_trajectory", "get_positions", "release", "stop"],
+                        "description": "Action to perform",
+                    },
+                    "left_arm": arm_schema,
+                    "right_arm": arm_schema,
+                    "duration": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "default": 2.0,
+                        "description": "Interpolation duration in seconds for move_to and default waypoint duration",
+                    },
+                    "trajectory": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "left_arm": arm_schema,
+                                "right_arm": arm_schema,
+                                "duration": {"type": "number", "exclusiveMinimum": 0, "description": "Waypoint duration in seconds"},
+                            },
+                        },
+                        "description": "Array of waypoints; omitted joints inherit the previous waypoint/current LowState and may be commanded to hold position during execution",
+                    },
+                    "kp": {"type": "number", "default": self._default_kp, "description": "Position gain"},
+                    "kd": {"type": "number", "default": self._default_kd, "description": "Velocity damping gain"},
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "set_positions": {"params": ["left_arm", "right_arm", "kp", "kd"], "description": "Immediately publish one LowCmd frame for the specified joints only"},
+                    "move_to": {"params": ["left_arm", "right_arm", "duration", "kp", "kd"], "description": "Move from current LowState angles to target positions with linear interpolation"},
+                    "execute_trajectory": {"params": ["trajectory", "duration", "kp", "kd"], "description": "Execute an asynchronous multi-waypoint arm trajectory"},
+                    "get_positions": {"params": [], "description": "Read current arm joint positions from LowState"},
+                    "release": {"params": [], "description": "Release all 14 arm motors by publishing mode 0 once"},
+                    "stop": {"params": [], "description": "Stop the active background trajectory without publishing an extra command"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass  # DDS publisher is initialized lazily on the first command
+
+    def stop(self) -> None:
+        self._cancel_trajectory()
+
+    @classmethod
+    def _all_motor_indexes(cls) -> list[int]:
+        return list(cls.LEFT_ARM_MOTORS.values()) + list(cls.RIGHT_ARM_MOTORS.values())
+
+    @classmethod
+    def _motor_name(cls, idx: int) -> tuple[str, str]:
+        for joint, motor_idx in cls.LEFT_ARM_MOTORS.items():
+            if idx == motor_idx:
+                return "left_arm", joint
+        for joint, motor_idx in cls.RIGHT_ARM_MOTORS.items():
+            if idx == motor_idx:
+                return "right_arm", joint
+        return "unknown", str(idx)
+
+    def _on_lowstate(self, msg) -> None:
+        with self._state_lock:
+            for idx in self._all_motor_indexes():
+                if idx < len(msg.motor_state):
+                    self._current_angles_rad[idx] = float(msg.motor_state[idx].q)
+
+    def _get_publisher(self):
+        if self._publisher is None:
+            from unitree_sdk2py.core.channel import ChannelPublisher
+            from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowCmd_
+            self._publisher = ChannelPublisher(self._lowcmd_topic, LowCmd_)
+            self._publisher.Init()
+        return self._publisher
+
+    def _clamp_angle(self, angle_rad: float) -> float:
+        # TODO: 真机确认各手臂关节物理限位；当前使用宽泛保护范围。
+        return max(math.radians(-180.0), min(math.radians(180.0), angle_rad))
+
+    def _parse_arm_targets(self, args: dict) -> tuple[dict[int, float], dict[str, dict[str, float]]]:
+        targets: dict[int, float] = {}
+        reported = {"left_arm": {}, "right_arm": {}}
+        for arm_key, mapping in (("left_arm", self.LEFT_ARM_MOTORS), ("right_arm", self.RIGHT_ARM_MOTORS)):
+            arm_values = args.get(arm_key) or {}
+            for joint, angle_deg in arm_values.items():
+                if joint not in mapping:
+                    continue
+                angle_rad = self._clamp_angle(math.radians(float(angle_deg)))
+                targets[mapping[joint]] = angle_rad
+                reported[arm_key][joint] = math.degrees(angle_rad)
+        return targets, reported
+
+    def _current_snapshot(self) -> dict[int, float] | None:
+        with self._state_lock:
+            if any(angle is None for angle in self._current_angles_rad.values()):
+                return None
+            return {idx: float(angle) for idx, angle in self._current_angles_rad.items() if angle is not None}
+
+    def _send_positions(self, targets_rad: dict[int, float], kp: float | None = None, kd: float | None = None) -> dict:
+        from unitree_sdk2py.idl.default import unitree_hg_msg_dds__LowCmd_
+
+        kp = self._default_kp if kp is None else float(kp)
+        kd = self._default_kd if kd is None else float(kd)
+        message = unitree_hg_msg_dds__LowCmd_()
+        set_joints = {"left_arm": {}, "right_arm": {}}
+        for idx, angle_rad in targets_rad.items():
+            if idx >= len(message.motor_cmd):
+                continue
+            angle_rad = self._clamp_angle(angle_rad)
+            motor = message.motor_cmd[idx]
+            # TODO: 真机确认手臂电机索引、position mode 10、角度方向与限位。
+            motor.mode = self._motor_mode
+            motor.q = angle_rad
+            motor.dq = 0.0
+            motor.tau = 0.0
+            motor.kp = kp
+            motor.kd = kd
+            arm_key, joint = self._motor_name(idx)
+            if arm_key in set_joints:
+                set_joints[arm_key][joint] = math.degrees(angle_rad)
+        # TODO: Confirm whether LowCmd CRC must be calculated before publishing.
+        published = self._get_publisher().Write(message)
+        return {"published": bool(published), "positions_deg": set_joints}
+
+    def _release_positions(self) -> dict:
+        from unitree_sdk2py.idl.default import unitree_hg_msg_dds__LowCmd_
+
+        self._cancel_trajectory()
+        message = unitree_hg_msg_dds__LowCmd_()
+        for idx in self._all_motor_indexes():
+            if idx >= len(message.motor_cmd):
+                continue
+            motor = message.motor_cmd[idx]
+            # Release requires the arm to be physically supported before relaxing motors.
+            motor.mode = 0
+            motor.q = 0.0
+            motor.dq = 0.0
+            motor.tau = 0.0
+            motor.kp = 0.0
+            motor.kd = 0.0
+        published = self._get_publisher().Write(message)
+        return {"state": "released", "published": bool(published)}
+
+    def _cancel_trajectory(self) -> None:
+        self._trajectory_stop.set()
+        if self._trajectory_thread and self._trajectory_thread.is_alive() and self._trajectory_thread is not threading.current_thread():
+            timeout = max(0.2, 2.0 / max(self._control_freq_hz, 1.0))
+            self._trajectory_thread.join(timeout=timeout)
+
+    def _interpolate(self, start_rad: dict[int, float], target_rad: dict[int, float], duration: float, stop_event: threading.Event, kp: float, kd: float) -> bool:
+        duration = max(float(duration), 0.001)
+        period = 1.0 / max(self._control_freq_hz, 1.0)
+        steps = max(1, int(duration * self._control_freq_hz))
+        for step in range(1, steps + 1):
+            if stop_event.is_set():
+                return False
+            ratio = step / steps
+            frame = {
+                idx: start_rad[idx] + (target - start_rad[idx]) * ratio
+                for idx, target in target_rad.items()
+            }
+            self._send_positions(frame, kp=kp, kd=kd)
+            stop_event.wait(period)
+        return not stop_event.is_set()
+
+    def _start_move(self, targets_rad: dict[int, float], duration: float, kp: float, kd: float) -> dict:
+        if not targets_rad:
+            return {"error": "Provide left_arm and/or right_arm target joints"}
+        snapshot = self._current_snapshot()
+        if snapshot is None:
+            return {"error": "No complete LowState arm position received yet"}
+        self._cancel_trajectory()
+        stop_event = threading.Event()
+        self._trajectory_stop = stop_event
+        start = {idx: snapshot[idx] for idx in targets_rad}
+
+        def animate():
+            self._interpolate(start, targets_rad, duration, stop_event, kp, kd)
+
+        self._trajectory_thread = threading.Thread(target=animate, daemon=True, name="arm_trajectory_move")
+        self._trajectory_thread.start()
+        return {"state": "moving", "duration": duration, "target_deg": self._format_positions(targets_rad)}
+
+    def _start_trajectory(self, trajectory: list, default_duration: float, kp: float, kd: float) -> dict:
+        if not trajectory:
+            return {"error": "trajectory must contain at least one waypoint"}
+        snapshot = self._current_snapshot()
+        if snapshot is None:
+            return {"error": "No complete LowState arm position received yet"}
+
+        waypoints = []
+        previous = dict(snapshot)
+        for waypoint in trajectory:
+            if not isinstance(waypoint, dict):
+                return {"error": "Each trajectory waypoint must be an object"}
+            waypoint_duration = float(waypoint.get("duration", default_duration))
+            if waypoint_duration <= 0:
+                return {"error": "waypoint duration must be greater than 0"}
+            targets, _ = self._parse_arm_targets(waypoint)
+            merged = dict(previous)
+            merged.update(targets)
+            waypoints.append((merged, waypoint_duration))
+            previous = merged
+
+        self._cancel_trajectory()
+        stop_event = threading.Event()
+        self._trajectory_stop = stop_event
+
+        def animate():
+            current = dict(snapshot)
+            for target, duration in waypoints:
+                if stop_event.is_set():
+                    return
+                if not self._interpolate(current, target, duration, stop_event, kp, kd):
+                    return
+                current = dict(target)
+
+        self._trajectory_thread = threading.Thread(target=animate, daemon=True, name="arm_trajectory_execute")
+        self._trajectory_thread.start()
+        return {"state": "executing", "waypoints": len(waypoints)}
+
+    def _format_positions(self, positions_rad: dict[int, float]) -> dict:
+        result = {"left_arm": {}, "right_arm": {}}
+        for idx, angle_rad in positions_rad.items():
+            arm_key, joint = self._motor_name(idx)
+            if arm_key in result:
+                result[arm_key][joint] = math.degrees(angle_rad)
+        return result
+
+    def _get_positions(self) -> dict:
+        snapshot = self._current_snapshot()
+        if snapshot is None:
+            return {"error": "No complete LowState arm position received yet"}
+        return self._format_positions(snapshot)
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "stop":
+            self._cancel_trajectory()
+            return {"state": "idle"}
+        if action == "set_positions":
+            targets, _ = self._parse_arm_targets(args)
+            if not targets:
+                return {"error": "Provide left_arm and/or right_arm target joints"}
+            self._cancel_trajectory()
+            return self._send_positions(targets, kp=args.get("kp"), kd=args.get("kd"))
+        if action == "move_to":
+            targets, _ = self._parse_arm_targets(args)
+            duration = float(args.get("duration", 2.0))
+            if duration <= 0:
+                return {"error": "duration must be greater than 0"}
+            return self._start_move(targets, duration, float(args.get("kp", self._default_kp)), float(args.get("kd", self._default_kd)))
+        if action == "execute_trajectory":
+            trajectory = args.get("trajectory")
+            if not isinstance(trajectory, list) or not trajectory:
+                return {"error": "trajectory must be a non-empty array"}
+            duration = float(args.get("duration", 2.0))
+            if duration <= 0:
+                return {"error": "duration must be greater than 0"}
+            return self._start_trajectory(trajectory, duration, float(args.get("kp", self._default_kp)), float(args.get("kd", self._default_kd)))
+        if action == "get_positions":
+            return self._get_positions()
+        if action == "release":
+            return self._release_positions()
+        return None
+
+
 # ── StatePlugin (sensor) ─────────────────────────────────────────────────────
 
 class _LowStateNode(Node):
@@ -2065,243 +2400,6 @@ class StatePlugin:
         return None
 
 
-# ── GripperStatePlugin (sensor) ──────────────────────────────────────────────
-
-class _GripperStateNode(Node):
-    """Subscribes to left/right gripper DDS state and republishes JSON to ROS2."""
-
-    def __init__(self, topic: str, plugin_config: dict):
-        super().__init__("g1_gripper_state")
-        self._publisher = self.create_publisher(String, topic, _LOW_LAT_QOS)
-        self._min_angle = float(plugin_config.get("min_angle_rad", 0.0))
-        self._max_angle = float(plugin_config.get("max_angle_rad", 1.5))
-        self._grasp_tau_threshold = float(plugin_config.get("grasp_tau_threshold", 0.1))
-        self._publish_interval = 1.0 / float(plugin_config.get("publish_hz", 20))
-        self._last_publish_time = {"left": 0.0, "right": 0.0}
-        self._subscribers = []
-
-        from unitree_sdk2py.core.channel import ChannelSubscriber
-        from unitree_sdk2py.idl.unitree_hg.msg.dds_ import HandState_
-
-        for side, config_key, default_topic in (
-            ("left", "left_dds_topic", "rt/hand/left_state"),
-            ("right", "right_dds_topic", "rt/hand/right_state"),
-        ):
-            dds_topic = plugin_config.get(config_key, default_topic)
-            try:
-                subscriber = ChannelSubscriber(dds_topic, HandState_)
-                subscriber.Init(lambda msg, side=side: self._on_state(side, msg), 10)
-                self._subscribers.append(subscriber)
-                self.get_logger().info(f"GripperStateNode subscribed {dds_topic} → {topic}")
-            except Exception as e:
-                self.get_logger().warn(f"GripperStateNode: failed to subscribe {dds_topic}: {e}")
-
-    def _on_state(self, side: str, msg) -> None:
-        now = time.monotonic()
-        if now - self._last_publish_time[side] < self._publish_interval:
-            return
-        self._last_publish_time[side] = now
-
-        # TODO: Confirm motor index 0 and whether larger angles mean a more closed gripper.
-        motor = msg.motor_state[0]
-        position_rad = float(motor.q)
-        position_pct = (position_rad - self._min_angle) / (self._max_angle - self._min_angle) * 100.0
-        position_pct = max(0.0, min(100.0, position_pct))
-        tau_est = float(motor.tau_est)
-        data = {
-            "side": side,
-            "position_pct": round(position_pct, 2),
-            "position_rad": position_rad,
-            "tau_est": tau_est,
-            "temperature": [int(value) for value in motor.temperature],
-            "object_grasped": abs(tau_est) >= self._grasp_tau_threshold,
-            "error_code": [int(value) for value in msg.error],
-            "power_v": float(msg.power_v),
-            "power_a": float(msg.power_a),
-        }
-        output = String()
-        output.data = json.dumps(data)
-        self._publisher.publish(output)
-
-
-class GripperStatePlugin:
-    PREFIX = "gripper_state"
-
-    def __init__(self, plugin_config: dict, namespace: str, executor):
-        self._topic = f"/{namespace}/gripper/state"
-        self._node = _GripperStateNode(self._topic, plugin_config)
-        executor.add_node(self._node)
-
-    def get_tool(self) -> dict:
-        return {
-            "name": "gripper_state",
-            "type": "sensor",
-            "multiInstance": False,
-            "description": f"G1 gripper state — position, torque, temperature, grasp detection, errors, and power. Publishes to {self._topic}",
-            "inputSchema": {"type": "object", "properties": {}},
-            "topic_out": [{"topic": self._topic, "format": "data/json"}],
-        }
-
-    def start(self) -> None:
-        pass  # DDS subscriptions start in __init__
-
-    def stop(self) -> None:
-        pass
-
-    def dispatch(self, action: str, args: dict) -> dict | None:
-        if action == "start":
-            return {"state": "running"}
-        if action == "stop":
-            return {"state": "idle"}
-        if action == "info":
-            return {"state": "running", "topic_out": [{"topic": self._topic, "format": "data/json"}]}
-        return None
-
-
-# ── GripperControlPlugin (actuator) ──────────────────────────────────────────
-
-class GripperControlPlugin:
-    PREFIX = "gripper_control"
-
-    def __init__(self, plugin_config: dict, namespace: str, executor):
-        self._dds_topics = {
-            "left": plugin_config.get("left_dds_topic", "rt/hand/left_cmd"),
-            "right": plugin_config.get("right_dds_topic", "rt/hand/right_cmd"),
-        }
-        self._min_angle = float(plugin_config.get("min_angle_rad", 0.0))
-        self._max_angle = float(plugin_config.get("max_angle_rad", 1.5))
-        self._motor_mode = int(plugin_config.get("motor_mode", 10))
-        self._default_kp = float(plugin_config.get("default_kp", 20.0))
-        self._default_kd = float(plugin_config.get("default_kd", 1.0))
-        self._force_pct = float(plugin_config.get("default_force_pct", 50))
-        self._max_tau = float(plugin_config.get("max_tau", 0.5))
-        self._publishers = {}
-        self._last_position_pct = {"left": 0.0, "right": 0.0}
-
-    def get_tool(self) -> dict:
-        return {
-            "name": "gripper_control",
-            "type": "actuator",
-            "multiInstance": False,
-            "description": "G1 parallel gripper control — open, close, set position or force, and stop",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string",
-                        "enum": ["open", "close", "set_position", "set_force", "stop"],
-                        "description": "Action to perform",
-                    },
-                    "side": {
-                        "type": "string",
-                        "enum": ["left", "right", "both"],
-                        "default": "both",
-                        "description": "Gripper side to control",
-                    },
-                    "position_pct": {
-                        "type": "number",
-                        "minimum": 0,
-                        "maximum": 100,
-                        "description": "Opening position, where 0% is open and 100% is closed",
-                    },
-                    "force_pct": {
-                        "type": "number",
-                        "minimum": 0,
-                        "maximum": 100,
-                        "description": "Gripping force limit percentage",
-                    },
-                },
-                "required": ["action"],
-                "x-action-params": {
-                    "open": {"params": ["side"], "description": "Fully open the selected gripper"},
-                    "close": {"params": ["side", "force_pct"], "description": "Close the selected gripper, optionally setting the force limit"},
-                    "set_position": {"params": ["side", "position_pct"], "description": "Set gripper position from 0% open to 100% closed"},
-                    "set_force": {"params": ["side", "force_pct"], "description": "Set the gripping force limit"},
-                    "stop": {"params": ["side"], "description": "Stop by holding the last commanded position"},
-                },
-            },
-        }
-
-    def start(self) -> None:
-        pass  # DDS publishers are initialized lazily on the first action
-
-    def stop(self) -> None:
-        pass
-
-    def _get_publisher(self, side: str):
-        if side not in self._publishers:
-            from unitree_sdk2py.core.channel import ChannelPublisher
-            from unitree_sdk2py.idl.unitree_hg.msg.dds_ import HandCmd_
-            publisher = ChannelPublisher(self._dds_topics[side], HandCmd_)
-            publisher.Init()
-            self._publishers[side] = publisher
-        return self._publishers[side]
-
-    def _send_position(self, side: str, position_pct: float) -> dict:
-        from unitree_sdk2py.idl.default import unitree_hg_msg_dds__HandCmd_
-
-        # TODO: Confirm motor index 0, mode 10, and whether larger angles mean a more closed gripper.
-        position_rad = self._min_angle + position_pct / 100.0 * (self._max_angle - self._min_angle)
-        message = unitree_hg_msg_dds__HandCmd_()
-        motor = message.motor_cmd[0]
-        motor.mode = self._motor_mode
-        motor.q = position_rad
-        motor.dq = 0.0
-        motor.tau = 0.0
-        motor.kp = self._default_kp
-        motor.kd = self._default_kd
-        published = self._get_publisher(side).Write(message)
-        self._last_position_pct[side] = position_pct
-        return {
-            "side": side,
-            "position_pct": position_pct,
-            "position_rad": position_rad,
-            "published": bool(published),
-        }
-
-    def dispatch(self, action: str, args: dict) -> dict | None:
-        if action == "start":
-            return {"state": "ready"}
-        side = args.get("side", "both")
-        if side not in ("left", "right", "both"):
-            return {"error": "side must be left, right, or both"}
-        sides = ("left", "right") if side == "both" else (side,)
-
-        if action == "set_force":
-            if "force_pct" not in args:
-                return {"error": "force_pct is required"}
-            force_pct = float(args["force_pct"])
-            if not 0.0 <= force_pct <= 100.0:
-                return {"error": "force_pct must be between 0 and 100"}
-            self._force_pct = force_pct
-            # TODO: Apply the force limit once the HandCmd_ force-control semantics are confirmed on hardware.
-            return {"side": side, "force_pct": force_pct, "max_tau": self._max_tau, "applied": False}
-
-        if action == "open":
-            position_pct = 0.0
-        elif action == "close":
-            if "force_pct" in args:
-                force_pct = float(args["force_pct"])
-                if not 0.0 <= force_pct <= 100.0:
-                    return {"error": "force_pct must be between 0 and 100"}
-                self._force_pct = force_pct
-            position_pct = 100.0
-        elif action == "set_position":
-            if "position_pct" not in args:
-                return {"error": "position_pct is required"}
-            position_pct = float(args["position_pct"])
-            if not 0.0 <= position_pct <= 100.0:
-                return {"error": "position_pct must be between 0 and 100"}
-        elif action == "stop":
-            # TODO: Replace last-target hold with measured-position hold if hardware testing requires it.
-            return {"results": [self._send_position(item, self._last_position_pct[item]) for item in sides]}
-        else:
-            return None
-
-        results = [self._send_position(item, position_pct) for item in sides]
-        return {"results": results, "force_pct": self._force_pct}
-
-
 # ── HeadControlPlugin (actuator) ─────────────────────────────────────────────
 
 class HeadControlPlugin:
@@ -2471,6 +2569,191 @@ class HeadControlPlugin:
             self._cancel_animation()
             return self._send_position(0.0)
         if action == "shake_head":
+            speed_hz = float(args.get("speed", self._shake_speed_hz))
+            times = int(args.get("times", self._shake_times))
+            if speed_hz <= 0:
+                return {"error": "speed must be greater than 0"}
+            if times < 1:
+                return {"error": "times must be at least 1"}
+            return self._start_shake(speed_hz, times)
+        if action == "get_angle":
+            with self._state_lock:
+                angle_rad = self._current_angle_rad
+            if angle_rad is None:
+                return {"error": "No LowState angle received yet"}
+            return {"angle_deg": math.degrees(angle_rad), "angle_rad": angle_rad}
+        return None
+
+
+# ── WaistControlPlugin (actuator) ────────────────────────────────────────────
+
+class WaistControlPlugin:
+    PREFIX = "waist_control"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor):
+        self._motor_index = int(plugin_config.get("motor_index", 12))
+        self._min_angle_rad = math.radians(float(plugin_config.get("min_angle_deg", -180.0)))
+        self._max_angle_rad = math.radians(float(plugin_config.get("max_angle_deg", 180.0)))
+        self._motor_mode = int(plugin_config.get("motor_mode", 10))
+        self._default_kp = float(plugin_config.get("default_kp", 20.0))
+        self._default_kd = float(plugin_config.get("default_kd", 1.0))
+        self._lowcmd_topic = plugin_config.get("lowcmd_topic", "rt/lowcmd")
+        self._lowstate_topic = plugin_config.get("lowstate_topic", "rt/lowstate")
+        self._shake_amplitude_deg = float(plugin_config.get("shake_amplitude_deg", 45.0))
+        self._shake_speed_hz = float(plugin_config.get("shake_speed_hz", 1.0))
+        self._shake_times = int(plugin_config.get("shake_times", 3))
+        self._publisher = None
+        self._animation_stop = threading.Event()
+        self._animation_thread = None
+        self._state_lock = threading.Lock()
+        self._current_angle_rad = None
+        self._last_commanded_angle_rad = 0.0
+
+        try:
+            from unitree_sdk2py.core.channel import ChannelSubscriber
+            from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowState_
+            self._subscriber = ChannelSubscriber(self._lowstate_topic, LowState_)
+            self._subscriber.Init(self._on_lowstate, 10)
+        except Exception as e:
+            self._subscriber = None
+            print(f"[waist_control] LowState subscription unavailable: {e}")
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "waist_control",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "G1 waist yaw control — set angle, recenter, shake waist, or read current angle",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["set_angle", "recenter", "shake_waist", "get_angle"],
+                        "description": "Action to perform",
+                    },
+                    "angle_deg": {
+                        "type": "number",
+                        "minimum": math.degrees(self._min_angle_rad),
+                        "maximum": math.degrees(self._max_angle_rad),
+                        "description": "Target yaw angle in degrees",
+                    },
+                    "speed": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "description": "Shake frequency in Hz",
+                    },
+                    "times": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Number of shake cycles",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "set_angle": {"params": ["angle_deg"], "description": "Set waist yaw angle"},
+                    "recenter": {"params": [], "description": "Return waist yaw to zero"},
+                    "shake_waist": {"params": ["speed", "times"], "description": "Shake waist asynchronously, then return to the starting angle"},
+                    "get_angle": {"params": [], "description": "Read the current waist yaw angle from LowState"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass  # DDS publisher is initialized lazily on the first motion command
+
+    def stop(self) -> None:
+        self._animation_stop.set()
+
+    def _on_lowstate(self, msg) -> None:
+        if self._motor_index >= len(msg.motor_state):
+            return
+        with self._state_lock:
+            self._current_angle_rad = float(msg.motor_state[self._motor_index].q)
+
+    def _get_publisher(self):
+        if self._publisher is None:
+            from unitree_sdk2py.core.channel import ChannelPublisher
+            from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowCmd_
+            self._publisher = ChannelPublisher(self._lowcmd_topic, LowCmd_)
+            self._publisher.Init()
+        return self._publisher
+
+    def _send_position(self, angle_rad: float) -> dict:
+        from unitree_sdk2py.idl.default import unitree_hg_msg_dds__LowCmd_
+
+        angle_rad = max(self._min_angle_rad, min(self._max_angle_rad, angle_rad))
+        message = unitree_hg_msg_dds__LowCmd_()
+        motor = message.motor_cmd[self._motor_index]
+        # TODO: Confirm motor index 12, position mode 10, angle direction, and physical limits on hardware.
+        motor.mode = self._motor_mode
+        motor.q = angle_rad
+        motor.dq = 0.0
+        motor.tau = 0.0
+        motor.kp = self._default_kp
+        motor.kd = self._default_kd
+        # TODO: Confirm whether LowCmd CRC must be calculated before publishing.
+        published = self._get_publisher().Write(message)
+        with self._state_lock:
+            self._last_commanded_angle_rad = angle_rad
+        return {
+            "angle_deg": math.degrees(angle_rad),
+            "angle_rad": angle_rad,
+            "published": bool(published),
+        }
+
+    def _cancel_animation(self) -> None:
+        self._animation_stop.set()
+
+    def _start_shake(self, speed_hz: float, times: int) -> dict:
+        self._cancel_animation()
+        stop_event = threading.Event()
+        self._animation_stop = stop_event
+        with self._state_lock:
+            origin = self._current_angle_rad
+            if origin is None:
+                origin = self._last_commanded_angle_rad
+
+        amplitude = math.radians(self._shake_amplitude_deg)
+        duration = times / speed_hz
+
+        def animate():
+            started = time.monotonic()
+            while not stop_event.is_set():
+                elapsed = time.monotonic() - started
+                if elapsed >= duration:
+                    break
+                angle = origin + amplitude * math.sin(2.0 * math.pi * speed_hz * elapsed)
+                self._send_position(angle)
+                stop_event.wait(0.02)
+            if not stop_event.is_set():
+                self._send_position(origin)
+
+        self._animation_thread = threading.Thread(target=animate, daemon=True, name="waist_shake")
+        self._animation_thread.start()
+        return {
+            "state": "shaking",
+            "speed_hz": speed_hz,
+            "times": times,
+            "amplitude_deg": self._shake_amplitude_deg,
+            "return_angle_deg": math.degrees(origin),
+        }
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "set_angle":
+            if "angle_deg" not in args:
+                return {"error": "angle_deg is required"}
+            angle_deg = float(args["angle_deg"])
+            if not math.degrees(self._min_angle_rad) <= angle_deg <= math.degrees(self._max_angle_rad):
+                return {"error": f"angle_deg must be between {math.degrees(self._min_angle_rad)} and {math.degrees(self._max_angle_rad)}"}
+            self._cancel_animation()
+            return self._send_position(math.radians(angle_deg))
+        if action == "recenter":
+            self._cancel_animation()
+            return self._send_position(0.0)
+        if action == "shake_waist":
             speed_hz = float(args.get("speed", self._shake_speed_hz))
             times = int(args.get("times", self._shake_times))
             if speed_hz <= 0:

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -1271,6 +1271,160 @@ class ContinuousGaitPlugin:
         return None
 
 
+# ── BmsControlPlugin (actuator) ───────────────────────────────────────────────
+
+class BmsControlPlugin:
+    PREFIX = "bms_control"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor):
+        from unitree_sdk2py.core.channel import ChannelPublisher, ChannelSubscriber
+        from unitree_sdk2py.idl.unitree_hg.msg.dds_ import BmsCmd_, BmsState_
+
+        self._bms_cmd_type = BmsCmd_
+        self._command_topic = plugin_config.get("command_topic", "rt/lf/bmscmd")
+        self._last_state: dict | None = None
+        self._lock = threading.Lock()
+
+        self._publisher = ChannelPublisher(self._command_topic, BmsCmd_)
+        self._publisher.Init()
+        self._subscriber = ChannelSubscriber("rt/lf/bmsstate", BmsState_)
+        self._subscriber.Init(self._on_state, 10)
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "bms_control",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "G1 BMS control — query battery state or send a raw BMS command byte",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["get_state", "get_soc", "get_soh", "get_voltage", "get_current",
+                                 "get_temperatures", "get_cell_voltages", "get_cycle_count",
+                                 "get_health_summary", "send_command"],
+                        "description": "Action to perform",
+                    },
+                    "cmd": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "description": "Raw BMS command byte (0-255)",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "get_state":          {"params": [],      "description": "Get full BMS state"},
+                    "get_soc":            {"params": [],      "description": "Get state of charge (%)"},
+                    "get_soh":            {"params": [],      "description": "Get state of health (%)"},
+                    "get_voltage":        {"params": [],      "description": "Get total battery voltage (V)"},
+                    "get_current":        {"params": [],      "description": "Get current (A) and direction"},
+                    "get_temperatures":   {"params": [],      "description": "Get all temperature sensors"},
+                    "get_cell_voltages":  {"params": [],      "description": "Get all cell voltages (V)"},
+                    "get_cycle_count":    {"params": [],      "description": "Get charge cycle count"},
+                    "get_health_summary": {"params": [],      "description": "Get battery health summary"},
+                    "send_command":       {"params": ["cmd"], "description": "Send raw BMS command byte"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def _on_state(self, msg) -> None:
+        state = {
+            "version_high":     int(msg.version_high),
+            "version_low":      int(msg.version_low),
+            "fn":               int(msg.fn),
+            "soc":              int(msg.soc),
+            "soh":              int(msg.soh),
+            "current":          int(msg.current),
+            "voltage":          [int(v) for v in msg.bmsvoltage if v > 0],
+            "cell_vol":         [int(v) for v in msg.cell_vol if v > 0],
+            "temperature":      [int(t) for t in msg.temperature if t > 0],
+            "cycle":            int(msg.cycle),
+            "manufacturer_date": int(msg.manufacturer_date),
+            "bmsstate":         [int(v) for v in msg.bmsstate],
+        }
+        with self._lock:
+            self._last_state = state
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action.startswith("get_"):
+            with self._lock:
+                state = dict(self._last_state) if self._last_state is not None else None
+            if state is None:
+                return {"error": "BMS state unavailable: no rt/lf/bmsstate message received"}
+
+            if action == "get_state":
+                return state
+            if action == "get_soc":
+                return {"soc": state["soc"], "unit": "%"}
+            if action == "get_soh":
+                return {"soh": state["soh"], "unit": "%"}
+            if action == "get_voltage":
+                voltage = state["voltage"][0] / 1000.0 if state["voltage"] else 0.0
+                return {"voltage": voltage, "unit": "V"}
+            if action == "get_current":
+                current = state["current"] / 1000.0
+                direction = "charging" if current < 0 else "discharging" if current > 0 else "idle"
+                return {"current": current, "unit": "A", "direction": direction}
+            if action == "get_temperatures":
+                temperatures = state["temperature"]
+                return {
+                    "temperatures": temperatures,
+                    "count": len(temperatures),
+                    "max": max(temperatures) if temperatures else 0,
+                    "min": min(temperatures) if temperatures else 0,
+                    "avg": sum(temperatures) / len(temperatures) if temperatures else 0.0,
+                    "unit": "°C",
+                }
+            if action == "get_cell_voltages":
+                voltages = [value / 1000.0 for value in state["cell_vol"]]
+                maximum = max(voltages) if voltages else 0.0
+                minimum = min(voltages) if voltages else 0.0
+                return {
+                    "voltages": voltages,
+                    "count": len(voltages),
+                    "max": maximum,
+                    "min": minimum,
+                    "delta": maximum - minimum,
+                    "unit": "V",
+                }
+            if action == "get_cycle_count":
+                return {"cycle": state["cycle"], "unit": "次"}
+            if action == "get_health_summary":
+                soc = state["soc"]
+                soh = state["soh"]
+                temperatures = state["temperature"]
+                status = "critical" if soc <= 10 or soh <= 60 else "warning" if soc <= 20 or soh <= 80 else "good"
+                return {
+                    "soc": soc,
+                    "soh": soh,
+                    "voltage": state["voltage"][0] / 1000.0 if state["voltage"] else 0.0,
+                    "current": state["current"] / 1000.0,
+                    "temperature_avg": sum(temperatures) / len(temperatures) if temperatures else 0.0,
+                    "cycle_count": state["cycle"],
+                    "status": status,
+                }
+        if action == "send_command":
+            cmd = args.get("cmd")
+            if isinstance(cmd, bool) or not isinstance(cmd, int) or not 0 <= cmd <= 255:
+                return {"error": "cmd must be an integer between 0 and 255"}
+            message = self._bms_cmd_type(cmd=cmd, reserve=[0] * 40)
+            published = self._publisher.Write(message)
+            return {"published": published, "cmd": cmd, "command_topic": self._command_topic}
+        return None
+
+
 # ── AsrPlugin (sensor) ───────────────────────────────────────────────────────
 
 class _AsrNode(Node):

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -2065,6 +2065,243 @@ class StatePlugin:
         return None
 
 
+# ── GripperStatePlugin (sensor) ──────────────────────────────────────────────
+
+class _GripperStateNode(Node):
+    """Subscribes to left/right gripper DDS state and republishes JSON to ROS2."""
+
+    def __init__(self, topic: str, plugin_config: dict):
+        super().__init__("g1_gripper_state")
+        self._publisher = self.create_publisher(String, topic, _LOW_LAT_QOS)
+        self._min_angle = float(plugin_config.get("min_angle_rad", 0.0))
+        self._max_angle = float(plugin_config.get("max_angle_rad", 1.5))
+        self._grasp_tau_threshold = float(plugin_config.get("grasp_tau_threshold", 0.1))
+        self._publish_interval = 1.0 / float(plugin_config.get("publish_hz", 20))
+        self._last_publish_time = {"left": 0.0, "right": 0.0}
+        self._subscribers = []
+
+        from unitree_sdk2py.core.channel import ChannelSubscriber
+        from unitree_sdk2py.idl.unitree_hg.msg.dds_ import HandState_
+
+        for side, config_key, default_topic in (
+            ("left", "left_dds_topic", "rt/hand/left_state"),
+            ("right", "right_dds_topic", "rt/hand/right_state"),
+        ):
+            dds_topic = plugin_config.get(config_key, default_topic)
+            try:
+                subscriber = ChannelSubscriber(dds_topic, HandState_)
+                subscriber.Init(lambda msg, side=side: self._on_state(side, msg), 10)
+                self._subscribers.append(subscriber)
+                self.get_logger().info(f"GripperStateNode subscribed {dds_topic} → {topic}")
+            except Exception as e:
+                self.get_logger().warn(f"GripperStateNode: failed to subscribe {dds_topic}: {e}")
+
+    def _on_state(self, side: str, msg) -> None:
+        now = time.monotonic()
+        if now - self._last_publish_time[side] < self._publish_interval:
+            return
+        self._last_publish_time[side] = now
+
+        # TODO: Confirm motor index 0 and whether larger angles mean a more closed gripper.
+        motor = msg.motor_state[0]
+        position_rad = float(motor.q)
+        position_pct = (position_rad - self._min_angle) / (self._max_angle - self._min_angle) * 100.0
+        position_pct = max(0.0, min(100.0, position_pct))
+        tau_est = float(motor.tau_est)
+        data = {
+            "side": side,
+            "position_pct": round(position_pct, 2),
+            "position_rad": position_rad,
+            "tau_est": tau_est,
+            "temperature": [int(value) for value in motor.temperature],
+            "object_grasped": abs(tau_est) >= self._grasp_tau_threshold,
+            "error_code": [int(value) for value in msg.error],
+            "power_v": float(msg.power_v),
+            "power_a": float(msg.power_a),
+        }
+        output = String()
+        output.data = json.dumps(data)
+        self._publisher.publish(output)
+
+
+class GripperStatePlugin:
+    PREFIX = "gripper_state"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor):
+        self._topic = f"/{namespace}/gripper/state"
+        self._node = _GripperStateNode(self._topic, plugin_config)
+        executor.add_node(self._node)
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "gripper_state",
+            "type": "sensor",
+            "multiInstance": False,
+            "description": f"G1 gripper state — position, torque, temperature, grasp detection, errors, and power. Publishes to {self._topic}",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        pass  # DDS subscriptions start in __init__
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "running"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "info":
+            return {"state": "running", "topic_out": [{"topic": self._topic, "format": "data/json"}]}
+        return None
+
+
+# ── GripperControlPlugin (actuator) ──────────────────────────────────────────
+
+class GripperControlPlugin:
+    PREFIX = "gripper_control"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor):
+        self._dds_topics = {
+            "left": plugin_config.get("left_dds_topic", "rt/hand/left_cmd"),
+            "right": plugin_config.get("right_dds_topic", "rt/hand/right_cmd"),
+        }
+        self._min_angle = float(plugin_config.get("min_angle_rad", 0.0))
+        self._max_angle = float(plugin_config.get("max_angle_rad", 1.5))
+        self._motor_mode = int(plugin_config.get("motor_mode", 10))
+        self._default_kp = float(plugin_config.get("default_kp", 20.0))
+        self._default_kd = float(plugin_config.get("default_kd", 1.0))
+        self._force_pct = float(plugin_config.get("default_force_pct", 50))
+        self._max_tau = float(plugin_config.get("max_tau", 0.5))
+        self._publishers = {}
+        self._last_position_pct = {"left": 0.0, "right": 0.0}
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "gripper_control",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "G1 parallel gripper control — open, close, set position or force, and stop",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["open", "close", "set_position", "set_force", "stop"],
+                        "description": "Action to perform",
+                    },
+                    "side": {
+                        "type": "string",
+                        "enum": ["left", "right", "both"],
+                        "default": "both",
+                        "description": "Gripper side to control",
+                    },
+                    "position_pct": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 100,
+                        "description": "Opening position, where 0% is open and 100% is closed",
+                    },
+                    "force_pct": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 100,
+                        "description": "Gripping force limit percentage",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "open": {"params": ["side"], "description": "Fully open the selected gripper"},
+                    "close": {"params": ["side", "force_pct"], "description": "Close the selected gripper, optionally setting the force limit"},
+                    "set_position": {"params": ["side", "position_pct"], "description": "Set gripper position from 0% open to 100% closed"},
+                    "set_force": {"params": ["side", "force_pct"], "description": "Set the gripping force limit"},
+                    "stop": {"params": ["side"], "description": "Stop by holding the last commanded position"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass  # DDS publishers are initialized lazily on the first action
+
+    def stop(self) -> None:
+        pass
+
+    def _get_publisher(self, side: str):
+        if side not in self._publishers:
+            from unitree_sdk2py.core.channel import ChannelPublisher
+            from unitree_sdk2py.idl.unitree_hg.msg.dds_ import HandCmd_
+            publisher = ChannelPublisher(self._dds_topics[side], HandCmd_)
+            publisher.Init()
+            self._publishers[side] = publisher
+        return self._publishers[side]
+
+    def _send_position(self, side: str, position_pct: float) -> dict:
+        from unitree_sdk2py.idl.default import unitree_hg_msg_dds__HandCmd_
+
+        # TODO: Confirm motor index 0, mode 10, and whether larger angles mean a more closed gripper.
+        position_rad = self._min_angle + position_pct / 100.0 * (self._max_angle - self._min_angle)
+        message = unitree_hg_msg_dds__HandCmd_()
+        motor = message.motor_cmd[0]
+        motor.mode = self._motor_mode
+        motor.q = position_rad
+        motor.dq = 0.0
+        motor.tau = 0.0
+        motor.kp = self._default_kp
+        motor.kd = self._default_kd
+        published = self._get_publisher(side).Write(message)
+        self._last_position_pct[side] = position_pct
+        return {
+            "side": side,
+            "position_pct": position_pct,
+            "position_rad": position_rad,
+            "published": bool(published),
+        }
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        side = args.get("side", "both")
+        if side not in ("left", "right", "both"):
+            return {"error": "side must be left, right, or both"}
+        sides = ("left", "right") if side == "both" else (side,)
+
+        if action == "set_force":
+            if "force_pct" not in args:
+                return {"error": "force_pct is required"}
+            force_pct = float(args["force_pct"])
+            if not 0.0 <= force_pct <= 100.0:
+                return {"error": "force_pct must be between 0 and 100"}
+            self._force_pct = force_pct
+            # TODO: Apply the force limit once the HandCmd_ force-control semantics are confirmed on hardware.
+            return {"side": side, "force_pct": force_pct, "max_tau": self._max_tau, "applied": False}
+
+        if action == "open":
+            position_pct = 0.0
+        elif action == "close":
+            if "force_pct" in args:
+                force_pct = float(args["force_pct"])
+                if not 0.0 <= force_pct <= 100.0:
+                    return {"error": "force_pct must be between 0 and 100"}
+                self._force_pct = force_pct
+            position_pct = 100.0
+        elif action == "set_position":
+            if "position_pct" not in args:
+                return {"error": "position_pct is required"}
+            position_pct = float(args["position_pct"])
+            if not 0.0 <= position_pct <= 100.0:
+                return {"error": "position_pct must be between 0 and 100"}
+        elif action == "stop":
+            # TODO: Replace last-target hold with measured-position hold if hardware testing requires it.
+            return {"results": [self._send_position(item, self._last_position_pct[item]) for item in sides]}
+        else:
+            return None
+
+        results = [self._send_position(item, position_pct) for item in sides]
+        return {"results": results, "force_pct": self._force_pct}
+
+
 # ── LidarPlugin (sensor) ─────────────────────────────────────────────────────
 
 LIDAR_CLOUD_INTERVAL = 0.05      # 20 Hz max (source is ~10Hz, allow headroom)

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -19,6 +19,7 @@ drivers/unitree/g1/device.py — Unitree G1 设备插件（重构版）。
 """
 
 import json
+import math
 import queue
 import socket
 import struct
@@ -1215,7 +1216,263 @@ class LocoPlugin:
         return result
 
 
-# ── ContinuousGaitPlugin (actuator) ────────────────────────────────────────────
+# ── FallRecoveryPlugin (sensor + actuator) ─────────────────────────────────────
+
+class _FallRecoveryNode(Node):
+    def __init__(self, namespace: str, imu_topic: str, foot_force_topic: str, events_topic: str, config: dict):
+        super().__init__("g1_fall_recovery")
+        self._namespace = namespace
+        self._imu_topic = imu_topic
+        self._foot_force_topic = foot_force_topic
+        self._events_topic = events_topic
+        self._fall_angle_threshold_deg = float(config.get("fall_angle_threshold_deg", 50))
+        self._fall_confirm_duration = float(config.get("fall_confirm_duration", 0.5))
+        self._foot_force_threshold = float(config.get("foot_force_threshold", 10))
+        self._lock = threading.Lock()
+        self._state = {
+            "is_fallen": False,
+            "fall_direction": "none",
+            "confidence": 0.0,
+            "imu_rpy": {"roll": 0.0, "pitch": 0.0, "yaw": 0.0},
+            "foot_force": [],
+            "last_fall_time": 0.0,
+        }
+        self._candidate_start = 0.0
+        self._last_direction = "none"
+        self._event_pub = self.create_publisher(String, events_topic, _LOW_LAT_QOS)
+
+        try:
+            self._imu_sub = self.create_subscription(String, imu_topic, self._on_imu, _LOW_LAT_QOS)
+            print(f"[fall_recovery] IMU subscribed: {imu_topic}", flush=True)
+        except Exception as e:
+            print(f"[fall_recovery] IMU subscribe failed: {e}", flush=True)
+
+        try:
+            self._foot_force_sub = self.create_subscription(String, foot_force_topic, self._on_loco_state, _LOW_LAT_QOS)
+            print(f"[fall_recovery] foot_force subscribed: {foot_force_topic}", flush=True)
+        except Exception as e:
+            print(f"[fall_recovery] foot_force subscribe failed: {e}", flush=True)
+
+    def _on_imu(self, msg) -> None:
+        try:
+            data = json.loads(msg.data)
+            rpy = data.get("rpy") or []
+            if len(rpy) < 3:
+                return
+            roll, pitch, yaw = [math.degrees(float(v)) for v in rpy[:3]]
+            with self._lock:
+                self._state["imu_rpy"] = {
+                    "roll": round(roll, 2),
+                    "pitch": round(pitch, 2),
+                    "yaw": round(yaw, 2),
+                }
+            self._update_detection()
+        except Exception as e:
+            print(f"[fall_recovery] IMU parse failed: {e}", flush=True)
+
+    def _on_loco_state(self, msg) -> None:
+        try:
+            data = json.loads(msg.data)
+            forces = data.get("foot_force") or []
+            with self._lock:
+                self._state["foot_force"] = [float(v) for v in forces]
+            self._update_detection()
+        except Exception as e:
+            print(f"[fall_recovery] foot_force parse failed: {e}", flush=True)
+
+    def _update_detection(self) -> None:
+        now_mono = time.monotonic()
+        event = None
+        with self._lock:
+            imu_rpy = dict(self._state["imu_rpy"])
+            forces = list(self._state["foot_force"])
+            roll = float(imu_rpy.get("roll", 0.0))
+            pitch = float(imu_rpy.get("pitch", 0.0))
+            direction = self._classify_direction(roll, pitch)
+            angle_ok = direction != "none"
+            foot_ok = len(forces) >= 4 and all(float(f) < self._foot_force_threshold for f in forces[:4])
+
+            if angle_ok and foot_ok:
+                if self._candidate_start == 0.0 or direction != self._last_direction:
+                    self._candidate_start = now_mono
+                    self._last_direction = direction
+                confirmed = now_mono - self._candidate_start >= self._fall_confirm_duration
+                confidence = self._confidence(roll, pitch, forces)
+                if confirmed:
+                    was_fallen = bool(self._state["is_fallen"])
+                    self._state.update({
+                        "is_fallen": True,
+                        "fall_direction": direction,
+                        "confidence": confidence,
+                    })
+                    if not was_fallen:
+                        self._state["last_fall_time"] = time.time()
+                        event = {"type": "fall_detected", "direction": direction, "confidence": confidence}
+                else:
+                    self._state["confidence"] = confidence
+            else:
+                self._candidate_start = 0.0
+                self._last_direction = "none"
+                self._state.update({
+                    "is_fallen": False,
+                    "fall_direction": "none",
+                    "confidence": 0.0,
+                })
+
+        if event:
+            self.publish_event(event["type"], {k: v for k, v in event.items() if k != "type"})
+
+    def _classify_direction(self, roll: float, pitch: float) -> str:
+        if max(abs(roll), abs(pitch)) < self._fall_angle_threshold_deg:
+            return "none"
+        if abs(pitch) >= abs(roll):
+            return "prone" if pitch > 0 else "supine"
+        return "right" if roll > 0 else "left"
+
+    def _confidence(self, roll: float, pitch: float, forces: list) -> float:
+        angle_score = min(1.0, max(abs(roll), abs(pitch)) / max(self._fall_angle_threshold_deg, 1.0))
+        force_score = 1.0 if len(forces) >= 4 and all(float(f) < self._foot_force_threshold for f in forces[:4]) else 0.0
+        return round(min(1.0, 0.7 * angle_score + 0.3 * force_score), 3)
+
+    def get_status(self) -> dict:
+        with self._lock:
+            return {
+                "is_fallen": bool(self._state["is_fallen"]),
+                "fall_direction": self._state["fall_direction"],
+                "confidence": float(self._state["confidence"]),
+                "imu_rpy": dict(self._state["imu_rpy"]),
+                "foot_force": list(self._state["foot_force"]),
+                "last_fall_time": float(self._state["last_fall_time"]),
+            }
+
+    def publish_event(self, event_type: str, data: dict | None = None) -> None:
+        try:
+            event = {"type": event_type, "timestamp": time.time()}
+            if data:
+                event.update(data)
+            msg = String()
+            msg.data = json.dumps(event)
+            self._event_pub.publish(msg)
+            print(f"[fall_recovery] event: {event_type} | {json.dumps(data or {})}", flush=True)
+        except Exception as e:
+            print(f"[fall_recovery] event publish failed: {e}", flush=True)
+
+
+class FallRecoveryPlugin:
+    PREFIX = "fall_recovery"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, loco_plugin=None):
+        self._namespace = namespace
+        self._config = plugin_config
+        self._loco_plugin = loco_plugin
+        self._recovery_timeout = float(plugin_config.get("recovery_timeout", 10))
+        self._imu_topic = self._resolve_topic(namespace, plugin_config.get("imu_topic", "state/imu"))
+        self._foot_force_topic = self._resolve_topic(namespace, plugin_config.get("foot_force_topic", "loco/state"))
+        self._events_topic = f"/{namespace}/fall_recovery/events"
+        self._node = _FallRecoveryNode(namespace, self._imu_topic, self._foot_force_topic, self._events_topic, plugin_config)
+        executor.add_node(self._node)
+
+    def _resolve_topic(self, namespace: str, topic: str) -> str:
+        topic = str(topic).strip()
+        if topic.startswith("/"):
+            return topic
+        return f"/{namespace}/{topic.lstrip('/')}"
+
+    def get_tools(self) -> list:
+        return [self._status_tool(), self._recover_tool(), self._fall_event_tool()]
+
+    def _status_tool(self) -> dict:
+        return {
+            "name": "fall_status",
+            "type": "sensor",
+            "multiInstance": False,
+            "description": "G1 fall detection status — fallen state, posture direction, confidence, IMU RPY and foot force.",
+            "inputSchema": {"type": "object", "properties": {}},
+        }
+
+    def _recover_tool(self) -> dict:
+        return {
+            "name": "fall_recover",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "G1 one-shot fall recovery. Uses existing safe switch_mode lie2standup sequence.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "direction": {
+                        "type": "string",
+                        "enum": ["auto", "prone", "supine", "left", "right"],
+                        "description": "Fall direction. auto uses current detection result.",
+                        "default": "auto",
+                    },
+                    "force": {
+                        "type": "boolean",
+                        "description": "Execute recovery even if no fall is detected.",
+                        "default": False,
+                    },
+                },
+            },
+        }
+
+    def _fall_event_tool(self) -> dict:
+        return {
+            "name": "fall_events",
+            "type": "sensor",
+            "multiInstance": False,
+            "description": f"G1 fall recovery events — fall_detected, recovery_started, recovery_completed, recovery_failed. Publishes to {self._events_topic}",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._events_topic, "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "running"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "info":
+            tool_name = args.get("_tool_name", "fall_status")
+            if tool_name == "fall_events":
+                return {"state": "running", "topic_out": [{"topic": self._events_topic, "format": "data/json"}]}
+            return self._node.get_status()
+        if action == "fall_status":
+            return self._node.get_status()
+        if action == "fall_recover":
+            return self._recover(args)
+        return None
+
+    def _recover(self, args: dict) -> dict:
+        status = self._node.get_status()
+        direction_arg = str(args.get("direction", "auto"))
+        force = bool(args.get("force", False))
+        direction = status["fall_direction"] if direction_arg == "auto" else direction_arg
+
+        if direction not in ("prone", "supine", "left", "right"):
+            direction = "none"
+        if not force and not status["is_fallen"]:
+            return {"success": False, "state": "not_fallen", "status": status, "error": "Robot is not detected as fallen. Set force=true to recover anyway."}
+        if not self._loco_plugin:
+            self._node.publish_event("recovery_failed", {"reason": "missing_loco_plugin", "direction": direction})
+            return {"success": False, "state": "failed", "direction": direction, "error": "LocoPlugin is unavailable"}
+
+        try:
+            self._node.publish_event("recovery_started", {"direction": direction, "forced": force})
+            result = self._loco_plugin.dispatch("switch_mode", {"mode": "lie2standup"})
+            if isinstance(result, dict) and "error" in result:
+                self._node.publish_event("recovery_failed", {"direction": direction, "error": result["error"]})
+                return {"success": False, "state": "failed", "direction": direction, "progress": "lie2standup", "result": result, "timeout": self._recovery_timeout}
+            self._node.publish_event("recovery_completed", {"direction": direction})
+            return {"success": True, "state": "completed", "direction": direction, "progress": "lie2standup", "result": result, "timeout": self._recovery_timeout}
+        except Exception as e:
+            print(f"[fall_recovery] recovery failed: {e}", flush=True)
+            self._node.publish_event("recovery_failed", {"direction": direction, "error": str(e)})
+            return {"success": False, "state": "failed", "direction": direction, "error": str(e)}
+
 
 class ContinuousGaitPlugin:
     PREFIX = "continuous_gait"

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -1215,6 +1215,62 @@ class LocoPlugin:
         return result
 
 
+# ── ContinuousGaitPlugin (actuator) ────────────────────────────────────────────
+
+class ContinuousGaitPlugin:
+    PREFIX = "continuous_gait"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, loco_client):
+        self._client = loco_client
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "continuous_gait",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "G1 continuous gait mode — enable/disable continuous gait, query balance mode",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["enable", "disable", "get_state"],
+                        "description": "Action to perform",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "enable":    {"params": [], "description": "Enable continuous gait mode (balance mode 1)"},
+                    "disable":   {"params": [], "description": "Disable continuous gait mode (balance mode 0)"},
+                    "get_state": {"params": [], "description": "Get current balance mode (0=standard gait, 1=continuous gait)"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "enable":
+            ret = self._client.ContinuousGait(True)
+            return {"ret": ret, "continuous_gait": True}
+        elif action == "disable":
+            ret = self._client.ContinuousGait(False)
+            return {"ret": ret, "continuous_gait": False}
+        elif action == "get_state":
+            code, mode = self._client.GetBalanceMode()
+            return {"ret": code, "balance_mode": mode,
+                    "description": "standard gait" if mode == 0 else "continuous gait" if mode == 1 else f"unknown mode {mode}"}
+        return None
+
+
 # ── AsrPlugin (sensor) ───────────────────────────────────────────────────────
 
 class _AsrNode(Node):

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -2302,6 +2302,191 @@ class GripperControlPlugin:
         return {"results": results, "force_pct": self._force_pct}
 
 
+# ── HeadControlPlugin (actuator) ─────────────────────────────────────────────
+
+class HeadControlPlugin:
+    PREFIX = "head_control"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor):
+        self._motor_index = int(plugin_config.get("motor_index", 23))
+        self._min_angle_rad = math.radians(float(plugin_config.get("min_angle_deg", -90.0)))
+        self._max_angle_rad = math.radians(float(plugin_config.get("max_angle_deg", 90.0)))
+        self._motor_mode = int(plugin_config.get("motor_mode", 10))
+        self._default_kp = float(plugin_config.get("default_kp", 20.0))
+        self._default_kd = float(plugin_config.get("default_kd", 1.0))
+        self._lowcmd_topic = plugin_config.get("lowcmd_topic", "rt/lowcmd")
+        self._lowstate_topic = plugin_config.get("lowstate_topic", "rt/lowstate")
+        self._shake_amplitude_deg = float(plugin_config.get("shake_amplitude_deg", 30.0))
+        self._shake_speed_hz = float(plugin_config.get("shake_speed_hz", 1.5))
+        self._shake_times = int(plugin_config.get("shake_times", 3))
+        self._publisher = None
+        self._animation_stop = threading.Event()
+        self._animation_thread = None
+        self._state_lock = threading.Lock()
+        self._current_angle_rad = None
+        self._last_commanded_angle_rad = 0.0
+
+        try:
+            from unitree_sdk2py.core.channel import ChannelSubscriber
+            from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowState_
+            self._subscriber = ChannelSubscriber(self._lowstate_topic, LowState_)
+            self._subscriber.Init(self._on_lowstate, 10)
+        except Exception as e:
+            self._subscriber = None
+            print(f"[head_control] LowState subscription unavailable: {e}")
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "head_control",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "G1 head yaw control — set angle, recenter, shake head, or read current angle",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["set_angle", "recenter", "shake_head", "get_angle"],
+                        "description": "Action to perform",
+                    },
+                    "angle_deg": {
+                        "type": "number",
+                        "minimum": math.degrees(self._min_angle_rad),
+                        "maximum": math.degrees(self._max_angle_rad),
+                        "description": "Target yaw angle in degrees; negative is left and positive is right",
+                    },
+                    "speed": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "description": "Shake frequency in Hz",
+                    },
+                    "times": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Number of shake cycles",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "set_angle": {"params": ["angle_deg"], "description": "Set head yaw angle"},
+                    "recenter": {"params": [], "description": "Return head yaw to zero"},
+                    "shake_head": {"params": ["speed", "times"], "description": "Shake head asynchronously, then return to the starting angle"},
+                    "get_angle": {"params": [], "description": "Read the current head yaw angle from LowState"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass  # DDS publisher is initialized lazily on the first motion command
+
+    def stop(self) -> None:
+        self._animation_stop.set()
+
+    def _on_lowstate(self, msg) -> None:
+        if self._motor_index >= len(msg.motor_state):
+            return
+        with self._state_lock:
+            self._current_angle_rad = float(msg.motor_state[self._motor_index].q)
+
+    def _get_publisher(self):
+        if self._publisher is None:
+            from unitree_sdk2py.core.channel import ChannelPublisher
+            from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowCmd_
+            self._publisher = ChannelPublisher(self._lowcmd_topic, LowCmd_)
+            self._publisher.Init()
+        return self._publisher
+
+    def _send_position(self, angle_rad: float) -> dict:
+        from unitree_sdk2py.idl.default import unitree_hg_msg_dds__LowCmd_
+
+        angle_rad = max(self._min_angle_rad, min(self._max_angle_rad, angle_rad))
+        message = unitree_hg_msg_dds__LowCmd_()
+        motor = message.motor_cmd[self._motor_index]
+        # TODO: Confirm motor index 23, position mode 10, angle direction, and physical limits on hardware.
+        motor.mode = self._motor_mode
+        motor.q = angle_rad
+        motor.dq = 0.0
+        motor.tau = 0.0
+        motor.kp = self._default_kp
+        motor.kd = self._default_kd
+        # TODO: Confirm whether LowCmd CRC must be calculated before publishing.
+        published = self._get_publisher().Write(message)
+        with self._state_lock:
+            self._last_commanded_angle_rad = angle_rad
+        return {
+            "angle_deg": math.degrees(angle_rad),
+            "angle_rad": angle_rad,
+            "published": bool(published),
+        }
+
+    def _cancel_animation(self) -> None:
+        self._animation_stop.set()
+
+    def _start_shake(self, speed_hz: float, times: int) -> dict:
+        self._cancel_animation()
+        stop_event = threading.Event()
+        self._animation_stop = stop_event
+        with self._state_lock:
+            origin = self._current_angle_rad
+            if origin is None:
+                origin = self._last_commanded_angle_rad
+
+        amplitude = math.radians(self._shake_amplitude_deg)
+        duration = times / speed_hz
+
+        def animate():
+            started = time.monotonic()
+            while not stop_event.is_set():
+                elapsed = time.monotonic() - started
+                if elapsed >= duration:
+                    break
+                angle = origin + amplitude * math.sin(2.0 * math.pi * speed_hz * elapsed)
+                self._send_position(angle)
+                stop_event.wait(0.02)
+            if not stop_event.is_set():
+                self._send_position(origin)
+
+        self._animation_thread = threading.Thread(target=animate, daemon=True, name="head_shake")
+        self._animation_thread.start()
+        return {
+            "state": "shaking",
+            "speed_hz": speed_hz,
+            "times": times,
+            "amplitude_deg": self._shake_amplitude_deg,
+            "return_angle_deg": math.degrees(origin),
+        }
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "set_angle":
+            if "angle_deg" not in args:
+                return {"error": "angle_deg is required"}
+            angle_deg = float(args["angle_deg"])
+            if not math.degrees(self._min_angle_rad) <= angle_deg <= math.degrees(self._max_angle_rad):
+                return {"error": f"angle_deg must be between {math.degrees(self._min_angle_rad)} and {math.degrees(self._max_angle_rad)}"}
+            self._cancel_animation()
+            return self._send_position(math.radians(angle_deg))
+        if action == "recenter":
+            self._cancel_animation()
+            return self._send_position(0.0)
+        if action == "shake_head":
+            speed_hz = float(args.get("speed", self._shake_speed_hz))
+            times = int(args.get("times", self._shake_times))
+            if speed_hz <= 0:
+                return {"error": "speed must be greater than 0"}
+            if times < 1:
+                return {"error": "times must be at least 1"}
+            return self._start_shake(speed_hz, times)
+        if action == "get_angle":
+            with self._state_lock:
+                angle_rad = self._current_angle_rad
+            if angle_rad is None:
+                return {"error": "No LowState angle received yet"}
+            return {"angle_deg": math.degrees(angle_rad), "angle_rad": angle_rad}
+        return None
+
+
 # ── LidarPlugin (sensor) ─────────────────────────────────────────────────────
 
 LIDAR_CLOUD_INTERVAL = 0.05      # 20 Hz max (source is ~10Hz, allow headroom)

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -100,6 +100,11 @@ class G1DeviceBundle:
             self._plugins.append(ContinuousGaitPlugin(plugins_cfg["continuous_gait"], namespace, executor, loco_client))
             print("[bundle] ContinuousGaitPlugin loaded")
 
+        if plugins_cfg.get("bms_control", {}).get("enabled", False):
+            from device import BmsControlPlugin
+            self._plugins.append(BmsControlPlugin(plugins_cfg["bms_control"], namespace, executor))
+            print("[bundle] BmsControlPlugin loaded")
+
         if plugins_cfg.get("arm", {}).get("enabled", False):
             from device import ArmActionPlugin
             self._plugins.append(ArmActionPlugin(plugins_cfg["arm"], namespace, executor, arm_client))

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -139,6 +139,11 @@ class G1DeviceBundle:
             self._plugins.append(GripperControlPlugin(plugins_cfg["gripper_control"], namespace, executor))
             print("[bundle] GripperControlPlugin loaded")
 
+        if plugins_cfg.get("head_control", {}).get("enabled", False):
+            from device import HeadControlPlugin
+            self._plugins.append(HeadControlPlugin(plugins_cfg["head_control"], namespace, executor))
+            print("[bundle] HeadControlPlugin loaded")
+
         if plugins_cfg.get("camera", {}).get("enabled", False):
             from device import RealSensePlugin
             self._plugins.append(RealSensePlugin(plugins_cfg["camera"], namespace, executor))

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -119,6 +119,11 @@ class G1DeviceBundle:
             self._plugins.append(ArmActionPlugin(plugins_cfg["arm"], namespace, executor, arm_client))
             print("[bundle] ArmActionPlugin loaded")
 
+        if plugins_cfg.get("arm_trajectory", {}).get("enabled", False):
+            from device import ArmTrajectoryPlugin
+            self._plugins.append(ArmTrajectoryPlugin(plugins_cfg["arm_trajectory"], namespace, executor))
+            print("[bundle] ArmTrajectoryPlugin loaded")
+
         if plugins_cfg.get("asr", {}).get("enabled", False):
             from device import AsrPlugin
             self._plugins.append(AsrPlugin(plugins_cfg["asr"], namespace, executor))
@@ -129,20 +134,15 @@ class G1DeviceBundle:
             self._plugins.append(StatePlugin(plugins_cfg["state"], namespace, executor))
             print("[bundle] StatePlugin loaded")
 
-        if plugins_cfg.get("gripper_state", {}).get("enabled", False):
-            from device import GripperStatePlugin
-            self._plugins.append(GripperStatePlugin(plugins_cfg["gripper_state"], namespace, executor))
-            print("[bundle] GripperStatePlugin loaded")
-
-        if plugins_cfg.get("gripper_control", {}).get("enabled", False):
-            from device import GripperControlPlugin
-            self._plugins.append(GripperControlPlugin(plugins_cfg["gripper_control"], namespace, executor))
-            print("[bundle] GripperControlPlugin loaded")
-
         if plugins_cfg.get("head_control", {}).get("enabled", False):
             from device import HeadControlPlugin
             self._plugins.append(HeadControlPlugin(plugins_cfg["head_control"], namespace, executor))
             print("[bundle] HeadControlPlugin loaded")
+
+        if plugins_cfg.get("waist_control", {}).get("enabled", False):
+            from device import WaistControlPlugin
+            self._plugins.append(WaistControlPlugin(plugins_cfg["waist_control"], namespace, executor))
+            print("[bundle] WaistControlPlugin loaded")
 
         if plugins_cfg.get("camera", {}).get("enabled", False):
             from device import RealSensePlugin

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -129,6 +129,16 @@ class G1DeviceBundle:
             self._plugins.append(StatePlugin(plugins_cfg["state"], namespace, executor))
             print("[bundle] StatePlugin loaded")
 
+        if plugins_cfg.get("gripper_state", {}).get("enabled", False):
+            from device import GripperStatePlugin
+            self._plugins.append(GripperStatePlugin(plugins_cfg["gripper_state"], namespace, executor))
+            print("[bundle] GripperStatePlugin loaded")
+
+        if plugins_cfg.get("gripper_control", {}).get("enabled", False):
+            from device import GripperControlPlugin
+            self._plugins.append(GripperControlPlugin(plugins_cfg["gripper_control"], namespace, executor))
+            print("[bundle] GripperControlPlugin loaded")
+
         if plugins_cfg.get("camera", {}).get("enabled", False):
             from device import RealSensePlugin
             self._plugins.append(RealSensePlugin(plugins_cfg["camera"], namespace, executor))

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -95,6 +95,11 @@ class G1DeviceBundle:
             self._plugins.append(LocoPlugin(plugins_cfg["loco"], namespace, executor, loco_client, slam_client=slam_client, smart_motion=smart_motion))
             print("[bundle] LocoStatePlugin + LocoPlugin loaded")
 
+        if plugins_cfg.get("continuous_gait", {}).get("enabled", False):
+            from device import ContinuousGaitPlugin
+            self._plugins.append(ContinuousGaitPlugin(plugins_cfg["continuous_gait"], namespace, executor, loco_client))
+            print("[bundle] ContinuousGaitPlugin loaded")
+
         if plugins_cfg.get("arm", {}).get("enabled", False):
             from device import ArmActionPlugin
             self._plugins.append(ArmActionPlugin(plugins_cfg["arm"], namespace, executor, arm_client))

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -95,6 +95,15 @@ class G1DeviceBundle:
             self._plugins.append(LocoPlugin(plugins_cfg["loco"], namespace, executor, loco_client, slam_client=slam_client, smart_motion=smart_motion))
             print("[bundle] LocoStatePlugin + LocoPlugin loaded")
 
+        if plugins_cfg.get("fall_recovery", {}).get("enabled", False):
+            from device import FallRecoveryPlugin
+            loco_plugin = next((p for p in self._plugins if getattr(p, 'PREFIX', '') == 'loco'), None)
+            self._plugins.append(FallRecoveryPlugin(
+                plugins_cfg["fall_recovery"], namespace, executor,
+                loco_plugin=loco_plugin,
+            ))
+            print("[bundle] FallRecoveryPlugin loaded")
+
         if plugins_cfg.get("continuous_gait", {}).get("enabled", False):
             from device import ContinuousGaitPlugin
             self._plugins.append(ContinuousGaitPlugin(plugins_cfg["continuous_gait"], namespace, executor, loco_client))


### PR DESCRIPTION
## 概述
为 Unitree G1 驱动新增两张卡片，均已完成真机验证：
- `continuous_gait` — 连续步态模式开关（actuator）
- `bms_control` — 电池管理系统查询/控制（actuator）

改动文件：`unitree/g1/device.py`、`unitree/g1/config.yaml`、`unitree/g1/main.py`

---

## 1. continuous_gait（连续步态）

**功能**：enable / disable / get_state，通过 loco_client 的 `SetBalanceMode(1/0)` 在标准步态与连续步态间切换。

**真机验证**（G1 真机，FSM 500 主运控 normal locomotion）：
- `enable`  → `ret:0`，机器人由静态站立切换为连续踏步 ✅
- `disable` → `ret:0`，恢复标准步态、安静站立 ✅

**已知限制**：本机固件不支持 `GetBalanceMode` 查询接口，`get_state` 返回 `7301 (LocoState not available)`；不影响 `SetBalanceMode` 写操作。建议后续对 `get_state` 做容错提示。

---

## 2. bms_control（电池管理）

**功能**：
- 只读查询：`get_state` / `get_soc` / `get_soh` / `get_voltage` / `get_current` / `get_temperatures` / `get_cell_voltages` / `get_cycle_count` / `get_health_summary`（订阅 DDS `rt/lf/bmsstate`）
- 写操作：`send_command`（发原始 BMS 命令字节，向 `rt/lf/bmscmd` 发布）

**真机验证**（G1 真机）：

`get_health_summary` 返回：
| 指标 | 数值 |
|------|------|
| SOC | 41% |
| SOH | 94% |
| 电压 | 47.58 V |
| 电流 | -2.1 A（充电中） |
| 平均温度 | 35 °C |
| 循环次数 | 57 |
| 状态 | good |

`get_state` 返回：13 节电芯电压 3658~3669 mV（压差仅 11 mV，一致性良好）、4 路温度 31~38 °C、BMS 固件 v1.6、充放电方向判断正确。

查询链路、DDS 订阅、单位换算（mV→V / mA→A）、健康分级均验证正确 ✅。

**说明**：`send_command` 为高风险写操作（未知命令字节可能触发掉电），本次未做真机测试。

---

## 验证环境
- 硬件：Unitree G1 真机
- 部署：基于官方 main 代码构建的驱动镜像，ROS_DOMAIN_ID=42 / FastDDS
- 验证方式：MCP HTTP 接口（`http://localhost:15701/mcp`）逐动作调用