### PR TITLE
feat(遥操作-影子模式): 新增可部署的通用 RTC 录制运行时

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Each driver is a standalone [MCP](https://modelcontextprotocol.io) HTTP server t
 | `unitree/g1` | Unitree G1 Humanoid | 15701 | Locomotion, arm control, mic, speaker, LED, state monitoring |
 | `engineai/t800` | EngineAI T800 Development Edition | 15708 | ROS2/Native SDK, full state, dance/gesture sequences, virtual gamepad, locomotion and low-level joint control |
 | `phanthy/remote_control` | Remote Control Bridge | 15710 | Remote control relay |
+| [`generic/teleop_shadow`](generic/teleop_shadow/README.md) | Robot-free Quest/WebRTC endpoint | 15711 | Strict Frame v1, fenced Shadow sessions, lease/Pose watchdogs and live WebRTC diagnostics; zero actuation |
 
 ## Quick Start
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -13,6 +13,7 @@
 | `unitree/g1` | Unitree G1 人形机器人 | 15701 | 运动控制、机械臂、麦克风、扬声器、LED、状态监控 |
 | `engineai/t800` | 众擎 T800 开发版 | 15708 | ROS2/Native SDK、全身状态、舞蹈/手势序列、虚拟手柄、运动与高低层控制 |
 | `phanthy/remote_control` | 远程控制桥接 | 15710 | 远程控制中继 |
+| [`generic/teleop_shadow`](generic/teleop_shadow/README.md) | 无机器人 Quest/WebRTC 端点 | 15711 | 严格 Frame v1、带 fencing 的 Shadow 会话、租约/Pose 看门狗与真实 WebRTC 诊断；永不执行硬件动作 |
 
 ## 快速开始
 

--- a/generic/teleop_shadow/Dockerfile
+++ b/generic/teleop_shadow/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12-slim-bookworm
+
+WORKDIR /work
+
+COPY requirements.txt /tmp/teleop-shadow-requirements.txt
+RUN pip install --no-cache-dir -r /tmp/teleop-shadow-requirements.txt
+
+COPY main.py protocol.py runtime.py dispatch.py rtc.py smoke_recording.py config.yaml driver.yaml /work/
+COPY deploy/ /deploy/
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV CONFIG_PATH=/work/config.yaml
+ENV MOTUS_MCP_PORT=15711
+
+EXPOSE 15711
+
+RUN useradd --create-home --uid 10001 teleop
+USER teleop
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD ["python", "-c", "import json,os,urllib.request; p=int(os.environ['MOTUS_MCP_PORT']); d=os.environ.get('MOTUS_DRIVER_ID','teleop-shadow-driver'); s=json.load(urllib.request.urlopen(f'http://127.0.0.1:{p}/health', timeout=2)); assert s['driver_id']==d and s['actuation_enabled'] is False and s['ready'] is True and s['rtc_enabled'] is True"]
+
+CMD ["python", "/work/main.py"]

--- a/generic/teleop_shadow/README.md
+++ b/generic/teleop_shadow/README.md
@@ -1,0 +1,411 @@
+# Generic Teleop Shadow Driver
+
+`generic/teleop_shadow` is a deployable, robot-free teleoperation endpoint for validating the Quest/WebRTC path before any robot adapter is connected. It implements MCP session control, strict Frame v1 validation, short-lived one-time RTC tickets, peer-bound browser frames that never disclose the session fence, the required WebRTC data channels, latest-only Pose storage, watchdog diagnostics, and a recording-only final-dispatch arbiter.
+
+This Driver is permanently constrained to:
+
+- `mode: shadow`
+- `actuation_enabled: false`
+- no robot SDK, ROS command publisher, motor API, or hardware output
+- bounded `would_apply` / `would_stop` records instead of device commands
+
+It is useful on its own: a team can negotiate a real local `aiortc` connection, stream Quest poses, observe freshness and rejection counters through `teleop_state`, and verify exactly which safe intents would reach a robot adapter without connecting a robot.
+
+## Interfaces
+
+| Interface | Purpose |
+|---|---|
+| `POST /mcp` | MCP `initialize`, `tools/list`, and `tools/call` |
+| `POST /offer` | Core-internal Bearer + one-time-ticket WebRTC SDP exchange; never called by browser JavaScript |
+| `GET /health` | Sanitized service, RTC, authentication, and registration status |
+| `teleop_session` | `start`, lifecycle `stop`, `prepare_shadow`, `heartbeat`, `pause`, `release`, `soft_stop`, `status`, and diagnostic `submit_shadow_frame` |
+| `teleop_state` | Callable read-only session/lease/Pose/RTC/final-dispatch snapshot |
+
+Only the authenticated MCP `teleop_session.heartbeat` action renews the Core-owned lease. RTC ping, RTC traffic, and Pose arrival never renew it. A stale Core lease, stale Pose, released deadman, tracking loss, or transport disconnect enters `HOLD`. Recovery from a recoverable HOLD requires both current-generation RTC channels plus a strictly higher `clutch_sequence`; `soft_stop`, `pause`, lease expiry, and `release` require release/newer `prepare_shadow` as applicable.
+
+The browser RTC wire frame contains pose and input data only. After a one-time
+offer ticket is verified, the Driver binds that peer to an immutable runtime
+generation and injects the private boot/session/epoch/fence identity internally.
+Client-supplied authority fields are rejected. Session mutations remain on the
+authenticated Core REST → MCP path; RTC control supports diagnostics only.
+
+## Recording final dispatch
+
+Accepted motion uses a one-element mailbox: if frames arrive faster than the
+recording adapter consumes them, only the newest pending frame survives. Before
+each `would_apply`, the owner thread rechecks authority, session generation,
+dispatch generation, deadline, deadman, and tracking. The adapter never receives
+the fence.
+
+Every prepare, HOLD, pause, release, watchdog trip, and graceful shutdown uses a
+separate non-droppable stop path. Control RPCs that promise a safety transition
+wait for its `would_stop` acknowledgement. `teleop_state.dispatch` exposes the
+mailbox depth, generations, last admitted/applied sequence, acknowledgement,
+fault latch, counters, and a bounded record list. These records are executable
+evidence for later live adapters; they are not evidence of physical motion.
+
+Python cannot safely interrupt a vendor SDK call that ignores its timeout. The
+arbiter revokes authority and reports not-ready when such a call exceeds its
+budget, but the process must then be restarted to reclaim the stuck owner
+thread. Live adapters must enforce the timeout in the SDK/transport itself.
+
+The full wire contract and state behavior are in [TELEOP.md](TELEOP.md).
+
+## Run locally
+
+Python 3.10 or newer is required (3.12 is used by the image).
+
+```bash
+cd generic/teleop_shadow
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+
+export MOTUS_DRIVER_TOKEN='replace-with-a-long-random-driver-token'
+export MOTUS_TELEOP_TICKET_SECRET='replace-with-at-least-32-random-bytes'
+export MOTUS_AGENT_CORE_VERIFY_TLS=0  # local development only
+python main.py
+```
+
+Check the independently usable service:
+
+```bash
+curl http://127.0.0.1:15711/health
+
+curl -H "Authorization: Bearer $MOTUS_DRIVER_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  http://127.0.0.1:15711/mcp
+```
+
+`start` is intentionally passive: it reports readiness and does not create a session. Agent Core must call `prepare_shadow` with a new UUID `session_id`, a strictly increasing `epoch`, and a 24–128 character URL-safe random `fence`. Every subsequent protected call and Frame must match `boot_id + session_id + epoch + fence`.
+
+The first adapter event after every process start is `would_stop/startup_safe`.
+If that acknowledgement fails, `/health` reports `ready=false`, registration is
+inhibited, and prepare cannot arm a session.
+
+For a one-command, robot-free proof of the final boundary:
+
+```bash
+python smoke_recording.py
+```
+
+The command exits non-zero unless one valid Frame becomes `would_apply`,
+`soft_stop` is acknowledged as `would_stop`, release revokes the session, and
+the printed JSON remains permanently `actuation_enabled=false`.
+
+## Production deployment
+
+Build through the repository's normal discovery path:
+
+```bash
+./build.sh generic/teleop_shadow
+```
+
+The service fragment explicitly uses `network_mode: host`, because the Dashboard
+deploy path installs the fragment as-is. Its HTTP server binds only
+`127.0.0.1`, so Agent Core can reach MCP and `/offer` through
+`localhost:15711`, while Quest JavaScript cannot reach either private endpoint.
+The `aiortc` peer still gathers host-network ICE candidates for the direct
+DTLS/SCTP data path. The fragment does not request host IPC, host PID, device
+mounts, or privileged mode. It mounts the host Core
+certificate directory read-only:
+
+```text
+/opt/phanthy-motus/data/certs -> /etc/motus-core-certs
+```
+
+Registration pins `/etc/motus-core-certs/cert.pem` with `CERT_REQUIRED`. Hostname checking is disabled because the deployed certificate is currently issued to `phanthy-motus` while host-network registration uses `https://localhost:15678`; certificate trust verification remains enabled. A missing or invalid certificate never silently downgrades TLS: registration reports `tls_error` in `/health` and retries while MCP and shadow diagnostics remain available.
+
+`MOTUS_AGENT_CORE_VERIFY_TLS=0` is the only supported insecure override and is for explicit local development only.
+
+The repository's real `aiortc` scenario currently uses a local test signer. The
+Driver validates and consumes tickets but does not mint them. Production Quest
+JavaScript sends only its SDP offer to authenticated Core; Core signs a ticket,
+calls the pinned loopback Driver `/offer` with its Driver Bearer credential, and
+returns only the sanitized SDP answer. Neither the ticket nor fence is exposed
+to the browser.
+An absent `MOTUS_TELEOP_TICKET_SECRET` is allowed only when registration is
+explicitly disabled and HTTP is bound to loopback for local MCP recording
+diagnostics. In that mode `/health.ready=false`, `rtc_enabled=false`, and the MCP
+descriptor omits signaling, so it cannot be mistaken for a deployable teleop
+instance. Any registering or non-loopback service requires the secret; absent,
+empty, too-short, or invalid UTF-8 values fail process startup instead of
+advertising partial teleoperation readiness. The deployed image health check
+also remains unhealthy until RTC verification is enabled.
+
+## Configuration
+
+| Environment variable | Default | Meaning |
+|---|---|---|
+| `MOTUS_BIND_HOST` | `127.0.0.1` | HTTP bind address; non-loopback requires Driver Bearer authentication and is not used by the bundled deployment |
+| `MOTUS_MCP_PORT` | `15711` | MCP/signaling port |
+| `MOTUS_MCP_URL` | `http://localhost:15711/mcp` | URL advertised to Core |
+| `MOTUS_DRIVER_ID` | `teleop-shadow-driver` | Stable unique 1–64 character instance ID; the default is only suitable for one local instance |
+| `MOTUS_DRIVER_NAME` | `Generic Teleop Shadow Diagnostics` | Human-readable instance name |
+| `MOTUS_ROBOT_ID` | unset | Optional stable 1–64 character robot authority ID; matches Agent Core's authority-domain boundary |
+| `AGENT_CORE_URL` | `https://localhost:15678` | Core base URL |
+| `MOTUS_AGENT_CORE_CA_FILE` | `/etc/motus-core-certs/cert.pem` | Pinned Core certificate |
+| `MOTUS_AGENT_CORE_VERIFY_TLS` | `1` | Set to `0` only for local development |
+| `MOTUS_DRIVER_TOKEN` | unset | Bearer protection for MCP, `/offer`, and registration forwarding; required whenever registration is enabled or HTTP binds beyond loopback; must use 24–4096 restricted ASCII Bearer characters (`A-Z a-z 0-9 . _ ~ + / = -`) |
+| `MOTUS_TELEOP_TICKET_SECRET` | unset | HMAC secret of at least 32 UTF-8 bytes; required for registration or non-loopback binding. Absence is allowed only for registration-disabled loopback diagnostics, whose health is not ready and whose descriptor omits signaling |
+| `CONFIG_PATH` | bundled `config.yaml` | Alternate configuration file |
+
+Do not put either secret into SDP, browser responses, Frames, logs, or status. The ticket is also confidential because its signed payload contains the fence. Public snapshots intentionally omit the fence and remove it from the retained latest Frame. The only unauthenticated mode is an explicitly registration-disabled service bound to loopback for local diagnostics.
+
+### Render multiple instances on one host
+
+[`deploy/instances.example.yml`](deploy/instances.example.yml) is a complete
+two-instance, standalone Shadow input for the strict deployment renderer. Copy it and edit only the
+non-secret instance data:
+
+```yaml
+schema_version: 2
+core_ca_file: /opt/phanthy-motus/data/certs/cert.pem
+instances:
+  - service: teleop-shadow-lab-a
+    container: motus-teleop-shadow-lab-a
+    driver_id: teleop-shadow-lab-a
+    driver_name: Lab A Quest Teleop Shadow
+    robot_id: teleop-shadow-lab-a
+    mcp_port: 15711
+    driver_token_env: MOTUS_TELEOP_SHADOW_LAB_A_DRIVER_TOKEN
+    ticket_secret_env: MOTUS_TELEOP_SHADOW_LAB_A_TICKET_SECRET
+```
+
+Every instance must have a unique `service`, `container`, `driver_id`,
+`robot_id`, and `mcp_port`. Schema v2 also requires `driver_token_env` and
+`ticket_secret_env`: these are non-secret names of host environment variables,
+must match the dedicated `MOTUS_TELEOP_*_DRIVER_TOKEN` or
+`MOTUS_TELEOP_*_TICKET_SECRET` namespace for their role, and must be globally
+unique across every credential role and instance. Generic process variables
+such as `PATH`/`HOME` and the legacy shared secret names are rejected, so an
+already-populated host variable cannot silently satisfy secret preflight. Both
+identity fields are stable 1–64 character
+IDs that match Agent Core's authority boundary; ports are restricted to the
+Driver allocation range `15700-15799`. Unknown fields, duplicate YAML keys,
+unsafe identifiers, non-normalized CA paths, Compose interpolation, and
+identity, port, or credential-reference conflicts are rejected.
+The renderer fixes `network_mode: host`, binds each HTTP endpoint to
+`127.0.0.1`, and mounts only the selected Core CA file read-only. Before any
+output is produced, `core_ca_file` must resolve to an existing regular X.509
+certificate/bundle inside the real `/opt/phanthy-motus` host deployment tree.
+An escaping symlink, device/FIFO, invalid certificate, oversized file, or any
+private-key PEM block is rejected. The canonical public-certificate path is
+written to Compose; the Core private key is never mounted.
+
+Run the renderer on the deployment host, where it can validate that CA file.
+If the bundled single instance is installed, release its session and stop it
+before reusing port `15711`. Confirm every selected port is free with
+`ss -ltnp`; another process can race this check, so Docker health and identity
+checks below remain mandatory. Then build or select an image, inspect the exact
+output, and atomically create a Compose file:
+
+```bash
+docker build -t teleop-shadow:local generic/teleop_shadow
+
+python generic/teleop_shadow/render_instances.py \
+  --instances generic/teleop_shadow/deploy/instances.example.yml \
+  --image teleop-shadow:local \
+  --dry-run
+
+python generic/teleop_shadow/render_instances.py \
+  --instances generic/teleop_shadow/deploy/instances.example.yml \
+  --image teleop-shadow:local \
+  --output generic/teleop_shadow/deploy/teleop-shadow.compose.yml
+
+docker compose \
+  -f /opt/phanthy-motus/docker-compose.yml \
+  stop generic-teleop-shadow  # only when the old bundled service exists
+```
+
+`--dry-run` and `--stdout` emit canonical Compose to stdout and never write a
+file. Normal output uses a same-directory temporary file plus atomic replace,
+so an interrupted render cannot leave a partial Compose document.
+
+#### Migrate a schema v1 instances file
+
+Schema v1 used the same host `MOTUS_DRIVER_TOKEN` and
+`MOTUS_TELEOP_TICKET_SECRET` for every generated service, placing all instances
+in one host trust zone. The v2 renderer deliberately rejects v1 instead of
+silently preserving that credential alias. Migration is a coordinated
+maintenance window, not a zero-downtime credential rotation:
+
+1. Release every active schema v1 session through Core. Do not continue while
+   Core reports an active session or a restart-recovery authority guard.
+2. Stop every service produced by the v1 Compose file. Keep the old services
+   stopped for the remainder of the migration.
+3. Generate a different Driver token using 24–4096 restricted ASCII Bearer
+   characters and a different ticket secret of at least 32 UTF-8 bytes for every
+   exact Driver ID. Provision each value under its new dedicated host
+   environment name.
+4. Put the same values into Core's exact-ID `MOTUS_DRIVER_TOKENS` and
+   `MOTUS_TELEOP_TICKET_SECRETS` maps, set
+   `MOTUS_ENFORCE_DRIVER_AUTH=true`, and restart Core. A mapped ID does not fall
+   back to the legacy shared credential; retain legacy fallbacks only for
+   unrelated Drivers that have not yet migrated.
+5. Change `schema_version` to `2`, add a distinct `driver_token_env` and
+   `ticket_secret_env` to every instance, re-render, run
+   `docker compose config --quiet`, and recreate the stopped services. Editing
+   an already generated Compose file is not a supported migration.
+6. Complete the health, registration, and real `/offer` checks below for every
+   instance before admitting a session.
+7. After every Driver has migrated, remove the legacy Core fallbacks and restart
+   Core once more.
+
+There is no old/new credential overlap for one mapped ID. Do not roll back by
+starting a v1 service against v2 Core maps. If rollback is unavoidable, keep
+the Driver stopped, restore one reviewed matching Core/Driver credential set
+during a maintenance window, restart Core, and repeat all acceptance checks.
+
+The bundled `deploy/service.yml` remains a compatible single-instance fragment
+for the Dashboard deployment path. It still passes the container-standard
+`MOTUS_DRIVER_TOKEN` and `MOTUS_TELEOP_TICKET_SECRET` variables directly. Use
+the schema v2 renderer whenever two or more independently authenticated Shadow
+instances run on one host.
+
+The instances YAML and generated Compose contain no secret values. For each
+service, Compose maps its unique host references into the unchanged container
+variables `MOTUS_DRIVER_TOKEN` and `MOTUS_TELEOP_TICKET_SECRET`; a missing or
+empty value makes `docker compose config` fail before a container starts. The
+renderer never reads these host values, so Compose checks only presence; Driver
+and Core enforce the contract of 24–4096 restricted ASCII Bearer characters and
+the 32-byte ticket minimum at startup. Agent Core must be configured through
+`MOTUS_DRIVER_TOKENS` and `MOTUS_TELEOP_TICKET_SECRETS` with the matching exact
+Driver-ID-specific values before that instance can register and negotiate RTC.
+Core must also reject duplicate secret values, because a renderer can prove
+references are distinct but cannot inspect secret-manager values.
+
+Supply both values from a secret manager or read them without putting literal
+values into shell history, then validate and start the independently named
+services:
+
+```bash
+read -rsp 'Lab A Driver token (24–4096 restricted ASCII Bearer characters): ' \
+  MOTUS_TELEOP_SHADOW_LAB_A_DRIVER_TOKEN \
+  && export MOTUS_TELEOP_SHADOW_LAB_A_DRIVER_TOKEN
+printf '\n'
+read -rsp 'Lab A ticket secret (at least 32 UTF-8 bytes): ' \
+  MOTUS_TELEOP_SHADOW_LAB_A_TICKET_SECRET \
+  && export MOTUS_TELEOP_SHADOW_LAB_A_TICKET_SECRET
+printf '\n'
+read -rsp 'Lab B Driver token (24–4096 restricted ASCII Bearer characters): ' \
+  MOTUS_TELEOP_SHADOW_LAB_B_DRIVER_TOKEN \
+  && export MOTUS_TELEOP_SHADOW_LAB_B_DRIVER_TOKEN
+printf '\n'
+read -rsp 'Lab B ticket secret (at least 32 UTF-8 bytes): ' \
+  MOTUS_TELEOP_SHADOW_LAB_B_TICKET_SECRET \
+  && export MOTUS_TELEOP_SHADOW_LAB_B_TICKET_SECRET
+printf '\n'
+
+docker compose \
+  -f generic/teleop_shadow/deploy/teleop-shadow.compose.yml \
+  config --quiet
+
+docker compose \
+  -f generic/teleop_shadow/deploy/teleop-shadow.compose.yml \
+  up -d
+```
+
+Use `docker compose config --quiet` for validation so resolved environment
+values are not printed. Do not use plain `docker compose config` in logs or
+review artifacts because it resolves the references. The example deliberately
+sets `robot_id == driver_id`:
+each service is therefore a directly usable, standalone Shadow authority
+domain and needs no physical-robot binding. The registration payload, tool
+descriptors, `teleop_state`, and `/health` report each configured identity;
+`boot_id` remains unique per process start. The image health check reads each
+service's `MOTUS_MCP_PORT`, so it follows the rendered per-instance port rather
+than the single-instance default.
+
+Verify both independent services instead of accepting only a container state:
+
+```bash
+docker compose \
+  -f generic/teleop_shadow/deploy/teleop-shadow.compose.yml \
+  ps
+curl -fsS http://127.0.0.1:15711/health | python3 -m json.tool
+curl -fsS http://127.0.0.1:15712/health | python3 -m json.tool
+```
+
+Each health response must show its exact `driver_id == robot_id`, the expected
+port's identity, `ready=true`, `rtc_enabled=true`, `mode=shadow`, and
+`actuation_enabled=false`. Then query Core's authenticated
+`GET /api/teleop/robots`; both entries must report `teleop_ready=true` and
+`reason=ready` before Acquire is considered usable. These checks prove local
+configuration, not that Core and Driver hold the same ticket secret.
+
+For each instance, acquire a fresh Shadow session in Core's `/teleop` console
+and click **Connect WebRTC Shadow**. This generates a real browser SDP offer,
+posts it through Core's authenticated
+`/api/teleop/sessions/{session_id}/signaling/offer` route, and exercises the
+private Driver `/offer` endpoint. Accept the instance only after the browser
+reports a connected peer, `teleop-control` and `teleop-pose` are both open, and
+Driver `teleop_state.rtc.connected` is true. Disconnect and release that
+session before checking the next instance. A Driver response of
+`401 invalid_signature` means its `ticket_secret_env` value does not match the
+Core map; fix the mapping instead of enabling a shared fallback. Browser code
+must never call the Driver `/offer` endpoint directly because the one-time
+ticket and authority fence remain server-side.
+
+#### Bind a Shadow adapter to an existing physical robot
+
+To share one command authority domain with a real robot, configure the Shadow
+instance's `robot_id` to the exact ID of an existing trusted HTTP root Driver
+*before its first registration*. That root must expose at least one ordinary
+actuator and must not itself be an authority alias. The Shadow Driver cannot
+approve this relationship and the renderer never accepts an owner token.
+
+After both Drivers have registered as trusted, an owner stages the binding:
+
+```bash
+curl --fail-with-body \
+  --cacert /opt/phanthy-motus/data/certs/cert.pem \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -X PUT \
+  -d '{"root_mcp_id":"g1-driver"}' \
+  https://localhost:15678/api/mcp/teleop-shadow-lab-a/authority-domain
+```
+
+The response must be `202` with `restart_required=true`. Release every teleop
+session, restart Core through the normal deployment path, and query
+`GET /api/mcp` plus `GET /api/teleop/robots`. Accept the binding only when the
+active `authority_domain`, descriptor `robot_id`, and root ID are identical and
+the teleop directory reports `reason=ready`. There is no automatic session,
+heartbeat, RTC, or authority recovery across that restart; Acquire again with
+a new epoch. To remove a binding, stop the Shadow instance, use the owner-only
+`DELETE /api/mcp/{driver_id}/authority-domain`, restart Core, and keep the
+instance stopped until its immutable registered robot identity is deliberately
+re-provisioned under a new reviewed Driver ID.
+
+The CA mount is canonicalized at render time. After Core certificate/CA
+rotation, re-run the renderer, recreate every generated service, and repeat
+registration TLS plus `/health` identity checks; do not assume an old bind
+mount followed a certificate-manager symlink.
+
+## Tests
+
+```bash
+cd generic/teleop_shadow
+python -m unittest discover -s tests -v
+```
+
+The suite covers pure protocol/runtime logic, the standalone recording smoke
+proof, authenticated MCP over local HTTP, certificate-pinned local TLS, and an
+actual local `aiortc` offer with both required data channels and visible
+`would_apply`/disconnect `would_stop` evidence. It also validates deterministic
+schema v2 multi-instance Compose rendering, strict identity and credential
+reference conflicts, 23/24-byte Bearer and 31/32-byte ticket boundaries,
+cross-instance Bearer rejection, A ticket acceptance on A plus
+`invalid_signature` rejection on B, secret absence from rendered output and
+health, atomic output, and the dynamic RTC-required container health check.
+
+## Third-party use
+
+- `aiohttp` provides HTTP/MCP signaling and outbound registration (Apache-2.0/MIT).
+- `aiortc` provides the standards-based ICE/DTLS/SCTP/WebRTC implementation (BSD-3-Clause). This Driver does not implement or fork WebRTC.
+- `cryptography` is the bounded TLS/DTLS crypto backend used by `aiortc` (Apache-2.0/BSD-3-Clause).
+- `PyYAML` loads deployment configuration (MIT).
+
+See `requirements.txt` for the bounded supported version ranges.

--- a/generic/teleop_shadow/TELEOP.md
+++ b/generic/teleop_shadow/TELEOP.md
@@ -1,0 +1,194 @@
+# Teleop Shadow Wire Contract
+
+This document defines the first deployable teleoperation slice. It is a protocol and diagnostics target, not a robot controller. Every response and capability declaration must continue to report `mode=shadow` and `actuation_enabled=false`.
+
+Both MCP tool descriptors advertise `x-teleop.protocol=motus.teleop.shadow.v1`
+and `x-teleop.dispatch_contract=motus.teleop.dispatch.recording.v1`; Core uses
+those exact values to select the session and final-dispatch validation contracts.
+
+## Authority and session identity
+
+Agent Core owns session authority. After a passive lifecycle `start`, Core calls:
+
+```json
+{
+  "action": "prepare_shadow",
+  "session_id": "11111111-1111-1111-1111-111111111111",
+  "epoch": 1,
+  "fence": "replace_with_24_or_more_urlsafe_chars"
+}
+```
+
+The Driver contributes a process-unique `boot_id`. The resulting identity tuple is:
+
+```text
+boot_id + session_id + epoch + fence
+```
+
+The epoch must strictly increase during one Driver boot. A restart changes `boot_id`, invalidating all earlier Frames and tickets. The fence is confidential authority material: MCP `status`, `teleop_state`, `/health`, `/offer` answers, and retained public Frame diagnostics never return it.
+
+## Lifecycle and watchdog behavior
+
+| Event | Result |
+|---|---|
+| `start` | Readiness only; state remains `idle` or the current safe state |
+| `prepare_shadow` with newer epoch | `prepared_shadow`; resets latest Pose and transport state |
+| First valid deadman/tracking Frame with fresh lease | `active_shadow` |
+| Pose older than configured timeout | `hold / pose_timeout` |
+| MCP heartbeat lease expires | irreversibly revokes authority, clears identity/Pose/RTC, and reports `hold / lease_timeout`; a new epoch is required |
+| deadman false or any required tracking false | `hold` |
+| RTC channel/peer disconnect | `hold` |
+| Valid Frame with a strictly higher `clutch_sequence` | resumes a recoverable HOLD only when the required transport is fully ready |
+| `pause` | `paused`; Frames cannot resume it |
+| `soft_stop` | acknowledged `hold / soft_stop`; Frames cannot resume it |
+| `release` or lifecycle `stop` | clears Pose and closes RTC; no output is possible |
+
+`release` atomically revokes the session/fence/lease, clears retained Pose, and advances the internal transport generation. Delayed heartbeat, pause, soft-stop, Frame, ticket, and RTC callback traffic from that authority cannot leave `released`; only `prepare_shadow` with a newer epoch/fence can create another session. A paused session likewise cannot be converted back into a recoverable HOLD by a delayed soft-stop.
+
+`soft_stop` retains the Core lease and authority only so Core can observe and
+release the held session. It is motion-inhibited and cannot be undone by a Pose
+Frame or higher `clutch_sequence`; recovery is release followed by a newer
+`prepare_shadow`.
+
+Lease expiry uses the same independent `authority_valid=false` latch; authorization never depends on the mutable display `reason`. Every authority boundary checks its monotonic deadline while holding the runtime lock, so even a heartbeat arriving after the deadline but before the watchdog tick is rejected. The first expiry clears session/fence/lease/Pose and RTC state and advances the internal generation exactly once. Delayed pause, soft-stop, heartbeat, Frame, ticket, and RTC callbacks cannot overwrite the latch. Only a higher-epoch `prepare_shadow` sets `authority_valid=true` again.
+
+All watchdog ages use the server monotonic clock. `client_monotonic_ns` is diagnostic sequencing data and is never trusted as the server watchdog clock.
+
+The Core lease and Pose freshness are independent:
+
+- only an authenticated MCP `heartbeat` renews the Core lease;
+- an RTC `heartbeat` message is explicitly rejected;
+- `peer_ping`, channel activity, and accepted Pose Frames do not renew the lease;
+- Pose arrival updates only Pose freshness.
+
+## Strict Frame v1
+
+Frames are JSON objects with no unknown fields and a maximum canonical JSON size of 64 KiB. Numbers must be finite. `sequence` and `clutch_sequence` are integers in `[0, 9223372036854775807]` (`2^63 - 1`) so recording-v1 values remain representable by Core. Positions are metres in `[-100, 100]`; orientations are normalized `[x,y,z,w]` quaternions; axes/buttons and optional twists are bounded by the validator.
+
+```json
+{
+  "schema_version": 1,
+  "boot_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  "session_id": "11111111-1111-1111-1111-111111111111",
+  "epoch": 1,
+  "fence": "replace_with_24_or_more_urlsafe_chars",
+  "sequence": 42,
+  "client_monotonic_ns": 1234567890,
+  "mode": "shadow",
+  "deadman": true,
+  "clutch_sequence": 3,
+  "tracking": {
+    "head": true,
+    "left_controller": true,
+    "right_controller": true
+  },
+  "head": {
+    "position": [0.0, 1.7, 0.0],
+    "orientation": [0.0, 0.0, 0.0, 1.0]
+  },
+  "left_controller": {
+    "position": [-0.3, 1.2, -0.2],
+    "orientation": [0.0, 0.0, 0.0, 1.0]
+  },
+  "right_controller": {
+    "position": [0.3, 1.2, -0.2],
+    "orientation": [0.0, 0.0, 0.0, 1.0]
+  },
+  "controllers": {
+    "left": {"axes": [0.0, 0.0], "buttons": [0.0, 1.0]},
+    "right": {"axes": [0.0, 0.0], "buttons": [0.0, 1.0]}
+  },
+  "base_twist": {
+    "linear": [0.0, 0.0, 0.0],
+    "angular": [0.0, 0.0, 0.0]
+  }
+}
+```
+
+`base_twist` is the only optional field. When a tracking flag is false, its matching Pose must be `null`; when true, that Pose is required. `sequence` must strictly increase per prepared session. The Driver retains only the latest normalized Frame, not an unbounded queue.
+
+`submit_shadow_frame` accepts this same contract through MCP for low-rate diagnostics and replay tests. Production high-rate Pose uses the RTC Pose channel.
+
+## WebRTC transport
+
+The browser wire subcontracts are explicitly versioned as
+`motus.teleop.rtc-frame.v1` and `motus.teleop.rtc-control.v1`; the SDP exchange
+is `motus.teleop.webrtc-offer-answer.v1`. They are advertised in the capability
+digest so a behavior change cannot silently reuse a pinned session contract.
+
+The client creates both channels before generating its offer:
+
+| Label | Contract | Payload |
+|---|---|---|
+| `teleop-control` | reliable and ordered (`ordered=true`, no retransmit/lifetime limit) | UTF-8 JSON control messages, max 8 KiB |
+| `teleop-pose` | unordered, no retransmission (`ordered=false`, `maxRetransmits=0`) | browser-safe RTC Frame v1 UTF-8 JSON, max 64 KiB |
+
+Unknown labels, duplicate labels, or different reliability parameters are closed. The service uses `aiortc` for SDP, ICE, DTLS, SCTP, and data channels.
+
+The RTC wire Frame contains the same motion fields as Frame v1 but must omit
+`boot_id`, `session_id`, `epoch`, and `fence`. After verifying the offer ticket,
+the Driver atomically captures the active authority and runtime generation and
+binds that immutable snapshot to the peer. It rejects client-supplied private
+identity fields, injects the peer binding server-side, and then runs the same
+strict Frame/runtime/final-dispatch checks as the authenticated MCP diagnostic
+path. The complete authority-bearing Frame v1 remains required for
+`submit_shadow_frame` over MCP.
+
+An RTC Frame is accepted only when its peer still belongs to the current internal session generation and both required channels are simultaneously open. A Pose-only connection cannot activate a session. If either channel closes, remaining Pose traffic is rejected and cannot reclutch out of HOLD; a complete transport reconnect must restore both channels first. This gate is atomic with Frame acceptance. The explicitly low-rate MCP `submit_shadow_frame` diagnostic path is independent of RTC readiness.
+
+Authenticated Core, never browser JavaScript, sends an offer to the Driver's
+loopback `POST /offer` endpoint with the Driver Bearer header:
+
+```json
+{"type":"offer","sdp":"v=0...","ticket":"<one-time ticket>"}
+```
+
+The response is a standard `answer` plus sanitized binding metadata. It never includes the fence. A ticket is signed, not encrypted, and contains the fence in its claims; production browser flows therefore send only SDP to authenticated Core, which proxies this private request and returns only `{type,sdp}`. The Driver rejects `/offer` without the configured Core Driver Bearer credential.
+
+## One-time offer ticket
+
+Core and the Driver share `MOTUS_TELEOP_TICKET_SECRET` (at least 32 bytes). A ticket is:
+
+```text
+base64url(canonical-json-claims) + "." + base64url(HMAC-SHA256)
+```
+
+Required claims are `v`, `aud`, `boot_id`, `session_id`, `epoch`, `fence`, `capability_digest`, `sdp_sha256`, `iat`, `exp`, and `jti`. The audience is `teleop-shadow-rtc`; the default maximum lifetime is 30 seconds. Verification requires:
+
+- a valid HMAC;
+- an unexpired, bounded lifetime;
+- exact active boot/session/epoch/fence/capability binding;
+- SHA-256 binding to the exact offer SDP;
+- a previously unseen `jti` in the bounded replay cache.
+
+The ticket is consumed before SDP negotiation, so a failed negotiation still requires a new ticket. An absent secret is allowed only for an explicitly registration-disabled, loopback-bound local diagnostic process; that process reports health not ready, omits signaling from its MCP descriptor, and returns fail-closed `503` from `/offer`. Registration, non-loopback binding, or any configured empty/too-short/invalid secret fails process startup.
+
+## Control messages
+
+`peer_ping` and `status` return only state and explicitly report `lease_renewed=false`. A message with `type=heartbeat` returns `rtc_cannot_renew_lease`. `pause`, `soft_stop`, and `release` return `rtc_control_requires_core`; callers must use the authenticated Core REST API, which keeps Core's ownership state and audit trail synchronized with Driver MCP state. Private authority fields are invalid on the RTC control channel.
+
+## Recording final-dispatch boundary
+
+There is deliberately no robot adapter in this package. Instead, a
+`RecordingAdapter` makes the complete final-dispatch decision visible as bounded
+`would_apply` and `would_stop` records.
+
+Motion and stop do not share a replaceable queue. Motion has a latest-only
+mailbox of depth one; stop requests use a non-droppable priority queue and carry
+their own acknowledgement. Before every `would_apply`, the serial owner thread
+rechecks authority digest, session generation, dispatch generation, server-side
+deadline, deadman, and tracking. The fence is consumed by admission and is never
+given to the adapter or returned in dispatch state.
+
+Preparing over an active session invalidates the previous generation and waits
+for a stop acknowledgement before the new authority is installed. Adapter
+failure latches a fault and schedules the independent safe-stop path. Graceful
+close revokes authority, waits for stop acknowledgement, closes the adapter, and
+rejects later Frames. A new process has a new `boot_id` and performs
+`startup_safe` before reporting ready.
+
+Future robot-specific PRs consume the same fenced intent/stop contract behind a
+hardware safety policy. They must not weaken this Driver's shadow-only contract
+or reinterpret recording state as proof of robot actuation. Physical adapters
+also need a downstream command TTL/watchdog so `kill -9` converges to zero even
+when the Driver process cannot run its graceful stop path.

--- a/generic/teleop_shadow/config.yaml
+++ b/generic/teleop_shadow/config.yaml
@@ -1,0 +1,22 @@
+driver_id: "teleop-shadow-driver"
+driver_name: "Generic Teleop Shadow Diagnostics"
+robot_id: null
+mcp_port: 15711
+bind_host: "127.0.0.1"
+
+teleop:
+  lease_timeout_ms: 1000
+  pose_timeout_ms: 200
+  watchdog_interval_ms: 25
+  dispatch_io_timeout_ms: 100
+  dispatch_ack_timeout_ms: 200
+  ticket_ttl_max_seconds: 30
+  ticket_replay_cache_entries: 4096
+
+registration:
+  enabled: true
+  agent_core_url: "https://localhost:15678"
+  advertise_url: "http://localhost:15711/mcp"
+  interval_seconds: 30
+  verify_tls: true
+  ca_file: "/etc/motus-core-certs/cert.pem"

--- a/generic/teleop_shadow/deploy/instances.example.yml
+++ b/generic/teleop_shadow/deploy/instances.example.yml
@@ -1,0 +1,19 @@
+schema_version: 2
+core_ca_file: /opt/phanthy-motus/data/certs/cert.pem
+instances:
+  - service: teleop-shadow-lab-a
+    container: motus-teleop-shadow-lab-a
+    driver_id: teleop-shadow-lab-a
+    driver_name: Lab A Quest Teleop Shadow
+    robot_id: teleop-shadow-lab-a
+    mcp_port: 15711
+    driver_token_env: MOTUS_TELEOP_SHADOW_LAB_A_DRIVER_TOKEN
+    ticket_secret_env: MOTUS_TELEOP_SHADOW_LAB_A_TICKET_SECRET
+  - service: teleop-shadow-lab-b
+    container: motus-teleop-shadow-lab-b
+    driver_id: teleop-shadow-lab-b
+    driver_name: Lab B Quest Teleop Shadow
+    robot_id: teleop-shadow-lab-b
+    mcp_port: 15712
+    driver_token_env: MOTUS_TELEOP_SHADOW_LAB_B_DRIVER_TOKEN
+    ticket_secret_env: MOTUS_TELEOP_SHADOW_LAB_B_TICKET_SECRET

--- a/generic/teleop_shadow/deploy/service.yml
+++ b/generic/teleop_shadow/deploy/service.yml
@@ -1,0 +1,25 @@
+generic-teleop-shadow:
+  image: __IMAGE__
+  container_name: embodied-generic-teleop-shadow
+  network_mode: host
+  volumes:
+    - /opt/phanthy-motus/data/certs:/etc/motus-core-certs:ro
+  environment:
+    - MOTUS_BIND_HOST=127.0.0.1
+    - MOTUS_MCP_PORT=15711
+    - MOTUS_MCP_URL=http://localhost:15711/mcp
+    - MOTUS_DRIVER_ID
+    - MOTUS_DRIVER_NAME
+    - MOTUS_ROBOT_ID
+    - MOTUS_DRIVER_TOKEN=${MOTUS_DRIVER_TOKEN:?set MOTUS_DRIVER_TOKEN before Docker Compose validation}
+    - MOTUS_TELEOP_TICKET_SECRET=${MOTUS_TELEOP_TICKET_SECRET:?set MOTUS_TELEOP_TICKET_SECRET before Docker Compose validation}
+    - AGENT_CORE_URL=https://localhost:15678
+    - MOTUS_AGENT_CORE_VERIFY_TLS=1
+    - MOTUS_AGENT_CORE_CA_FILE=/etc/motus-core-certs/cert.pem
+    - PYTHONUNBUFFERED=1
+  logging:
+    driver: local
+    options:
+      max-size: "10m"
+      max-file: "3"
+  restart: unless-stopped

--- a/generic/teleop_shadow/dispatch.py
+++ b/generic/teleop_shadow/dispatch.py
@@ -1,0 +1,826 @@
+"""Final-dispatch arbitration for the robot-free teleop Shadow Driver.
+
+The adapter in this package records what a live adapter *would* receive.  It
+never imports a robot SDK or publishes a hardware command.  The arbiter is the
+executable reference for the safety boundary that later live adapters must
+implement: a one-slot motion mailbox, a non-droppable stop path, generation
+fencing, final deadline checks, and acknowledged startup/shutdown safety.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import hmac
+import json
+import math
+import re
+import threading
+import time
+from collections import Counter, deque
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from protocol import MAX_SEQUENCE
+
+_TRACKING_KEYS = frozenset({"head", "left_controller", "right_controller"})
+_ACK_CODE_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+
+def _tracking_ready(value: Any) -> bool:
+    return (
+        isinstance(value, Mapping)
+        and set(value) == _TRACKING_KEYS
+        and all(item is True for item in value.values())
+    )
+
+
+def _normalized_ack(value: Any, invalid_code: str) -> AdapterAck:
+    if not isinstance(value, AdapterAck) or not isinstance(value.ok, bool):
+        return AdapterAck(False, invalid_code)
+    if not isinstance(value.code, str) or not _ACK_CODE_RE.fullmatch(value.code):
+        return AdapterAck(False, invalid_code)
+    return value
+
+
+@dataclass(frozen=True)
+class AdapterAck:
+    """Bounded adapter acknowledgement with a stable, non-secret code."""
+
+    ok: bool
+    code: str = "ok"
+
+
+@dataclass(frozen=True)
+class MotionIntent:
+    """Sanitized motion intent delivered to an output adapter.
+
+    ``frame`` deliberately omits the fence.  Session and dispatch generations
+    are internal monotonic fences and are safe to expose to a test adapter.
+    """
+
+    session_generation: int
+    dispatch_generation: int
+    sequence: int
+    clutch_sequence: int
+    admitted_monotonic: float
+    expires_monotonic: float
+    frame: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class StopRequest:
+    dispatch_generation: int
+    reason: str
+    requested_monotonic: float
+    deadline_monotonic: float
+
+
+class OutputAdapter(Protocol):
+    """Serial adapter contract used by the final-dispatch owner thread.
+
+    Implementations must enforce their deadline in the same critical section as
+    the real SDK write. ``apply`` may not leave an unbounded background output;
+    any asynchronous downstream work must carry the supplied generation and a
+    hardware-enforced TTL. A successful ``safe_stop`` ack means all older
+    generations are cancelled, drained, or made incapable of later output.
+    Adapter methods must also impose their own downstream I/O timeout: Python
+    can detect a stalled call and revoke authority, but cannot interrupt a
+    blocking vendor SDK call safely. Adapter methods must not re-enter the
+    arbiter; a defensive self-close rejection exists only to avoid deadlock.
+    """
+
+    def startup_safe(self, deadline_monotonic: float) -> AdapterAck: ...
+
+    def apply(self, intent: MotionIntent) -> AdapterAck: ...
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck: ...
+
+    def snapshot(self) -> dict: ...
+
+    def close(self) -> AdapterAck | None: ...
+
+
+class StopHandle:
+    """Waitable result for one non-droppable safety request."""
+
+    def __init__(self, request: StopRequest, *, safety_deadline: float):
+        self.request = request
+        self.safety_deadline = safety_deadline
+        self._event = threading.Event()
+        self._ack: AdapterAck | None = None
+
+    def _finish(self, ack: AdapterAck) -> None:
+        self._ack = ack
+        self._event.set()
+
+    def wait(self, timeout: float) -> AdapterAck:
+        if not self._event.wait(timeout):
+            return AdapterAck(False, "stop_ack_timeout")
+        return self._ack or AdapterAck(False, "stop_ack_missing")
+
+    @property
+    def done(self) -> bool:
+        return self._event.is_set()
+
+
+@dataclass(frozen=True)
+class _PendingMotion:
+    intent: MotionIntent
+    authority_digest: str
+
+
+def _binding_digest(value: Mapping[str, Any]) -> str:
+    required = ("boot_id", "session_id", "epoch", "fence")
+    if any(key not in value for key in required):
+        raise ValueError("authority binding is incomplete")
+    encoded = json.dumps(
+        {key: value[key] for key in required},
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class RecordingAdapter:
+    """Bounded, thread-safe zero-actuation adapter for visible verification."""
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        max_records: int = 64,
+    ):
+        if max_records < 8 or max_records > 4096:
+            raise ValueError("max_records must be in [8, 4096]")
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._records: deque[dict] = deque(maxlen=max_records)
+        self._current = {"kind": "safe", "reason": "not_started"}
+        self._closed = False
+
+    def _record(self, value: dict) -> None:
+        record = {"recorded_monotonic": self._clock(), **copy.deepcopy(value)}
+        self._records.append(record)
+        self._current = copy.deepcopy(value)
+
+    def startup_safe(self, deadline_monotonic: float) -> AdapterAck:
+        with self._lock:
+            if self._closed:
+                return AdapterAck(False, "adapter_closed")
+            self._record({
+                "kind": "would_stop",
+                "reason": "startup_safe",
+                "dispatch_generation": 0,
+                "deadline_monotonic": deadline_monotonic,
+            })
+            if self._clock() >= deadline_monotonic:
+                return AdapterAck(False, "startup_safe_deadline_missed")
+            return AdapterAck(True)
+
+    def apply(self, intent: MotionIntent) -> AdapterAck:
+        with self._lock:
+            if self._closed:
+                return AdapterAck(False, "adapter_closed")
+            if self._clock() >= intent.expires_monotonic:
+                return AdapterAck(False, "intent_expired_at_adapter")
+            # The adapter contract itself refuses unsafe content even if a
+            # caller accidentally bypasses the runtime admission layer.
+            if intent.frame.get("deadman") is not True:
+                return AdapterAck(False, "unsafe_deadman")
+            if not _tracking_ready(intent.frame.get("tracking")):
+                return AdapterAck(False, "unsafe_tracking")
+            self._record({
+                "kind": "would_apply",
+                "sequence": intent.sequence,
+                "clutch_sequence": intent.clutch_sequence,
+                "session_generation": intent.session_generation,
+                "dispatch_generation": intent.dispatch_generation,
+                "base_twist": copy.deepcopy(intent.frame.get("base_twist")),
+            })
+            return AdapterAck(True)
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck:
+        with self._lock:
+            if self._closed:
+                return AdapterAck(False, "adapter_closed")
+            self._record({
+                "kind": "would_stop",
+                "reason": request.reason,
+                "dispatch_generation": request.dispatch_generation,
+                "deadline_monotonic": request.deadline_monotonic,
+            })
+            if self._clock() >= request.deadline_monotonic:
+                return AdapterAck(False, "adapter_stop_deadline_missed")
+            return AdapterAck(True)
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            return {
+                "kind": "recording",
+                "closed": self._closed,
+                "current": copy.deepcopy(self._current),
+                "records": copy.deepcopy(list(self._records)),
+            }
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+
+
+class FinalDispatchArbiter:
+    """Own all adapter I/O and enforce the last command authority check."""
+
+    _MOTION_STATES = frozenset({"safe_waiting_frame", "motion_eligible"})
+
+    def __init__(
+        self,
+        adapter: OutputAdapter,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        safety_clock: Callable[[], float] = time.monotonic,
+        io_timeout_ms: int = 250,
+    ):
+        if io_timeout_ms < 20 or io_timeout_ms > 5000:
+            raise ValueError("io_timeout_ms must be in [20, 5000]")
+        self._adapter = adapter
+        self._clock = clock
+        self._safety_clock = safety_clock
+        self._io_timeout = io_timeout_ms / 1000.0
+        self._condition = threading.Condition(threading.RLock())
+        self._stop_queue: deque[StopHandle] = deque()
+        self._mailbox: _PendingMotion | None = None
+        self._generation = 0
+        self._authority_digest: str | None = None
+        self._session_generation: int | None = None
+        self._state = "starting"
+        self._fault_code: str | None = None
+        self._stop_acknowledged = False
+        self._last_admitted_sequence: int | None = None
+        self._last_applied_sequence: int | None = None
+        self._last_decision = "starting"
+        self._counters: Counter[str] = Counter()
+        self._shutdown = False
+        self._closed = False
+        self._close_lock = threading.Lock()
+        self._adapter_snapshot_lock = threading.Lock()
+        self._close_result: AdapterAck | None = None
+        self._adapter_close_ack: AdapterAck | None = None
+        self._adapter_snapshot: dict = {
+            "kind": "unavailable",
+            "reason": "startup_in_progress",
+        }
+        self._io_inflight_kind: str | None = None
+        self._io_deadline_safety: float | None = None
+        self._startup_done = threading.Event()
+        self._startup_decision = threading.Event()
+        self._startup_owner_done = threading.Event()
+        # Fail-safe default: unless the constructor explicitly hands the
+        # adapter to the final-dispatch worker, the startup owner closes it
+        # after startup_safe eventually returns.
+        self._startup_should_close = True
+
+        started_at = self._clock()
+        started_safety = self._safety_clock()
+        startup_result: list[AdapterAck] = []
+
+        def run_startup_safe() -> None:
+            try:
+                startup_result.append(_normalized_ack(
+                    adapter.startup_safe(started_at + self._io_timeout),
+                    "invalid_startup_ack",
+                ))
+            except Exception:  # noqa: BLE001 -- normalize adapter faults
+                startup_result.append(AdapterAck(False, "startup_safe_exception"))
+            finally:
+                self._capture_adapter_snapshot_owned()
+                self._startup_done.set()
+            # The startup call may outlive the constructor timeout.  It keeps
+            # exclusive adapter ownership until the constructor chooses either
+            # a worker hand-off or cleanup; close/snapshot never race it.
+            self._startup_decision.wait()
+            try:
+                if self._startup_should_close:
+                    self._close_adapter_owned()
+            finally:
+                self._startup_owner_done.set()
+
+        self._startup_thread = threading.Thread(
+            target=run_startup_safe,
+            daemon=True,
+            name="teleop-shadow-startup-safe",
+        )
+        self._startup_thread.start()
+        completed = self._startup_done.wait(self._io_timeout)
+        elapsed_safety = self._safety_clock() - started_safety
+        ack = (
+            startup_result[0]
+            if completed and startup_result
+            else AdapterAck(False, "startup_safe_timeout")
+        )
+        if ack.ok and elapsed_safety <= self._io_timeout:
+            self._state = "safe_unarmed"
+            self._stop_acknowledged = True
+            self._last_decision = "startup_safe_ack"
+            self._counters["startup_safe_acks"] += 1
+        else:
+            self._state = "fault_latched"
+            self._fault_code = "startup_safe_timeout" if ack.ok else ack.code
+            self._last_decision = "startup_safe_failed"
+            self._counters["adapter_faults"] += 1
+
+        self._worker: threading.Thread | None = None
+        if self._fault_code is None:
+            self._startup_should_close = False
+        self._startup_decision.set()
+        if self._fault_code is None:
+            # The startup owner performs no adapter calls after hand-off.  This
+            # short wait also prevents successful starts from leaving a
+            # transient daemon behind in short-lived tests.
+            self._startup_owner_done.wait(self._io_timeout)
+            self._worker = threading.Thread(
+                target=self._worker_loop,
+                daemon=True,
+                name="teleop-shadow-final-dispatch",
+            )
+            self._worker.start()
+
+    @property
+    def ready(self) -> bool:
+        with self._condition:
+            self._refresh_io_stall_locked()
+            return self._fault_code is None and not self._closed
+
+    def begin_prepare(self) -> StopHandle:
+        return self.trip(
+            "prepare_shadow",
+            target_state="transitioning",
+            retain_authority=False,
+        )
+
+    def complete_prepare(
+        self,
+        handle: StopHandle,
+        binding: Mapping[str, Any],
+        session_generation: int,
+    ) -> AdapterAck:
+        digest = _binding_digest(binding)
+        with self._condition:
+            if self._closed:
+                return AdapterAck(False, "dispatch_closed")
+            if self._fault_code is not None:
+                return AdapterAck(False, self._fault_code)
+            if (
+                handle.request.dispatch_generation != self._generation
+                or not handle.done
+                or self._state != "transitioning"
+            ):
+                return AdapterAck(False, "prepare_superseded")
+            ack = handle.wait(0)
+            if not ack.ok:
+                return ack
+            self._authority_digest = digest
+            self._session_generation = session_generation
+            self._state = "safe_waiting_frame"
+            self._stop_acknowledged = True
+            self._last_admitted_sequence = None
+            self._last_applied_sequence = None
+            self._last_decision = "prepared_after_stop_ack"
+            self._counters["sessions_armed"] += 1
+            return AdapterAck(True)
+
+    def publish_latest(
+        self,
+        frame: Mapping[str, Any],
+        *,
+        session_generation: int,
+        expires_monotonic: float,
+        allow_reclutch: bool = False,
+    ) -> AdapterAck:
+        if frame.get("deadman") is not True:
+            return AdapterAck(False, "unsafe_deadman")
+        if not _tracking_ready(frame.get("tracking")):
+            return AdapterAck(False, "unsafe_tracking")
+        try:
+            digest = _binding_digest(frame)
+            sequence = frame["sequence"]
+            clutch_sequence = frame["clutch_sequence"]
+            if (
+                isinstance(sequence, bool)
+                or not isinstance(sequence, int)
+                or sequence < 0
+                or sequence > MAX_SEQUENCE
+            ):
+                raise ValueError("invalid sequence")
+            if (
+                isinstance(clutch_sequence, bool)
+                or not isinstance(clutch_sequence, int)
+                or clutch_sequence < 0
+                or clutch_sequence > MAX_SEQUENCE
+            ):
+                raise ValueError("invalid clutch sequence")
+            expiry = float(expires_monotonic)
+            if not math.isfinite(expiry):
+                raise ValueError("invalid expiry")
+        except (KeyError, TypeError, ValueError, OverflowError):
+            return AdapterAck(False, "invalid_intent")
+
+        admitted = self._clock()
+        sanitized = copy.deepcopy(dict(frame))
+        sanitized.pop("fence", None)
+        with self._condition:
+            if self._closed:
+                return AdapterAck(False, "dispatch_closed")
+            if self._fault_code is not None:
+                return AdapterAck(False, self._fault_code)
+            if self._session_generation != session_generation:
+                return AdapterAck(False, "stale_session_generation")
+            if self._authority_digest is None or not hmac.compare_digest(
+                digest, self._authority_digest
+            ):
+                return AdapterAck(False, "authority_mismatch")
+            if self._state == "safe_reclutch_required" and allow_reclutch:
+                self._state = "motion_eligible"
+                self._counters["dispatch_reclutches"] += 1
+            elif self._state not in self._MOTION_STATES:
+                return AdapterAck(False, "motion_inhibited")
+            if expiry <= admitted:
+                return AdapterAck(False, "intent_expired")
+            if (
+                self._last_admitted_sequence is not None
+                and sequence <= self._last_admitted_sequence
+            ):
+                return AdapterAck(False, "sequence_not_increasing")
+            if self._mailbox is not None:
+                self._counters["mailbox_replacements"] += 1
+            intent = MotionIntent(
+                session_generation=session_generation,
+                dispatch_generation=self._generation,
+                sequence=sequence,
+                clutch_sequence=clutch_sequence,
+                admitted_monotonic=admitted,
+                expires_monotonic=expiry,
+                frame=sanitized,
+            )
+            self._mailbox = _PendingMotion(intent, digest)
+            self._state = "motion_eligible"
+            self._last_admitted_sequence = sequence
+            self._last_decision = "admitted"
+            self._counters["motion_admitted"] += 1
+            self._condition.notify_all()
+            return AdapterAck(True)
+
+    def trip(
+        self,
+        reason: str,
+        *,
+        target_state: str,
+        retain_authority: bool,
+    ) -> StopHandle:
+        if not isinstance(reason, str) or not reason:
+            raise ValueError("stop reason is required")
+        with self._condition:
+            self._generation += 1
+            now = self._clock()
+            request = StopRequest(
+                dispatch_generation=self._generation,
+                reason=reason,
+                requested_monotonic=now,
+                deadline_monotonic=now + self._io_timeout,
+            )
+            handle = StopHandle(
+                request,
+                safety_deadline=self._safety_clock() + self._io_timeout,
+            )
+            if self._mailbox is not None:
+                self._mailbox = None
+                self._counters["mailbox_cleared_by_stop"] += 1
+            self._state = target_state
+            self._stop_acknowledged = False
+            self._last_decision = f"stop_requested:{reason}"
+            if not retain_authority:
+                self._authority_digest = None
+                self._session_generation = None
+            if self._closed or self._shutdown:
+                handle._finish(AdapterAck(False, "dispatch_closed"))
+            elif self._worker is None:
+                handle._finish(AdapterAck(False, "dispatch_unavailable"))
+            else:
+                self._stop_queue.append(handle)
+                self._counters["stop_requests"] += 1
+                self._condition.notify_all()
+            return handle
+
+    @staticmethod
+    def wait_safe(handle: StopHandle, timeout: float = 0.5) -> AdapterAck:
+        return handle.wait(timeout)
+
+    def wait_applied(self, sequence: int, timeout: float = 1.0) -> bool:
+        deadline = time.monotonic() + timeout
+        with self._condition:
+            while self._last_applied_sequence != sequence:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or self._fault_code is not None or self._closed:
+                    return False
+                self._condition.wait(remaining)
+            return True
+
+    def snapshot(self) -> dict:
+        with self._condition:
+            self._refresh_io_stall_locked()
+            state = {
+                "kind": "recording",
+                "state": self._state,
+                "ready": self._fault_code is None and not self._closed,
+                "generation": self._generation,
+                "mailbox_depth": int(self._mailbox is not None),
+                "stop_queue_depth": len(self._stop_queue),
+                "last_admitted_sequence": self._last_admitted_sequence,
+                "last_would_apply_sequence": self._last_applied_sequence,
+                "last_decision": self._last_decision,
+                "stop_acknowledged": self._stop_acknowledged,
+                "fault_code": self._fault_code,
+                "io_inflight": self._io_inflight_kind,
+                "counters": dict(sorted(self._counters.items())),
+            }
+        with self._adapter_snapshot_lock:
+            cached_adapter = self._adapter_snapshot
+        # Cache entries are replaced, never mutated.  Copying outside both
+        # arbiter locks prevents high-rate status reads from starving the I/O
+        # owner while still returning an isolated public value.
+        state["adapter"] = copy.deepcopy(cached_adapter)
+        return state
+
+    def _refresh_io_stall_locked(self) -> None:
+        if (
+            self._io_inflight_kind is None
+            or self._io_deadline_safety is None
+            or self._fault_code is not None
+            or self._safety_clock() < self._io_deadline_safety
+        ):
+            return
+        self._fault_code = "adapter_io_stalled"
+        self._state = "fault_latched"
+        self._authority_digest = None
+        self._session_generation = None
+        self._mailbox = None
+        self._stop_acknowledged = False
+        self._last_decision = f"io_stalled:{self._io_inflight_kind}"
+        self._counters["adapter_faults"] += 1
+        self._counters["adapter_io_stalls"] += 1
+        # The owner may currently be blocked, but the stop remains queued and
+        # will be its first operation if the vendor call ever returns.
+        self.trip(
+            "adapter_io_stalled",
+            target_state="fault_latched",
+            retain_authority=False,
+        )
+
+    def close(self, timeout: float = 0.5) -> AdapterAck:
+        if self._worker is threading.current_thread():
+            return AdapterAck(False, "owner_cannot_self_close")
+        with self._close_lock:
+            unavailable_result: AdapterAck | None = None
+            with self._condition:
+                if self._close_result is not None:
+                    return self._close_result
+                worker = self._worker
+                if worker is None:
+                    code = self._fault_code or "dispatch_unavailable"
+                    self._closed = True
+                    self._shutdown = True
+                    self._state = "fault_latched"
+                    self._stop_acknowledged = False
+                    self._close_result = AdapterAck(False, code)
+                    unavailable_result = self._close_result
+            if unavailable_result is not None:
+                # A timed-out startup call still owns the adapter.  It will
+                # close it serially if it ever returns; wait only within the
+                # caller's shutdown budget.
+                if self._startup_thread is not threading.current_thread():
+                    self._startup_owner_done.wait(timeout)
+                return unavailable_result
+
+            handle = self.trip(
+                "service_close",
+                target_state="closing",
+                retain_authority=False,
+            )
+            stop_ack = self.wait_safe(handle, timeout)
+            with self._condition:
+                self._closed = True
+                self._shutdown = True
+                self._mailbox = None
+                self._state = "closing" if stop_ack.ok else "fault_latched"
+                if not stop_ack.ok:
+                    self._fault_code = self._fault_code or stop_ack.code
+                self._condition.notify_all()
+            worker.join(timeout=max(timeout, self._io_timeout * 2))
+            with self._condition:
+                if worker.is_alive():
+                    result = AdapterAck(False, stop_ack.code if not stop_ack.ok else "owner_close_timeout")
+                elif not stop_ack.ok:
+                    result = stop_ack
+                elif self._adapter_close_ack is None:
+                    result = AdapterAck(False, "adapter_close_ack_missing")
+                else:
+                    result = self._adapter_close_ack
+                self._close_result = result
+                self._state = "closed" if result.ok else "fault_latched"
+                if not result.ok:
+                    self._fault_code = self._fault_code or result.code
+                    self._stop_acknowledged = False
+                return result
+
+    def _worker_loop(self) -> None:
+        try:
+            while True:
+                with self._condition:
+                    while not self._stop_queue and self._mailbox is None and not self._shutdown:
+                        self._condition.wait()
+                    if self._shutdown and not self._stop_queue:
+                        break
+                    if self._stop_queue:
+                        item: StopHandle | _PendingMotion = self._stop_queue.popleft()
+                        is_stop = True
+                    else:
+                        assert self._mailbox is not None
+                        item = self._mailbox
+                        self._mailbox = None
+                        is_stop = False
+                if is_stop:
+                    assert isinstance(item, StopHandle)
+                    self._perform_stop(item)
+                else:
+                    assert isinstance(item, _PendingMotion)
+                    self._perform_motion(item)
+        finally:
+            self._close_adapter_owned()
+
+    def _close_adapter_owned(self) -> None:
+        """Close the adapter from its sole current owner thread."""
+
+        try:
+            raw_ack = self._adapter.close()
+            close_ack = _normalized_ack(
+                AdapterAck(True) if raw_ack is None else raw_ack,
+                "invalid_close_ack",
+            )
+        except Exception:  # noqa: BLE001 -- normalize adapter close faults
+            close_ack = AdapterAck(False, "adapter_close_exception")
+        self._capture_adapter_snapshot_owned()
+        with self._condition:
+            self._adapter_close_ack = close_ack
+            self._condition.notify_all()
+
+    def _capture_adapter_snapshot_owned(self) -> None:
+        """Refresh public adapter evidence without crossing the owner boundary."""
+
+        try:
+            snapshot = self._adapter.snapshot()
+            if not isinstance(snapshot, dict):
+                snapshot = {
+                    "kind": "unavailable",
+                    "reason": "invalid_adapter_snapshot",
+                }
+            else:
+                snapshot = copy.deepcopy(snapshot)
+        except Exception:  # noqa: BLE001 -- status must survive adapter diagnostics
+            snapshot = {
+                "kind": "unavailable",
+                "reason": "adapter_snapshot_exception",
+            }
+        with self._adapter_snapshot_lock:
+            self._adapter_snapshot = snapshot
+
+    def _perform_stop(self, handle: StopHandle) -> None:
+        request = handle.request
+        started_safety = self._safety_clock()
+        with self._condition:
+            self._io_inflight_kind = "safe_stop"
+            self._io_deadline_safety = handle.safety_deadline
+        try:
+            ack = _normalized_ack(
+                self._adapter.safe_stop(request),
+                "invalid_stop_ack",
+            )
+            self._capture_adapter_snapshot_owned()
+        except Exception:  # noqa: BLE001 -- normalize adapter faults
+            ack = AdapterAck(False, "adapter_stop_exception")
+        finished_safety = self._safety_clock()
+        elapsed_safety = finished_safety - started_safety
+        if ack.ok:
+            if finished_safety >= handle.safety_deadline:
+                ack = AdapterAck(False, "adapter_stop_deadline_missed")
+            elif elapsed_safety > self._io_timeout:
+                ack = AdapterAck(False, "adapter_stop_timeout")
+        with self._condition:
+            self._io_inflight_kind = None
+            self._io_deadline_safety = None
+            handle._finish(ack)
+            if ack.ok:
+                self._counters["stop_acks"] += 1
+                if request.dispatch_generation == self._generation:
+                    self._stop_acknowledged = True
+                    self._last_decision = f"would_stop:{request.reason}"
+            else:
+                self._fault_code = self._fault_code or ack.code
+                self._state = "fault_latched"
+                self._authority_digest = None
+                self._session_generation = None
+                self._mailbox = None
+                self._stop_acknowledged = False
+                self._last_decision = f"stop_failed:{ack.code}"
+                self._counters["adapter_faults"] += 1
+            self._condition.notify_all()
+
+    def _perform_motion(self, pending: _PendingMotion) -> None:
+        intent = pending.intent
+        with self._condition:
+            now = self._clock()
+            valid = (
+                self._fault_code is None
+                and not self._closed
+                and self._state == "motion_eligible"
+                and intent.dispatch_generation == self._generation
+                and intent.session_generation == self._session_generation
+                and self._authority_digest is not None
+                and hmac.compare_digest(pending.authority_digest, self._authority_digest)
+            )
+            if not valid:
+                self._last_decision = "motion_dropped_stale"
+                self._counters["motion_dropped_stale"] += 1
+                self._condition.notify_all()
+                return
+            if now >= intent.expires_monotonic:
+                self._last_decision = "motion_dropped_expired"
+                self._counters["motion_dropped_expired"] += 1
+                self.trip(
+                    "dispatch_deadline",
+                    target_state="safe_reclutch_required",
+                    retain_authority=True,
+                )
+                self._condition.notify_all()
+                return
+            # This is the linearization point.  A concurrent trip after this
+            # commit is queued behind the bounded apply and cannot acknowledge
+            # until its safe-stop has executed.
+            self._last_decision = "motion_committed"
+            remaining = max(0.0, intent.expires_monotonic - now)
+            started_safety = self._safety_clock()
+            self._io_inflight_kind = "apply"
+            self._io_deadline_safety = started_safety + min(self._io_timeout, remaining)
+
+        try:
+            ack = _normalized_ack(
+                self._adapter.apply(intent),
+                "invalid_apply_ack",
+            )
+            self._capture_adapter_snapshot_owned()
+        except Exception:  # noqa: BLE001 -- normalize adapter faults
+            ack = AdapterAck(False, "adapter_apply_exception")
+        finished = self._clock()
+        finished_safety = self._safety_clock()
+        elapsed_safety = finished_safety - started_safety
+        if ack.ok:
+            if finished >= intent.expires_monotonic:
+                ack = AdapterAck(False, "adapter_apply_deadline_missed")
+            elif elapsed_safety > self._io_timeout:
+                ack = AdapterAck(False, "adapter_apply_timeout")
+        with self._condition:
+            self._io_inflight_kind = None
+            self._io_deadline_safety = None
+            if (
+                ack.ok
+                and self._fault_code is None
+                and not self._closed
+                and intent.dispatch_generation == self._generation
+            ):
+                self._last_applied_sequence = intent.sequence
+                self._last_decision = "would_apply"
+                self._counters["motion_applied"] += 1
+            elif ack.ok:
+                self._counters["late_adapter_returns"] += 1
+            else:
+                already_faulted = self._fault_code is not None
+                self._fault_code = self._fault_code or ack.code
+                self._state = "fault_latched"
+                self._authority_digest = None
+                self._session_generation = None
+                self._mailbox = None
+                self._stop_acknowledged = False
+                self._last_decision = f"apply_failed:{self._fault_code}"
+                if not already_faulted:
+                    self._counters["adapter_faults"] += 1
+                # A failed motion write still schedules the independent safety
+                # path.  Its acknowledgement cannot clear the fault latch.
+                if not already_faulted:
+                    self.trip(
+                        "adapter_fault",
+                        target_state="fault_latched",
+                        retain_authority=False,
+                    )
+            self._condition.notify_all()

--- a/generic/teleop_shadow/driver.yaml
+++ b/generic/teleop_shadow/driver.yaml
@@ -1,0 +1,9 @@
+id: teleop-shadow-driver
+name: Generic Teleop Shadow Diagnostics
+category: driver
+hardware_provider: generic
+hardware_model: "teleop-shadow"
+image_name: teleop-shadow
+port: 15711
+mcp_url: "http://localhost:15711/mcp"
+description: "Robot-free Quest/WebRTC protocol, fencing and recording final-dispatch diagnostics; permanently zero hardware actuation"

--- a/generic/teleop_shadow/main.py
+++ b/generic/teleop_shadow/main.py
@@ -1,0 +1,618 @@
+"""Deployable MCP + WebRTC server for the generic teleop shadow Driver."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import json
+import logging
+import os
+import re
+import ssl
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+import yaml
+from aiohttp import web
+from protocol import (
+    CAPABILITY_DIGEST,
+    DISPATCH_CONTRACT,
+    PROTOCOL,
+    SIGNALING_PROTOCOL,
+    ProtocolError,
+    TicketCodec,
+    TicketVerifier,
+)
+from rtc import RtcManager, RtcRequestError
+from runtime import ShadowRuntime
+
+LOGGER = logging.getLogger("teleop-shadow")
+DEFAULT_DRIVER_ID = "teleop-shadow-driver"
+DEFAULT_DRIVER_NAME = "Generic Teleop Shadow Diagnostics"
+DEFAULT_CONFIG_PATH = Path(__file__).with_name("config.yaml")
+_INSTANCE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_DRIVER_BEARER_RE = re.compile(r"^[A-Za-z0-9._~+/=-]{24,4096}$")
+
+
+class RegistrationTlsError(RuntimeError):
+    """Agent Core registration cannot establish the required pinned TLS trust."""
+
+
+def _is_loopback_bind(host: object) -> bool:
+    if not isinstance(host, str):
+        return False
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return host.lower() == "localhost"
+
+
+def _identity_properties() -> dict:
+    return {
+        "boot_id": {"type": "string", "format": "uuid"},
+        "session_id": {"type": "string", "format": "uuid"},
+        "epoch": {"type": "integer", "minimum": 1},
+        "fence": {"type": "string", "minLength": 24},
+    }
+
+
+def tool_definitions(
+    *,
+    driver_id: str = DEFAULT_DRIVER_ID,
+    driver_name: str = DEFAULT_DRIVER_NAME,
+    robot_id: str | None = None,
+    signaling_enabled: bool = True,
+) -> list[dict]:
+    identity = _identity_properties()
+    actions = {
+        "start": {"params": [], "description": "Passive lifecycle readiness check; never prepares a session"},
+        "stop": {"params": [], "description": "Stop lifecycle and safely release the Shadow session"},
+        "prepare_shadow": {
+            "params": ["session_id", "epoch", "fence"],
+            "description": "Install a new Core-issued epoch/fence for a Shadow session",
+        },
+        "heartbeat": {"params": list(identity), "description": "Renew the lease from authenticated Agent Core MCP only"},
+        "pause": {"params": list(identity), "description": "Pause diagnostics and enter a non-resuming state"},
+        "release": {"params": list(identity), "description": "Release the current fenced session"},
+        "soft_stop": {"params": list(identity), "description": "Enter HOLD; no hardware action exists"},
+        "status": {"params": [], "description": "Read the current session and transport diagnostics"},
+        "submit_shadow_frame": {
+            "params": ["frame"],
+            "description": "Submit one strict Frame v1 for diagnostics/replay; not a production high-rate path",
+        },
+    }
+    signaling = ({
+        "signaling": {
+            "protocol": SIGNALING_PROTOCOL,
+            "path": "/offer",
+            "access": "authenticated-core-proxy-only",
+        },
+    } if signaling_enabled else {})
+    return [
+        {
+            "name": "teleop_session",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": (
+                "Robot-free Quest/WebRTC Shadow diagnostics with a bounded would-apply/would-stop "
+                "final-dispatch trace. It can never actuate hardware; only authenticated MCP "
+                "heartbeat renews the lease."
+            ),
+            "annotations": {"destructiveHint": False, "idempotentHint": False},
+            "inputSchema": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "action": {"type": "string", "enum": list(actions)},
+                    **identity,
+                    "frame": {"type": "object", "description": "Strict Teleop Frame v1 object"},
+                },
+                "required": ["action"],
+                "x-action-params": actions,
+            },
+            "x-teleop": {
+                "protocol": PROTOCOL,
+                "driver_id": driver_id,
+                "driver_name": driver_name,
+                "robot_id": robot_id,
+                "mode": "shadow",
+                "actuation_enabled": False,
+                "capability_digest": CAPABILITY_DIGEST,
+                "dispatch_contract": DISPATCH_CONTRACT,
+                **signaling,
+            },
+        },
+        {
+            "name": "teleop_state",
+            "type": "resource",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": "Callable read-only snapshot of Shadow session, lease, Pose, RTC and rejection counters",
+            "annotations": {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+            "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+            "x-teleop": {
+                "protocol": PROTOCOL,
+                "driver_id": driver_id,
+                "driver_name": driver_name,
+                "robot_id": robot_id,
+                "mode": "shadow",
+                "actuation_enabled": False,
+                "capability_digest": CAPABILITY_DIGEST,
+                "dispatch_contract": DISPATCH_CONTRACT,
+                **signaling,
+            },
+        },
+    ]
+
+
+def load_config(path: str | Path | None = None) -> dict:
+    config_path = Path(path or os.environ.get("CONFIG_PATH", DEFAULT_CONFIG_PATH))
+    with config_path.open(encoding="utf-8") as handle:
+        config = yaml.safe_load(handle) or {}
+    config["driver_id"] = os.environ.get(
+        "MOTUS_DRIVER_ID", config.get("driver_id", DEFAULT_DRIVER_ID)
+    )
+    config["driver_name"] = os.environ.get(
+        "MOTUS_DRIVER_NAME", config.get("driver_name", DEFAULT_DRIVER_NAME)
+    )
+    if "MOTUS_ROBOT_ID" in os.environ:
+        config["robot_id"] = os.environ["MOTUS_ROBOT_ID"] or None
+    config["bind_host"] = os.environ.get("MOTUS_BIND_HOST", config.get("bind_host", "127.0.0.1"))
+    config["mcp_port"] = int(os.environ.get("MOTUS_MCP_PORT", config.get("mcp_port", 15711)))
+    registration = config.setdefault("registration", {})
+    registration["agent_core_url"] = os.environ.get(
+        "AGENT_CORE_URL", registration.get("agent_core_url", "https://localhost:15678")
+    )
+    registration["advertise_url"] = os.environ.get(
+        "MOTUS_MCP_URL", registration.get("advertise_url", f"http://localhost:{config['mcp_port']}/mcp")
+    )
+    # Production always verifies the mounted Core certificate.  Disabling it
+    # requires the explicit, conspicuous local-development environment value.
+    registration["verify_tls"] = True
+    if "MOTUS_AGENT_CORE_VERIFY_TLS" in os.environ:
+        verify_value = os.environ["MOTUS_AGENT_CORE_VERIFY_TLS"].strip()
+        if verify_value not in ("0", "1"):
+            raise ValueError("MOTUS_AGENT_CORE_VERIFY_TLS must be 1, or 0 for explicit local development")
+        registration["verify_tls"] = verify_value == "1"
+    registration["ca_file"] = os.environ.get(
+        "MOTUS_AGENT_CORE_CA_FILE",
+        registration.get("ca_file", "/etc/motus-core-certs/cert.pem"),
+    )
+    return config
+
+
+def _validated_instance_id(
+    value: Any,
+    name: str,
+    *,
+    optional: bool = False,
+    max_length: int = 128,
+) -> str | None:
+    if optional and value is None:
+        return None
+    if (
+        not isinstance(value, str)
+        or len(value) > max_length
+        or not _INSTANCE_ID_RE.fullmatch(value)
+    ):
+        suffix = " or null" if optional else ""
+        raise ValueError(
+            f"{name} must be a stable 1-{max_length} character instance identifier{suffix}"
+        )
+    return value
+
+
+def build_registration_ssl_context(registration: dict) -> ssl.SSLContext | bool:
+    """Build an Agent Core client context pinned to the deployed Core certificate."""
+
+    if not bool(registration.get("verify_tls", True)):
+        return False
+
+    ca_file = Path(str(registration.get("ca_file", "/etc/motus-core-certs/cert.pem")))
+    if not ca_file.is_file():
+        raise RegistrationTlsError(f"Agent Core pinned CA file is missing: {ca_file}")
+    try:
+        context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH, cafile=str(ca_file))
+    except (OSError, ssl.SSLError) as exc:
+        raise RegistrationTlsError(f"Agent Core pinned CA file is invalid: {ca_file}: {exc}") from exc
+
+    # The current self-signed Core certificate is issued to `phanthy-motus`, while
+    # host-network registration intentionally targets https://localhost:15678.
+    # Chain verification remains mandatory; only the DNS-name check is disabled.
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_REQUIRED
+    return context
+
+
+class ShadowDriverService:
+    def __init__(self, config: dict):
+        self.driver_id = str(_validated_instance_id(
+            config.get("driver_id", DEFAULT_DRIVER_ID), "driver_id", max_length=64
+        ))
+        driver_name = config.get("driver_name", DEFAULT_DRIVER_NAME)
+        if not isinstance(driver_name, str) or not driver_name.strip() or len(driver_name) > 200:
+            raise ValueError("driver_name must be a non-empty string of at most 200 characters")
+        self.driver_name = driver_name.strip()
+        self.robot_id = _validated_instance_id(
+            config.get("robot_id"),
+            "robot_id",
+            optional=True,
+            # Agent Core uses the same 64-character authority-domain boundary.
+            max_length=64,
+        )
+        registration = config.get("registration", {})
+        registration_enabled = bool(registration.get("enabled", True))
+        raw_driver_token = os.environ.get("MOTUS_DRIVER_TOKEN")
+        if raw_driver_token and not _DRIVER_BEARER_RE.fullmatch(raw_driver_token):
+            raise ValueError(
+                "MOTUS_DRIVER_TOKEN must use 24–4096 restricted ASCII Bearer "
+                "characters (allowed: A-Z a-z 0-9 . _ ~ + / = -)"
+            )
+        self.driver_token = raw_driver_token or None
+        if self.driver_token is None and (
+            registration_enabled
+            or not _is_loopback_bind(config.get("bind_host", "127.0.0.1"))
+        ):
+            raise ValueError(
+                "MOTUS_DRIVER_TOKEN is required for registration or non-loopback binding"
+            )
+        teleop = config.get("teleop", {})
+        ticket_secret = os.environ.get("MOTUS_TELEOP_TICKET_SECRET")
+        if ticket_secret is None:
+            if registration_enabled or not _is_loopback_bind(
+                config.get("bind_host", "127.0.0.1")
+            ):
+                raise ValueError(
+                    "MOTUS_TELEOP_TICKET_SECRET is required for registration "
+                    "or non-loopback binding"
+                )
+            ticket_codec = None
+        else:
+            # A configured empty or malformed value is an operator error, not
+            # a request to silently downgrade signaling readiness.
+            ticket_codec = TicketCodec(ticket_secret)
+        self.runtime = ShadowRuntime(
+            lease_timeout_ms=int(teleop.get("lease_timeout_ms", 1000)),
+            pose_timeout_ms=int(teleop.get("pose_timeout_ms", 200)),
+            watchdog_interval_ms=int(teleop.get("watchdog_interval_ms", 25)),
+            driver_id=self.driver_id,
+            driver_name=self.driver_name,
+            robot_id=self.robot_id,
+            dispatch_io_timeout_ms=int(teleop.get("dispatch_io_timeout_ms", 100)),
+            dispatch_ack_timeout_ms=int(teleop.get("dispatch_ack_timeout_ms", 200)),
+        )
+        if ticket_codec is None:
+            verifier = None
+            LOGGER.warning("RTC disabled: MOTUS_TELEOP_TICKET_SECRET is not configured")
+        else:
+            verifier = TicketVerifier(
+                ticket_codec,
+                max_ttl_seconds=int(teleop.get("ticket_ttl_max_seconds", 30)),
+                max_replay_entries=int(teleop.get("ticket_replay_cache_entries", 4096)),
+            )
+        self.rtc = RtcManager(self.runtime, verifier)
+        self.config = config
+        self.registration_task: asyncio.Task | None = None
+        self.registration_status = {
+            "state": "starting" if registration_enabled else "disabled",
+            "attempts": 0,
+            "successes": 0,
+            "last_http_status": None,
+            "last_error": None,
+            "tls_verification": (
+                "pinned_certificate"
+                if bool(registration.get("verify_tls", True))
+                else "disabled_local_development"
+            ),
+        }
+
+    def authorized(self, request: web.Request) -> bool:
+        if not self.driver_token:
+            return True
+        header = request.headers.get("Authorization", "")
+        if not header.startswith("Bearer "):
+            return False
+        import hmac
+
+        return hmac.compare_digest(header[7:], self.driver_token)
+
+    async def dispatch_tool(self, name: str, arguments: Any) -> dict:
+        if not isinstance(arguments, dict):
+            raise ProtocolError("invalid_arguments", "tool arguments must be an object")
+        args = dict(arguments)
+        if name == "teleop_state":
+            if args:
+                raise ProtocolError("invalid_arguments", "teleop_state accepts no arguments")
+            return self.runtime.status()
+        if name != "teleop_session":
+            raise ProtocolError("unknown_tool", f"unknown tool: {name}")
+        action = args.pop("action", None)
+        if not isinstance(action, str):
+            raise ProtocolError("missing_action", "teleop_session requires an action")
+        if action == "start":
+            if args:
+                raise ProtocolError("invalid_arguments", "start accepts no arguments")
+            result = self.runtime.status()
+            result["lifecycle_state"] = (
+                "ready" if result["dispatch"]["ready"] else "fault"
+            )
+            return result
+        if action == "stop":
+            if args:
+                raise ProtocolError("invalid_arguments", "stop accepts no arguments")
+            result = await asyncio.to_thread(self.runtime.release, lifecycle=True)
+            await self.rtc.close_all()
+            return result
+        if action == "prepare_shadow":
+            if set(args) != {"session_id", "epoch", "fence"}:
+                raise ProtocolError(
+                    "invalid_arguments", "prepare_shadow requires session_id, epoch and fence"
+                )
+            result = await asyncio.to_thread(self.runtime.prepare_shadow, args)
+            # Stale/invalid prepare requests are rejected before touching the
+            # active RTC peer.  Successful prepare advances the generation, so
+            # callbacks from the old peer are diagnostics-only while it closes.
+            await self.rtc.close_all()
+            return result
+        if action == "heartbeat":
+            self._require_only_identity(args)
+            return self.runtime.heartbeat(args)
+        if action == "pause":
+            self._require_only_identity(args)
+            result = await asyncio.to_thread(self.runtime.pause, args)
+            await self.rtc.close_all()
+            return result
+        if action == "release":
+            self._require_only_identity(args)
+            result = await asyncio.to_thread(self.runtime.release, args)
+            await self.rtc.close_all()
+            return result
+        if action == "soft_stop":
+            self._require_only_identity(args)
+            result = await asyncio.to_thread(self.runtime.soft_stop, args)
+            await self.rtc.close_all()
+            return result
+        if action == "status":
+            if args:
+                raise ProtocolError("invalid_arguments", "status accepts no arguments")
+            return self.runtime.status()
+        if action == "submit_shadow_frame":
+            if set(args) != {"frame"}:
+                raise ProtocolError("invalid_arguments", "submit_shadow_frame requires only frame")
+            return self.runtime.submit_shadow_frame(args["frame"], source="mcp_diagnostic")
+        raise ProtocolError("unknown_action", f"unknown teleop_session action: {action}")
+
+    @staticmethod
+    def _require_only_identity(args: dict) -> None:
+        expected = {"boot_id", "session_id", "epoch", "fence"}
+        if set(args) != expected:
+            raise ProtocolError("invalid_arguments", f"action requires exactly {sorted(expected)}")
+
+    async def close(self) -> None:
+        if self.registration_task:
+            self.registration_task.cancel()
+            try:
+                await self.registration_task
+            except asyncio.CancelledError:
+                pass
+        await self.rtc.close_all()
+        await asyncio.to_thread(self.runtime.close)
+
+
+SERVICE_KEY = web.AppKey("teleop_shadow_service", ShadowDriverService)
+
+
+def _rpc_success(request_id: Any, result: Any) -> web.Response:
+    return web.json_response({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+
+def _rpc_error(request_id: Any, code: int, message: str, *, data: dict | None = None) -> web.Response:
+    error = {"code": code, "message": message}
+    if data:
+        error["data"] = data
+    return web.json_response({"jsonrpc": "2.0", "id": request_id, "error": error})
+
+
+async def mcp_handler(request: web.Request) -> web.Response:
+    service = request.app[SERVICE_KEY]
+    if not service.authorized(request):
+        return web.json_response({"error": "unauthorized"}, status=401)
+    try:
+        rpc = await request.json()
+    except (json.JSONDecodeError, ValueError, RecursionError):
+        return _rpc_error(None, -32700, "Parse error")
+    if not isinstance(rpc, dict) or rpc.get("jsonrpc") != "2.0":
+        return _rpc_error(rpc.get("id") if isinstance(rpc, dict) else None, -32600, "Invalid Request")
+    request_id = rpc.get("id")
+    if request_id is None:
+        return web.Response(status=202)
+    method = rpc.get("method")
+    params = rpc.get("params") or {}
+    try:
+        if method == "initialize":
+            return _rpc_success(request_id, {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "teleop-shadow-driver", "version": "1.2.0"},
+            })
+        if method == "tools/list":
+            return _rpc_success(request_id, {"tools": tool_definitions(
+                driver_id=service.driver_id,
+                driver_name=service.driver_name,
+                robot_id=service.robot_id,
+                signaling_enabled=service.rtc.enabled,
+            )})
+        if method == "tools/call":
+            if not isinstance(params, dict):
+                raise ProtocolError("invalid_params", "params must be an object")
+            result = await service.dispatch_tool(params.get("name", ""), params.get("arguments") or {})
+            return _rpc_success(request_id, {
+                "content": [{"type": "text", "text": json.dumps(result, ensure_ascii=False, allow_nan=False)}]
+            })
+        return _rpc_error(request_id, -32601, f"Method not found: {method}")
+    except ProtocolError as exc:
+        if exc.code in ("unknown_tool", "unknown_action"):
+            return _rpc_error(request_id, -32601, str(exc), data={"code": exc.code})
+        return _rpc_error(request_id, -32602, str(exc), data={"code": exc.code})
+    except Exception:
+        LOGGER.exception("unhandled MCP request failure")
+        return _rpc_error(request_id, -32603, "Internal error")
+
+
+async def offer_handler(request: web.Request) -> web.Response:
+    service = request.app[SERVICE_KEY]
+    if not service.authorized(request):
+        return web.json_response({"error": "unauthorized"}, status=401)
+    try:
+        payload = await request.json()
+        return web.json_response(await service.rtc.accept_offer(payload))
+    except (json.JSONDecodeError, ValueError, RecursionError):
+        return web.json_response({"error": {"code": "invalid_json", "message": "body must be JSON"}}, status=400)
+    except RtcRequestError as exc:
+        return web.json_response({"error": {"code": exc.code, "message": str(exc)}}, status=exc.status)
+
+
+async def health_handler(request: web.Request) -> web.Response:
+    service = request.app[SERVICE_KEY]
+    state = service.runtime.status()
+    dispatch_ready = bool(state["dispatch"]["ready"])
+    ready = dispatch_ready and service.rtc.enabled
+    return web.json_response({
+        "state": "running" if ready else "diagnostic" if dispatch_ready else "fault",
+        "ready": ready,
+        "driver": service.driver_id,
+        "driver_id": service.driver_id,
+        "driver_name": service.driver_name,
+        "robot_id": service.robot_id,
+        "mode": "shadow",
+        "actuation_enabled": False,
+        "boot_id": state["boot_id"],
+        "dispatch": {
+            "kind": state["dispatch"]["kind"],
+            "state": state["dispatch"]["state"],
+            "stop_acknowledged": state["dispatch"]["stop_acknowledged"],
+            "fault_code": state["dispatch"]["fault_code"],
+        },
+        "rtc_enabled": service.rtc.enabled,
+        "mcp_auth_enabled": bool(service.driver_token),
+        "registration": dict(service.registration_status),
+    })
+
+
+def registration_payload(service: ShadowDriverService, registration: dict | None = None) -> dict:
+    registration = registration or service.config.get("registration", {})
+    payload = {
+        "id": service.driver_id,
+        "name": service.driver_name,
+        "url": registration.get("advertise_url", "http://localhost:15711/mcp"),
+        "transport": "http",
+        "category": "driver",
+    }
+    if service.robot_id is not None:
+        payload["robot_id"] = service.robot_id
+    return payload
+
+
+def registration_headers(service: ShadowDriverService) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if service.driver_token:
+        headers["Authorization"] = f"Bearer {service.driver_token}"
+    return headers
+
+
+async def _registration_loop(service: ShadowDriverService) -> None:
+    registration = service.config.get("registration", {})
+    interval = max(5.0, float(registration.get("interval_seconds", 30)))
+    endpoint = registration.get("agent_core_url", "https://localhost:15678").rstrip("/") + "/api/mcp"
+    payload = registration_payload(service, registration)
+    headers = registration_headers(service)
+    timeout = aiohttp.ClientTimeout(total=5)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        while True:
+            if not service.rtc.enabled:
+                service.registration_status["state"] = "rtc_unavailable"
+                service.registration_status["last_error"] = (
+                    "ticket verification is not ready; registration inhibited"
+                )
+                await asyncio.sleep(interval)
+                continue
+            if not service.runtime.status()["dispatch"]["ready"]:
+                service.registration_status["state"] = "dispatch_fault"
+                service.registration_status["last_error"] = (
+                    "final dispatch is not ready; registration inhibited"
+                )
+                await asyncio.sleep(interval)
+                continue
+            service.registration_status["attempts"] += 1
+            try:
+                ssl_context = build_registration_ssl_context(registration)
+                async with session.post(endpoint, json=payload, headers=headers, ssl=ssl_context) as response:
+                    service.registration_status["last_http_status"] = response.status
+                    if response.status >= 400:
+                        service.registration_status["state"] = "http_error"
+                        service.registration_status["last_error"] = f"Agent Core returned HTTP {response.status}"
+                        LOGGER.warning("registration failed with HTTP %s", response.status)
+                    else:
+                        service.registration_status["state"] = "registered"
+                        service.registration_status["successes"] += 1
+                        service.registration_status["last_error"] = None
+            except asyncio.CancelledError:
+                raise
+            except RegistrationTlsError as exc:
+                service.registration_status["state"] = "tls_error"
+                service.registration_status["last_error"] = str(exc)
+                LOGGER.warning("registration TLS setup failed; will retry: %s", exc)
+            except (aiohttp.ClientError, OSError) as exc:
+                service.registration_status["state"] = "connection_error"
+                service.registration_status["last_error"] = f"{type(exc).__name__}: {exc}"
+                LOGGER.warning("registration failed: %s", exc)
+            await asyncio.sleep(interval)
+
+
+def create_app(config: dict | None = None) -> web.Application:
+    effective = config or load_config()
+    service = ShadowDriverService(effective)
+    app = web.Application(client_max_size=2 * 1024 * 1024)
+    app[SERVICE_KEY] = service
+    app.router.add_post("/mcp", mcp_handler)
+    app.router.add_post("/offer", offer_handler)
+    app.router.add_get("/health", health_handler)
+
+    async def startup(_app: web.Application) -> None:
+        if (
+            effective.get("registration", {}).get("enabled", True)
+            and service.runtime.status()["dispatch"]["ready"]
+            and service.rtc.enabled
+        ):
+            service.registration_task = asyncio.create_task(
+                _registration_loop(service), name="teleop-shadow-registration"
+            )
+        elif effective.get("registration", {}).get("enabled", True):
+            if not service.rtc.enabled:
+                service.registration_status["state"] = "rtc_unavailable"
+                service.registration_status["last_error"] = (
+                    "ticket verification is not ready; registration inhibited"
+                )
+            else:
+                service.registration_status["state"] = "dispatch_fault"
+                service.registration_status["last_error"] = (
+                    "startup safe-stop was not acknowledged; registration inhibited"
+                )
+
+    async def cleanup(_app: web.Application) -> None:
+        await service.close()
+
+    app.on_startup.append(startup)
+    app.on_cleanup.append(cleanup)
+    return app
+
+
+def main() -> None:
+    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
+    config = load_config()
+    web.run_app(create_app(config), host=config["bind_host"], port=int(config["mcp_port"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/generic/teleop_shadow/protocol.py
+++ b/generic/teleop_shadow/protocol.py
@@ -1,0 +1,540 @@
+"""Pure protocol validation and HMAC ticket helpers for teleop-shadow.
+
+This module deliberately has no aiohttp or aiortc dependency.  It is shared by
+the HTTP/RTC adapters and the offline protocol tests.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import math
+import re
+import threading
+import time
+import uuid
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+FRAME_SCHEMA_VERSION = 1
+MODE = "shadow"
+PROTOCOL = "motus.teleop.shadow.v1"
+RTC_FRAME_PROTOCOL = "motus.teleop.rtc-frame.v1"
+RTC_CONTROL_PROTOCOL = "motus.teleop.rtc-control.v1"
+SIGNALING_PROTOCOL = "motus.teleop.webrtc-offer-answer.v1"
+DISPATCH_CONTRACT = "motus.teleop.dispatch.recording.v1"
+MAX_FRAME_BYTES = 64 * 1024
+MAX_SEQUENCE = (1 << 63) - 1
+_TOKEN_ID_RE = re.compile(r"^[A-Za-z0-9_-]{16,128}$")
+_FENCE_RE = re.compile(r"^[A-Za-z0-9_-]{24,128}$")
+
+
+class ProtocolError(ValueError):
+    """A stable, user-visible protocol validation failure."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+class TicketError(ProtocolError):
+    """A ticket authentication or replay failure."""
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+FRAME_V1_DESCRIPTION = {
+    "schema_version": FRAME_SCHEMA_VERSION,
+    "mode": MODE,
+    "required": [
+        "schema_version",
+        "boot_id",
+        "session_id",
+        "epoch",
+        "fence",
+        "sequence",
+        "client_monotonic_ns",
+        "mode",
+        "deadman",
+        "clutch_sequence",
+        "tracking",
+        "head",
+        "left_controller",
+        "right_controller",
+        "controllers",
+    ],
+    "optional": ["base_twist"],
+    "integer_bounds": {
+        "sequence": {"minimum": 0, "maximum": MAX_SEQUENCE},
+        "clutch_sequence": {"minimum": 0, "maximum": MAX_SEQUENCE},
+    },
+    "pose": {
+        "position": "[x,y,z] metres, finite, abs <= 100",
+        "orientation": "[x,y,z,w] unit quaternion",
+    },
+    "transport": {
+        "control": {"label": "teleop-control", "ordered": True, "reliable": True},
+        "pose": {"label": "teleop-pose", "ordered": False, "maxRetransmits": 0},
+    },
+}
+
+RTC_FRAME_V1_DESCRIPTION = {
+    "protocol": RTC_FRAME_PROTOCOL,
+    "schema_version": FRAME_SCHEMA_VERSION,
+    "mode": MODE,
+    "required": [
+        field
+        for field in FRAME_V1_DESCRIPTION["required"]
+        if field not in {"boot_id", "session_id", "epoch", "fence"}
+    ],
+    "optional": list(FRAME_V1_DESCRIPTION["optional"]),
+    "authority_binding": "verified-offer-ticket",
+    "forbidden_private_fields": ["boot_id", "session_id", "epoch", "fence"],
+    "integer_bounds": dict(FRAME_V1_DESCRIPTION["integer_bounds"]),
+    "pose": dict(FRAME_V1_DESCRIPTION["pose"]),
+}
+
+CAPABILITIES = {
+    "driver": "teleop-shadow",
+    "protocol": PROTOCOL,
+    "mode": MODE,
+    "actuation_enabled": False,
+    "frame": FRAME_V1_DESCRIPTION,
+    "rtc_frame": RTC_FRAME_V1_DESCRIPTION,
+    "rtc_control": {
+        "protocol": RTC_CONTROL_PROTOCOL,
+        "allowed": ["peer_ping", "status"],
+        "core_required": ["heartbeat", "pause", "soft_stop", "release"],
+        "private_authority_fields_allowed": False,
+    },
+    "signaling": {
+        "protocol": SIGNALING_PROTOCOL,
+        "path": "/offer",
+        "access": "authenticated-core-proxy-only",
+    },
+    "lease": {
+        "authority": "agent-core-mcp-heartbeat-only",
+        "pose_renews_lease": False,
+        "rtc_ping_renews_lease": False,
+    },
+    "dispatch": {
+        "contract": DISPATCH_CONTRACT,
+        "kind": "recording",
+        "hardware_output": False,
+        "motion_mailbox_depth": 1,
+        "stop_path": "non-droppable-acknowledged",
+        "final_checks": [
+            "authority",
+            "session_generation",
+            "dispatch_generation",
+            "deadline",
+            "deadman",
+            "tracking",
+        ],
+    },
+}
+CAPABILITY_DIGEST = hashlib.sha256(canonical_json(CAPABILITIES)).hexdigest()
+
+
+def _strict_object(value: Any, name: str, required: set[str], optional: set[str] | None = None) -> dict:
+    if not isinstance(value, dict):
+        raise ProtocolError("invalid_type", f"{name} must be an object")
+    optional = optional or set()
+    keys = set(value)
+    missing = required - keys
+    unknown = keys - required - optional
+    if missing:
+        raise ProtocolError("missing_field", f"{name} missing fields: {sorted(missing)}")
+    if unknown:
+        raise ProtocolError("unknown_field", f"{name} contains unknown fields: {sorted(unknown)}")
+    return value
+
+
+def _strict_int(
+    value: Any,
+    name: str,
+    *,
+    minimum: int = 0,
+    maximum: int | None = None,
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ProtocolError("invalid_type", f"{name} must be an integer")
+    if value < minimum:
+        raise ProtocolError("out_of_range", f"{name} must be >= {minimum}")
+    if maximum is not None and value > maximum:
+        raise ProtocolError("out_of_range", f"{name} must be <= {maximum}")
+    return value
+
+
+def _strict_bool(value: Any, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ProtocolError("invalid_type", f"{name} must be a boolean")
+    return value
+
+
+def _finite_number(value: Any, name: str, *, lower: float, upper: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ProtocolError("invalid_type", f"{name} must be a number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ProtocolError("non_finite", f"{name} must be finite")
+    if number < lower or number > upper:
+        raise ProtocolError("out_of_range", f"{name} must be in [{lower}, {upper}]")
+    return number
+
+
+def _float_array(value: Any, name: str, *, size: int | None, maximum_size: int | None,
+                 lower: float, upper: float) -> list[float]:
+    if not isinstance(value, list):
+        raise ProtocolError("invalid_type", f"{name} must be an array")
+    if size is not None and len(value) != size:
+        raise ProtocolError("invalid_length", f"{name} must contain exactly {size} values")
+    if maximum_size is not None and len(value) > maximum_size:
+        raise ProtocolError("invalid_length", f"{name} may contain at most {maximum_size} values")
+    return [
+        _finite_number(item, f"{name}[{index}]", lower=lower, upper=upper)
+        for index, item in enumerate(value)
+    ]
+
+
+def _validate_uuid(value: Any, name: str) -> str:
+    if not isinstance(value, str):
+        raise ProtocolError("invalid_type", f"{name} must be a UUID string")
+    try:
+        parsed = uuid.UUID(value)
+    except (ValueError, AttributeError) as exc:
+        raise ProtocolError("invalid_value", f"{name} must be a valid UUID") from exc
+    if str(parsed) != value.lower():
+        raise ProtocolError("invalid_value", f"{name} must use canonical UUID form")
+    return str(parsed)
+
+
+def _validate_fence(value: Any) -> str:
+    if not isinstance(value, str) or not _FENCE_RE.fullmatch(value):
+        raise ProtocolError("invalid_value", "fence must be a URL-safe token of 24-128 characters")
+    return value
+
+
+def _validate_pose(value: Any, name: str, tracking_valid: bool) -> dict | None:
+    if value is None:
+        if tracking_valid:
+            raise ProtocolError("tracking_mismatch", f"{name} is required while tracking is valid")
+        return None
+    if not tracking_valid:
+        raise ProtocolError("tracking_mismatch", f"{name} must be null while tracking is invalid")
+    pose = _strict_object(value, name, {"position", "orientation"})
+    position = _float_array(
+        pose["position"], f"{name}.position", size=3, maximum_size=None, lower=-100.0, upper=100.0
+    )
+    orientation = _float_array(
+        pose["orientation"], f"{name}.orientation", size=4, maximum_size=None, lower=-1.0, upper=1.0
+    )
+    norm = math.sqrt(sum(item * item for item in orientation))
+    if abs(norm - 1.0) > 0.02:
+        raise ProtocolError("invalid_quaternion", f"{name}.orientation must be normalized")
+    return {"position": position, "orientation": orientation}
+
+
+def _validate_controller(value: Any, name: str) -> dict:
+    controller = _strict_object(value, name, {"axes", "buttons"})
+    return {
+        "axes": _float_array(
+            controller["axes"], f"{name}.axes", size=None, maximum_size=8, lower=-1.0, upper=1.0
+        ),
+        "buttons": _float_array(
+            controller["buttons"], f"{name}.buttons", size=None, maximum_size=16, lower=0.0, upper=1.0
+        ),
+    }
+
+
+def _normalize_frame_v1(value: Any) -> dict:
+    required = set(FRAME_V1_DESCRIPTION["required"])
+    frame = _strict_object(value, "frame", required, {"base_twist"})
+    version = _strict_int(frame["schema_version"], "schema_version", minimum=1)
+    if version != FRAME_SCHEMA_VERSION:
+        raise ProtocolError("unsupported_version", f"schema_version must be {FRAME_SCHEMA_VERSION}")
+    if frame["mode"] != MODE:
+        raise ProtocolError("unsupported_mode", f"mode must be {MODE!r}")
+
+    tracking = _strict_object(
+        frame["tracking"], "tracking", {"head", "left_controller", "right_controller"}
+    )
+    normalized_tracking = {
+        key: _strict_bool(tracking[key], f"tracking.{key}")
+        for key in ("head", "left_controller", "right_controller")
+    }
+    controllers = _strict_object(frame["controllers"], "controllers", {"left", "right"})
+
+    normalized = {
+        "schema_version": version,
+        "boot_id": _validate_uuid(frame["boot_id"], "boot_id"),
+        "session_id": _validate_uuid(frame["session_id"], "session_id"),
+        "epoch": _strict_int(frame["epoch"], "epoch", minimum=1),
+        "fence": _validate_fence(frame["fence"]),
+        "sequence": _strict_int(
+            frame["sequence"], "sequence", minimum=0, maximum=MAX_SEQUENCE
+        ),
+        "client_monotonic_ns": _strict_int(
+            frame["client_monotonic_ns"], "client_monotonic_ns", minimum=0
+        ),
+        "mode": MODE,
+        "deadman": _strict_bool(frame["deadman"], "deadman"),
+        "clutch_sequence": _strict_int(
+            frame["clutch_sequence"],
+            "clutch_sequence",
+            minimum=0,
+            maximum=MAX_SEQUENCE,
+        ),
+        "tracking": normalized_tracking,
+        "head": _validate_pose(frame["head"], "head", normalized_tracking["head"]),
+        "left_controller": _validate_pose(
+            frame["left_controller"], "left_controller", normalized_tracking["left_controller"]
+        ),
+        "right_controller": _validate_pose(
+            frame["right_controller"], "right_controller", normalized_tracking["right_controller"]
+        ),
+        "controllers": {
+            "left": _validate_controller(controllers["left"], "controllers.left"),
+            "right": _validate_controller(controllers["right"], "controllers.right"),
+        },
+    }
+    if "base_twist" in frame:
+        twist = _strict_object(frame["base_twist"], "base_twist", {"linear", "angular"})
+        normalized["base_twist"] = {
+            "linear": _float_array(
+                twist["linear"], "base_twist.linear", size=3, maximum_size=None, lower=-20.0, upper=20.0
+            ),
+            "angular": _float_array(
+                twist["angular"], "base_twist.angular", size=3, maximum_size=None,
+                lower=-20.0, upper=20.0
+            ),
+        }
+    return normalized
+
+
+def validate_frame_v1(value: Any, *, max_bytes: int = MAX_FRAME_BYTES) -> dict:
+    """Validate and normalize one authority-bearing Teleop Frame v1 object."""
+
+    try:
+        encoded_size = len(canonical_json(value))
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise ProtocolError("invalid_json", "frame must contain JSON-compatible finite values") from exc
+    if encoded_size > max_bytes:
+        raise ProtocolError("frame_too_large", f"frame exceeds {max_bytes} bytes")
+    return _normalize_frame_v1(value)
+
+
+def bind_rtc_frame_v1(
+    value: Any,
+    *,
+    authority: Mapping[str, Any],
+    max_bytes: int = MAX_FRAME_BYTES,
+) -> dict:
+    """Bind a public RTC wire Frame to its ticket-authorized private identity.
+
+    The browser is deliberately forbidden from supplying any authority field.
+    The returned internal Frame can therefore use the same runtime and final
+    dispatch validation as authenticated MCP diagnostics without disclosing the
+    session fence to JavaScript.
+    """
+
+    try:
+        encoded_size = len(canonical_json(value))
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise ProtocolError("invalid_json", "RTC frame must contain JSON-compatible finite values") from exc
+    if encoded_size > max_bytes:
+        raise ProtocolError("frame_too_large", f"RTC frame exceeds {max_bytes} bytes")
+    wire = _strict_object(
+        value,
+        "RTC frame",
+        set(RTC_FRAME_V1_DESCRIPTION["required"]),
+        set(RTC_FRAME_V1_DESCRIPTION["optional"]),
+    )
+    if not isinstance(authority, Mapping):
+        raise ProtocolError("invalid_rtc_binding", "RTC authority binding is invalid")
+    try:
+        internal = {
+            "boot_id": authority["boot_id"],
+            "session_id": authority["session_id"],
+            "epoch": authority["epoch"],
+            "fence": authority["fence"],
+            **wire,
+        }
+    except KeyError as exc:
+        raise ProtocolError("invalid_rtc_binding", "RTC authority binding is incomplete") from exc
+    return _normalize_frame_v1(internal)
+
+
+def sdp_digest(sdp: str) -> str:
+    if not isinstance(sdp, str) or not sdp:
+        raise TicketError("invalid_sdp", "sdp must be a non-empty string")
+    return hashlib.sha256(sdp.encode("utf-8")).hexdigest()
+
+
+def _b64encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(value: str) -> bytes:
+    if not isinstance(value, str) or not value:
+        raise TicketError("malformed_ticket", "ticket segment is empty")
+    try:
+        return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+    except Exception as exc:
+        raise TicketError("malformed_ticket", "ticket is not valid base64url") from exc
+
+
+@dataclass(frozen=True)
+class TicketClaims:
+    boot_id: str
+    session_id: str
+    epoch: int
+    fence: str
+    capability_digest: str
+    sdp_sha256: str
+    iat: int
+    exp: int
+    jti: str
+
+    def as_dict(self) -> dict:
+        return {
+            "v": 1,
+            "aud": "teleop-shadow-rtc",
+            "boot_id": self.boot_id,
+            "session_id": self.session_id,
+            "epoch": self.epoch,
+            "fence": self.fence,
+            "capability_digest": self.capability_digest,
+            "sdp_sha256": self.sdp_sha256,
+            "iat": self.iat,
+            "exp": self.exp,
+            "jti": self.jti,
+        }
+
+
+class TicketCodec:
+    """Small HMAC-SHA256 token codec shared with Core-side integration tests."""
+
+    def __init__(self, secret: str | bytes):
+        if isinstance(secret, str):
+            try:
+                secret_bytes = secret.encode("utf-8")
+            except UnicodeEncodeError:
+                raise ValueError(
+                    "MOTUS_TELEOP_TICKET_SECRET must be valid UTF-8"
+                ) from None
+        else:
+            secret_bytes = bytes(secret)
+        if len(secret_bytes) < 32:
+            raise ValueError("MOTUS_TELEOP_TICKET_SECRET must contain at least 32 bytes")
+        self._secret = secret_bytes
+
+    def sign(self, claims: TicketClaims) -> str:
+        payload = _b64encode(canonical_json(claims.as_dict()))
+        signature = _b64encode(hmac.new(self._secret, payload.encode("ascii"), hashlib.sha256).digest())
+        return f"{payload}.{signature}"
+
+    def decode_and_verify_signature(self, token: str) -> dict:
+        if not isinstance(token, str) or token.count(".") != 1:
+            raise TicketError("malformed_ticket", "ticket must contain payload and signature")
+        payload, signature = token.split(".", 1)
+        expected = _b64encode(hmac.new(self._secret, payload.encode("ascii"), hashlib.sha256).digest())
+        if not hmac.compare_digest(signature, expected):
+            raise TicketError("invalid_signature", "ticket signature is invalid")
+        try:
+            decoded = json.loads(_b64decode(payload))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise TicketError("malformed_ticket", "ticket payload is not valid JSON") from exc
+        return _strict_object(
+            decoded,
+            "ticket",
+            {
+                "v", "aud", "boot_id", "session_id", "epoch", "fence",
+                "capability_digest", "sdp_sha256", "iat", "exp", "jti",
+            },
+        )
+
+
+class TicketVerifier:
+    """Verify binding, expiry and one-time use for RTC offers."""
+
+    def __init__(
+        self,
+        codec: TicketCodec,
+        *,
+        max_ttl_seconds: int = 30,
+        max_replay_entries: int = 4096,
+        wall_clock: Callable[[], float] = time.time,
+    ):
+        self._codec = codec
+        self._max_ttl = int(max_ttl_seconds)
+        self._max_replay_entries = int(max_replay_entries)
+        self._wall_clock = wall_clock
+        self._used: dict[str, int] = {}
+        self._lock = threading.Lock()
+
+    def verify_and_consume(self, token: str, *, expected: Mapping[str, Any], sdp: str) -> dict:
+        claims = self._codec.decode_and_verify_signature(token)
+        now = int(self._wall_clock())
+        if claims["v"] != 1 or claims["aud"] != "teleop-shadow-rtc":
+            raise TicketError("invalid_audience", "ticket version or audience is invalid")
+        iat = _strict_int(claims["iat"], "ticket.iat", minimum=0)
+        exp = _strict_int(claims["exp"], "ticket.exp", minimum=1)
+        if iat > now + 5:
+            raise TicketError("ticket_not_yet_valid", "ticket issue time is in the future")
+        if exp <= now:
+            raise TicketError("ticket_expired", "ticket has expired")
+        if exp - iat <= 0 or exp - iat > self._max_ttl:
+            raise TicketError("invalid_ticket_ttl", f"ticket TTL must be <= {self._max_ttl} seconds")
+        jti = claims["jti"]
+        if not isinstance(jti, str) or not _TOKEN_ID_RE.fullmatch(jti):
+            raise TicketError("invalid_jti", "ticket jti is invalid")
+        if claims["sdp_sha256"] != sdp_digest(sdp):
+            raise TicketError("sdp_mismatch", "ticket is not bound to this SDP offer")
+        for key, value in expected.items():
+            if claims.get(key) != value:
+                raise TicketError("binding_mismatch", f"ticket {key} does not match the active session")
+
+        with self._lock:
+            self._used = {key: expiry for key, expiry in self._used.items() if expiry > now}
+            if jti in self._used:
+                raise TicketError("ticket_replayed", "ticket has already been used")
+            if len(self._used) >= self._max_replay_entries:
+                raise TicketError("replay_cache_full", "ticket replay cache is full")
+            self._used[jti] = exp
+        return claims
+
+
+def make_ticket_claims(
+    *,
+    session: Mapping[str, Any],
+    sdp: str,
+    ttl_seconds: int = 20,
+    wall_clock: Callable[[], float] = time.time,
+    jti: str | None = None,
+) -> TicketClaims:
+    """Reference claim builder for Core integration and local tests."""
+
+    now = int(wall_clock())
+    return TicketClaims(
+        boot_id=str(session["boot_id"]),
+        session_id=str(session["session_id"]),
+        epoch=int(session["epoch"]),
+        fence=str(session["fence"]),
+        capability_digest=str(session["capability_digest"]),
+        sdp_sha256=sdp_digest(sdp),
+        iat=now,
+        exp=now + int(ttl_seconds),
+        jti=jti or _b64encode(uuid.uuid4().bytes),
+    )

--- a/generic/teleop_shadow/render_instances.py
+++ b/generic/teleop_shadow/render_instances.py
@@ -1,0 +1,551 @@
+"""Render validated teleop-shadow instances into deterministic Docker Compose."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import re
+import ssl
+import stat
+import sys
+import tempfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+from yaml.constructor import ConstructorError
+from yaml.nodes import MappingNode
+
+SCHEMA_VERSION = 2
+MIN_MCP_PORT = 15700
+MAX_MCP_PORT = 15799
+MAX_INPUT_BYTES = 256 * 1024
+MAX_INSTANCES = 64
+MAX_CORE_CA_BYTES = 4 * 1024 * 1024
+CORE_CA_TARGET = "/etc/motus-core-ca/core-ca.pem"
+CORE_CA_SOURCE_ROOT = pathlib.Path("/opt/phanthy-motus")
+AGENT_CORE_URL = "https://localhost:15678"
+_ROOT_FIELDS = frozenset({"schema_version", "core_ca_file", "instances"})
+_INSTANCE_FIELDS = frozenset(
+    {
+        "service",
+        "container",
+        "driver_id",
+        "driver_name",
+        "robot_id",
+        "mcp_port",
+        "driver_token_env",
+        "ticket_secret_env",
+    }
+)
+_COMPOSE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+_INSTANCE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_IMAGE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/@:+-]{0,254}$")
+_DRIVER_TOKEN_ENV_RE = re.compile(
+    r"^MOTUS_TELEOP_[A-Z0-9_]{1,96}_DRIVER_TOKEN$"
+)
+_TICKET_SECRET_ENV_RE = re.compile(
+    r"^MOTUS_TELEOP_[A-Z0-9_]{1,96}_TICKET_SECRET$"
+)
+_SAFE_ABSOLUTE_PATH_RE = re.compile(r"^/[A-Za-z0-9._/-]+$")
+_PRIVATE_KEY_PEM_RE = re.compile(br"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----")
+_PEM_BLOCK_RE = re.compile(
+    br"-----BEGIN ([A-Z0-9][A-Z0-9 ]*)-----\r?\n.*?-----END \1-----",
+    re.DOTALL,
+)
+_PUBLIC_CERTIFICATE_LABELS = frozenset({b"CERTIFICATE", b"TRUSTED CERTIFICATE"})
+
+
+class RenderError(ValueError):
+    """The instances document cannot safely produce a Compose deployment."""
+
+
+class _StrictSafeLoader(yaml.SafeLoader):
+    """SafeLoader variant that rejects duplicate mapping keys."""
+
+    def construct_mapping(self, node: MappingNode, deep: bool = False) -> dict:
+        if not isinstance(node, MappingNode):
+            raise ConstructorError(
+                None,
+                None,
+                f"expected a mapping node, got {node.id}",
+                node.start_mark,
+            )
+        self.flatten_mapping(node)
+        mapping: dict[Any, Any] = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            try:
+                duplicate = key in mapping
+            except TypeError as exc:
+                raise ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "found an unhashable key",
+                    key_node.start_mark,
+                ) from exc
+            if duplicate:
+                raise ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    f"found duplicate key {key!r}",
+                    key_node.start_mark,
+                )
+            mapping[key] = self.construct_object(value_node, deep=deep)
+        return mapping
+
+
+@dataclass(frozen=True, slots=True)
+class InstanceSpec:
+    service: str
+    container: str
+    driver_id: str
+    driver_name: str
+    robot_id: str
+    mcp_port: int
+    driver_token_env: str
+    ticket_secret_env: str
+
+
+@dataclass(frozen=True, slots=True)
+class DeploymentSpec:
+    core_ca_file: str
+    instances: tuple[InstanceSpec, ...]
+
+
+def _mapping(value: object, location: str) -> dict:
+    if type(value) is not dict:
+        raise RenderError(f"{location} must be a mapping")
+    if any(not isinstance(key, str) for key in value):
+        raise RenderError(f"{location} field names must be strings")
+    return value
+
+
+def _reject_unknown_and_missing(
+    value: dict,
+    allowed: frozenset[str],
+    location: str,
+) -> None:
+    unknown = sorted(set(value) - allowed)
+    missing = sorted(allowed - set(value))
+    if unknown:
+        raise RenderError(f"{location} has unknown fields: {', '.join(unknown)}")
+    if missing:
+        raise RenderError(f"{location} is missing fields: {', '.join(missing)}")
+
+
+def _compose_name(value: object, field: str) -> str:
+    if not isinstance(value, str) or not _COMPOSE_NAME_RE.fullmatch(value):
+        raise RenderError(
+            f"{field} must match {_COMPOSE_NAME_RE.pattern!r} and be at most 63 characters"
+        )
+    return value
+
+
+def _instance_id(value: object, field: str, max_length: int) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) > max_length
+        or not _INSTANCE_ID_RE.fullmatch(value)
+    ):
+        raise RenderError(
+            f"{field} must be a stable 1-{max_length} character instance identifier"
+        )
+    return value
+
+
+def _driver_name(value: object, field: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > 200
+        or value != value.strip()
+        or not value.isprintable()
+        or "$" in value
+    ):
+        raise RenderError(
+            f"{field} must be a trimmed printable string of 1-200 characters without '$'"
+        )
+    return value
+
+
+def _mcp_port(value: object, field: str) -> int:
+    if type(value) is not int or not MIN_MCP_PORT <= value <= MAX_MCP_PORT:
+        raise RenderError(
+            f"{field} must be an integer in the Driver range {MIN_MCP_PORT}-{MAX_MCP_PORT}"
+        )
+    return value
+
+
+def _secret_env_name(value: object, field: str, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str) or not pattern.fullmatch(value):
+        raise RenderError(
+            f"{field} must be a dedicated environment name matching "
+            f"{pattern.pattern!r} and be at most 128 characters"
+        )
+    return value
+
+
+def _core_ca_file(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) > 1024
+        or not _SAFE_ABSOLUTE_PATH_RE.fullmatch(value)
+    ):
+        raise RenderError(
+            "core_ca_file must be a safe absolute POSIX file path without interpolation"
+        )
+    path = pathlib.PurePosixPath(value)
+    if path == pathlib.PurePosixPath("/") or ".." in path.parts or str(path) != value:
+        raise RenderError("core_ca_file must be normalized and must not contain '..'")
+    lexical_root = pathlib.PurePosixPath(CORE_CA_SOURCE_ROOT.as_posix())
+    if lexical_root not in path.parents or path.suffix.lower() not in {".pem", ".crt"}:
+        raise RenderError(
+            "core_ca_file must be a .pem or .crt file below /opt/phanthy-motus"
+        )
+    return _validate_core_ca_file_on_host(pathlib.Path(value))
+
+
+def _validate_core_ca_file_on_host(path: pathlib.Path) -> str:
+    """Return a canonical, public X.509-only CA path inside the deployment root."""
+
+    root = CORE_CA_SOURCE_ROOT
+    if root.is_symlink() or not root.is_dir():
+        raise RenderError(
+            "the host deployment root /opt/phanthy-motus must be an existing real directory"
+        )
+    try:
+        resolved_root = root.resolve(strict=True)
+        resolved = path.resolve(strict=True)
+        resolved.relative_to(resolved_root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RenderError(
+            "core_ca_file must resolve to an existing file inside /opt/phanthy-motus"
+        ) from exc
+    if resolved_root != root:
+        raise RenderError(
+            "core_ca_file requires /opt/phanthy-motus to be a real, canonical directory"
+        )
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    flags |= getattr(os, "O_NONBLOCK", 0)
+    descriptor = -1
+    try:
+        descriptor = os.open(resolved, flags)
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise RenderError("core_ca_file must resolve to a regular file")
+        if not 1 <= metadata.st_size <= MAX_CORE_CA_BYTES:
+            raise RenderError(
+                f"core_ca_file must contain 1-{MAX_CORE_CA_BYTES} bytes"
+            )
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = -1
+            encoded = handle.read(MAX_CORE_CA_BYTES + 1)
+    except OSError as exc:
+        raise RenderError("core_ca_file must be a readable regular file") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if not 1 <= len(encoded) <= MAX_CORE_CA_BYTES:
+        raise RenderError(f"core_ca_file must contain 1-{MAX_CORE_CA_BYTES} bytes")
+    if _PRIVATE_KEY_PEM_RE.search(encoded):
+        raise RenderError("core_ca_file must never contain a private-key PEM block")
+    position = 0
+    block_count = 0
+    for match in _PEM_BLOCK_RE.finditer(encoded):
+        if encoded[position:match.start()].strip():
+            raise RenderError("core_ca_file must contain only public X.509 PEM blocks")
+        if match.group(1) not in _PUBLIC_CERTIFICATE_LABELS:
+            raise RenderError("core_ca_file must contain only public X.509 PEM blocks")
+        block_count += 1
+        position = match.end()
+    if block_count == 0 or encoded[position:].strip():
+        raise RenderError("core_ca_file must contain only public X.509 PEM blocks")
+    try:
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.load_verify_locations(cadata=encoded.decode("ascii"))
+    except (OSError, UnicodeError, ssl.SSLError) as exc:
+        raise RenderError(
+            "core_ca_file must contain a parseable X.509 certificate or CA bundle"
+        ) from exc
+    return str(resolved)
+
+
+def _parse_instance(raw: object, index: int) -> InstanceSpec:
+    location = f"instances[{index}]"
+    value = _mapping(raw, location)
+    _reject_unknown_and_missing(value, _INSTANCE_FIELDS, location)
+    return InstanceSpec(
+        service=_compose_name(value["service"], f"{location}.service"),
+        container=_compose_name(value["container"], f"{location}.container"),
+        driver_id=_instance_id(
+            value["driver_id"], f"{location}.driver_id", max_length=64
+        ),
+        driver_name=_driver_name(value["driver_name"], f"{location}.driver_name"),
+        robot_id=_instance_id(
+            value["robot_id"], f"{location}.robot_id", max_length=64
+        ),
+        mcp_port=_mcp_port(value["mcp_port"], f"{location}.mcp_port"),
+        driver_token_env=_secret_env_name(
+            value["driver_token_env"],
+            f"{location}.driver_token_env",
+            _DRIVER_TOKEN_ENV_RE,
+        ),
+        ticket_secret_env=_secret_env_name(
+            value["ticket_secret_env"],
+            f"{location}.ticket_secret_env",
+            _TICKET_SECRET_ENV_RE,
+        ),
+    )
+
+
+def _require_unique(instances: Sequence[InstanceSpec], field: str) -> None:
+    seen: dict[object, int] = {}
+    for index, instance in enumerate(instances):
+        value = getattr(instance, field)
+        if value in seen:
+            raise RenderError(
+                f"instances[{index}].{field} duplicates instances[{seen[value]}].{field}"
+            )
+        seen[value] = index
+
+
+def _require_unique_secret_env_names(instances: Sequence[InstanceSpec]) -> None:
+    seen: dict[str, str] = {}
+    for index, instance in enumerate(instances):
+        for field in ("driver_token_env", "ticket_secret_env"):
+            value = getattr(instance, field)
+            location = f"instances[{index}].{field}"
+            previous = seen.get(value)
+            if previous is not None:
+                raise RenderError(
+                    f"{location} duplicates secret environment name used by {previous}"
+                )
+            seen[value] = location
+
+
+def parse_instances_document(document: object) -> DeploymentSpec:
+    """Validate a loaded instances document and return its typed form."""
+
+    root = _mapping(document, "document")
+    _reject_unknown_and_missing(root, _ROOT_FIELDS, "document")
+    if type(root["schema_version"]) is not int or root["schema_version"] != SCHEMA_VERSION:
+        raise RenderError(f"schema_version must be exactly {SCHEMA_VERSION}")
+    raw_instances = root["instances"]
+    if type(raw_instances) is not list:
+        raise RenderError("instances must be a list")
+    if not 1 <= len(raw_instances) <= MAX_INSTANCES:
+        raise RenderError(f"instances must contain 1-{MAX_INSTANCES} entries")
+
+    instances = tuple(
+        _parse_instance(raw_instance, index)
+        for index, raw_instance in enumerate(raw_instances)
+    )
+    for field in ("service", "container", "driver_id", "robot_id", "mcp_port"):
+        _require_unique(instances, field)
+    _require_unique_secret_env_names(instances)
+    return DeploymentSpec(
+        core_ca_file=_core_ca_file(root["core_ca_file"]),
+        instances=instances,
+    )
+
+
+def load_instances(path: str | pathlib.Path) -> DeploymentSpec:
+    """Load a bounded UTF-8 YAML file with duplicate-key rejection."""
+
+    input_path = pathlib.Path(path)
+    if not input_path.is_file():
+        raise RenderError(f"instances input is not a regular file: {input_path}")
+    try:
+        with input_path.open("rb") as handle:
+            encoded = handle.read(MAX_INPUT_BYTES + 1)
+        if len(encoded) > MAX_INPUT_BYTES:
+            raise RenderError(f"instances input exceeds {MAX_INPUT_BYTES} bytes")
+        text = encoded.decode("utf-8")
+        document = yaml.load(text, Loader=_StrictSafeLoader)
+    except UnicodeError as exc:
+        raise RenderError("instances input must be valid UTF-8") from exc
+    except RecursionError as exc:
+        raise RenderError("instances input YAML nesting is too deep") from exc
+    except yaml.YAMLError as exc:
+        raise RenderError(f"instances input is invalid YAML: {exc}") from exc
+    return parse_instances_document(document)
+
+
+def validate_image(image: object) -> str:
+    """Accept a conservative Compose-safe image reference."""
+
+    if not isinstance(image, str) or not _IMAGE_RE.fullmatch(image) or ".." in image:
+        raise RenderError(
+            "image must be a 1-255 character container reference without whitespace or interpolation"
+        )
+    return image
+
+
+def _service(instance: InstanceSpec, deployment: DeploymentSpec, image: str) -> dict:
+    port = instance.mcp_port
+    return {
+        "image": image,
+        "container_name": instance.container,
+        "network_mode": "host",
+        "volumes": [
+            {
+                "type": "bind",
+                "source": deployment.core_ca_file,
+                "target": CORE_CA_TARGET,
+                "read_only": True,
+                "bind": {"create_host_path": False},
+            }
+        ],
+        "environment": [
+            "MOTUS_BIND_HOST=127.0.0.1",
+            f"MOTUS_MCP_PORT={port}",
+            f"MOTUS_MCP_URL=http://localhost:{port}/mcp",
+            f"MOTUS_DRIVER_ID={instance.driver_id}",
+            f"MOTUS_DRIVER_NAME={instance.driver_name}",
+            f"MOTUS_ROBOT_ID={instance.robot_id}",
+            (
+                "MOTUS_DRIVER_TOKEN="
+                f"${{{instance.driver_token_env}:?set {instance.driver_token_env} "
+                "before Docker Compose validation}"
+            ),
+            (
+                "MOTUS_TELEOP_TICKET_SECRET="
+                f"${{{instance.ticket_secret_env}:?set {instance.ticket_secret_env} "
+                "before Docker Compose validation}"
+            ),
+            f"AGENT_CORE_URL={AGENT_CORE_URL}",
+            "MOTUS_AGENT_CORE_VERIFY_TLS=1",
+            f"MOTUS_AGENT_CORE_CA_FILE={CORE_CA_TARGET}",
+            "PYTHONUNBUFFERED=1",
+        ],
+        "logging": {
+            "driver": "local",
+            "options": {"max-size": "10m", "max-file": "3"},
+        },
+        "restart": "unless-stopped",
+    }
+
+
+def render_compose(deployment: DeploymentSpec, image: str) -> str:
+    """Render canonical Compose YAML without consulting process secrets."""
+
+    safe_image = validate_image(image)
+    services = {
+        instance.service: _service(instance, deployment, safe_image)
+        for instance in sorted(deployment.instances, key=lambda item: item.service)
+    }
+    rendered = yaml.safe_dump(
+        {"services": services},
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=False,
+        width=1000,
+    )
+    return "# Generated by render_instances.py; contains no secret values.\n" + rendered
+
+
+def atomic_write(path: str | pathlib.Path, content: str) -> None:
+    """Atomically replace a regular output file in an existing directory."""
+
+    output_path = pathlib.Path(path)
+    parent = output_path.parent
+    if not parent.is_dir():
+        raise RenderError(f"output parent is not a directory: {parent}")
+    if output_path.is_symlink() or (output_path.exists() and not output_path.is_file()):
+        raise RenderError(f"output must be a regular file path: {output_path}")
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{output_path.name}.",
+        suffix=".tmp",
+        dir=parent,
+        text=True,
+    )
+    temporary_path = pathlib.Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            os.fchmod(handle.fileno(), 0o644)
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, output_path)
+        directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        directory_flags |= getattr(os, "O_CLOEXEC", 0)
+        directory_fd = os.open(parent, directory_flags)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        if temporary_path.exists() or temporary_path.is_symlink():
+            temporary_path.unlink()
+
+
+def require_distinct_input_output(
+    input_path: str | pathlib.Path,
+    output_path: str | pathlib.Path,
+) -> None:
+    """Refuse to replace the source YAML through a direct path or hard link."""
+
+    source = pathlib.Path(input_path)
+    destination = pathlib.Path(output_path)
+    try:
+        source_resolved = source.resolve(strict=True)
+        destination_resolved = destination.resolve(strict=False)
+        aliases = source_resolved == destination_resolved
+        if destination.exists() and source.samefile(destination):
+            aliases = True
+    except OSError as exc:
+        raise RenderError("instances input and output paths could not be compared safely") from exc
+    if aliases:
+        raise RenderError("output must not replace or alias the instances input file")
+
+
+def _argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Render strict teleop-shadow instances into Docker Compose."
+    )
+    parser.add_argument("--instances", required=True, help="strict instances YAML input")
+    parser.add_argument("--image", required=True, help="one image reference for all instances")
+    parser.add_argument(
+        "--output",
+        default="teleop-shadow.compose.yml",
+        help="atomic output path (default: teleop-shadow.compose.yml)",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--stdout", action="store_true", help="render to stdout; write no file")
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="validate and render to stdout; write no file",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _argument_parser()
+    arguments = parser.parse_args(argv)
+    try:
+        deployment = load_instances(arguments.instances)
+        rendered = render_compose(deployment, arguments.image)
+        if arguments.stdout or arguments.dry_run:
+            sys.stdout.write(rendered)
+        else:
+            require_distinct_input_output(arguments.instances, arguments.output)
+            atomic_write(arguments.output, rendered)
+            print(
+                f"rendered {len(deployment.instances)} teleop-shadow instances to "
+                f"{arguments.output}",
+                file=sys.stderr,
+            )
+    except (OSError, RenderError) as exc:
+        print(f"render error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/generic/teleop_shadow/requirements.txt
+++ b/generic/teleop_shadow/requirements.txt
@@ -1,0 +1,8 @@
+# aiohttp: MCP, registration and WebRTC signaling HTTP service (Apache-2.0/MIT).
+aiohttp>=3.13,<3.15
+# aiortc: standards-based ICE/DTLS/SCTP/DataChannel implementation (BSD-3-Clause).
+# The Driver does not implement or fork WebRTC itself.
+aiortc>=1.14,<1.16
+# Keep aiortc's crypto backend on a wheel-backed, reproducible range (Apache-2.0/BSD-3-Clause).
+cryptography>=44,<47
+PyYAML>=6.0,<7

--- a/generic/teleop_shadow/rtc.py
+++ b/generic/teleop_shadow/rtc.py
@@ -1,0 +1,262 @@
+"""aiortc transport for the teleop-shadow diagnostic Driver."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from aiortc import RTCDataChannel, RTCPeerConnection, RTCSessionDescription
+from protocol import ProtocolError, TicketError, TicketVerifier
+from runtime import ShadowRuntime
+
+
+class RtcRequestError(RuntimeError):
+    def __init__(self, status: int, code: str, message: str):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+
+
+class RtcManager:
+    def __init__(self, runtime: ShadowRuntime, verifier: TicketVerifier | None):
+        self._runtime = runtime
+        self._verifier = verifier
+        self._peers: set[RTCPeerConnection] = set()
+        self._lock = asyncio.Lock()
+
+    @property
+    def enabled(self) -> bool:
+        return self._verifier is not None
+
+    async def accept_offer(self, payload: Any) -> dict:
+        if self._verifier is None:
+            raise RtcRequestError(
+                503,
+                "rtc_ticket_secret_missing",
+                "RTC is disabled until MOTUS_TELEOP_TICKET_SECRET is configured",
+            )
+        if not isinstance(payload, dict):
+            raise RtcRequestError(400, "invalid_offer", "offer body must be an object")
+        unknown = set(payload) - {"sdp", "type", "ticket"}
+        missing = {"sdp", "type", "ticket"} - set(payload)
+        if missing or unknown:
+            raise RtcRequestError(
+                400,
+                "invalid_offer",
+                f"offer fields invalid; missing={sorted(missing)}, unknown={sorted(unknown)}",
+            )
+        if payload["type"] != "offer" or not isinstance(payload["sdp"], str):
+            raise RtcRequestError(400, "invalid_offer", "type must be 'offer' and sdp must be a string")
+
+        try:
+            binding, generation = self._runtime.rtc_authority_snapshot()
+            self._verifier.verify_and_consume(
+                payload["ticket"],
+                expected=binding,
+                sdp=payload["sdp"],
+            )
+        except TicketError as exc:
+            self._runtime.record_protocol_error(exc.code)
+            raise RtcRequestError(401, exc.code, str(exc)) from exc
+        except ProtocolError as exc:
+            raise RtcRequestError(409, exc.code, str(exc)) from exc
+
+        async with self._lock:
+            # MCP may prepare a newer session while an offer is being verified.
+            # Never let a ticket for the old authority create a peer whose
+            # callbacks are accidentally bound to the new runtime generation.
+            try:
+                current_binding, current_generation = (
+                    self._runtime.rtc_authority_snapshot()
+                )
+                if current_binding != binding or current_generation != generation:
+                    raise RtcRequestError(
+                        409,
+                        "session_changed",
+                        "session changed while the RTC offer was being authorized",
+                    )
+            except ProtocolError as exc:
+                raise RtcRequestError(409, exc.code, str(exc)) from exc
+            await self._close_all_locked()
+            peer = RTCPeerConnection()
+            self._peers.add(peer)
+            self._install_peer_handlers(peer, generation, binding)
+            try:
+                await peer.setRemoteDescription(
+                    RTCSessionDescription(sdp=payload["sdp"], type=payload["type"])
+                )
+                answer = await peer.createAnswer()
+                await peer.setLocalDescription(answer)
+            except Exception as exc:
+                self._peers.discard(peer)
+                await peer.close()
+                self._runtime.record_protocol_error("invalid_sdp")
+                raise RtcRequestError(400, "invalid_sdp", f"failed to negotiate offer: {exc}") from exc
+
+        local = peer.localDescription
+        return {
+            "sdp": local.sdp,
+            "type": local.type,
+            "boot_id": binding["boot_id"],
+            "session_id": binding["session_id"],
+            "epoch": binding["epoch"],
+            "capability_digest": binding["capability_digest"],
+            "mode": "shadow",
+            "actuation_enabled": False,
+        }
+
+    async def close_all(self) -> None:
+        async with self._lock:
+            await self._close_all_locked()
+
+    async def _close_all_locked(self) -> None:
+        peers = list(self._peers)
+        self._peers.clear()
+        if peers:
+            await asyncio.gather(*(peer.close() for peer in peers), return_exceptions=True)
+
+    def _install_peer_handlers(
+        self,
+        peer: RTCPeerConnection,
+        generation: int,
+        authority: dict,
+    ) -> None:
+        accepted_labels: set[str] = set()
+
+        @peer.on("datachannel")
+        def on_datachannel(channel: RTCDataChannel) -> None:
+            label = channel.label
+            if label in accepted_labels or not self._channel_contract_valid(channel):
+                self._runtime.record_protocol_error("invalid_data_channel")
+                channel.close()
+                return
+            accepted_labels.add(label)
+
+            @channel.on("open")
+            def on_open() -> None:
+                self._runtime.mark_channel(generation, label, True)
+
+            @channel.on("close")
+            def on_close() -> None:
+                self._runtime.mark_channel(generation, label, False)
+
+            @channel.on("message")
+            def on_message(message: str | bytes) -> None:
+                if label == "teleop-pose":
+                    self._handle_pose_message(message, generation, authority)
+                else:
+                    if not self._runtime.generation_matches(generation):
+                        self._runtime.record_protocol_error("stale_rtc_message")
+                        return
+                    self._handle_control_message(channel, message)
+
+            # aiortc emits the remote `datachannel` event after moving the
+            # channel to open, so its earlier `open` event is not observable
+            # from this callback.  Record that already-open state explicitly.
+            if channel.readyState == "open":
+                self._runtime.mark_channel(generation, label, True)
+
+        @peer.on("connectionstatechange")
+        async def on_connectionstatechange() -> None:
+            if peer.connectionState in ("failed", "closed", "disconnected"):
+                self._runtime.mark_rtc_disconnected(generation, f"rtc_{peer.connectionState}")
+                self._peers.discard(peer)
+                if peer.connectionState != "closed":
+                    await peer.close()
+
+    @staticmethod
+    def _channel_contract_valid(channel: RTCDataChannel) -> bool:
+        if channel.label == "teleop-control":
+            return (
+                channel.ordered is True
+                and channel.maxRetransmits is None
+                and channel.maxPacketLifeTime is None
+            )
+        if channel.label == "teleop-pose":
+            return (
+                channel.ordered is False
+                and channel.maxRetransmits == 0
+                and channel.maxPacketLifeTime is None
+            )
+        return False
+
+    def _decode_message(self, message: str | bytes, *, maximum: int) -> Any:
+        if isinstance(message, bytes):
+            if len(message) > maximum:
+                raise ProtocolError("message_too_large", f"RTC message exceeds {maximum} bytes")
+            try:
+                message = message.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ProtocolError("invalid_encoding", "RTC message must be UTF-8 JSON") from exc
+        if not isinstance(message, str):
+            raise ProtocolError("invalid_encoding", "RTC message must be UTF-8 JSON")
+        try:
+            encoded_size = len(message.encode("utf-8"))
+        except UnicodeEncodeError as exc:
+            raise ProtocolError("invalid_encoding", "RTC message must be UTF-8 JSON") from exc
+        if encoded_size > maximum:
+            raise ProtocolError("message_too_large", f"RTC message exceeds {maximum} bytes")
+        try:
+            return json.loads(message)
+        except (json.JSONDecodeError, ValueError, RecursionError) as exc:
+            raise ProtocolError("invalid_json", "RTC message must be valid JSON") from exc
+
+    def _handle_pose_message(
+        self,
+        message: str | bytes,
+        generation: int,
+        authority: dict,
+    ) -> None:
+        try:
+            self._runtime.submit_rtc_frame(
+                self._decode_message(message, maximum=64 * 1024),
+                authority=authority,
+                rtc_generation=generation,
+            )
+        except ProtocolError as exc:
+            self._runtime.record_protocol_error(exc.code)
+
+    def _handle_control_message(
+        self,
+        channel: RTCDataChannel,
+        message: str | bytes,
+    ) -> None:
+        try:
+            payload = self._decode_message(message, maximum=8 * 1024)
+            if not isinstance(payload, dict) or set(payload) - {"type", "request_id"}:
+                raise ProtocolError(
+                    "invalid_control",
+                    "control message contains invalid or private authority fields",
+                )
+            message_type = payload.get("type")
+            if message_type in ("peer_ping", "status"):
+                result = self._runtime.status()
+            elif message_type == "heartbeat":
+                raise ProtocolError(
+                    "rtc_cannot_renew_lease",
+                    "RTC control messages never renew the Core-owned lease",
+                )
+            elif message_type in ("pause", "soft_stop", "release"):
+                raise ProtocolError(
+                    "rtc_control_requires_core",
+                    "session mutations must use the authenticated Core REST API",
+                )
+            else:
+                raise ProtocolError("invalid_control", f"unsupported control message type: {message_type}")
+            channel.send(json.dumps({
+                "type": "response",
+                "request_id": payload.get("request_id"),
+                "ok": True,
+                "state": result["state"],
+                "lease_renewed": False,
+            }, separators=(",", ":")))
+        except ProtocolError as exc:
+            self._runtime.record_protocol_error(exc.code)
+            if channel.readyState == "open":
+                channel.send(json.dumps({
+                    "type": "response",
+                    "ok": False,
+                    "error": {"code": exc.code, "message": str(exc)},
+                    "lease_renewed": False,
+                }, separators=(",", ":")))

--- a/generic/teleop_shadow/runtime.py
+++ b/generic/teleop_shadow/runtime.py
@@ -1,0 +1,725 @@
+"""Thread-safe, robot-free teleoperation shadow session runtime."""
+
+from __future__ import annotations
+
+import copy
+import re
+import secrets
+import threading
+import time
+import uuid
+from collections import Counter
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from dispatch import FinalDispatchArbiter, RecordingAdapter, StopHandle
+from protocol import (
+    CAPABILITIES,
+    CAPABILITY_DIGEST,
+    MODE,
+    ProtocolError,
+    bind_rtc_frame_v1,
+    validate_frame_v1,
+)
+
+SESSION_STATES = {
+    "idle",
+    "prepared_shadow",
+    "active_shadow",
+    "hold",
+    "paused",
+    "released",
+    "fault",
+}
+
+
+class ShadowRuntime:
+    """Own fencing, watchdogs and a recording-only final dispatch boundary."""
+
+    def __init__(
+        self,
+        *,
+        lease_timeout_ms: int = 1000,
+        pose_timeout_ms: int = 200,
+        watchdog_interval_ms: int = 25,
+        driver_id: str = "teleop-shadow-driver",
+        driver_name: str = "Generic Teleop Shadow Diagnostics",
+        robot_id: str | None = None,
+        clock: Callable[[], float] = time.monotonic,
+        auto_watchdog: bool = True,
+        dispatch_io_timeout_ms: int = 100,
+        dispatch_ack_timeout_ms: int = 200,
+        dispatcher: FinalDispatchArbiter | None = None,
+    ):
+        if lease_timeout_ms < 100:
+            raise ValueError("lease_timeout_ms must be >= 100")
+        if pose_timeout_ms < 20:
+            raise ValueError("pose_timeout_ms must be >= 20")
+        if watchdog_interval_ms < 5:
+            raise ValueError("watchdog_interval_ms must be >= 5")
+        if dispatch_io_timeout_ms < 20 or dispatch_io_timeout_ms > 150:
+            raise ValueError("dispatch_io_timeout_ms must be in [20, 150]")
+        if (
+            dispatch_ack_timeout_ms < dispatch_io_timeout_ms
+            or dispatch_ack_timeout_ms > 200
+        ):
+            raise ValueError(
+                "dispatch_ack_timeout_ms must be >= dispatch_io_timeout_ms and <= 200"
+            )
+        self.boot_id = str(uuid.uuid4())
+        self.driver_id = driver_id
+        self.driver_name = driver_name
+        self.robot_id = robot_id
+        self.capability_digest = CAPABILITY_DIGEST
+        self._lease_timeout = lease_timeout_ms / 1000.0
+        self._pose_timeout = pose_timeout_ms / 1000.0
+        self._watchdog_interval = watchdog_interval_ms / 1000.0
+        self._clock = clock
+        self._lock = threading.RLock()
+        self._transition_lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._watchdog_thread: threading.Thread | None = None
+        self._dispatch_ack_timeout = dispatch_ack_timeout_ms / 1000.0
+        self._dispatcher = dispatcher or FinalDispatchArbiter(
+            RecordingAdapter(clock=clock),
+            clock=clock,
+            io_timeout_ms=dispatch_io_timeout_ms,
+        )
+        self._closed = False
+
+        self._epoch = 0
+        self._generation = 0
+        self._state = "idle"
+        self._reason: str | None = None
+        self._session_id: str | None = None
+        self._fence: str | None = None
+        self._prepared_at: float | None = None
+        self._last_lease_at: float | None = None
+        self._authority_valid = False
+        self._authority_invalid_reason: str | None = "not_prepared"
+        self._last_pose_at: float | None = None
+        self._latest_frame: dict | None = None
+        self._last_sequence: int | None = None
+        self._hold_clutch_sequence = -1
+        self._rtc_connected = False
+        self._channels = {"teleop-control": False, "teleop-pose": False}
+        self._counters: Counter[str] = Counter()
+        if auto_watchdog:
+            self.start()
+
+    def start(self) -> None:
+        """Start one long-lived watchdog thread; calling twice is harmless."""
+
+        with self._lock:
+            if self._closed:
+                return
+            if self._watchdog_thread and self._watchdog_thread.is_alive():
+                return
+            self._stop_event.clear()
+            self._watchdog_thread = threading.Thread(
+                target=self._watchdog_loop,
+                daemon=True,
+                name="teleop-shadow-watchdog",
+            )
+            self._watchdog_thread.start()
+
+    def close(self) -> None:
+        self._stop_event.set()
+        thread = self._watchdog_thread
+        if thread and thread is not threading.current_thread():
+            thread.join(timeout=max(1.0, self._watchdog_interval * 4))
+        with self._transition_lock:
+            with self._lock:
+                if self._closed:
+                    return
+                self._closed = True
+                if self._authority_valid:
+                    self._generation += 1
+                self._authority_valid = False
+                self._authority_invalid_reason = "service_close"
+                self._state = "released"
+                self._reason = "service_close"
+                self._clear_session_locked()
+            ack = self._dispatcher.close(self._dispatch_ack_timeout)
+            if not ack.ok:
+                with self._lock:
+                    self._latch_dispatch_fault_locked(ack.code)
+
+    def prepare_shadow(self, args: dict) -> dict:
+        session_id = self._canonical_uuid(args.get("session_id"), "session_id")
+        epoch = args.get("epoch")
+        if isinstance(epoch, bool) or not isinstance(epoch, int) or epoch < 1:
+            raise ProtocolError("invalid_epoch", "epoch must be an integer >= 1")
+        fence = args.get("fence")
+        if not isinstance(fence, str) or not re.fullmatch(r"[A-Za-z0-9_-]{24,128}", fence):
+            raise ProtocolError("invalid_fence", "fence must be a URL-safe token of 24-128 characters")
+        binding = {
+            "boot_id": self.boot_id,
+            "session_id": session_id,
+            "epoch": epoch,
+            "fence": fence,
+        }
+        with self._transition_lock:
+            with self._lock:
+                self._require_open_locked()
+                if epoch <= self._epoch:
+                    raise ProtocolError("stale_epoch", f"epoch must be greater than {self._epoch}")
+                # Fence RTC and Frame callbacks before the safe-stop leaves the
+                # runtime lock.  The new authority is installed only after the
+                # final adapter has acknowledged that stop.
+                self._generation += 1
+                generation = self._generation
+                self._authority_valid = False
+                self._authority_invalid_reason = "prepare_shadow"
+                self._state = "hold"
+                self._reason = "prepare_shadow"
+                self._clear_session_locked()
+                handle = self._dispatcher.begin_prepare()
+            ack = self._dispatcher.wait_safe(handle, self._dispatch_ack_timeout)
+            if not ack.ok:
+                with self._lock:
+                    self._latch_dispatch_fault_locked(ack.code)
+                raise ProtocolError(
+                    "dispatch_stop_unconfirmed",
+                    "final output adapter did not acknowledge prepare safe-stop",
+                )
+            with self._lock:
+                self._require_open_locked()
+                dispatch_ack = self._dispatcher.complete_prepare(handle, binding, generation)
+                if not dispatch_ack.ok:
+                    self._latch_dispatch_fault_locked(dispatch_ack.code)
+                    raise ProtocolError(
+                        "dispatch_prepare_failed",
+                        "final output adapter could not arm the Shadow recording session",
+                    )
+                now = self._clock()
+                self._epoch = epoch
+                self._state = "prepared_shadow"
+                self._reason = None
+                self._session_id = session_id
+                self._fence = fence
+                self._prepared_at = now
+                self._last_lease_at = now
+                self._authority_valid = True
+                self._authority_invalid_reason = None
+                self._last_pose_at = None
+                self._latest_frame = None
+                self._last_sequence = None
+                self._hold_clutch_sequence = -1
+                self._rtc_connected = False
+                self._channels = {"teleop-control": False, "teleop-pose": False}
+                self._counters["sessions_prepared"] += 1
+                return self._public_snapshot_locked(now)
+
+    def heartbeat(self, args: dict) -> dict:
+        now = self._clock()
+        with self._lock:
+            self._require_open_locked()
+            self._require_session_live_locked()
+            self._require_identity_locked(args)
+            self._require_authority_valid_locked(now)
+            self._last_lease_at = now
+            self._counters["lease_heartbeats"] += 1
+            return self._public_snapshot_locked(now)
+
+    def pause(self, args: dict) -> dict:
+        with self._transition_lock:
+            now = self._clock()
+            with self._lock:
+                self._require_open_locked()
+                self._require_session_live_locked()
+                self._require_identity_locked(args)
+                self._require_authority_valid_locked(now)
+                handle = self._enter_hold_locked("operator_pause", target_state="paused")
+            self._wait_for_transition_stop(handle, "pause")
+            with self._lock:
+                return self._public_snapshot_locked(self._clock())
+
+    def soft_stop(self, args: dict) -> dict:
+        with self._transition_lock:
+            now = self._clock()
+            with self._lock:
+                self._require_open_locked()
+                self._require_session_live_locked()
+                self._require_identity_locked(args)
+                self._require_authority_valid_locked(now)
+                if self._state == "paused":
+                    raise ProtocolError("session_paused", "a paused session requires a new prepare_shadow")
+                handle = self._enter_hold_locked("soft_stop")
+                self._counters["soft_stops"] += 1
+            self._wait_for_transition_stop(handle, "soft_stop")
+            with self._lock:
+                return self._public_snapshot_locked(self._clock())
+
+    def release(self, args: dict | None = None, *, lifecycle: bool = False) -> dict:
+        with self._transition_lock:
+            with self._lock:
+                self._require_open_locked()
+                if not lifecycle:
+                    self._require_session_live_locked()
+                    self._require_identity_locked(args or {})
+                reason = "lifecycle_stop" if lifecycle else "operator_release"
+                handle = self._invalidate_authority_locked(reason, target_state="released")
+                self._counters["sessions_released"] += 1
+            self._wait_for_transition_stop(handle, "release")
+            with self._lock:
+                return self._public_snapshot_locked(self._clock())
+
+    def submit_shadow_frame(
+        self,
+        raw_frame: Any,
+        *,
+        source: str,
+        rtc_generation: int | None = None,
+    ) -> dict:
+        try:
+            frame = validate_frame_v1(raw_frame)
+        except ProtocolError as exc:
+            with self._lock:
+                self._counters["frames_rejected"] += 1
+                self._counters[f"reject_{exc.code}"] += 1
+            raise
+
+        now = self._clock()
+        with self._lock:
+            try:
+                self._require_open_locked()
+                self._require_session_live_locked()
+                self._require_identity_locked(frame)
+                self._require_authority_valid_locked(now)
+                if source == "rtc":
+                    if rtc_generation != self._generation:
+                        raise ProtocolError(
+                            "stale_rtc_generation",
+                            "RTC Pose belongs to a stale session generation",
+                        )
+                    if not self._rtc_connected or not all(self._channels.values()):
+                        if self._state in ("prepared_shadow", "active_shadow"):
+                            self._enter_hold_locked("rtc_not_ready")
+                        raise ProtocolError(
+                            "rtc_not_ready",
+                            "both teleop-control and teleop-pose must be open for RTC Pose",
+                        )
+                if self._state == "paused":
+                    raise ProtocolError("session_inactive", f"cannot accept frames in state {self._state}")
+                sequence = frame["sequence"]
+                if self._last_sequence is not None and sequence <= self._last_sequence:
+                    raise ProtocolError(
+                        "sequence_not_increasing",
+                        f"sequence must be greater than {self._last_sequence}",
+                    )
+            except ProtocolError as exc:
+                self._counters["frames_rejected"] += 1
+                self._counters[f"reject_{exc.code}"] += 1
+                raise
+
+            self._latest_frame = frame
+            self._last_sequence = sequence
+            self._last_pose_at = now
+            self._counters["frames_accepted"] += 1
+            self._counters[f"frames_from_{source}"] += 1
+
+            tracking_ok = all(frame["tracking"].values())
+            dispatch_frame = False
+            allow_reclutch = False
+            if self._state == "hold" and self._reason == "soft_stop":
+                # Core has no resume/rearm action.  An operator soft-stop is a
+                # latch: only release followed by a newer prepare can re-arm.
+                self._counters["frames_held_after_soft_stop"] += 1
+            elif not frame["deadman"]:
+                self._enter_hold_locked("deadman_released")
+            elif not tracking_ok:
+                self._enter_hold_locked("tracking_lost")
+            elif self._state == "prepared_shadow":
+                self._state = "active_shadow"
+                self._reason = None
+                dispatch_frame = True
+            elif self._state == "hold":
+                if frame["clutch_sequence"] > self._hold_clutch_sequence:
+                    self._state = "active_shadow"
+                    self._reason = None
+                    self._counters["explicit_reclutches"] += 1
+                    dispatch_frame = True
+                    allow_reclutch = True
+                else:
+                    self._counters["frames_held_without_reclutch"] += 1
+            elif self._state == "active_shadow":
+                dispatch_frame = True
+
+            if dispatch_frame:
+                lease_started = (
+                    self._last_lease_at if self._last_lease_at is not None else now
+                )
+                dispatch_ack = self._dispatcher.publish_latest(
+                    frame,
+                    session_generation=self._generation,
+                    expires_monotonic=min(
+                        now + self._pose_timeout,
+                        lease_started + self._lease_timeout,
+                    ),
+                    allow_reclutch=allow_reclutch,
+                )
+                if not dispatch_ack.ok:
+                    self._counters["dispatch_rejections"] += 1
+                    self._counters[f"dispatch_reject_{dispatch_ack.code}"] += 1
+                    dispatch_state = self._dispatcher.snapshot()["state"]
+                    if dispatch_ack.code == "intent_expired" or (
+                        dispatch_ack.code == "motion_inhibited"
+                        and dispatch_state == "safe_reclutch_required"
+                    ):
+                        self._enter_hold_locked("pose_timeout")
+                    else:
+                        self._dispatcher.trip(
+                            "dispatch_fault",
+                            target_state="fault_latched",
+                            retain_authority=False,
+                        )
+                        self._latch_dispatch_fault_locked(dispatch_ack.code)
+                        raise ProtocolError(
+                            "dispatch_fault",
+                            "final output authority check failed; a new Driver process is required",
+                        )
+
+            result = self._public_snapshot_locked(now)
+            result["accepted_sequence"] = sequence
+            return result
+
+    def mark_channel(self, generation: int, label: str, opened: bool) -> dict:
+        now = self._clock()
+        with self._lock:
+            if generation != self._generation:
+                self._counters["stale_rtc_callbacks"] += 1
+                return self._public_snapshot_locked(now)
+            if self._state in ("idle", "released"):
+                self._counters["terminal_rtc_callbacks_ignored"] += 1
+                return self._public_snapshot_locked(now)
+            if not self._authority_valid or self._lease_deadline_passed_locked(now):
+                if self._authority_valid:
+                    self._invalidate_authority_locked("lease_timeout", target_state="hold")
+                self._counters["expired_rtc_callbacks_ignored"] += 1
+                return self._public_snapshot_locked(now)
+            if label in self._channels:
+                self._channels[label] = bool(opened)
+            self._rtc_connected = all(self._channels.values())
+            if not opened and self._state in ("prepared_shadow", "active_shadow"):
+                self._enter_hold_locked("rtc_disconnected")
+            return self._public_snapshot_locked(now)
+
+    def submit_rtc_frame(
+        self,
+        raw_frame: Any,
+        *,
+        authority: Mapping[str, Any],
+        rtc_generation: int,
+    ) -> dict:
+        """Bind one public RTC frame before entering the common safety path."""
+
+        try:
+            frame = bind_rtc_frame_v1(raw_frame, authority=authority)
+        except ProtocolError as exc:
+            with self._lock:
+                self._counters["frames_rejected"] += 1
+                self._counters[f"reject_{exc.code}"] += 1
+            raise
+        return self.submit_shadow_frame(
+            frame,
+            source="rtc",
+            rtc_generation=rtc_generation,
+        )
+
+    def mark_rtc_disconnected(self, generation: int, reason: str = "rtc_disconnected") -> dict:
+        now = self._clock()
+        with self._lock:
+            if generation != self._generation:
+                self._counters["stale_rtc_callbacks"] += 1
+                return self._public_snapshot_locked(now)
+            if self._state in ("idle", "released"):
+                self._counters["terminal_rtc_callbacks_ignored"] += 1
+                return self._public_snapshot_locked(now)
+            if not self._authority_valid or self._lease_deadline_passed_locked(now):
+                if self._authority_valid:
+                    self._invalidate_authority_locked("lease_timeout", target_state="hold")
+                self._counters["expired_rtc_callbacks_ignored"] += 1
+                return self._public_snapshot_locked(now)
+            self._rtc_connected = False
+            self._channels = {"teleop-control": False, "teleop-pose": False}
+            if self._state in ("prepared_shadow", "active_shadow"):
+                self._enter_hold_locked(reason)
+            self._counters["rtc_disconnects"] += 1
+            return self._public_snapshot_locked(now)
+
+    def record_protocol_error(self, code: str) -> None:
+        with self._lock:
+            self._counters["protocol_errors"] += 1
+            self._counters[f"protocol_{code}"] += 1
+
+    def status(self) -> dict:
+        with self._lock:
+            now = self._clock()
+            if self._authority_valid and self._lease_deadline_passed_locked(now):
+                self._invalidate_authority_locked("lease_timeout", target_state="hold")
+            return self._public_snapshot_locked(now)
+
+    def ticket_binding(self) -> dict:
+        with self._lock:
+            self._require_open_locked()
+            self._require_session_live_locked()
+            self._require_authority_valid_locked(self._clock())
+            return self._ticket_binding_locked()
+
+    def rtc_authority_snapshot(self) -> tuple[dict, int]:
+        """Capture one immutable RTC authority tuple under the runtime lock."""
+
+        with self._lock:
+            self._require_open_locked()
+            self._require_session_live_locked()
+            self._require_authority_valid_locked(self._clock())
+            return self._ticket_binding_locked(), self._generation
+
+    def session_generation(self) -> int:
+        """Return the opaque internal generation used only to fence RTC callbacks."""
+
+        with self._lock:
+            return self._generation
+
+    def generation_matches(self, generation: int) -> bool:
+        with self._lock:
+            self._sync_dispatch_fault_locked()
+            if generation != self._generation:
+                return False
+            if not self._authority_valid:
+                return False
+            if self._lease_deadline_passed_locked(self._clock()):
+                self._invalidate_authority_locked("lease_timeout", target_state="hold")
+                return False
+            return True
+
+    def watchdog_tick(self) -> dict:
+        now = self._clock()
+        with self._lock:
+            if self._authority_valid and self._state in (
+                "prepared_shadow", "active_shadow", "hold", "paused"
+            ):
+                if self._lease_deadline_passed_locked(now):
+                    self._invalidate_authority_locked("lease_timeout", target_state="hold")
+                elif (
+                    self._state == "active_shadow"
+                    and self._last_pose_at is not None
+                    and now - self._last_pose_at > self._pose_timeout
+                ):
+                    self._enter_hold_locked("pose_timeout")
+                    self._counters["pose_timeouts"] += 1
+            return self._public_snapshot_locked(now)
+
+    def _watchdog_loop(self) -> None:
+        while not self._stop_event.wait(self._watchdog_interval):
+            self.watchdog_tick()
+
+    def _enter_hold_locked(
+        self,
+        reason: str,
+        *,
+        target_state: str = "hold",
+    ) -> StopHandle | None:
+        changed = self._state != target_state or self._reason != reason
+        self._state = target_state
+        self._reason = reason
+        if self._latest_frame is not None:
+            self._hold_clutch_sequence = max(
+                self._hold_clutch_sequence,
+                int(self._latest_frame["clutch_sequence"]),
+            )
+        if not changed:
+            return None
+        dispatch_state = (
+            "safe_latched"
+            if target_state == "paused" or reason == "soft_stop"
+            else "safe_reclutch_required"
+        )
+        return self._dispatcher.trip(
+            reason,
+            target_state=dispatch_state,
+            retain_authority=True,
+        )
+
+    def _lease_deadline_passed_locked(self, now: float) -> bool:
+        return self._last_lease_at is None or now - self._last_lease_at > self._lease_timeout
+
+    def _invalidate_authority_locked(
+        self,
+        reason: str,
+        *,
+        target_state: str,
+    ) -> StopHandle:
+        was_valid = self._authority_valid
+        self._authority_valid = False
+        self._authority_invalid_reason = reason
+        if was_valid:
+            self._generation += 1
+        self._state = target_state
+        self._reason = reason
+        self._clear_session_locked()
+        handle = self._dispatcher.trip(
+            reason,
+            target_state="safe_revoked",
+            retain_authority=False,
+        )
+        if was_valid and reason == "lease_timeout":
+            self._counters["lease_timeouts"] += 1
+        return handle
+
+    def _clear_session_locked(self) -> None:
+        self._session_id = None
+        self._fence = None
+        self._prepared_at = None
+        self._last_lease_at = None
+        self._last_pose_at = None
+        self._latest_frame = None
+        self._last_sequence = None
+        self._hold_clutch_sequence = -1
+        self._rtc_connected = False
+        self._channels = {"teleop-control": False, "teleop-pose": False}
+
+    def _wait_for_transition_stop(
+        self,
+        handle: StopHandle | None,
+        operation: str,
+    ) -> None:
+        if handle is None:
+            return
+        ack = self._dispatcher.wait_safe(handle, self._dispatch_ack_timeout)
+        if ack.ok:
+            return
+        with self._lock:
+            self._latch_dispatch_fault_locked(ack.code)
+        raise ProtocolError(
+            "dispatch_stop_unconfirmed",
+            f"final output adapter did not acknowledge {operation} safe-stop",
+        )
+
+    def _latch_dispatch_fault_locked(self, code: str) -> None:
+        if self._authority_valid:
+            self._generation += 1
+        self._authority_valid = False
+        self._authority_invalid_reason = "dispatch_fault"
+        self._state = "fault"
+        self._reason = "dispatch_fault"
+        self._clear_session_locked()
+        self._counters["dispatch_faults"] += 1
+        self._counters[f"dispatch_fault_{code}"] += 1
+
+    def _sync_dispatch_fault_locked(self) -> None:
+        dispatch = self._dispatcher.snapshot()
+        code = dispatch.get("fault_code")
+        if code is not None and self._authority_invalid_reason != "dispatch_fault":
+            self._latch_dispatch_fault_locked(str(code))
+
+    def _require_open_locked(self) -> None:
+        if self._closed:
+            raise ProtocolError("service_closed", "the Driver process is closing")
+        self._sync_dispatch_fault_locked()
+
+    def _require_authority_valid_locked(self, now: float) -> None:
+        if not self._authority_valid:
+            self._raise_invalid_authority_locked()
+        if self._lease_deadline_passed_locked(now):
+            self._invalidate_authority_locked("lease_timeout", target_state="hold")
+            raise ProtocolError(
+                "session_expired",
+                "Core MCP heartbeat lease expired; a new prepare_shadow is required",
+            )
+
+    def _require_session_live_locked(self) -> None:
+        if not self._authority_valid:
+            self._raise_invalid_authority_locked()
+
+    def _raise_invalid_authority_locked(self) -> None:
+        if self._authority_invalid_reason == "lease_timeout":
+            raise ProtocolError(
+                "session_expired",
+                "Core MCP heartbeat lease expired; a new prepare_shadow is required",
+            )
+        raise ProtocolError("session_inactive", "a new prepare_shadow session is required")
+
+    def _require_identity_locked(self, value: dict) -> None:
+        required = ("boot_id", "session_id", "epoch", "fence")
+        missing = [key for key in required if key not in value]
+        if missing:
+            raise ProtocolError("missing_identity", f"missing session identity fields: {missing}")
+        if value["boot_id"] != self.boot_id:
+            raise ProtocolError("boot_mismatch", "boot_id does not match this Driver process")
+        if value["session_id"] != self._session_id:
+            raise ProtocolError("session_mismatch", "session_id does not match the active session")
+        if isinstance(value["epoch"], bool) or value["epoch"] != self._epoch:
+            raise ProtocolError("epoch_mismatch", "epoch does not match the active session")
+        if not isinstance(value["fence"], str) or not secrets.compare_digest(value["fence"], self._fence or ""):
+            raise ProtocolError("fence_mismatch", "fence does not match the active session")
+
+    def _ticket_binding_locked(self) -> dict:
+        assert self._session_id is not None and self._fence is not None
+        return {
+            "boot_id": self.boot_id,
+            "session_id": self._session_id,
+            "epoch": self._epoch,
+            "fence": self._fence,
+            "capability_digest": self.capability_digest,
+        }
+
+    @staticmethod
+    def _canonical_uuid(value: Any, name: str) -> str:
+        if not isinstance(value, str):
+            raise ProtocolError("invalid_session_id", f"{name} must be a canonical UUID")
+        try:
+            parsed = uuid.UUID(value)
+        except ValueError as exc:
+            raise ProtocolError("invalid_session_id", f"{name} must be a canonical UUID") from exc
+        if str(parsed) != value.lower():
+            raise ProtocolError("invalid_session_id", f"{name} must be a canonical UUID")
+        return str(parsed)
+
+    def _public_snapshot_locked(self, now: float) -> dict:
+        self._sync_dispatch_fault_locked()
+        lease_age = None if self._last_lease_at is None else max(0.0, now - self._last_lease_at)
+        pose_age = None if self._last_pose_at is None else max(0.0, now - self._last_pose_at)
+        latest = copy.deepcopy(self._latest_frame)
+        if latest is not None:
+            latest.pop("fence", None)
+        return {
+            "driver": self.driver_id,
+            "driver_id": self.driver_id,
+            "driver_name": self.driver_name,
+            "driver_type": "teleop-shadow",
+            "robot_id": self.robot_id,
+            "mode": MODE,
+            "actuation_enabled": False,
+            "boot_id": self.boot_id,
+            "session_id": self._session_id,
+            "epoch": self._epoch,
+            "state": self._state,
+            "reason": self._reason,
+            "authority_valid": self._authority_valid,
+            "capability_digest": self.capability_digest,
+            "capabilities": copy.deepcopy(CAPABILITIES),
+            "lease": {
+                "source": "agent-core-mcp-heartbeat-only",
+                "timeout_ms": round(self._lease_timeout * 1000),
+                "age_ms": None if lease_age is None else round(lease_age * 1000, 3),
+                "fresh": lease_age is not None and lease_age <= self._lease_timeout,
+                "authority_valid": self._authority_valid,
+                "expired_latched": self._authority_invalid_reason == "lease_timeout",
+            },
+            "pose": {
+                "timeout_ms": round(self._pose_timeout * 1000),
+                "age_ms": None if pose_age is None else round(pose_age * 1000, 3),
+                "fresh": pose_age is not None and pose_age <= self._pose_timeout,
+                "latest_sequence": self._last_sequence,
+                "latest": latest,
+            },
+            "rtc": {
+                "connected": self._rtc_connected,
+                "channels": dict(self._channels),
+                "renews_lease": False,
+            },
+            "dispatch": self._dispatcher.snapshot(),
+            "counters": dict(sorted(self._counters.items())),
+        }

--- a/generic/teleop_shadow/smoke_recording.py
+++ b/generic/teleop_shadow/smoke_recording.py
@@ -1,0 +1,125 @@
+"""Run a visible, robot-free final-dispatch smoke scenario."""
+
+from __future__ import annotations
+
+import json
+import secrets
+import time
+import uuid
+
+from runtime import ShadowRuntime
+
+
+def _frame(runtime: ShadowRuntime, session: dict) -> dict:
+    pose = {
+        "position": [0.0, 1.0, 0.0],
+        "orientation": [0.0, 0.0, 0.0, 1.0],
+    }
+    return {
+        "schema_version": 1,
+        "mode": "shadow",
+        "boot_id": runtime.boot_id,
+        **session,
+        "sequence": 1,
+        "client_monotonic_ns": 1,
+        "deadman": True,
+        "clutch_sequence": 1,
+        "tracking": {
+            "head": True,
+            "left_controller": True,
+            "right_controller": True,
+        },
+        "head": dict(pose),
+        "left_controller": dict(pose),
+        "right_controller": dict(pose),
+        "controllers": {
+            "left": {"axes": [0.0, 0.0], "buttons": [1.0]},
+            "right": {"axes": [0.0, 0.0], "buttons": [1.0]},
+        },
+        "base_twist": {
+            "linear": [0.1, 0.0, 0.0],
+            "angular": [0.0, 0.0, 0.1],
+        },
+    }
+
+
+def _wait_for_apply(runtime: ShadowRuntime, sequence: int) -> dict:
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        dispatch = runtime.status()["dispatch"]
+        if dispatch["last_would_apply_sequence"] == sequence:
+            return dispatch
+        time.sleep(0.005)
+    raise RuntimeError("recording adapter did not acknowledge the motion intent")
+
+
+def run_smoke() -> dict:
+    runtime = ShadowRuntime(auto_watchdog=False)
+    session = {
+        "session_id": str(uuid.uuid4()),
+        "epoch": 1,
+        "fence": secrets.token_urlsafe(32),
+    }
+    identity = {"boot_id": runtime.boot_id, **session}
+    try:
+        prepared = runtime.prepare_shadow(session)
+        submitted = runtime.submit_shadow_frame(
+            _frame(runtime, session),
+            source="mcp_diagnostic",
+        )
+        applied = _wait_for_apply(runtime, 1)
+        held = runtime.soft_stop(identity)
+        released = runtime.release(identity)
+        decisions = []
+        for record in released["dispatch"]["adapter"]["records"]:
+            if record["kind"] == "would_apply":
+                decisions.append(
+                    {"kind": "would_apply", "sequence": record["sequence"]}
+                )
+            elif record["kind"] == "would_stop":
+                decisions.append(
+                    {"kind": "would_stop", "reason": record["reason"]}
+                )
+        proof = {
+            "mode": prepared["mode"],
+            "actuation_enabled": prepared["actuation_enabled"],
+            "prepared_state": prepared["state"],
+            "motion_state": submitted["state"],
+            "last_would_apply_sequence": applied["last_would_apply_sequence"],
+            "soft_stop": {
+                "state": held["state"],
+                "reason": held["reason"],
+                "acknowledged": held["dispatch"]["stop_acknowledged"],
+            },
+            "release": {
+                "state": released["state"],
+                "authority_valid": released["authority_valid"],
+                "stop_acknowledged": released["dispatch"]["stop_acknowledged"],
+            },
+            "recorded_decisions": decisions,
+        }
+        if proof["actuation_enabled"] is not False:
+            raise RuntimeError("Shadow smoke unexpectedly enabled actuation")
+        if proof["last_would_apply_sequence"] != 1:
+            raise RuntimeError("motion intent did not reach recording dispatch")
+        if not proof["soft_stop"]["acknowledged"]:
+            raise RuntimeError("soft-stop was not acknowledged")
+        if proof["release"] != {
+            "state": "released",
+            "authority_valid": False,
+            "stop_acknowledged": True,
+        }:
+            raise RuntimeError("release did not revoke and stop the session")
+        if session["fence"] in json.dumps(proof, sort_keys=True):
+            raise RuntimeError("public proof disclosed the session fence")
+        return proof
+    finally:
+        runtime.close()
+
+
+def main() -> None:
+    print(json.dumps(run_smoke(), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/generic/teleop_shadow/tests/__init__.py
+++ b/generic/teleop_shadow/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the teleop-shadow Driver."""

--- a/generic/teleop_shadow/tests/helpers.py
+++ b/generic/teleop_shadow/tests/helpers.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import uuid
+
+TEST_SECRET = "test-only-teleop-ticket-secret-32-bytes-minimum"
+TEST_DRIVER_TOKEN = "test-driver-token-private-0001"
+
+
+class FakeClock:
+    def __init__(self, value: float = 100.0):
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def new_session(*, epoch: int = 1, fence: str | None = None) -> dict:
+    return {
+        "session_id": str(uuid.uuid4()),
+        "epoch": epoch,
+        "fence": fence or ("f" * 32),
+    }
+
+
+def identity(runtime, session: dict) -> dict:
+    return {
+        "boot_id": runtime.boot_id,
+        "session_id": session["session_id"],
+        "epoch": session["epoch"],
+        "fence": session["fence"],
+    }
+
+
+def valid_frame(runtime, session: dict, *, sequence: int = 1, clutch_sequence: int = 1,
+                deadman: bool = True, tracking: bool = True) -> dict:
+    pose = {"position": [0.0, 1.0, 0.0], "orientation": [0.0, 0.0, 0.0, 1.0]}
+    return {
+        "schema_version": 1,
+        **identity(runtime, session),
+        "sequence": sequence,
+        "client_monotonic_ns": sequence * 1_000_000,
+        "mode": "shadow",
+        "deadman": deadman,
+        "clutch_sequence": clutch_sequence,
+        "tracking": {
+            "head": tracking,
+            "left_controller": tracking,
+            "right_controller": tracking,
+        },
+        "head": dict(pose) if tracking else None,
+        "left_controller": dict(pose) if tracking else None,
+        "right_controller": dict(pose) if tracking else None,
+        "controllers": {
+            "left": {"axes": [0.0, 0.0], "buttons": [0.0, 1.0]},
+            "right": {"axes": [0.0, 0.0], "buttons": [0.0, 1.0]},
+        },
+        "base_twist": {"linear": [0.0, 0.0, 0.0], "angular": [0.0, 0.0, 0.0]},
+    }
+
+
+def rtc_wire_frame(runtime, session: dict, **kwargs) -> dict:
+    frame = valid_frame(runtime, session, **kwargs)
+    for field in ("boot_id", "session_id", "epoch", "fence"):
+        frame.pop(field)
+    return frame
+
+
+def contains_value(value, needle: str) -> bool:
+    if isinstance(value, dict):
+        return any(key == needle or contains_value(item, needle) for key, item in value.items())
+    if isinstance(value, list):
+        return any(contains_value(item, needle) for item in value)
+    return value == needle

--- a/generic/teleop_shadow/tests/test_dispatch.py
+++ b/generic/teleop_shadow/tests/test_dispatch.py
@@ -1,0 +1,539 @@
+from __future__ import annotations
+
+import copy
+import sys
+import threading
+import time
+import unittest
+import uuid
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from dispatch import (
+    AdapterAck,
+    FinalDispatchArbiter,
+    MotionIntent,
+    RecordingAdapter,
+    StopRequest,
+)
+from protocol import MAX_SEQUENCE
+
+
+def binding(*, epoch: int = 1, fence: str = "f" * 32) -> dict:
+    return {
+        "boot_id": str(uuid.uuid4()),
+        "session_id": str(uuid.uuid4()),
+        "epoch": epoch,
+        "fence": fence,
+    }
+
+
+def frame(authority: dict, sequence: int, *, deadman: bool = True) -> dict:
+    pose = {"position": [0.0, 1.0, 0.0], "orientation": [0.0, 0.0, 0.0, 1.0]}
+    return {
+        **authority,
+        "sequence": sequence,
+        "clutch_sequence": 1,
+        "deadman": deadman,
+        "tracking": {"head": True, "left_controller": True, "right_controller": True},
+        "head": dict(pose),
+        "left_controller": dict(pose),
+        "right_controller": dict(pose),
+        "controllers": {
+            "left": {"axes": [0.0, 0.0], "buttons": [1.0]},
+            "right": {"axes": [0.0, 0.0], "buttons": [1.0]},
+        },
+        "base_twist": {"linear": [0.1, 0.0, 0.0], "angular": [0.0, 0.0, 0.1]},
+    }
+
+
+class ControllableAdapter:
+    def __init__(self, *, startup_ack: AdapterAck | None = None, fail_apply: bool = False):
+        self.startup_ack = startup_ack or AdapterAck(True)
+        self.fail_apply = fail_apply
+        self.first_apply_started = threading.Event()
+        self.allow_first_apply = threading.Event()
+        self.block_first_apply = False
+        self.events: list[tuple] = []
+        self.snapshot_threads: list[str] = []
+        self.closed = False
+        self._lock = threading.Lock()
+
+    def startup_safe(self, deadline_monotonic: float) -> AdapterAck:
+        with self._lock:
+            self.events.append(("stop", "startup_safe", 0))
+        return self.startup_ack
+
+    def apply(self, intent: MotionIntent) -> AdapterAck:
+        if self.block_first_apply and not self.first_apply_started.is_set():
+            self.first_apply_started.set()
+            self.allow_first_apply.wait(1.0)
+        with self._lock:
+            self.events.append(("apply", intent.sequence, intent.dispatch_generation))
+        if self.fail_apply:
+            return AdapterAck(False, "injected_apply_failure")
+        return AdapterAck(True)
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck:
+        with self._lock:
+            self.events.append(("stop", request.reason, request.dispatch_generation))
+        return AdapterAck(True)
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            self.snapshot_threads.append(threading.current_thread().name)
+            return {"kind": "test", "events": copy.deepcopy(self.events), "closed": self.closed}
+
+    def close(self) -> None:
+        with self._lock:
+            self.events.append(("close",))
+            self.closed = True
+
+
+class HangingStartupAdapter(ControllableAdapter):
+    def __init__(self):
+        super().__init__()
+        self.startup_entered = threading.Event()
+        self.release_startup = threading.Event()
+        self.concurrent_calls: list[str] = []
+
+    def startup_safe(self, deadline_monotonic: float) -> AdapterAck:
+        self.startup_entered.set()
+        self.release_startup.wait(1.0)
+        return AdapterAck(True)
+
+    def snapshot(self) -> dict:
+        if not self.release_startup.is_set():
+            self.concurrent_calls.append("snapshot")
+        return super().snapshot()
+
+    def close(self) -> None:
+        if not self.release_startup.is_set():
+            self.concurrent_calls.append("close")
+        super().close()
+
+
+class DelayedStopAdapter(ControllableAdapter):
+    def __init__(self):
+        super().__init__()
+        self.stop_delay = 0.0
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck:
+        if self.stop_delay:
+            time.sleep(self.stop_delay)
+        return super().safe_stop(request)
+
+
+class AdvancingStopAdapter(ControllableAdapter):
+    def __init__(self, safety_time: list[float], *, advance: float):
+        super().__init__()
+        self.safety_time = safety_time
+        self.advance = advance
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck:
+        self.safety_time[0] += self.advance
+        return super().safe_stop(request)
+
+
+class GatedRecordingAdapter(RecordingAdapter):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.apply_entered = threading.Event()
+        self.release_apply = threading.Event()
+
+    def apply(self, intent: MotionIntent) -> AdapterAck:
+        self.apply_entered.set()
+        self.release_apply.wait(1.0)
+        return super().apply(intent)
+
+
+class FalseCloseAdapter(ControllableAdapter):
+    def close(self):
+        super().close()
+        return False
+
+
+class ReentrantCloseAdapter(ControllableAdapter):
+    def __init__(self):
+        super().__init__()
+        self.arbiter: FinalDispatchArbiter | None = None
+        self.reentrant_ack: AdapterAck | None = None
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck:
+        if request.reason == "service_close":
+            assert self.arbiter is not None
+            self.reentrant_ack = self.arbiter.close()
+        return super().safe_stop(request)
+
+
+class FinalDispatchArbiterTests(unittest.TestCase):
+    def setUp(self):
+        self.adapter = ControllableAdapter()
+        self.arbiter = FinalDispatchArbiter(self.adapter, io_timeout_ms=250)
+        self.authority = binding()
+        handle = self.arbiter.begin_prepare()
+        self.assertTrue(self.arbiter.wait_safe(handle).ok)
+        self.assertTrue(self.arbiter.complete_prepare(handle, self.authority, 7).ok)
+
+    def tearDown(self):
+        self.adapter.allow_first_apply.set()
+        self.arbiter.close()
+
+    def publish(self, sequence: int, *, expiry: float = 1.0, deadman: bool = True) -> AdapterAck:
+        return self.arbiter.publish_latest(
+            frame(self.authority, sequence, deadman=deadman),
+            session_generation=7,
+            expires_monotonic=time.monotonic() + expiry,
+        )
+
+    def wait_until(self, predicate, timeout: float = 1.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            value = predicate()
+            if value:
+                return value
+            time.sleep(0.005)
+        self.fail("condition not reached")
+
+    def test_latest_only_mailbox_keeps_one_inflight_and_newest_pending(self):
+        self.adapter.block_first_apply = True
+        self.assertTrue(self.publish(1).ok)
+        self.assertTrue(self.adapter.first_apply_started.wait(1.0))
+        for sequence in range(2, 101):
+            self.assertTrue(self.publish(sequence).ok)
+            self.assertLessEqual(self.arbiter.snapshot()["mailbox_depth"], 1)
+        self.adapter.allow_first_apply.set()
+        self.assertTrue(self.arbiter.wait_applied(100))
+        applies = [event[1] for event in self.adapter.events if event[0] == "apply"]
+        self.assertEqual([1, 100], applies)
+        self.assertEqual(98, self.arbiter.snapshot()["counters"]["mailbox_replacements"])
+
+    def test_stop_clears_admitted_motion_and_ack_fences_old_generation(self):
+        self.adapter.block_first_apply = True
+        self.assertTrue(self.publish(1).ok)
+        self.assertTrue(self.adapter.first_apply_started.wait(1.0))
+        self.assertTrue(self.publish(2).ok)
+        handle = self.arbiter.trip(
+            "operator_release",
+            target_state="safe_revoked",
+            retain_authority=False,
+        )
+        self.adapter.allow_first_apply.set()
+        self.assertTrue(self.arbiter.wait_safe(handle).ok)
+        time.sleep(0.02)
+        applies = [event[1] for event in self.adapter.events if event[0] == "apply"]
+        self.assertEqual([1], applies)
+        self.assertEqual(("stop", "operator_release"), self.adapter.events[-1][:2])
+        self.assertFalse(self.publish(3).ok)
+        self.assertTrue(self.arbiter.snapshot()["stop_acknowledged"])
+
+    def test_final_deadline_check_drops_queued_motion_and_stops(self):
+        self.adapter.block_first_apply = True
+        self.assertTrue(self.publish(1).ok)
+        self.assertTrue(self.adapter.first_apply_started.wait(1.0))
+        self.assertTrue(self.publish(2, expiry=0.02).ok)
+        time.sleep(0.03)
+        self.adapter.allow_first_apply.set()
+        self.wait_until(
+            lambda: any(
+                event[:2] == ("stop", "dispatch_deadline") for event in self.adapter.events
+            )
+        )
+        applies = [event[1] for event in self.adapter.events if event[0] == "apply"]
+        self.assertEqual([1], applies)
+        self.assertEqual("safe_reclutch_required", self.arbiter.snapshot()["state"])
+
+    def test_adapter_never_receives_unsafe_or_wrong_authority(self):
+        self.assertEqual("unsafe_deadman", self.publish(1, deadman=False).code)
+        missing_tracking = frame(self.authority, 1)
+        missing_tracking["tracking"].pop("head")
+        self.assertEqual(
+            "unsafe_tracking",
+            self.arbiter.publish_latest(
+                missing_tracking,
+                session_generation=7,
+                expires_monotonic=time.monotonic() + 1,
+            ).code,
+        )
+        wrong = binding(epoch=2, fence="x" * 32)
+        ack = self.arbiter.publish_latest(
+            frame(wrong, 2),
+            session_generation=7,
+            expires_monotonic=time.monotonic() + 1,
+        )
+        self.assertEqual("authority_mismatch", ack.code)
+        self.assertFalse(any(event[0] == "apply" for event in self.adapter.events))
+
+    def test_final_boundary_rejects_non_increasing_sequence(self):
+        self.adapter.block_first_apply = True
+        self.assertTrue(self.publish(5).ok)
+        self.assertTrue(self.adapter.first_apply_started.wait(1.0))
+        self.assertEqual("sequence_not_increasing", self.publish(5).code)
+        self.assertEqual("sequence_not_increasing", self.publish(4).code)
+        self.adapter.allow_first_apply.set()
+        self.assertTrue(self.arbiter.wait_applied(5))
+
+    def test_final_boundary_enforces_sequence_wire_limits(self):
+        at_limit = frame(self.authority, MAX_SEQUENCE)
+        at_limit["clutch_sequence"] = MAX_SEQUENCE
+        self.assertTrue(
+            self.arbiter.publish_latest(
+                at_limit,
+                session_generation=7,
+                expires_monotonic=time.monotonic() + 1,
+            ).ok
+        )
+
+        above_sequence = frame(self.authority, MAX_SEQUENCE + 1)
+        self.assertEqual(
+            "invalid_intent",
+            self.arbiter.publish_latest(
+                above_sequence,
+                session_generation=7,
+                expires_monotonic=time.monotonic() + 1,
+            ).code,
+        )
+
+        above_clutch = frame(self.authority, MAX_SEQUENCE)
+        above_clutch["clutch_sequence"] = MAX_SEQUENCE + 1
+        self.assertEqual(
+            "invalid_intent",
+            self.arbiter.publish_latest(
+                above_clutch,
+                session_generation=7,
+                expires_monotonic=time.monotonic() + 1,
+            ).code,
+        )
+
+    def test_adapter_apply_failure_latches_fault_and_runs_safety_path(self):
+        self.adapter.fail_apply = True
+        self.assertTrue(self.publish(1).ok)
+        self.wait_until(lambda: self.arbiter.snapshot()["fault_code"] is not None)
+        self.wait_until(
+            lambda: any(event[:2] == ("stop", "adapter_fault") for event in self.adapter.events)
+        )
+        state = self.arbiter.snapshot()
+        self.assertEqual("fault_latched", state["state"])
+        self.assertEqual("injected_apply_failure", state["fault_code"])
+        self.assertFalse(self.publish(2).ok)
+
+    def test_public_snapshot_contains_no_fence(self):
+        self.assertNotIn(self.authority["fence"], repr(self.arbiter.snapshot()))
+
+    def test_public_snapshot_uses_owner_cache_only(self):
+        before = len(self.adapter.snapshot_threads)
+        for _ in range(100):
+            self.arbiter.snapshot()
+        self.assertEqual(before, len(self.adapter.snapshot_threads))
+        self.assertNotIn("MainThread", self.adapter.snapshot_threads)
+        self.assertTrue(
+            set(self.adapter.snapshot_threads)
+            <= {"teleop-shadow-startup-safe", "teleop-shadow-final-dispatch"}
+        )
+
+
+class StartupAndRestartTests(unittest.TestCase):
+    def test_failed_startup_safe_is_not_ready_or_armable(self):
+        adapter = ControllableAdapter(startup_ack=AdapterAck(False, "no_stop_ack"))
+        arbiter = FinalDispatchArbiter(adapter)
+        try:
+            self.assertFalse(arbiter.ready)
+            handle = arbiter.begin_prepare()
+            self.assertEqual("dispatch_unavailable", arbiter.wait_safe(handle).code)
+            self.assertFalse(arbiter.complete_prepare(handle, binding(), 1).ok)
+            self.assertFalse(arbiter.snapshot()["ready"])
+        finally:
+            first_close = arbiter.close()
+            self.assertFalse(first_close.ok)
+            self.assertEqual(first_close, arbiter.close())
+            self.assertTrue(adapter.closed)
+
+    def test_new_arbiter_starts_with_safe_stop_before_any_motion(self):
+        adapter = ControllableAdapter()
+        arbiter = FinalDispatchArbiter(adapter)
+        try:
+            self.assertEqual(("stop", "startup_safe", 0), adapter.events[0])
+            self.assertIsNone(arbiter.snapshot()["last_would_apply_sequence"])
+        finally:
+            arbiter.close()
+
+    def test_hung_startup_fails_closed_without_concurrent_adapter_calls(self):
+        adapter = HangingStartupAdapter()
+        started = time.monotonic()
+        arbiter = FinalDispatchArbiter(adapter, io_timeout_ms=20)
+        self.assertLess(time.monotonic() - started, 0.2)
+        try:
+            self.assertTrue(adapter.startup_entered.is_set())
+            state = arbiter.snapshot()
+            self.assertEqual("startup_safe_timeout", state["fault_code"])
+            self.assertEqual("unavailable", state["adapter"]["kind"])
+            close_ack = arbiter.close()
+            self.assertFalse(close_ack.ok)
+            self.assertEqual([], adapter.concurrent_calls)
+        finally:
+            adapter.release_startup.set()
+            deadline = time.monotonic() + 1.0
+            while not adapter.closed and time.monotonic() < deadline:
+                time.sleep(0.005)
+            self.assertTrue(adapter.closed)
+            self.assertEqual([], adapter.concurrent_calls)
+
+
+class DeadlineAndShutdownTests(unittest.TestCase):
+    def test_frozen_protocol_clock_does_not_hide_real_io_stall(self):
+        adapter = ControllableAdapter()
+        adapter.block_first_apply = True
+        arbiter = FinalDispatchArbiter(adapter, clock=lambda: 100.0, io_timeout_ms=20)
+        authority = binding()
+        prepare = arbiter.begin_prepare()
+        self.assertTrue(arbiter.wait_safe(prepare).ok)
+        self.assertTrue(arbiter.complete_prepare(prepare, authority, 1).ok)
+        try:
+            self.assertTrue(arbiter.publish_latest(
+                frame(authority, 1),
+                session_generation=1,
+                expires_monotonic=101.0,
+            ).ok)
+            self.assertTrue(adapter.first_apply_started.wait(1.0))
+            time.sleep(0.03)
+            state = arbiter.snapshot()
+            self.assertEqual("adapter_io_stalled", state["fault_code"])
+            self.assertFalse(state["ready"])
+            self.assertEqual("apply", state["io_inflight"])
+        finally:
+            adapter.allow_first_apply.set()
+            arbiter.close()
+
+    def test_stop_completion_after_total_deadline_is_not_acknowledged(self):
+        adapter = DelayedStopAdapter()
+        arbiter = FinalDispatchArbiter(adapter, clock=lambda: 100.0, io_timeout_ms=20)
+        authority = binding()
+        prepare = arbiter.begin_prepare()
+        self.assertTrue(arbiter.wait_safe(prepare).ok)
+        self.assertTrue(arbiter.complete_prepare(prepare, authority, 1).ok)
+        adapter.stop_delay = 0.03
+        try:
+            handle = arbiter.trip(
+                "deadline_test",
+                target_state="safe_revoked",
+                retain_authority=False,
+            )
+            ack = arbiter.wait_safe(handle, 0.2)
+            self.assertFalse(ack.ok)
+            self.assertEqual("adapter_stop_deadline_missed", ack.code)
+            self.assertEqual("fault_latched", arbiter.snapshot()["state"])
+        finally:
+            arbiter.close()
+
+    def test_queued_stops_each_keep_their_original_total_deadline(self):
+        safety_time = [10.0]
+        adapter = AdvancingStopAdapter(safety_time, advance=0.015)
+        arbiter = FinalDispatchArbiter(
+            adapter,
+            safety_clock=lambda: safety_time[0],
+            io_timeout_ms=20,
+        )
+        try:
+            first = arbiter.trip(
+                "first_stop",
+                target_state="safe_revoked",
+                retain_authority=False,
+            )
+            second = arbiter.trip(
+                "second_stop",
+                target_state="safe_revoked",
+                retain_authority=False,
+            )
+            self.assertTrue(arbiter.wait_safe(first, 0.2).ok)
+            second_ack = arbiter.wait_safe(second, 0.2)
+            self.assertFalse(second_ack.ok)
+            self.assertEqual("adapter_stop_deadline_missed", second_ack.code)
+        finally:
+            arbiter.close()
+
+    def test_close_never_overtakes_blocked_apply_and_caches_failure(self):
+        adapter = ControllableAdapter()
+        adapter.block_first_apply = True
+        arbiter = FinalDispatchArbiter(adapter, io_timeout_ms=200)
+        authority = binding()
+        prepare = arbiter.begin_prepare()
+        self.assertTrue(arbiter.wait_safe(prepare).ok)
+        self.assertTrue(arbiter.complete_prepare(prepare, authority, 1).ok)
+        self.assertTrue(arbiter.publish_latest(
+            frame(authority, 1),
+            session_generation=1,
+            expires_monotonic=time.monotonic() + 1,
+        ).ok)
+        self.assertTrue(adapter.first_apply_started.wait(1.0))
+
+        results: list[AdapterAck] = []
+        close_thread = threading.Thread(target=lambda: results.append(arbiter.close(0.03)))
+        close_thread.start()
+        time.sleep(0.05)
+        self.assertFalse(adapter.closed)
+        self.assertTrue(close_thread.is_alive())
+        adapter.allow_first_apply.set()
+        close_thread.join(1.0)
+        self.assertFalse(close_thread.is_alive())
+        self.assertFalse(results[0].ok)
+        self.assertEqual(results[0], arbiter.close())
+        kinds = [event[0] for event in adapter.events]
+        self.assertLess(kinds.index("apply"), kinds.index("close"))
+        self.assertLess(
+            max(index for index, kind in enumerate(kinds) if kind == "stop"),
+            kinds.index("close"),
+        )
+
+    def test_false_close_result_is_not_treated_as_success(self):
+        adapter = FalseCloseAdapter()
+        arbiter = FinalDispatchArbiter(adapter)
+        ack = arbiter.close()
+        self.assertFalse(ack.ok)
+        self.assertEqual("invalid_close_ack", ack.code)
+        self.assertEqual("fault_latched", arbiter.snapshot()["state"])
+
+    def test_reentrant_owner_close_does_not_poison_external_close(self):
+        adapter = ReentrantCloseAdapter()
+        arbiter = FinalDispatchArbiter(adapter)
+        adapter.arbiter = arbiter
+        ack = arbiter.close()
+        self.assertTrue(ack.ok)
+        self.assertEqual(AdapterAck(False, "owner_cannot_self_close"), adapter.reentrant_ack)
+        self.assertTrue(adapter.closed)
+        self.assertEqual(ack, arbiter.close())
+
+    def test_recording_adapter_rechecks_expiry_inside_final_output_lock(self):
+        now = [100.0]
+        adapter = GatedRecordingAdapter(clock=lambda: now[0])
+        arbiter = FinalDispatchArbiter(adapter, clock=lambda: now[0], io_timeout_ms=100)
+        authority = binding()
+        prepare = arbiter.begin_prepare()
+        self.assertTrue(arbiter.wait_safe(prepare).ok)
+        self.assertTrue(arbiter.complete_prepare(prepare, authority, 1).ok)
+        try:
+            self.assertTrue(arbiter.publish_latest(
+                frame(authority, 1),
+                session_generation=1,
+                expires_monotonic=100.05,
+            ).ok)
+            self.assertTrue(adapter.apply_entered.wait(1.0))
+            now[0] = 100.06
+            adapter.release_apply.set()
+            deadline = time.monotonic() + 1
+            while arbiter.snapshot()["fault_code"] is None and time.monotonic() < deadline:
+                time.sleep(0.005)
+            records = adapter.snapshot()["records"]
+            self.assertFalse(any(record["kind"] == "would_apply" for record in records))
+            self.assertEqual(
+                "intent_expired_at_adapter",
+                arbiter.snapshot()["fault_code"],
+            )
+        finally:
+            adapter.release_apply.set()
+            arbiter.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_http_mcp.py
+++ b/generic/teleop_shadow/tests/test_http_mcp.py
@@ -1,0 +1,611 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import os
+import sys
+import unittest
+import uuid
+from pathlib import Path
+from unittest import mock
+
+from aiohttp.test_utils import TestClient, TestServer
+from aiortc import RTCPeerConnection, RTCSessionDescription
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from main import (
+    SERVICE_KEY,
+    ShadowDriverService,
+    create_app,
+    load_config,
+    registration_headers,
+    registration_payload,
+    tool_definitions,
+)
+from protocol import TicketCodec, make_ticket_claims
+
+from tests.helpers import TEST_DRIVER_TOKEN, TEST_SECRET, contains_value, valid_frame
+
+TEST_CONFIG = {
+    "mcp_port": 15711,
+    "bind_host": "127.0.0.1",
+    "teleop": {
+        "lease_timeout_ms": 5000,
+        "pose_timeout_ms": 500,
+        "watchdog_interval_ms": 25,
+        "ticket_ttl_max_seconds": 30,
+        "ticket_replay_cache_entries": 128,
+    },
+    "registration": {"enabled": False},
+}
+
+
+class McpHttpTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.env = mock.patch.dict(os.environ, {
+            "MOTUS_DRIVER_TOKEN": TEST_DRIVER_TOKEN,
+            "MOTUS_TELEOP_TICKET_SECRET": TEST_SECRET,
+        })
+        self.env.start()
+        self.client = TestClient(TestServer(create_app(TEST_CONFIG)))
+        await self.client.start_server()
+        self.request_id = 0
+
+    async def asyncTearDown(self):
+        await self.client.close()
+        self.env.stop()
+
+    async def rpc(self, method: str, params: dict | None = None, *, authorized: bool = True):
+        self.request_id += 1
+        headers = {"Authorization": f"Bearer {TEST_DRIVER_TOKEN}"} if authorized else {}
+        response = await self.client.post("/mcp", json={
+            "jsonrpc": "2.0",
+            "id": self.request_id,
+            "method": method,
+            "params": params or {},
+        }, headers=headers)
+        return response.status, await response.json()
+
+    async def call(self, name: str, arguments: dict) -> dict:
+        status, payload = await self.rpc("tools/call", {"name": name, "arguments": arguments})
+        self.assertEqual(200, status)
+        self.assertNotIn("error", payload)
+        return json.loads(payload["result"]["content"][0]["text"])
+
+    async def test_mcp_requires_driver_token_when_configured(self):
+        status, _ = await self.rpc("tools/list", authorized=False)
+        self.assertEqual(401, status)
+        status, payload = await self.rpc("initialize")
+        self.assertEqual("teleop-shadow-driver", payload["result"]["serverInfo"]["name"])
+        service = self.client.server.app[SERVICE_KEY]
+        self.assertEqual(
+            f"Bearer {TEST_DRIVER_TOKEN}", registration_headers(service)["Authorization"]
+        )
+
+    async def test_tools_are_real_and_start_is_passive(self):
+        _, payload = await self.rpc("tools/list")
+        tools = {tool["name"]: tool for tool in payload["result"]["tools"]}
+        self.assertEqual({"teleop_session", "teleop_state"}, set(tools))
+        self.assertTrue(tools["teleop_state"]["readOnly"])
+        for tool in tools.values():
+            self.assertEqual("motus.teleop.shadow.v1", tool["x-teleop"]["protocol"])
+            self.assertEqual(
+                "motus.teleop.dispatch.recording.v1",
+                tool["x-teleop"]["dispatch_contract"],
+            )
+            self.assertEqual("shadow", tool["x-teleop"]["mode"])
+            self.assertFalse(tool["x-teleop"]["actuation_enabled"])
+            self.assertEqual(
+                {
+                    "protocol": "motus.teleop.webrtc-offer-answer.v1",
+                    "path": "/offer",
+                    "access": "authenticated-core-proxy-only",
+                },
+                tool["x-teleop"]["signaling"],
+            )
+        session_actions = tools["teleop_session"]["inputSchema"]["x-action-params"]
+        self.assertEqual(
+            {
+                "start", "stop", "prepare_shadow", "heartbeat", "pause", "release",
+                "soft_stop", "status", "submit_shadow_frame",
+            },
+            set(session_actions),
+        )
+        started = await self.call("teleop_session", {"action": "start"})
+        self.assertEqual("ready", started["lifecycle_state"])
+        self.assertEqual("idle", started["state"])
+        self.assertFalse(started["actuation_enabled"])
+
+    async def test_prepare_submit_and_state_are_sanitized(self):
+        service = self.client.server.app[SERVICE_KEY]
+        session = {"session_id": str(uuid.uuid4()), "epoch": 1, "fence": "x" * 32}
+        prepared = await self.call("teleop_session", {"action": "prepare_shadow", **session})
+        self.assertNotIn("fence", prepared)
+        frame = valid_frame(service.runtime, session)
+        submitted = await self.call("teleop_session", {
+            "action": "submit_shadow_frame",
+            "frame": frame,
+        })
+        self.assertEqual("active_shadow", submitted["state"])
+        state = await self.call("teleop_state", {})
+        self.assertEqual(1, state["pose"]["latest_sequence"])
+        for _ in range(100):
+            state = await self.call("teleop_state", {})
+            if state["dispatch"]["last_would_apply_sequence"] == 1:
+                break
+            await asyncio.sleep(0.005)
+        self.assertEqual(1, state["dispatch"]["last_would_apply_sequence"])
+        self.assertEqual("recording", state["dispatch"]["kind"])
+        self.assertFalse(contains_value(state, session["fence"]))
+        self.assertFalse(contains_value(state, TEST_SECRET))
+
+    async def test_stale_prepare_does_not_disconnect_current_rtc(self):
+        service = self.client.server.app[SERVICE_KEY]
+        service.rtc.close_all = mock.AsyncMock()
+        session = {"session_id": str(uuid.uuid4()), "epoch": 1, "fence": "q" * 32}
+        await self.call("teleop_session", {"action": "prepare_shadow", **session})
+        service.rtc.close_all.reset_mock()
+
+        _, payload = await self.rpc("tools/call", {
+            "name": "teleop_session",
+            "arguments": {
+                "action": "prepare_shadow",
+                "session_id": str(uuid.uuid4()),
+                "epoch": 1,
+                "fence": "w" * 32,
+            },
+        })
+        self.assertEqual("stale_epoch", payload["error"]["data"]["code"])
+        service.rtc.close_all.assert_not_awaited()
+        self.assertEqual(session["session_id"], service.runtime.status()["session_id"])
+
+    async def test_only_mcp_heartbeat_renews_lease(self):
+        service = self.client.server.app[SERVICE_KEY]
+        session = {"session_id": str(uuid.uuid4()), "epoch": 1, "fence": "h" * 32}
+        await self.call("teleop_session", {"action": "prepare_shadow", **session})
+        result = await self.call("teleop_session", {
+            "action": "heartbeat",
+            "boot_id": service.runtime.boot_id,
+            **session,
+        })
+        self.assertEqual(1, result["counters"]["lease_heartbeats"])
+        self.assertEqual("agent-core-mcp-heartbeat-only", result["lease"]["source"])
+
+    async def test_invalid_frame_is_json_rpc_invalid_params(self):
+        session = {"session_id": str(uuid.uuid4()), "epoch": 1, "fence": "z" * 32}
+        await self.call("teleop_session", {"action": "prepare_shadow", **session})
+        _, payload = await self.rpc("tools/call", {
+            "name": "teleop_session",
+            "arguments": {"action": "submit_shadow_frame", "frame": {"schema_version": 1}},
+        })
+        self.assertEqual(-32602, payload["error"]["code"])
+        self.assertEqual("missing_field", payload["error"]["data"]["code"])
+
+    async def test_health_discloses_no_secret(self):
+        response = await self.client.get("/health")
+        payload = await response.json()
+        self.assertTrue(payload["rtc_enabled"])
+        self.assertTrue(payload["ready"])
+        self.assertEqual("recording", payload["dispatch"]["kind"])
+        self.assertFalse(payload["actuation_enabled"])
+        serialized = json.dumps(payload, sort_keys=True)
+        self.assertNotIn(TEST_DRIVER_TOKEN, serialized)
+        self.assertNotIn(TEST_SECRET, serialized)
+
+
+class MissingSecretTests(unittest.IsolatedAsyncioTestCase):
+    async def test_registration_disabled_loopback_is_explicit_diagnostic_mode(self):
+        old_secret = os.environ.pop("MOTUS_TELEOP_TICKET_SECRET", None)
+        try:
+            with mock.patch.dict(os.environ, {"MOTUS_DRIVER_TOKEN": TEST_DRIVER_TOKEN}):
+                client = TestClient(TestServer(create_app(TEST_CONFIG)))
+                await client.start_server()
+                try:
+                    health = await (await client.get("/health")).json()
+                    self.assertFalse(health["rtc_enabled"])
+                    self.assertFalse(health["ready"])
+                    self.assertEqual("diagnostic", health["state"])
+                    self.assertEqual("disabled", health["registration"]["state"])
+                    offer = await client.post(
+                        "/offer",
+                        json={"type": "offer", "sdp": "x", "ticket": "x.y"},
+                        headers={"Authorization": f"Bearer {TEST_DRIVER_TOKEN}"},
+                    )
+                    self.assertEqual(503, offer.status)
+                    mcp = await client.post("/mcp", json={
+                        "jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {},
+                    }, headers={"Authorization": f"Bearer {TEST_DRIVER_TOKEN}"})
+                    self.assertEqual(200, mcp.status)
+                    tools = (await mcp.json())["result"]["tools"]
+                    self.assertTrue(tools)
+                    for tool in tools:
+                        self.assertNotIn("signaling", tool["x-teleop"])
+                finally:
+                    await client.close()
+        finally:
+            if old_secret is not None:
+                os.environ["MOTUS_TELEOP_TICKET_SECRET"] = old_secret
+
+
+class DeploymentAuthenticationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_driver_bearer_matches_core_length_and_character_contract(self):
+        invalid_tokens = (
+            "x" * 23,
+            "x" * 24 + "!",
+            "遥" * 24,
+            "x" * 4097,
+        )
+        for token in invalid_tokens:
+            with (
+                self.subTest(length=len(token), suffix=token[-1:]),
+                mock.patch.dict(os.environ, {
+                    "MOTUS_DRIVER_TOKEN": token,
+                    "MOTUS_TELEOP_TICKET_SECRET": TEST_SECRET,
+                }),
+                self.assertRaisesRegex(
+                    ValueError, "24–4096 restricted ASCII Bearer characters"
+                ),
+            ):
+                ShadowDriverService(copy.deepcopy(TEST_CONFIG))
+
+        for token in ("x" * 24, "A._~+/=-" * 3, "x" * 4096):
+            with (
+                self.subTest(valid_length=len(token)),
+                mock.patch.dict(os.environ, {
+                    "MOTUS_DRIVER_TOKEN": token,
+                    "MOTUS_TELEOP_TICKET_SECRET": TEST_SECRET,
+                }),
+            ):
+                service = ShadowDriverService(copy.deepcopy(TEST_CONFIG))
+            try:
+                self.assertEqual(token, service.driver_token)
+            finally:
+                await service.close()
+
+    async def test_ticket_secret_requires_32_utf8_bytes_when_configured(self):
+        for invalid_secret in ("", "t" * 31):
+            with (
+                self.subTest(length=len(invalid_secret)),
+                mock.patch.dict(os.environ, {
+                    "MOTUS_DRIVER_TOKEN": TEST_DRIVER_TOKEN,
+                    "MOTUS_TELEOP_TICKET_SECRET": invalid_secret,
+                }),
+                self.assertRaisesRegex(ValueError, "at least 32 bytes"),
+            ):
+                ShadowDriverService(copy.deepcopy(TEST_CONFIG))
+
+        for secret in ("t" * 32, "遥" * 11):
+            with (
+                self.subTest(utf8_bytes=len(secret.encode("utf-8"))),
+                mock.patch.dict(os.environ, {
+                    "MOTUS_DRIVER_TOKEN": TEST_DRIVER_TOKEN,
+                    "MOTUS_TELEOP_TICKET_SECRET": secret,
+                }),
+            ):
+                service = ShadowDriverService(copy.deepcopy(TEST_CONFIG))
+            try:
+                self.assertTrue(service.rtc.enabled)
+            finally:
+                await service.close()
+
+    async def test_registration_enabled_requires_driver_token(self):
+        config = copy.deepcopy(TEST_CONFIG)
+        config["registration"]["enabled"] = True
+        with (
+            mock.patch.dict(os.environ, {"MOTUS_DRIVER_TOKEN": ""}),
+            self.assertRaisesRegex(ValueError, "MOTUS_DRIVER_TOKEN is required"),
+        ):
+            ShadowDriverService(config)
+
+    async def test_registration_enabled_requires_ticket_secret(self):
+        config = copy.deepcopy(TEST_CONFIG)
+        config["registration"]["enabled"] = True
+        with (
+            mock.patch.dict(os.environ, {
+                "MOTUS_DRIVER_TOKEN": TEST_DRIVER_TOKEN,
+            }, clear=True),
+            self.assertRaisesRegex(
+                ValueError, "MOTUS_TELEOP_TICKET_SECRET is required"
+            ),
+        ):
+            ShadowDriverService(config)
+
+    async def test_non_loopback_bind_requires_driver_token(self):
+        config = copy.deepcopy(TEST_CONFIG)
+        config["bind_host"] = "0.0.0.0"
+        with (
+            mock.patch.dict(os.environ, {"MOTUS_DRIVER_TOKEN": ""}),
+            self.assertRaisesRegex(ValueError, "MOTUS_DRIVER_TOKEN is required"),
+        ):
+            ShadowDriverService(config)
+
+    async def test_registration_disabled_loopback_allows_local_diagnostics(self):
+        with mock.patch.dict(os.environ, {
+            "MOTUS_DRIVER_TOKEN": "",
+        }, clear=True):
+            service = ShadowDriverService(copy.deepcopy(TEST_CONFIG))
+        try:
+            self.assertIsNone(service.driver_token)
+            self.assertTrue(service.runtime.status()["dispatch"]["ready"])
+            self.assertFalse(service.rtc.enabled)
+        finally:
+            await service.close()
+
+
+class MultiInstanceIdentityTests(unittest.IsolatedAsyncioTestCase):
+    async def test_instance_environment_overrides_are_loaded(self):
+        with mock.patch.dict(os.environ, {
+            "MOTUS_DRIVER_ID": "teleop-shadow-env-instance",
+            "MOTUS_DRIVER_NAME": "Environment Instance",
+            "MOTUS_ROBOT_ID": "robot-env-1",
+            "MOTUS_AGENT_CORE_VERIFY_TLS": "0",
+        }):
+            config = load_config(ROOT / "config.yaml")
+        self.assertEqual("teleop-shadow-env-instance", config["driver_id"])
+        self.assertEqual("Environment Instance", config["driver_name"])
+        self.assertEqual("robot-env-1", config["robot_id"])
+        self.assertFalse(config["registration"]["verify_tls"])
+
+    async def test_driver_id_matches_core_64_character_boundary(self):
+        accepted_config = copy.deepcopy(TEST_CONFIG)
+        accepted_config["driver_id"] = "d" * 64
+        rejected_config = copy.deepcopy(TEST_CONFIG)
+        rejected_config["driver_id"] = "d" * 65
+        with mock.patch.dict(os.environ, {"MOTUS_TELEOP_TICKET_SECRET": TEST_SECRET}):
+            accepted = ShadowDriverService(accepted_config)
+            try:
+                self.assertEqual("d" * 64, accepted.runtime.status()["driver_id"])
+            finally:
+                await accepted.close()
+            with self.assertRaisesRegex(ValueError, "1-64"):
+                ShadowDriverService(rejected_config)
+
+    async def test_robot_id_matches_core_64_character_authority_boundary(self):
+        accepted_config = copy.deepcopy(TEST_CONFIG)
+        accepted_config["robot_id"] = "r" * 64
+        rejected_config = copy.deepcopy(TEST_CONFIG)
+        rejected_config["robot_id"] = "r" * 65
+        with mock.patch.dict(os.environ, {"MOTUS_TELEOP_TICKET_SECRET": TEST_SECRET}):
+            accepted = ShadowDriverService(accepted_config)
+            try:
+                self.assertEqual("r" * 64, accepted.runtime.status()["robot_id"])
+            finally:
+                await accepted.close()
+            with self.assertRaisesRegex(ValueError, "1-64"):
+                ShadowDriverService(rejected_config)
+
+    async def test_two_instances_have_distinct_consistent_ids(self):
+        config_a = copy.deepcopy(TEST_CONFIG)
+        config_a.update({
+            "driver_id": "teleop-shadow-lab-a",
+            "driver_name": "Lab A Quest Teleop",
+            "robot_id": "teleop-shadow-lab-a",
+        })
+        config_b = copy.deepcopy(TEST_CONFIG)
+        config_b.update({
+            "driver_id": "teleop-shadow-lab-b",
+            "driver_name": "Lab B Quest Teleop",
+            "robot_id": "teleop-shadow-lab-b",
+        })
+        with mock.patch.dict(os.environ, {"MOTUS_TELEOP_TICKET_SECRET": TEST_SECRET}):
+            service_a = ShadowDriverService(config_a)
+            service_b = ShadowDriverService(config_b)
+        try:
+            state_a = await service_a.dispatch_tool("teleop_state", {})
+            state_b = await service_b.dispatch_tool("teleop_state", {})
+            self.assertEqual("teleop-shadow-lab-a", state_a["driver_id"])
+            self.assertEqual("teleop-shadow-lab-b", state_b["driver_id"])
+            self.assertNotEqual(state_a["driver_id"], state_b["driver_id"])
+            self.assertNotEqual(state_a["boot_id"], state_b["boot_id"])
+
+            payload_a = registration_payload(service_a)
+            payload_b = registration_payload(service_b)
+            self.assertEqual(("teleop-shadow-lab-a", "teleop-shadow-lab-a"), (
+                payload_a["id"], payload_a["robot_id"]
+            ))
+            self.assertEqual(("teleop-shadow-lab-b", "teleop-shadow-lab-b"), (
+                payload_b["id"], payload_b["robot_id"]
+            ))
+
+            descriptor_a = tool_definitions(
+                driver_id=service_a.driver_id,
+                driver_name=service_a.driver_name,
+                robot_id=service_a.robot_id,
+            )[0]["x-teleop"]
+            descriptor_b = tool_definitions(
+                driver_id=service_b.driver_id,
+                driver_name=service_b.driver_name,
+                robot_id=service_b.robot_id,
+            )[0]["x-teleop"]
+            self.assertEqual(payload_a["id"], descriptor_a["driver_id"])
+            self.assertEqual(payload_b["id"], descriptor_b["driver_id"])
+        finally:
+            await service_a.close()
+            await service_b.close()
+
+    async def test_two_instances_reject_cross_instance_credentials_without_disclosure(self):
+        config_a = copy.deepcopy(TEST_CONFIG)
+        config_a.update({
+            "driver_id": "teleop-shadow-auth-a",
+            "driver_name": "Auth A",
+            "robot_id": "teleop-shadow-auth-a",
+        })
+        config_a["teleop"]["lease_timeout_ms"] = 15_000
+        config_b = copy.deepcopy(TEST_CONFIG)
+        config_b.update({
+            "driver_id": "teleop-shadow-auth-b",
+            "driver_name": "Auth B",
+            "robot_id": "teleop-shadow-auth-b",
+        })
+        config_b["teleop"]["lease_timeout_ms"] = 15_000
+        driver_token_a = "driver-a-private-sentinel"
+        driver_token_b = "driver-b-private-sentinel"
+        ticket_secret_a = "ticket-a-private-sentinel-at-least-32-bytes"
+        ticket_secret_b = "ticket-b-private-sentinel-at-least-32-bytes"
+
+        with mock.patch.dict(os.environ, {
+            "MOTUS_DRIVER_TOKEN": driver_token_a,
+            "MOTUS_TELEOP_TICKET_SECRET": ticket_secret_a,
+        }):
+            client_a = TestClient(TestServer(create_app(config_a)))
+        with mock.patch.dict(os.environ, {
+            "MOTUS_DRIVER_TOKEN": driver_token_b,
+            "MOTUS_TELEOP_TICKET_SECRET": ticket_secret_b,
+        }):
+            client_b = TestClient(TestServer(create_app(config_b)))
+
+        peer_a = RTCPeerConnection()
+        await client_a.start_server()
+        await client_b.start_server()
+        try:
+            services = (
+                (client_a, driver_token_a, driver_token_b),
+                (client_b, driver_token_b, driver_token_a),
+            )
+            request = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list",
+                "params": {},
+            }
+            for client, own_token, other_token in services:
+                with self.subTest(driver=client.server.app[SERVICE_KEY].driver_id):
+                    accepted = await client.post(
+                        "/mcp",
+                        json=request,
+                        headers={"Authorization": f"Bearer {own_token}"},
+                    )
+                    self.assertEqual(200, accepted.status)
+
+                    rejected = await client.post(
+                        "/mcp",
+                        json=request,
+                        headers={"Authorization": f"Bearer {other_token}"},
+                    )
+                    self.assertEqual(401, rejected.status)
+                    self.assertEqual({"error": "unauthorized"}, await rejected.json())
+
+                    rejected_offer = await client.post(
+                        "/offer",
+                        json={},
+                        headers={"Authorization": f"Bearer {other_token}"},
+                    )
+                    self.assertEqual(401, rejected_offer.status)
+
+                    health = await (await client.get("/health")).json()
+                    serialized = json.dumps(health, sort_keys=True)
+                    for secret in (
+                        driver_token_a,
+                        driver_token_b,
+                        ticket_secret_a,
+                        ticket_secret_b,
+                    ):
+                        self.assertNotIn(secret, serialized)
+                    self.assertTrue(health["mcp_auth_enabled"])
+                    self.assertTrue(health["rtc_enabled"])
+
+                    headers = registration_headers(client.server.app[SERVICE_KEY])
+                    self.assertEqual(f"Bearer {own_token}", headers["Authorization"])
+
+            control_open = asyncio.Event()
+            pose_open = asyncio.Event()
+            control = peer_a.createDataChannel("teleop-control", ordered=True)
+            pose = peer_a.createDataChannel(
+                "teleop-pose",
+                ordered=False,
+                maxRetransmits=0,
+            )
+
+            @control.on("open")
+            def on_control_open():
+                control_open.set()
+
+            @pose.on("open")
+            def on_pose_open():
+                pose_open.set()
+
+            await peer_a.setLocalDescription(await peer_a.createOffer())
+            offer_sdp = peer_a.localDescription.sdp
+
+            service_a = client_a.server.app[SERVICE_KEY]
+            service_b = client_b.server.app[SERVICE_KEY]
+            session_a = {
+                "session_id": str(uuid.uuid4()),
+                "epoch": 1,
+                "fence": "a" * 32,
+            }
+            session_b = {
+                "session_id": str(uuid.uuid4()),
+                "epoch": 1,
+                "fence": "b" * 32,
+            }
+            prepared_a = await service_a.dispatch_tool(
+                "teleop_session",
+                {"action": "prepare_shadow", **session_a},
+            )
+            ticket = TicketCodec(ticket_secret_a).sign(make_ticket_claims(
+                session={
+                    "boot_id": service_a.runtime.boot_id,
+                    **session_a,
+                    "capability_digest": prepared_a["capability_digest"],
+                },
+                sdp=offer_sdp,
+                jti="instance_a_ticket_0001",
+            ))
+            offer_payload = {"type": "offer", "sdp": offer_sdp, "ticket": ticket}
+
+            accepted_offer = await client_a.post(
+                "/offer",
+                json=offer_payload,
+                headers={"Authorization": f"Bearer {driver_token_a}"},
+            )
+            accepted_text = await accepted_offer.text()
+            self.assertEqual(200, accepted_offer.status, accepted_text)
+            answer = json.loads(accepted_text)
+            self.assertNotIn("fence", answer)
+            self.assertNotIn("ticket", answer)
+            await peer_a.setRemoteDescription(RTCSessionDescription(
+                sdp=answer["sdp"],
+                type=answer["type"],
+            ))
+            await asyncio.wait_for(
+                asyncio.gather(control_open.wait(), pose_open.wait()),
+                timeout=10,
+            )
+
+            await service_b.dispatch_tool(
+                "teleop_session",
+                {"action": "prepare_shadow", **session_b},
+            )
+            cross_instance_offer = await client_b.post(
+                "/offer",
+                json=offer_payload,
+                headers={"Authorization": f"Bearer {driver_token_b}"},
+            )
+            self.assertEqual(401, cross_instance_offer.status)
+            cross_instance_error = await cross_instance_offer.json()
+            self.assertEqual(
+                "invalid_signature",
+                cross_instance_error["error"]["code"],
+            )
+            cross_instance_scan = json.dumps(cross_instance_error, sort_keys=True)
+            for secret in (
+                driver_token_a,
+                driver_token_b,
+                ticket_secret_a,
+                ticket_secret_b,
+                session_a["fence"],
+                session_b["fence"],
+            ):
+                self.assertNotIn(secret, cross_instance_scan)
+        finally:
+            await peer_a.close()
+            await client_a.close()
+            await client_b.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_manifest.py
+++ b/generic/teleop_shadow/tests/test_manifest.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class DeploymentManifestTests(unittest.TestCase):
+    def test_service_http_is_loopback_only_for_core_proxy(self):
+        with (ROOT / "deploy/service.yml").open(encoding="utf-8") as handle:
+            manifest = yaml.safe_load(handle)
+        service = manifest["generic-teleop-shadow"]
+        self.assertEqual("host", service["network_mode"])
+        self.assertNotIn("ipc", service)
+        self.assertNotIn("pid", service)
+        self.assertIn("MOTUS_BIND_HOST=127.0.0.1", service["environment"])
+        self.assertIn("MOTUS_MCP_URL=http://localhost:15711/mcp", service["environment"])
+        self.assertIn(
+            "MOTUS_DRIVER_TOKEN=${MOTUS_DRIVER_TOKEN:?set MOTUS_DRIVER_TOKEN before Docker Compose validation}",
+            service["environment"],
+        )
+        self.assertIn(
+            "MOTUS_TELEOP_TICKET_SECRET=${MOTUS_TELEOP_TICKET_SECRET:?set MOTUS_TELEOP_TICKET_SECRET before Docker Compose validation}",
+            service["environment"],
+        )
+
+        self.assertIn(
+            "/opt/phanthy-motus/data/certs:/etc/motus-core-certs:ro",
+            service["volumes"],
+        )
+        self.assertIn(
+            "MOTUS_AGENT_CORE_CA_FILE=/etc/motus-core-certs/cert.pem",
+            service["environment"],
+        )
+
+    def test_driver_and_runtime_ports_match(self):
+        with (ROOT / "driver.yaml").open(encoding="utf-8") as handle:
+            driver = yaml.safe_load(handle)
+        with (ROOT / "config.yaml").open(encoding="utf-8") as handle:
+            config = yaml.safe_load(handle)
+        self.assertEqual(15711, driver["port"])
+        self.assertEqual(driver["port"], config["mcp_port"])
+
+    def test_image_contains_final_dispatch_and_health_requires_readiness(self):
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+        self.assertIn("dispatch.py", dockerfile)
+        self.assertIn("smoke_recording.py", dockerfile)
+        self.assertIn("ENV MOTUS_MCP_PORT=15711", dockerfile)
+        self.assertIn("os.environ['MOTUS_MCP_PORT']", dockerfile)
+        self.assertIn("s['driver_id']==d", dockerfile)
+        self.assertNotIn("127.0.0.1:15711/health", dockerfile)
+        self.assertIn("s['ready'] is True", dockerfile)
+        self.assertIn("s['rtc_enabled'] is True", dockerfile)
+        command_line = next(
+            line.strip() for line in dockerfile.splitlines() if line.strip().startswith("CMD [")
+        )
+        command = json.loads(command_line.removeprefix("CMD "))
+        self.assertEqual(["python", "-c"], command[:2])
+        compile(command[2], "<docker-healthcheck>", "exec")
+
+    def test_readme_exposes_direct_multi_instance_render_and_start_commands(self):
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn("render_instances.py", readme)
+        self.assertIn("deploy/instances.example.yml", readme)
+        self.assertIn("--dry-run", readme)
+        self.assertIn("config --quiet", readme)
+        self.assertIn("up -d", readme)
+        self.assertIn("contain no secret values", readme)
+        self.assertIn("schema_version: 2", readme)
+        self.assertIn("MOTUS_TELEOP_SHADOW_LAB_A_DRIVER_TOKEN", readme)
+        self.assertIn("MOTUS_TELEOP_SHADOW_LAB_A_TICKET_SECRET", readme)
+        self.assertIn("schema v1", readme)
+        self.assertIn("compatible single-instance fragment", readme)
+        self.assertIn("lifecycle `stop`", readme)
+        self.assertIn("24–4096 restricted ASCII Bearer characters", readme)
+        self.assertIn("A-Z a-z 0-9 . _ ~ + / = -", readme)
+        self.assertIn("MOTUS_DRIVER_TOKENS", readme)
+        self.assertIn("rtc_enabled=true", readme)
+        self.assertIn("invalid_signature", readme)
+        self.assertIn("Release every active schema v1 session", readme)
+        self.assertIn("robot_id == driver_id", readme)
+        self.assertIn("private-key PEM block is rejected", readme)
+        self.assertIn("one host trust zone", readme)
+        self.assertIn("authority-domain", readme)
+        self.assertIn("restart_required=true", readme)
+        self.assertIn("teleop_ready=true", readme)
+        self.assertIn("ss -ltnp", readme)
+
+    def test_example_instances_are_direct_standalone_authority_domains(self):
+        with (ROOT / "deploy/instances.example.yml").open(encoding="utf-8") as handle:
+            example = yaml.safe_load(handle)
+        self.assertEqual(2, example["schema_version"])
+        self.assertEqual(2, len(example["instances"]))
+        secret_environment_names = []
+        for instance in example["instances"]:
+            self.assertEqual(instance["driver_id"], instance["robot_id"])
+            secret_environment_names.extend((
+                instance["driver_token_env"],
+                instance["ticket_secret_env"],
+            ))
+        self.assertEqual(len(secret_environment_names), len(set(secret_environment_names)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_protocol.py
+++ b/generic/teleop_shadow/tests/test_protocol.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import math
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from protocol import (
+    CAPABILITIES,
+    CAPABILITY_DIGEST,
+    FRAME_V1_DESCRIPTION,
+    MAX_SEQUENCE,
+    RTC_FRAME_V1_DESCRIPTION,
+    ProtocolError,
+    TicketCodec,
+    TicketError,
+    TicketVerifier,
+    bind_rtc_frame_v1,
+    make_ticket_claims,
+    validate_frame_v1,
+)
+from rtc import RtcManager
+from runtime import ShadowRuntime
+
+from tests.helpers import (
+    TEST_SECRET,
+    FakeClock,
+    new_session,
+    rtc_wire_frame,
+    valid_frame,
+)
+
+
+class FrameV1Tests(unittest.TestCase):
+    def setUp(self):
+        self.clock = FakeClock()
+        self.runtime = ShadowRuntime(clock=self.clock, auto_watchdog=False)
+        self.addCleanup(self.runtime.close)
+        self.session = new_session()
+        self.runtime.prepare_shadow(self.session)
+
+    def test_valid_frame_is_normalized(self):
+        frame = validate_frame_v1(valid_frame(self.runtime, self.session))
+        self.assertEqual(1, frame["schema_version"])
+        self.assertEqual("shadow", frame["mode"])
+        self.assertEqual([0.0, 0.0], frame["controllers"]["left"]["axes"])
+
+    def test_unknown_fields_are_rejected(self):
+        frame = valid_frame(self.runtime, self.session)
+        frame["vendor_extension"] = True
+        with self.assertRaisesRegex(ProtocolError, "unknown fields"):
+            validate_frame_v1(frame)
+
+    def test_nan_and_bad_quaternion_are_rejected(self):
+        frame = valid_frame(self.runtime, self.session)
+        frame["base_twist"]["linear"][0] = math.nan
+        with self.assertRaisesRegex(ProtocolError, "finite"):
+            validate_frame_v1(frame)
+        frame = valid_frame(self.runtime, self.session)
+        frame["head"]["orientation"] = [0.0, 0.0, 0.0, 0.2]
+        with self.assertRaisesRegex(ProtocolError, "normalized"):
+            validate_frame_v1(frame)
+
+    def test_tracking_false_requires_null_pose(self):
+        frame = valid_frame(self.runtime, self.session, tracking=False)
+        frame["head"] = {"position": [0, 0, 0], "orientation": [0, 0, 0, 1]}
+        with self.assertRaisesRegex(ProtocolError, "tracking is invalid"):
+            validate_frame_v1(frame)
+        frame = valid_frame(self.runtime, self.session, tracking=True)
+        frame["head"] = None
+        with self.assertRaisesRegex(ProtocolError, "tracking is valid"):
+            validate_frame_v1(frame)
+
+    def test_sequence_fields_accept_signed_64_bit_maximum(self):
+        frame = valid_frame(self.runtime, self.session)
+        frame["sequence"] = MAX_SEQUENCE
+        frame["clutch_sequence"] = MAX_SEQUENCE
+
+        normalized = validate_frame_v1(frame)
+
+        self.assertEqual(MAX_SEQUENCE, normalized["sequence"])
+        self.assertEqual(MAX_SEQUENCE, normalized["clutch_sequence"])
+
+    def test_sequence_fields_reject_values_above_signed_64_bit_maximum(self):
+        for field in ("sequence", "clutch_sequence"):
+            with self.subTest(field=field):
+                frame = valid_frame(self.runtime, self.session)
+                frame[field] = MAX_SEQUENCE + 1
+
+                with self.assertRaises(ProtocolError) as raised:
+                    validate_frame_v1(frame)
+
+                self.assertEqual("out_of_range", raised.exception.code)
+
+    def test_capability_schema_advertises_sequence_bounds(self):
+        expected = {"minimum": 0, "maximum": MAX_SEQUENCE}
+        bounds = FRAME_V1_DESCRIPTION["integer_bounds"]
+        self.assertEqual(expected, bounds["sequence"])
+        self.assertEqual(expected, bounds["clutch_sequence"])
+        self.assertEqual(bounds, CAPABILITIES["frame"]["integer_bounds"])
+
+    def test_rtc_wire_frame_is_bound_server_side_without_private_identity(self):
+        wire = rtc_wire_frame(self.runtime, self.session, sequence=7)
+        authority, _generation = self.runtime.rtc_authority_snapshot()
+
+        normalized = bind_rtc_frame_v1(wire, authority=authority)
+
+        self.assertEqual(7, normalized["sequence"])
+        self.assertEqual(self.runtime.boot_id, normalized["boot_id"])
+        self.assertEqual(self.session["session_id"], normalized["session_id"])
+        self.assertEqual(self.session["fence"], normalized["fence"])
+
+    def test_rtc_wire_frame_rejects_client_supplied_private_identity(self):
+        wire = rtc_wire_frame(self.runtime, self.session)
+        wire["fence"] = self.session["fence"]
+        authority, _generation = self.runtime.rtc_authority_snapshot()
+
+        with self.assertRaises(ProtocolError) as raised:
+            bind_rtc_frame_v1(wire, authority=authority)
+
+        self.assertEqual("unknown_field", raised.exception.code)
+
+    def test_rtc_capability_contract_has_no_private_identity_fields(self):
+        private = {"boot_id", "session_id", "epoch", "fence"}
+        self.assertTrue(private.isdisjoint(RTC_FRAME_V1_DESCRIPTION["required"]))
+        self.assertEqual(
+            sorted(private),
+            sorted(RTC_FRAME_V1_DESCRIPTION["forbidden_private_fields"]),
+        )
+        self.assertEqual(
+            RTC_FRAME_V1_DESCRIPTION,
+            CAPABILITIES["rtc_frame"],
+        )
+        self.assertEqual(
+            "motus.teleop.rtc-frame.v1",
+            CAPABILITIES["rtc_frame"]["protocol"],
+        )
+        self.assertEqual(
+            ["peer_ping", "status"],
+            CAPABILITIES["rtc_control"]["allowed"],
+        )
+        self.assertFalse(
+            CAPABILITIES["rtc_control"]["private_authority_fields_allowed"]
+        )
+
+
+class RtcMessageDecodingTests(unittest.TestCase):
+    def setUp(self):
+        self.runtime = ShadowRuntime(auto_watchdog=False)
+        self.addCleanup(self.runtime.close)
+        self.rtc = RtcManager(self.runtime, None)
+
+    def test_pose_huge_integer_is_stable_invalid_json(self):
+        message = '{"sequence":' + ('9' * 5000) + '}'
+
+        with self.assertRaises(ProtocolError) as raised:
+            self.rtc._decode_message(message, maximum=64 * 1024)
+
+        self.assertEqual("invalid_json", raised.exception.code)
+
+    def test_control_deep_json_is_stable_invalid_json(self):
+        with (
+            mock.patch("rtc.json.loads", side_effect=RecursionError),
+            self.assertRaises(ProtocolError) as raised,
+        ):
+            self.rtc._decode_message("[]", maximum=8 * 1024)
+
+        self.assertEqual("invalid_json", raised.exception.code)
+
+    def test_unencodable_text_is_stable_invalid_encoding(self):
+        message = '"' + chr(0xD800) + '"'
+
+        with self.assertRaises(ProtocolError) as raised:
+            self.rtc._decode_message(message, maximum=8 * 1024)
+
+        self.assertEqual("invalid_encoding", raised.exception.code)
+
+
+class TicketTests(unittest.TestCase):
+    def setUp(self):
+        self.wall = FakeClock(1_000)
+        self.codec = TicketCodec(TEST_SECRET)
+        self.verifier = TicketVerifier(self.codec, wall_clock=self.wall)
+        self.session = {
+            "boot_id": "11111111-1111-1111-1111-111111111111",
+            "session_id": "22222222-2222-2222-2222-222222222222",
+            "epoch": 7,
+            "fence": "f" * 32,
+            "capability_digest": CAPABILITY_DIGEST,
+        }
+        self.sdp = "v=0\r\nt=test-offer\r\n"
+
+    def ticket(self, *, jti: str = "ticket_identifier_1234", sdp: str | None = None) -> str:
+        claims = make_ticket_claims(
+            session=self.session,
+            sdp=sdp or self.sdp,
+            wall_clock=self.wall,
+            jti=jti,
+        )
+        return self.codec.sign(claims)
+
+    def test_ticket_is_bound_and_one_time(self):
+        ticket = self.ticket()
+        claims = self.verifier.verify_and_consume(ticket, expected=self.session, sdp=self.sdp)
+        self.assertEqual(self.session["fence"], claims["fence"])
+        with self.assertRaisesRegex(TicketError, "already been used"):
+            self.verifier.verify_and_consume(ticket, expected=self.session, sdp=self.sdp)
+
+    def test_wrong_sdp_and_expired_ticket_are_rejected(self):
+        with self.assertRaisesRegex(TicketError, "SDP"):
+            self.verifier.verify_and_consume(self.ticket(), expected=self.session, sdp="other")
+        ticket = self.ticket(jti="ticket_identifier_5678")
+        self.wall.advance(31)
+        with self.assertRaisesRegex(TicketError, "expired"):
+            self.verifier.verify_and_consume(ticket, expected=self.session, sdp=self.sdp)
+
+    def test_short_secret_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "32 bytes"):
+            TicketCodec("too-short")
+
+    def test_ticket_secret_must_be_valid_utf8_without_disclosure(self):
+        secret = "private-prefix-" + ("\ud800" * 32)
+        with self.assertRaisesRegex(ValueError, "valid UTF-8") as raised:
+            TicketCodec(secret)
+        self.assertNotIn("private-prefix", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_registration_tls.py
+++ b/generic/teleop_shadow/tests/test_registration_tls.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import asyncio
+import datetime
+import ipaddress
+import os
+import ssl
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import aiohttp
+from aiohttp import web
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from main import (
+    RegistrationTlsError,
+    ShadowDriverService,
+    _registration_loop,
+    build_registration_ssl_context,
+)
+
+from tests.helpers import TEST_SECRET
+
+
+def _write_self_signed_certificate(directory: Path, stem: str) -> tuple[Path, Path]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "phanthy-motus")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.DNSName("phanthy-motus"),
+                x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
+            ]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    certificate_path = directory / f"{stem}.pem"
+    key_path = directory / f"{stem}-key.pem"
+    certificate_path.write_bytes(certificate.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ))
+    return certificate_path, key_path
+
+
+async def _registration_ok(_request: web.Request) -> web.Response:
+    return web.json_response({"registered": True})
+
+
+class RegistrationTlsTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        directory = Path(self.temporary_directory.name)
+        self.core_certificate, core_key = _write_self_signed_certificate(directory, "core")
+        self.wrong_certificate, _ = _write_self_signed_certificate(directory, "wrong")
+
+        self.server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        self.server_context.load_cert_chain(self.core_certificate, core_key)
+
+    async def asyncSetUp(self):
+        app = web.Application()
+        app.router.add_post("/api/mcp", _registration_ok)
+        self.runner = web.AppRunner(app)
+        await self.runner.setup()
+        self.site = web.TCPSite(self.runner, "127.0.0.1", 0, ssl_context=self.server_context)
+        await self.site.start()
+        sockets = self.site._server.sockets  # type: ignore[union-attr]
+        self.endpoint = f"https://127.0.0.1:{sockets[0].getsockname()[1]}/api/mcp"
+
+    async def asyncTearDown(self):
+        await self.runner.cleanup()
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    async def test_pinned_core_certificate_succeeds(self):
+        context = build_registration_ssl_context({
+            "verify_tls": True,
+            "ca_file": str(self.core_certificate),
+        })
+        self.assertIsInstance(context, ssl.SSLContext)
+        self.assertEqual(ssl.CERT_REQUIRED, context.verify_mode)
+        self.assertFalse(context.check_hostname)
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(self.endpoint, ssl=context) as response,
+        ):
+            self.assertEqual(200, response.status)
+            self.assertTrue((await response.json())["registered"])
+
+    async def test_wrong_pinned_certificate_fails_handshake(self):
+        context = build_registration_ssl_context({
+            "verify_tls": True,
+            "ca_file": str(self.wrong_certificate),
+        })
+        loop = asyncio.get_running_loop()
+        previous_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, _context: None)
+        try:
+            with self.assertRaises(aiohttp.ClientError):
+                async with aiohttp.ClientSession() as session:
+                    await session.post(self.endpoint, ssl=context)
+            await asyncio.sleep(0.05)
+        finally:
+            loop.set_exception_handler(previous_handler)
+
+    async def test_missing_certificate_fails_before_connection(self):
+        missing = Path(self.temporary_directory.name) / "missing.pem"
+        with self.assertRaisesRegex(RegistrationTlsError, "pinned CA file is missing"):
+            build_registration_ssl_context({"verify_tls": True, "ca_file": str(missing)})
+
+    async def test_explicit_local_development_override_disables_verification(self):
+        self.assertIs(False, build_registration_ssl_context({"verify_tls": False}))
+
+    async def test_registration_reports_missing_pin_and_keeps_retrying(self):
+        missing = Path(self.temporary_directory.name) / "never-created.pem"
+        config = {
+            "driver_id": "teleop-shadow-tls-retry",
+            "driver_name": "TLS retry test",
+            "mcp_port": 15711,
+            "teleop": {},
+            "registration": {
+                "enabled": True,
+                "agent_core_url": "https://127.0.0.1:1",
+                "interval_seconds": 30,
+                "verify_tls": True,
+                "ca_file": str(missing),
+            },
+        }
+        real_sleep = asyncio.sleep
+
+        async def yield_immediately(_delay: float) -> None:
+            await real_sleep(0)
+
+        with mock.patch.dict(os.environ, {
+            "MOTUS_DRIVER_TOKEN": "registration-tls-test-driver-token",
+            "MOTUS_TELEOP_TICKET_SECRET": TEST_SECRET,
+        }):
+            service = ShadowDriverService(config)
+        with (
+            self.assertLogs("teleop-shadow", level="WARNING"),
+            mock.patch("main.asyncio.sleep", new=yield_immediately),
+        ):
+            task = asyncio.create_task(_registration_loop(service))
+            try:
+                for _ in range(100):
+                    if service.registration_status["attempts"] >= 2:
+                        break
+                    await real_sleep(0)
+                self.assertGreaterEqual(service.registration_status["attempts"], 2)
+                self.assertEqual("tls_error", service.registration_status["state"])
+                self.assertIn("pinned CA file is missing", service.registration_status["last_error"])
+            finally:
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+                await service.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_render_instances.py
+++ b/generic/teleop_shadow/tests/test_render_instances.py
@@ -1,0 +1,539 @@
+from __future__ import annotations
+
+import contextlib
+import copy
+import io
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import render_instances as renderer
+import yaml
+from render_instances import (
+    CORE_CA_TARGET,
+    RenderError,
+    _validate_core_ca_file_on_host,
+    atomic_write,
+    load_instances,
+    main,
+    parse_instances_document,
+    render_compose,
+    require_distinct_input_output,
+    validate_image,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _instances_document() -> dict:
+    return {
+        "schema_version": 2,
+        "core_ca_file": "/opt/phanthy-motus/data/certs/cert.pem",
+        "instances": [
+            {
+                "service": "teleop-shadow-lab-b",
+                "container": "motus-teleop-shadow-lab-b",
+                "driver_id": "teleop-shadow-lab-b",
+                "driver_name": "Lab B Quest Teleop Shadow",
+                "robot_id": "teleop-shadow-lab-b",
+                "mcp_port": 15712,
+                "driver_token_env": "MOTUS_TELEOP_SHADOW_LAB_B_DRIVER_TOKEN",
+                "ticket_secret_env": "MOTUS_TELEOP_SHADOW_LAB_B_TICKET_SECRET",
+            },
+            {
+                "service": "teleop-shadow-lab-a",
+                "container": "motus-teleop-shadow-lab-a",
+                "driver_id": "teleop-shadow-lab-a",
+                "driver_name": "Lab A Quest Teleop Shadow",
+                "robot_id": "teleop-shadow-lab-a",
+                "mcp_port": 15711,
+                "driver_token_env": "MOTUS_TELEOP_SHADOW_LAB_A_DRIVER_TOKEN",
+                "ticket_secret_env": "MOTUS_TELEOP_SHADOW_LAB_A_TICKET_SECRET",
+            },
+        ],
+    }
+
+
+class RenderInstancesTests(unittest.TestCase):
+    def setUp(self):
+        validation = mock.patch(
+            "render_instances._validate_core_ca_file_on_host",
+            side_effect=lambda path: str(path),
+        )
+        validation.start()
+        self.addCleanup(validation.stop)
+
+    def test_two_instances_render_canonical_safe_compose(self):
+        deployment = parse_instances_document(_instances_document())
+        rendered = render_compose(deployment, "registry.example/motus/teleop-shadow:1.2.3")
+        compose = yaml.safe_load(rendered)
+
+        self.assertEqual(
+            ["teleop-shadow-lab-a", "teleop-shadow-lab-b"],
+            list(compose["services"]),
+        )
+        expected = {
+            "teleop-shadow-lab-a": (
+                "motus-teleop-shadow-lab-a",
+                "teleop-shadow-lab-a",
+                "teleop-shadow-lab-a",
+                15711,
+                "MOTUS_TELEOP_SHADOW_LAB_A_DRIVER_TOKEN",
+                "MOTUS_TELEOP_SHADOW_LAB_A_TICKET_SECRET",
+            ),
+            "teleop-shadow-lab-b": (
+                "motus-teleop-shadow-lab-b",
+                "teleop-shadow-lab-b",
+                "teleop-shadow-lab-b",
+                15712,
+                "MOTUS_TELEOP_SHADOW_LAB_B_DRIVER_TOKEN",
+                "MOTUS_TELEOP_SHADOW_LAB_B_TICKET_SECRET",
+            ),
+        }
+        for service_name, (
+            container,
+            driver_id,
+            robot_id,
+            port,
+            driver_token_env,
+            ticket_secret_env,
+        ) in expected.items():
+            service = compose["services"][service_name]
+            self.assertEqual("host", service["network_mode"])
+            self.assertEqual(container, service["container_name"])
+            self.assertNotIn("ports", service)
+            self.assertNotIn("privileged", service)
+            self.assertIn("MOTUS_BIND_HOST=127.0.0.1", service["environment"])
+            self.assertIn(f"MOTUS_MCP_PORT={port}", service["environment"])
+            self.assertIn(
+                f"MOTUS_MCP_URL=http://localhost:{port}/mcp",
+                service["environment"],
+            )
+            self.assertIn(f"MOTUS_DRIVER_ID={driver_id}", service["environment"])
+            self.assertIn(f"MOTUS_ROBOT_ID={robot_id}", service["environment"])
+            self.assertEqual(
+                [
+                    (
+                        f"MOTUS_DRIVER_TOKEN=${{{driver_token_env}:?set {driver_token_env} "
+                        "before Docker Compose validation}"
+                    ),
+                    (
+                        "MOTUS_TELEOP_TICKET_SECRET="
+                        f"${{{ticket_secret_env}:?set {ticket_secret_env} "
+                        "before Docker Compose validation}"
+                    ),
+                ],
+                [
+                    entry
+                    for entry in service["environment"]
+                    if entry.startswith(("MOTUS_DRIVER_TOKEN=", "MOTUS_TELEOP_TICKET_SECRET="))
+                ],
+            )
+
+            self.assertEqual(1, len(service["volumes"]))
+            ca_mount = service["volumes"][0]
+            self.assertEqual("bind", ca_mount["type"])
+            self.assertEqual(deployment.core_ca_file, ca_mount["source"])
+            self.assertEqual(CORE_CA_TARGET, ca_mount["target"])
+            self.assertIs(True, ca_mount["read_only"])
+            self.assertIs(False, ca_mount["bind"]["create_host_path"])
+
+    def test_rendering_is_deterministic_across_input_order(self):
+        first = _instances_document()
+        second = copy.deepcopy(first)
+        second["instances"].reverse()
+
+        first_render = render_compose(parse_instances_document(first), "teleop-shadow:local")
+        second_render = render_compose(parse_instances_document(second), "teleop-shadow:local")
+
+        self.assertEqual(first_render, second_render)
+
+    def test_every_runtime_identity_and_port_must_be_unique(self):
+        for field in ("service", "container", "driver_id", "robot_id", "mcp_port"):
+            with self.subTest(field=field):
+                document = _instances_document()
+                document["instances"][1][field] = document["instances"][0][field]
+                with self.assertRaisesRegex(RenderError, field):
+                    parse_instances_document(document)
+
+    def test_every_secret_environment_reference_is_globally_unique(self):
+        duplicate_cases = (
+            ("driver_token_env", "driver_token_env"),
+            ("ticket_secret_env", "ticket_secret_env"),
+        )
+        for source_field, destination_field in duplicate_cases:
+            with self.subTest(source_field=source_field, destination_field=destination_field):
+                document = _instances_document()
+                document["instances"][1][destination_field] = (
+                    document["instances"][0][source_field]
+                )
+                with self.assertRaisesRegex(RenderError, "secret environment name"):
+                    parse_instances_document(document)
+
+    def test_schema_v1_and_missing_secret_references_fail_with_migration_signal(self):
+        document = _instances_document()
+        document["schema_version"] = 1
+        with self.assertRaisesRegex(RenderError, "schema_version must be exactly 2"):
+            parse_instances_document(document)
+
+        for field in ("driver_token_env", "ticket_secret_env"):
+            with self.subTest(field=field):
+                document = _instances_document()
+                document["instances"][0].pop(field)
+                with self.assertRaisesRegex(RenderError, field):
+                    parse_instances_document(document)
+
+    def test_unknown_fields_and_secret_fields_are_rejected(self):
+        document = _instances_document()
+        document["unknown"] = True
+        with self.assertRaisesRegex(RenderError, "unknown fields"):
+            parse_instances_document(document)
+
+        document = _instances_document()
+        document["instances"][0]["MOTUS_DRIVER_TOKEN"] = "must-not-be-here"
+        with self.assertRaisesRegex(RenderError, "MOTUS_DRIVER_TOKEN"):
+            parse_instances_document(document)
+
+    def test_identifiers_ports_names_and_paths_reject_injection(self):
+        mutations = (
+            ("service", "Bad/Service"),
+            ("container", "../container"),
+            ("driver_id", "driver\nINJECTED=1"),
+            ("robot_id", "${MOTUS_DRIVER_TOKEN}"),
+            ("robot_id", "r" * 65),
+            ("driver_name", "${MOTUS_DRIVER_TOKEN}"),
+            ("mcp_port", 15699),
+            ("mcp_port", 15800),
+            ("mcp_port", "15711"),
+            ("mcp_port", True),
+            ("driver_token_env", "lowercase_secret"),
+            ("driver_token_env", "MOTUS-DRIVER-TOKEN-A"),
+            ("driver_token_env", "PATH"),
+            ("driver_token_env", "MOTUS_DRIVER_TOKEN"),
+            ("driver_token_env", "MOTUS_TELEOP_LAB_A_TICKET_SECRET"),
+            ("ticket_secret_env", "${MOTUS_TELEOP_TICKET_SECRET}"),
+            ("ticket_secret_env", "HOME"),
+            ("ticket_secret_env", "MOTUS_TELEOP_TICKET_SECRET"),
+            ("ticket_secret_env", "MOTUS_TELEOP_LAB_A_DRIVER_TOKEN"),
+            ("ticket_secret_env", "T" * 129),
+        )
+        for field, value in mutations:
+            with self.subTest(field=field, value=value):
+                document = _instances_document()
+                document["instances"][0][field] = value
+                with self.assertRaises(RenderError):
+                    parse_instances_document(document)
+
+        for path in (
+            "relative/cert.pem",
+            "/opt/phanthy-motus/../secret.pem",
+            "/opt/phanthy-motus/${CORE_CA}",
+            "/opt//phanthy-motus/cert.pem",
+            "/etc/shadow",
+            "/opt/phanthy-motus/tls/private.key",
+        ):
+            with self.subTest(path=path):
+                document = _instances_document()
+                document["core_ca_file"] = path
+                with self.assertRaises(RenderError):
+                    parse_instances_document(document)
+
+        for image in ("", "../image", "image\nservices:", "${SECRET_IMAGE}"):
+            with self.subTest(image=image), self.assertRaises(RenderError):
+                validate_image(image)
+
+    def test_duplicate_yaml_keys_are_rejected(self):
+        text = """\
+schema_version: 2
+core_ca_file: /opt/phanthy-motus/data/certs/cert.pem
+core_ca_file: /tmp/overridden.pem
+instances: []
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "instances.yml"
+            path.write_text(text, encoding="utf-8")
+            with self.assertRaisesRegex(RenderError, "duplicate key"):
+                load_instances(path)
+
+    def test_renderer_never_reads_or_materializes_process_secrets(self):
+        deployment = parse_instances_document(_instances_document())
+        secret_environment = {
+            "MOTUS_TELEOP_SHADOW_LAB_A_DRIVER_TOKEN": "driver-secret-a-sentinel-0001",
+            "MOTUS_TELEOP_SHADOW_LAB_A_TICKET_SECRET": (
+                "ticket-secret-a-sentinel-at-least-32-bytes"
+            ),
+            "MOTUS_TELEOP_SHADOW_LAB_B_DRIVER_TOKEN": "driver-secret-b-sentinel-0002",
+            "MOTUS_TELEOP_SHADOW_LAB_B_TICKET_SECRET": (
+                "ticket-secret-b-sentinel-at-least-32-bytes"
+            ),
+            # The v1 deployment names must no longer influence schema v2 output.
+            "MOTUS_DRIVER_TOKEN": "legacy-driver-secret-sentinel",
+            "MOTUS_TELEOP_TICKET_SECRET": "legacy-ticket-secret-sentinel",
+        }
+        with mock.patch.dict(
+            os.environ,
+            secret_environment,
+        ):
+            rendered = render_compose(deployment, "teleop-shadow:local")
+
+        for secret in secret_environment.values():
+            self.assertNotIn(secret, rendered)
+        self.assertNotIn("${MOTUS_DRIVER_TOKEN:?", rendered)
+        self.assertNotIn("${MOTUS_TELEOP_TICKET_SECRET:?", rendered)
+        for environment_name in secret_environment:
+            if environment_name in ("MOTUS_DRIVER_TOKEN", "MOTUS_TELEOP_TICKET_SECRET"):
+                continue
+            self.assertEqual(1, rendered.count(f"${{{environment_name}:?"))
+
+    def test_atomic_output_replaces_complete_file_and_leaves_no_temp(self):
+        deployment = parse_instances_document(_instances_document())
+        rendered = render_compose(deployment, "teleop-shadow:local")
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "teleop-shadow.compose.yml"
+            output.write_text("old-partial-content", encoding="utf-8")
+
+            atomic_write(output, rendered)
+
+            self.assertEqual(rendered, output.read_text(encoding="utf-8"))
+            self.assertEqual(0o644, output.stat().st_mode & 0o777)
+            self.assertEqual([], list(output.parent.glob(f".{output.name}.*.tmp")))
+
+    def test_atomic_output_rejects_broken_symlink(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "teleop-shadow.compose.yml"
+            missing = Path(directory) / "must-not-be-created"
+            output.symlink_to(missing)
+
+            with self.assertRaisesRegex(RenderError, "regular file path"):
+                atomic_write(output, "services: {}\n")
+
+            self.assertTrue(output.is_symlink())
+            self.assertFalse(missing.exists())
+
+    def test_input_output_aliases_are_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "instances.yml"
+            source.write_text("schema_version: 2\n", encoding="utf-8")
+            with self.assertRaisesRegex(RenderError, "must not replace"):
+                require_distinct_input_output(source, source)
+
+            hard_link = Path(directory) / "hard-link.yml"
+            os.link(source, hard_link)
+            with self.assertRaisesRegex(RenderError, "must not replace"):
+                require_distinct_input_output(source, hard_link)
+
+    def test_cli_stdout_and_dry_run_write_no_output_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            instances = Path(directory) / "instances.yml"
+            instances.write_text(
+                yaml.safe_dump(_instances_document(), sort_keys=False),
+                encoding="utf-8",
+            )
+            for flag in ("--stdout", "--dry-run"):
+                with self.subTest(flag=flag):
+                    output = Path(directory) / f"{flag[2:]}.compose.yml"
+                    stdout = io.StringIO()
+                    stderr = io.StringIO()
+                    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                        return_code = main([
+                            "--instances",
+                            str(instances),
+                            "--image",
+                            "teleop-shadow:local",
+                            "--output",
+                            str(output),
+                            flag,
+                        ])
+                    self.assertEqual(0, return_code, stderr.getvalue())
+                    self.assertFalse(output.exists())
+                    self.assertEqual(
+                        ["teleop-shadow-lab-a", "teleop-shadow-lab-b"],
+                        list(yaml.safe_load(stdout.getvalue())["services"]),
+                    )
+                    self.assertNotIn("secret-sentinel", stdout.getvalue())
+
+    def test_cli_writes_a_complete_atomic_output_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            instances = Path(directory) / "instances.yml"
+            output = Path(directory) / "teleop-shadow.compose.yml"
+            instances.write_text(
+                yaml.safe_dump(_instances_document(), sort_keys=False),
+                encoding="utf-8",
+            )
+
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                return_code = main([
+                    "--instances",
+                    str(instances),
+                    "--image",
+                    "teleop-shadow:local",
+                    "--output",
+                    str(output),
+                ])
+
+            self.assertEqual(0, return_code, stderr.getvalue())
+            self.assertEqual("", stdout.getvalue())
+            self.assertIn("rendered 2 teleop-shadow instances", stderr.getvalue())
+            self.assertEqual(2, len(yaml.safe_load(output.read_text())["services"]))
+            self.assertEqual([], list(output.parent.glob(f".{output.name}.*.tmp")))
+
+    def test_cli_refuses_to_overwrite_its_instances_input(self):
+        with tempfile.TemporaryDirectory() as directory:
+            instances = Path(directory) / "instances.yml"
+            original = yaml.safe_dump(_instances_document(), sort_keys=False)
+            instances.write_text(original, encoding="utf-8")
+            stderr = io.StringIO()
+
+            with contextlib.redirect_stderr(stderr):
+                return_code = main([
+                    "--instances",
+                    str(instances),
+                    "--image",
+                    "teleop-shadow:local",
+                    "--output",
+                    str(instances),
+                ])
+
+            self.assertEqual(2, return_code)
+            self.assertIn("must not replace", stderr.getvalue())
+            self.assertEqual(original, instances.read_text(encoding="utf-8"))
+
+    def test_bundled_example_is_directly_renderable(self):
+        deployment = load_instances(ROOT / "deploy/instances.example.yml")
+        rendered = render_compose(deployment, "teleop-shadow:local")
+
+        self.assertEqual(2, len(yaml.safe_load(rendered)["services"]))
+
+    @unittest.skipUnless(shutil.which("docker"), "Docker Compose is unavailable")
+    def test_rendered_document_passes_real_docker_compose_secret_preflight(self):
+        version = subprocess.run(
+            ["docker", "compose", "version"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if version.returncode != 0:
+            self.skipTest("Docker Compose plugin is unavailable")
+        deployment = parse_instances_document(_instances_document())
+        rendered = render_compose(deployment, "teleop-shadow:local")
+        with tempfile.TemporaryDirectory() as directory:
+            compose = Path(directory) / "compose.yml"
+            compose.write_text(rendered, encoding="utf-8")
+            secret_environment = {
+                "MOTUS_TELEOP_SHADOW_LAB_A_DRIVER_TOKEN": "driver-a-secret-sentinel",
+                "MOTUS_TELEOP_SHADOW_LAB_A_TICKET_SECRET": (
+                    "ticket-a-secret-sentinel-at-least-32-bytes"
+                ),
+                "MOTUS_TELEOP_SHADOW_LAB_B_DRIVER_TOKEN": "driver-b-secret-sentinel",
+                "MOTUS_TELEOP_SHADOW_LAB_B_TICKET_SECRET": (
+                    "ticket-b-secret-sentinel-at-least-32-bytes"
+                ),
+            }
+            environment = {**os.environ, **secret_environment}
+            valid = subprocess.run(
+                ["docker", "compose", "-f", str(compose), "config", "--quiet"],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            self.assertEqual(0, valid.returncode, valid.stderr)
+
+            environment.pop("MOTUS_TELEOP_SHADOW_LAB_B_TICKET_SECRET")
+            missing = subprocess.run(
+                ["docker", "compose", "-f", str(compose), "config", "--quiet"],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            self.assertNotEqual(0, missing.returncode)
+            for secret in secret_environment.values():
+                self.assertNotIn(secret, missing.stderr)
+
+
+class CoreCaValidationTests(unittest.TestCase):
+    @unittest.skipUnless(shutil.which("openssl"), "OpenSSL is unavailable")
+    def test_ca_must_be_public_x509_inside_the_real_deployment_root(self):
+        with tempfile.TemporaryDirectory() as directory:
+            temporary = Path(directory).resolve()
+            root = temporary / "opt" / "phanthy-motus"
+            tls_dir = root / "tls"
+            tls_dir.mkdir(parents=True)
+            certificate = tls_dir / "core-ca.pem"
+            private_key = temporary / "private-key.pem"
+            subprocess.run(
+                [
+                    "openssl",
+                    "req",
+                    "-x509",
+                    "-newkey",
+                    "rsa:2048",
+                    "-keyout",
+                    str(private_key),
+                    "-out",
+                    str(certificate),
+                    "-days",
+                    "1",
+                    "-nodes",
+                    "-subj",
+                    "/CN=motus-renderer-test",
+                ],
+                check=True,
+                capture_output=True,
+            )
+            with mock.patch.object(renderer, "CORE_CA_SOURCE_ROOT", root):
+                self.assertEqual(
+                    str(certificate.resolve()),
+                    _validate_core_ca_file_on_host(certificate),
+                )
+
+                managed_link = tls_dir / "managed-link.pem"
+                managed_link.symlink_to(certificate)
+                self.assertEqual(
+                    str(certificate.resolve()),
+                    _validate_core_ca_file_on_host(managed_link),
+                )
+
+                private_inside_root = tls_dir / "privkey.pem"
+                shutil.copyfile(private_key, private_inside_root)
+                with self.assertRaisesRegex(RenderError, "private-key PEM"):
+                    _validate_core_ca_file_on_host(private_inside_root)
+
+                combined = tls_dir / "combined.pem"
+                combined.write_bytes(
+                    certificate.read_bytes()
+                    + b"\n-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----\n"
+                )
+                with self.assertRaisesRegex(RenderError, "private-key PEM"):
+                    _validate_core_ca_file_on_host(combined)
+
+                public_plus_garbage = tls_dir / "garbage.pem"
+                public_plus_garbage.write_bytes(
+                    certificate.read_bytes() + b"not-a-certificate"
+                )
+                with self.assertRaisesRegex(RenderError, "only public X.509"):
+                    _validate_core_ca_file_on_host(public_plus_garbage)
+
+                outside = temporary / "outside-ca.pem"
+                shutil.copyfile(certificate, outside)
+                escaped = tls_dir / "escaped.pem"
+                escaped.symlink_to(outside)
+                with self.assertRaisesRegex(RenderError, "inside /opt/phanthy-motus"):
+                    _validate_core_ca_file_on_host(escaped)
+
+                if hasattr(os, "mkfifo"):
+                    fifo = tls_dir / "fifo.pem"
+                    os.mkfifo(fifo)
+                    with self.assertRaisesRegex(RenderError, "regular file"):
+                        _validate_core_ca_file_on_host(fifo)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_rtc_scenario.py
+++ b/generic/teleop_shadow/tests/test_rtc_scenario.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import unittest
+import uuid
+from pathlib import Path
+from unittest import mock
+
+from aiohttp.test_utils import TestClient, TestServer
+from aiortc import RTCPeerConnection, RTCSessionDescription
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from main import SERVICE_KEY, create_app
+from protocol import TicketCodec, make_ticket_claims
+
+from tests.helpers import (
+    TEST_DRIVER_TOKEN,
+    TEST_SECRET,
+    rtc_wire_frame,
+    valid_frame,
+)
+
+RTC_CONFIG = {
+    "mcp_port": 15711,
+    "bind_host": "127.0.0.1",
+    "teleop": {
+        "lease_timeout_ms": 15_000,
+        "pose_timeout_ms": 1000,
+        "watchdog_interval_ms": 25,
+        "ticket_ttl_max_seconds": 30,
+        "ticket_replay_cache_entries": 128,
+    },
+    "registration": {"enabled": False},
+}
+
+
+class LocalAiortcScenarioTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.env = mock.patch.dict(os.environ, {
+            "MOTUS_DRIVER_TOKEN": TEST_DRIVER_TOKEN,
+            "MOTUS_TELEOP_TICKET_SECRET": TEST_SECRET,
+        })
+        self.env.start()
+        self.http = TestClient(TestServer(create_app(RTC_CONFIG)))
+        await self.http.start_server()
+        self.peer = RTCPeerConnection()
+
+    async def asyncTearDown(self):
+        await self.peer.close()
+        await self.http.close()
+        self.env.stop()
+
+    async def rpc_call(self, name: str, arguments: dict) -> dict:
+        response = await self.http.post("/mcp", json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        }, headers={"Authorization": f"Bearer {TEST_DRIVER_TOKEN}"})
+        payload = await response.json()
+        self.assertNotIn("error", payload, payload)
+        return json.loads(payload["result"]["content"][0]["text"])
+
+    async def wait_until(self, predicate, *, timeout: float = 10.0):
+        deadline = asyncio.get_running_loop().time() + timeout
+        while asyncio.get_running_loop().time() < deadline:
+            value = predicate()
+            if value:
+                return value
+            await asyncio.sleep(0.02)
+        self.fail("timed out waiting for RTC condition")
+
+    async def test_real_offer_two_channels_pose_and_replay_protection(self):
+        service = self.http.server.app[SERVICE_KEY]
+        session = {"session_id": str(uuid.uuid4()), "epoch": 1, "fence": "r" * 32}
+        prepared = await self.rpc_call("teleop_session", {"action": "prepare_shadow", **session})
+        await self.rpc_call("teleop_session", {
+            "action": "heartbeat",
+            "boot_id": service.runtime.boot_id,
+            **session,
+        })
+
+        control_open = asyncio.Event()
+        pose_open = asyncio.Event()
+        control_response = asyncio.Event()
+        responses: list[dict] = []
+        control = self.peer.createDataChannel("teleop-control", ordered=True)
+        pose = self.peer.createDataChannel("teleop-pose", ordered=False, maxRetransmits=0)
+
+        @control.on("open")
+        def on_control_open():
+            control_open.set()
+
+        @pose.on("open")
+        def on_pose_open():
+            pose_open.set()
+
+        @control.on("message")
+        def on_control_message(message):
+            responses.append(json.loads(message))
+            control_response.set()
+
+        await self.peer.setLocalDescription(await self.peer.createOffer())
+        offer_sdp = self.peer.localDescription.sdp
+        ticket_session = {
+            "boot_id": service.runtime.boot_id,
+            "session_id": session["session_id"],
+            "epoch": session["epoch"],
+            "fence": session["fence"],
+            "capability_digest": prepared["capability_digest"],
+        }
+        ticket = TicketCodec(TEST_SECRET).sign(make_ticket_claims(
+            session=ticket_session,
+            sdp=offer_sdp,
+            ttl_seconds=20,
+            jti="local_aiortc_ticket_1234",
+        ))
+        offer_payload = {
+            "type": "offer", "sdp": offer_sdp, "ticket": ticket,
+        }
+        unauthorized = await self.http.post("/offer", json=offer_payload)
+        self.assertEqual(401, unauthorized.status)
+        response = await self.http.post(
+            "/offer",
+            json=offer_payload,
+            headers={"Authorization": f"Bearer {TEST_DRIVER_TOKEN}"},
+        )
+        self.assertEqual(200, response.status, await response.text())
+        answer = await response.json()
+        self.assertNotIn("fence", answer)
+        self.assertFalse(answer["actuation_enabled"])
+        await self.peer.setRemoteDescription(RTCSessionDescription(sdp=answer["sdp"], type=answer["type"]))
+        await asyncio.wait_for(asyncio.gather(control_open.wait(), pose_open.wait()), timeout=10)
+        await self.wait_until(lambda: service.runtime.status()["rtc"]["connected"])
+
+        # A peer heartbeat is rejected and never renews the Core-owned lease.
+        control.send(json.dumps({
+            "type": "heartbeat",
+            "request_id": "rtc-heartbeat",
+        }))
+        await asyncio.wait_for(control_response.wait(), timeout=2)
+        self.assertFalse(responses[-1]["ok"])
+        self.assertEqual("rtc_cannot_renew_lease", responses[-1]["error"]["code"])
+        lease_count = service.runtime.status()["counters"]["lease_heartbeats"]
+        self.assertEqual(1, lease_count)
+
+        # A browser cannot submit or even echo private authority fields.  The
+        # peer-bound RTC contract rejects them before the shared runtime path.
+        pose.send(json.dumps(valid_frame(service.runtime, session, sequence=1)))
+        await self.wait_until(
+            lambda: service.runtime.status()["counters"].get(
+                "protocol_unknown_field"
+            )
+        )
+        self.assertIsNone(service.runtime.status()["pose"]["latest_sequence"])
+
+        wire_frame = rtc_wire_frame(service.runtime, session, sequence=1)
+        self.assertTrue(
+            {"boot_id", "session_id", "epoch", "fence"}.isdisjoint(wire_frame)
+        )
+        pose.send(json.dumps(wire_frame))
+        await self.wait_until(lambda: service.runtime.status()["pose"]["latest_sequence"] == 1)
+        await self.wait_until(
+            lambda: service.runtime.status()["dispatch"]["last_would_apply_sequence"]
+            == 1
+        )
+        state = await self.rpc_call("teleop_state", {})
+        self.assertEqual("active_shadow", state["state"])
+        self.assertEqual(1, state["counters"]["frames_from_rtc"])
+        self.assertEqual(1, state["dispatch"]["last_would_apply_sequence"])
+        self.assertNotIn("fence", state["pose"]["latest"])
+
+        # State-changing commands remain on the authenticated Core REST path so
+        # Driver and Core cannot disagree about session ownership.
+        control.send(json.dumps({"type": "pause", "request_id": "rtc-pause"}))
+        await self.wait_until(lambda: len(responses) >= 2)
+        self.assertFalse(responses[-1]["ok"])
+        self.assertEqual(
+            "rtc_control_requires_core",
+            responses[-1]["error"]["code"],
+        )
+        self.assertEqual("active_shadow", service.runtime.status()["state"])
+
+        replay = await self.http.post(
+            "/offer",
+            json={"type": "offer", "sdp": offer_sdp, "ticket": ticket},
+            headers={"Authorization": f"Bearer {TEST_DRIVER_TOKEN}"},
+        )
+        self.assertEqual(401, replay.status)
+        self.assertEqual("ticket_replayed", (await replay.json())["error"]["code"])
+
+        delayed_ticket = TicketCodec(TEST_SECRET).sign(make_ticket_claims(
+            session=ticket_session,
+            sdp=offer_sdp,
+            ttl_seconds=20,
+            jti="post_release_ticket_1234",
+        ))
+
+        control.close()
+        await self.wait_until(lambda: service.runtime.status()["state"] == "hold")
+        self.assertIn(service.runtime.status()["reason"], ("rtc_disconnected", "rtc_closed"))
+        stopped = await self.wait_until(
+            lambda: (
+                dispatch
+                if (dispatch := service.runtime.status()["dispatch"])[
+                    "stop_acknowledged"
+                ]
+                and dispatch["adapter"]["records"][-1]["kind"] == "would_stop"
+                and dispatch["adapter"]["records"][-1]["reason"]
+                in ("rtc_disconnected", "rtc_closed")
+                else None
+            )
+        )
+        self.assertEqual("safe_reclutch_required", stopped["state"])
+
+        released = await self.rpc_call("teleop_session", {
+            "action": "release",
+            "boot_id": service.runtime.boot_id,
+            **session,
+        })
+        self.assertEqual("released", released["state"])
+        self.assertIsNone(released["session_id"])
+        delayed_offer = await self.http.post(
+            "/offer",
+            json={"type": "offer", "sdp": offer_sdp, "ticket": delayed_ticket},
+            headers={"Authorization": f"Bearer {TEST_DRIVER_TOKEN}"},
+        )
+        self.assertEqual(409, delayed_offer.status)
+        self.assertEqual("session_inactive", (await delayed_offer.json())["error"]["code"])
+        self.assertEqual("released", service.runtime.status()["state"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_runtime.py
+++ b/generic/teleop_shadow/tests/test_runtime.py
@@ -1,0 +1,627 @@
+from __future__ import annotations
+
+import sys
+import threading
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from dispatch import FinalDispatchArbiter, RecordingAdapter, StopRequest
+from protocol import ProtocolError
+from runtime import ShadowRuntime
+
+from tests.helpers import (
+    FakeClock,
+    contains_value,
+    identity,
+    new_session,
+    rtc_wire_frame,
+    valid_frame,
+)
+
+
+class GatedStopRecordingAdapter(RecordingAdapter):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.block_reason: str | None = None
+        self.stop_entered = threading.Event()
+        self.release_stop = threading.Event()
+
+    def safe_stop(self, request: StopRequest):
+        if request.reason == self.block_reason:
+            self.stop_entered.set()
+            self.release_stop.wait(1.0)
+        return super().safe_stop(request)
+
+
+class ShadowRuntimeTests(unittest.TestCase):
+    def setUp(self):
+        self.clock = FakeClock()
+        # Keep synthetic mailbox tests on one deterministic clock. Real
+        # monotonic adapter-stall behavior is covered by DeadlineAndShutdownTests.
+        dispatcher = FinalDispatchArbiter(
+            RecordingAdapter(clock=self.clock),
+            clock=self.clock,
+            safety_clock=self.clock,
+            io_timeout_ms=100,
+        )
+        self.runtime = ShadowRuntime(
+            lease_timeout_ms=1000,
+            pose_timeout_ms=200,
+            clock=self.clock,
+            auto_watchdog=False,
+            dispatch_io_timeout_ms=100,
+            dispatcher=dispatcher,
+        )
+        self.addCleanup(self.runtime.close)
+        self.session = new_session()
+        self.prepared = self.runtime.prepare_shadow(self.session)
+
+    def wait_until(self, predicate, timeout: float = 1.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            value = predicate()
+            if value:
+                return value
+            time.sleep(0.005)
+        self.fail("condition not reached")
+
+    def gated_runtime(self):
+        clock = FakeClock()
+        adapter = GatedStopRecordingAdapter(clock=clock)
+        dispatcher = FinalDispatchArbiter(
+            adapter,
+            clock=clock,
+            io_timeout_ms=150,
+        )
+        runtime = ShadowRuntime(
+            clock=clock,
+            auto_watchdog=False,
+            dispatch_io_timeout_ms=150,
+            dispatch_ack_timeout_ms=200,
+            dispatcher=dispatcher,
+        )
+        self.addCleanup(runtime.close)
+        self.addCleanup(adapter.release_stop.set)
+        return clock, adapter, runtime
+
+    def test_prepare_and_public_status_never_disclose_fence(self):
+        self.assertNotIn("fence", self.prepared)
+        status = self.runtime.status()
+        self.assertNotIn("fence", status)
+        self.assertFalse(contains_value(status, self.session["fence"]))
+        self.assertFalse(status["actuation_enabled"])
+        self.assertEqual("shadow", status["mode"])
+
+    def test_latest_only_and_public_frame_is_sanitized(self):
+        for sequence in range(1, 1001):
+            self.runtime.submit_shadow_frame(
+                valid_frame(self.runtime, self.session, sequence=sequence), source="test"
+            )
+            # This synthetic producer is much faster than a headset. Yield the
+            # GIL periodically so it tests mailbox replacement without
+            # manufacturing an adapter-owner scheduling stall (>100 ms).
+            if sequence % 32 == 0:
+                time.sleep(0.001)
+        status = self.runtime.status()
+        self.assertEqual(1000, status["pose"]["latest_sequence"])
+        self.assertEqual(1000, status["counters"]["frames_accepted"])
+        self.assertNotIn("fence", status["pose"]["latest"])
+        self.assertFalse(contains_value(status, self.session["fence"]))
+
+    def test_valid_frame_reaches_visible_recording_dispatch(self):
+        self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=7), source="test"
+        )
+        dispatch = self.wait_until(
+            lambda: (
+                state
+                if (state := self.runtime.status()["dispatch"])["last_would_apply_sequence"] == 7
+                else None
+            )
+        )
+        self.assertEqual("would_apply", dispatch["last_decision"])
+        self.assertEqual("recording", dispatch["kind"])
+        self.assertEqual(0, dispatch["mailbox_depth"])
+        self.assertNotIn(self.session["fence"], repr(dispatch))
+
+    def test_unsafe_frame_stops_without_reaching_recording_apply(self):
+        held = self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1, deadman=False), source="test"
+        )
+        self.assertEqual(("hold", "deadman_released"), (held["state"], held["reason"]))
+        dispatch = self.wait_until(
+            lambda: (
+                state
+                if (state := self.runtime.status()["dispatch"])["stop_acknowledged"]
+                else None
+            )
+        )
+        self.assertIsNone(dispatch["last_would_apply_sequence"])
+        records = dispatch["adapter"]["records"]
+        self.assertEqual("deadman_released", records[-1]["reason"])
+        self.assertFalse(any(record["kind"] == "would_apply" for record in records))
+
+    def test_soft_stop_is_latched_until_new_prepare(self):
+        self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1, clutch_sequence=1), source="test"
+        )
+        self.wait_until(
+            lambda: self.runtime.status()["dispatch"]["last_would_apply_sequence"] == 1
+        )
+        stopped = self.runtime.soft_stop(identity(self.runtime, self.session))
+        self.assertEqual(("hold", "soft_stop"), (stopped["state"], stopped["reason"]))
+        held = self.runtime.submit_shadow_frame(
+            valid_frame(
+                self.runtime,
+                self.session,
+                sequence=2,
+                clutch_sequence=999,
+            ),
+            source="test",
+        )
+        self.assertEqual(("hold", "soft_stop"), (held["state"], held["reason"]))
+        time.sleep(0.02)
+        self.assertEqual(1, self.runtime.status()["dispatch"]["last_would_apply_sequence"])
+
+    def test_prepare_over_active_waits_for_visible_stop_ack(self):
+        self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1), source="test"
+        )
+        self.wait_until(
+            lambda: self.runtime.status()["dispatch"]["last_would_apply_sequence"] == 1
+        )
+        newer = new_session(epoch=2, fence="n" * 32)
+        prepared = self.runtime.prepare_shadow(newer)
+        self.assertEqual("prepared_shadow", prepared["state"])
+        self.assertTrue(prepared["dispatch"]["stop_acknowledged"])
+        self.assertEqual("safe_waiting_frame", prepared["dispatch"]["state"])
+        self.assertEqual(
+            "prepare_shadow",
+            prepared["dispatch"]["adapter"]["records"][-1]["reason"],
+        )
+
+    def test_prepare_stop_fences_old_rtc_callbacks_while_ack_is_pending(self):
+        _, adapter, runtime = self.gated_runtime()
+        first = new_session()
+        runtime.prepare_shadow(first)
+        old_generation = runtime.session_generation()
+        adapter.block_reason = "prepare_shadow"
+        adapter.stop_entered.clear()
+        adapter.release_stop.clear()
+        second = new_session(epoch=2, fence="n" * 32)
+        results: list[dict] = []
+        errors: list[Exception] = []
+        worker = threading.Thread(
+            target=lambda: self._capture_call(
+                lambda: runtime.prepare_shadow(second), results, errors
+            )
+        )
+        worker.start()
+        self.assertTrue(adapter.stop_entered.wait(1.0))
+        runtime.mark_channel(old_generation, "teleop-control", True)
+        runtime.mark_rtc_disconnected(old_generation, "rtc_closed")
+        adapter.release_stop.set()
+        worker.join(1.0)
+        self.assertFalse(worker.is_alive())
+        self.assertEqual([], errors)
+        self.assertEqual("prepared_shadow", results[0]["state"])
+        self.assertEqual(second["session_id"], results[0]["session_id"])
+        self.assertEqual(2, results[0]["counters"]["stale_rtc_callbacks"])
+
+    def test_release_cannot_be_revived_while_stop_ack_is_pending(self):
+        _, adapter, runtime = self.gated_runtime()
+        session = new_session()
+        runtime.prepare_shadow(session)
+        old_generation = runtime.session_generation()
+        adapter.block_reason = "operator_release"
+        adapter.stop_entered.clear()
+        adapter.release_stop.clear()
+        results: list[dict] = []
+        errors: list[Exception] = []
+        worker = threading.Thread(
+            target=lambda: self._capture_call(
+                lambda: runtime.release(identity(runtime, session)), results, errors
+            )
+        )
+        worker.start()
+        self.assertTrue(adapter.stop_entered.wait(1.0))
+        runtime.mark_channel(old_generation, "teleop-control", True)
+        runtime.mark_rtc_disconnected(old_generation, "rtc_closed")
+        pending = runtime.status()
+        self.assertEqual("released", pending["state"])
+        self.assertFalse(pending["authority_valid"])
+        self.assertFalse(pending["dispatch"]["stop_acknowledged"])
+        adapter.release_stop.set()
+        worker.join(1.0)
+        self.assertFalse(worker.is_alive())
+        self.assertEqual([], errors)
+        self.assertEqual("released", results[0]["state"])
+        self.assertFalse(results[0]["authority_valid"])
+        self.assertTrue(results[0]["dispatch"]["stop_acknowledged"])
+
+    def test_watchdog_revocation_supersedes_pause_while_stop_is_pending(self):
+        clock = FakeClock()
+        adapter = GatedStopRecordingAdapter(clock=clock)
+        dispatcher = FinalDispatchArbiter(
+            adapter,
+            clock=clock,
+            safety_clock=clock,
+            io_timeout_ms=150,
+        )
+        runtime = ShadowRuntime(
+            lease_timeout_ms=100,
+            clock=clock,
+            auto_watchdog=False,
+            dispatch_io_timeout_ms=150,
+            dispatch_ack_timeout_ms=200,
+            dispatcher=dispatcher,
+        )
+        self.addCleanup(runtime.close)
+        self.addCleanup(adapter.release_stop.set)
+        session = new_session()
+        runtime.prepare_shadow(session)
+        adapter.block_reason = "operator_pause"
+        adapter.stop_entered.clear()
+        adapter.release_stop.clear()
+        results: list[dict] = []
+        errors: list[Exception] = []
+        worker = threading.Thread(
+            target=lambda: self._capture_call(
+                lambda: runtime.pause(identity(runtime, session)), results, errors
+            )
+        )
+        worker.start()
+        self.assertTrue(adapter.stop_entered.wait(1.0))
+        clock.advance(0.11)
+        expired = runtime.watchdog_tick()
+        self.assertEqual(("hold", "lease_timeout"), (expired["state"], expired["reason"]))
+        self.assertFalse(expired["authority_valid"])
+        adapter.release_stop.set()
+        worker.join(1.0)
+        self.assertFalse(worker.is_alive())
+        self.assertEqual([], errors)
+        final = self.wait_until(
+            lambda: (
+                state
+                if (state := runtime.status())["dispatch"]["stop_acknowledged"]
+                else None
+            )
+        )
+        self.assertEqual(("hold", "lease_timeout"), (final["state"], final["reason"]))
+        reasons = [
+            record["reason"]
+            for record in final["dispatch"]["adapter"]["records"]
+            if record["kind"] == "would_stop"
+        ]
+        self.assertLess(reasons.index("operator_pause"), reasons.index("lease_timeout"))
+        self.assertIsNone(final["dispatch"]["last_would_apply_sequence"])
+
+    @staticmethod
+    def _capture_call(call, results: list[dict], errors: list[Exception]) -> None:
+        try:
+            results.append(call())
+        except Exception as exc:  # noqa: BLE001 -- test captures thread failures
+            errors.append(exc)
+
+    def test_close_revokes_authority_stops_and_rejects_late_frame(self):
+        late = valid_frame(self.runtime, self.session, sequence=1)
+        self.runtime.close()
+        state = self.runtime.status()
+        self.assertEqual(("released", "service_close"), (state["state"], state["reason"]))
+        self.assertFalse(state["authority_valid"])
+        self.assertEqual("closed", state["dispatch"]["state"])
+        self.assertTrue(state["dispatch"]["stop_acknowledged"])
+        with self.assertRaisesRegex(ProtocolError, "process is closing"):
+            self.runtime.submit_shadow_frame(late, source="late")
+
+    def test_pose_never_renews_core_lease(self):
+        self.clock.advance(0.9)
+        self.runtime.submit_shadow_frame(valid_frame(self.runtime, self.session), source="test")
+        self.clock.advance(0.15)
+        status = self.runtime.watchdog_tick()
+        self.assertEqual("hold", status["state"])
+        self.assertEqual("lease_timeout", status["reason"])
+        self.assertFalse(status["authority_valid"])
+        self.assertTrue(status["lease"]["expired_latched"])
+        self.assertIsNone(status["pose"]["latest_sequence"])
+
+    def test_pose_timeout_holds_and_requires_higher_clutch(self):
+        self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1, clutch_sequence=4), source="test"
+        )
+        self.clock.advance(0.21)
+        self.assertEqual("pose_timeout", self.runtime.watchdog_tick()["reason"])
+        held = self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=2, clutch_sequence=4), source="test"
+        )
+        self.assertEqual("hold", held["state"])
+        resumed = self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=3, clutch_sequence=5), source="test"
+        )
+        self.assertEqual("active_shadow", resumed["state"])
+
+    def test_old_identity_is_rejected_after_new_epoch(self):
+        old_identity = identity(self.runtime, self.session)
+        newer = new_session(epoch=2, fence="n" * 32)
+        self.runtime.prepare_shadow(newer)
+        with self.assertRaisesRegex(ProtocolError, "session_id"):
+            self.runtime.heartbeat(old_identity)
+
+    def test_stale_peer_callbacks_cannot_pollute_new_session(self):
+        old_generation = self.runtime.session_generation()
+        self.runtime.mark_channel(old_generation, "teleop-control", True)
+        newer = new_session(epoch=2, fence="n" * 32)
+        self.runtime.prepare_shadow(newer)
+        before = self.runtime.status()
+
+        self.runtime.mark_channel(old_generation, "teleop-control", True)
+        self.runtime.mark_channel(old_generation, "teleop-pose", True)
+        self.runtime.mark_rtc_disconnected(old_generation, "rtc_closed")
+
+        after = self.runtime.status()
+        self.assertEqual("prepared_shadow", after["state"])
+        self.assertEqual(before["rtc"]["channels"], after["rtc"]["channels"])
+        self.assertFalse(after["rtc"]["connected"])
+        self.assertEqual(3, after["counters"]["stale_rtc_callbacks"])
+
+    def test_rtc_ping_cannot_renew_lease_by_runtime_contract(self):
+        initial = self.runtime.status()["lease"]["age_ms"]
+        generation = self.runtime.session_generation()
+        self.clock.advance(0.5)
+        self.runtime.mark_channel(generation, "teleop-control", True)
+        self.runtime.mark_channel(generation, "teleop-pose", True)
+        later = self.runtime.status()["lease"]["age_ms"]
+        self.assertGreater(later, initial)
+
+    def test_release_revokes_old_authority_and_is_not_revivable(self):
+        old_identity = identity(self.runtime, self.session)
+        old_generation = self.runtime.session_generation()
+        delayed_frame = valid_frame(
+            self.runtime,
+            self.session,
+            sequence=2,
+            clutch_sequence=999,
+        )
+        self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1), source="test"
+        )
+
+        released = self.runtime.release(old_identity)
+        self.assertEqual("released", released["state"])
+        self.assertIsNone(released["session_id"])
+        self.assertIsNone(released["lease"]["age_ms"])
+        self.assertIsNone(released["pose"]["latest_sequence"])
+        terminal_generation = self.runtime.session_generation()
+        self.assertGreater(terminal_generation, old_generation)
+
+        for old_command in (
+            self.runtime.heartbeat,
+            self.runtime.pause,
+            self.runtime.soft_stop,
+        ):
+            with self.assertRaisesRegex(ProtocolError, "new prepare_shadow"):
+                old_command(old_identity)
+            self.assertEqual("released", self.runtime.status()["state"])
+
+        with self.assertRaisesRegex(ProtocolError, "new prepare_shadow"):
+            self.runtime.submit_shadow_frame(delayed_frame, source="delayed_rtc")
+        with self.assertRaisesRegex(ProtocolError, "new prepare_shadow"):
+            self.runtime.ticket_binding()
+
+        # Both real stale callbacks and a fabricated callback using the
+        # terminal generation are diagnostics-only and cannot leave released.
+        self.runtime.mark_channel(old_generation, "teleop-control", True)
+        self.runtime.mark_rtc_disconnected(old_generation, "rtc_closed")
+        self.runtime.mark_channel(terminal_generation, "teleop-control", True)
+        self.runtime.mark_rtc_disconnected(terminal_generation, "rtc_closed")
+        terminal = self.runtime.watchdog_tick()
+        self.assertEqual("released", terminal["state"])
+        self.assertFalse(terminal["rtc"]["connected"])
+        self.assertEqual({"teleop-control": False, "teleop-pose": False}, terminal["rtc"]["channels"])
+
+        newer = new_session(epoch=2, fence="n" * 32)
+        prepared = self.runtime.prepare_shadow(newer)
+        self.assertEqual("prepared_shadow", prepared["state"])
+        with self.assertRaises(ProtocolError):
+            self.runtime.submit_shadow_frame(delayed_frame, source="delayed_rtc")
+
+    def test_pause_cannot_be_downgraded_to_recoverable_hold(self):
+        old_identity = identity(self.runtime, self.session)
+        self.runtime.pause(old_identity)
+        with self.assertRaisesRegex(ProtocolError, "paused session"):
+            self.runtime.soft_stop(old_identity)
+        with self.assertRaisesRegex(ProtocolError, "state paused"):
+            self.runtime.submit_shadow_frame(
+                valid_frame(self.runtime, self.session, clutch_sequence=999), source="test"
+            )
+        self.assertEqual("paused", self.runtime.status()["state"])
+
+    def test_rtc_pose_requires_both_channels_in_same_generation(self):
+        generation = self.runtime.session_generation()
+        self.runtime.mark_channel(generation, "teleop-pose", True)
+        with self.assertRaisesRegex(ProtocolError, "both teleop-control and teleop-pose"):
+            self.runtime.submit_shadow_frame(
+                valid_frame(self.runtime, self.session, sequence=1),
+                source="rtc",
+                rtc_generation=generation,
+            )
+        pose_only = self.runtime.status()
+        self.assertEqual("hold", pose_only["state"])
+        self.assertFalse(pose_only["rtc"]["connected"])
+        self.assertIsNone(pose_only["pose"]["latest_sequence"])
+
+        # The diagnostic MCP path remains deliberately independent from RTC.
+        diagnostic = self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1),
+            source="mcp_diagnostic",
+        )
+        self.assertEqual("active_shadow", diagnostic["state"])
+
+    def test_control_close_blocks_pose_recovery_until_full_transport(self):
+        generation = self.runtime.session_generation()
+        self.runtime.mark_channel(generation, "teleop-control", True)
+        self.runtime.mark_channel(generation, "teleop-pose", True)
+        active = self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1, clutch_sequence=4),
+            source="rtc",
+            rtc_generation=generation,
+        )
+        self.assertEqual("active_shadow", active["state"])
+
+        self.runtime.mark_channel(generation, "teleop-control", False)
+        with self.assertRaisesRegex(ProtocolError, "both teleop-control and teleop-pose"):
+            self.runtime.submit_shadow_frame(
+                valid_frame(self.runtime, self.session, sequence=2, clutch_sequence=999),
+                source="rtc",
+                rtc_generation=generation,
+            )
+        held = self.runtime.status()
+        self.assertEqual("hold", held["state"])
+        self.assertFalse(held["rtc"]["connected"])
+        self.assertEqual(1, held["pose"]["latest_sequence"])
+
+    def test_stale_generation_pose_cannot_enter_new_session(self):
+        stale_generation = self.runtime.session_generation()
+        newer = new_session(epoch=2, fence="n" * 32)
+        self.runtime.prepare_shadow(newer)
+        self.runtime.mark_channel(stale_generation, "teleop-control", True)
+        self.runtime.mark_channel(stale_generation, "teleop-pose", True)
+        with self.assertRaisesRegex(ProtocolError, "stale session generation"):
+            self.runtime.submit_shadow_frame(
+                valid_frame(self.runtime, newer, sequence=1),
+                source="rtc",
+                rtc_generation=stale_generation,
+            )
+        state = self.runtime.status()
+        self.assertEqual("prepared_shadow", state["state"])
+        self.assertFalse(state["rtc"]["connected"])
+        self.assertIsNone(state["pose"]["latest_sequence"])
+
+    def test_old_peer_authority_cannot_enter_new_session(self):
+        old_authority, old_generation = self.runtime.rtc_authority_snapshot()
+        delayed_wire_frame = rtc_wire_frame(
+            self.runtime,
+            self.session,
+            sequence=1,
+        )
+        newer = new_session(epoch=2, fence="n" * 32)
+        self.runtime.prepare_shadow(newer)
+        current_generation = self.runtime.session_generation()
+        self.runtime.mark_channel(current_generation, "teleop-control", True)
+        self.runtime.mark_channel(current_generation, "teleop-pose", True)
+
+        with self.assertRaises(ProtocolError) as raised:
+            self.runtime.submit_rtc_frame(
+                delayed_wire_frame,
+                authority=old_authority,
+                rtc_generation=old_generation,
+            )
+
+        self.assertEqual("session_mismatch", raised.exception.code)
+        state = self.runtime.status()
+        self.assertEqual("prepared_shadow", state["state"])
+        self.assertIsNone(state["pose"]["latest_sequence"])
+
+    def test_lease_timeout_latch_cannot_be_overwritten_or_reclutched(self):
+        old_identity = identity(self.runtime, self.session)
+        old_generation = self.runtime.session_generation()
+        delayed_frame = valid_frame(
+            self.runtime,
+            self.session,
+            sequence=2,
+            clutch_sequence=999,
+        )
+        self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1), source="test"
+        )
+        self.clock.advance(1.01)
+        expired = self.runtime.watchdog_tick()
+        self.assertEqual(("hold", "lease_timeout"), (expired["state"], expired["reason"]))
+        self.assertFalse(expired["authority_valid"])
+        self.assertIsNone(expired["session_id"])
+        self.assertIsNone(expired["lease"]["age_ms"])
+        self.assertIsNone(expired["pose"]["latest_sequence"])
+        expired_generation = self.runtime.session_generation()
+        self.assertGreater(expired_generation, old_generation)
+
+        for old_command in (
+            self.runtime.soft_stop,
+            self.runtime.pause,
+            self.runtime.heartbeat,
+        ):
+            with self.assertRaisesRegex(ProtocolError, "lease expired"):
+                old_command(old_identity)
+            self.assertEqual(("hold", "lease_timeout"), (
+                self.runtime.status()["state"], self.runtime.status()["reason"]
+            ))
+        with self.assertRaisesRegex(ProtocolError, "lease expired"):
+            self.runtime.submit_shadow_frame(delayed_frame, source="mcp_diagnostic")
+        with self.assertRaisesRegex(ProtocolError, "lease expired"):
+            self.runtime.ticket_binding()
+
+        self.runtime.mark_channel(old_generation, "teleop-control", True)
+        self.runtime.mark_rtc_disconnected(old_generation, "rtc_closed")
+        self.runtime.mark_channel(expired_generation, "teleop-control", True)
+        self.assertEqual("hold", self.runtime.status()["state"])
+        self.assertFalse(self.runtime.status()["authority_valid"])
+        self.runtime.watchdog_tick()
+        self.assertEqual(1, self.runtime.status()["counters"]["lease_timeouts"])
+
+        newer = new_session(epoch=2, fence="n" * 32)
+        prepared = self.runtime.prepare_shadow(newer)
+        self.assertTrue(prepared["authority_valid"])
+        self.assertEqual("prepared_shadow", prepared["state"])
+        heartbeat = self.runtime.heartbeat(identity(self.runtime, newer))
+        self.assertTrue(heartbeat["lease"]["fresh"])
+
+    def test_authority_boundaries_latch_overdue_lease_without_watchdog(self):
+        boundaries = (
+            "heartbeat", "pause", "soft_stop", "frame", "ticket", "rtc_callback", "status"
+        )
+        for boundary in boundaries:
+            with self.subTest(boundary=boundary):
+                clock = FakeClock()
+                runtime = ShadowRuntime(clock=clock, auto_watchdog=False)
+                try:
+                    session = new_session()
+                    runtime.prepare_shadow(session)
+                    generation = runtime.session_generation()
+                    frame = valid_frame(runtime, session)
+                    old_identity = identity(runtime, session)
+                    clock.advance(1.01)
+
+                    if boundary == "rtc_callback":
+                        runtime.mark_channel(generation, "teleop-control", True)
+                    elif boundary == "status":
+                        runtime.status()
+                    else:
+                        with self.assertRaisesRegex(ProtocolError, "lease expired"):
+                            if boundary == "heartbeat":
+                                runtime.heartbeat(old_identity)
+                            elif boundary == "pause":
+                                runtime.pause(old_identity)
+                            elif boundary == "soft_stop":
+                                runtime.soft_stop(old_identity)
+                            elif boundary == "frame":
+                                runtime.submit_shadow_frame(frame, source="mcp_diagnostic")
+                            else:
+                                runtime.ticket_binding()
+
+                    state = runtime.status()
+                    self.assertEqual(
+                        ("hold", "lease_timeout"),
+                        (state["state"], state["reason"]),
+                    )
+                    self.assertFalse(state["authority_valid"])
+                    self.assertTrue(state["lease"]["expired_latched"])
+                    self.assertGreater(runtime.session_generation(), generation)
+                finally:
+                    runtime.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_smoke_recording.py
+++ b/generic/teleop_shadow/tests/test_smoke_recording.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from smoke_recording import run_smoke
+
+
+class RecordingSmokeTests(unittest.TestCase):
+    def test_smoke_produces_visible_apply_stop_and_release_proof(self):
+        proof = run_smoke()
+        self.assertFalse(proof["actuation_enabled"])
+        self.assertEqual("active_shadow", proof["motion_state"])
+        self.assertEqual(1, proof["last_would_apply_sequence"])
+        self.assertEqual(
+            {"state": "hold", "reason": "soft_stop", "acknowledged": True},
+            proof["soft_stop"],
+        )
+        self.assertEqual("released", proof["release"]["state"])
+        self.assertIn(
+            {"kind": "would_apply", "sequence": 1},
+            proof["recorded_decisions"],
+        )
+        self.assertIn(
+            {"kind": "would_stop", "reason": "soft_stop"},
+            proof["recorded_decisions"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 交付结果

本 PR 新增一个可部署、无需机器人的遥操作 Shadow Driver。它接收公开 RTC 姿态帧合同，完整执行会话、传输和最终调度链路，并输出可观察的录制证据，但不会创建任何执行器或 Publisher。

它用于在引入机器人专用适配器之前，验证头显和 Core 部署是否能够完成端到端遥操作链路。

## 包含内容

- 严格校验并有界解码 `motus.teleop.rtc-frame.v1`
- 可靠的控制 DataChannel，以及只保留最新帧的姿态 DataChannel
- 租约、姿态新鲜度、deadman、clutch、序列、generation 和重放保护
- 由 `RecordingAdapter` 提供的单一所有者最终调度器
- 可见的 `would_apply`、`would_stop`、计数器和延迟诊断
- 可信注册、逐实例身份、Bearer/ticket 密钥和固定 Core TLS
- 可复现的多实例配置生成器和独立录制冒烟检查

## 安全边界

- 此 Driver 永久保持 `mode=shadow`、`actuation_enabled=false` 和 `hardware_output=false`。
- 实现中不包含 Unitree/G1 代码、SDK 调用计划、IK、DDS 或 Publisher。
- 姿态和控制流量不能续期 Core 租约，也不能携带私有控制权字段。

## 验证结果

- 离线单元与集成测试：**108 项通过**
- Docker Compose 清单测试：验证主机没有 Docker Compose，因此 **1 项跳过**
- 本地真实 `aiortc` offer、双 DataChannel 和 ticket 重放保护：通过
- 录制冒烟检查能够显示 apply、stop 和 release 证据：通过
- 合成 mailbox 压力测试已统一使用确定性安全时钟；真实单调时钟的 I/O 停滞行为仍由独立测试覆盖
- `git diff --check`：通过

## 依赖与草稿边界

- 配套 Core 控制台与控制面见 [phanthymotus#84](https://github.com/4paradigm/phanthymotus/pull/84)。
- 本 PR 可以在本地诊断模式独立运行，但可信的端到端控制台流程依赖上述 Core PR。
- 本 PR 不声明任何物理机器人或头显真机验收完成。
