### PR TITLE
feat(G1): 新增 G1_23 双臂 OpenXR 遥操作适配器

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Each driver is a standalone [MCP](https://modelcontextprotocol.io) HTTP server t
 
 | Driver | Hardware | Port | Description |
 |--------|----------|------|-------------|
-| `unitree/g1` | Unitree G1 Humanoid | 15701 | Locomotion, arm control, mic, speaker, LED, state monitoring |
+| [`unitree/g1`](unitree/g1/TELEOP.md) | Unitree G1 Humanoid | 15701 | Locomotion, arm control, mic, speaker, LED, state monitoring, and opt-in single-Driver Quest G1_23 dual-arm Shadow/Live teleoperation |
 | `engineai/t800` | EngineAI T800 Development Edition | 15708 | ROS2/Native SDK, full state, dance/gesture sequences, virtual gamepad, locomotion and low-level joint control |
 | `phanthy/remote_control` | Remote Control Bridge | 15710 | Remote control relay |
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,7 +10,7 @@
 
 | 驱动 | 硬件 | 端口 | 说明 |
 |------|------|------|------|
-| `unitree/g1` | Unitree G1 人形机器人 | 15701 | 运动控制、机械臂、麦克风、扬声器、LED、状态监控 |
+| [`unitree/g1`](unitree/g1/TELEOP.md) | Unitree G1 人形机器人 | 15701 | 运动控制、机械臂、麦克风、扬声器、LED、状态监控，以及显式启用的单 Driver Quest G1_23 双臂 Shadow/Live 遥操作 |
 | `engineai/t800` | 众擎 T800 开发版 | 15708 | ROS2/Native SDK、全身状态、舞蹈/手势序列、虚拟手柄、运动与高低层控制 |
 | `phanthy/remote_control` | 远程控制桥接 | 15710 | 远程控制中继 |
 

--- a/unitree/g1/Dockerfile
+++ b/unitree/g1/Dockerfile
@@ -2,12 +2,14 @@ ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base:latest
 ARG PYPI_MIRROR=https://pypi.org/simple/
 FROM ${ROS_BASE_IMAGE}
 ARG PYPI_MIRROR
+ARG TARGETARCH
+ARG MINIFORGE_VERSION=24.7.1-2
+ARG MINIFORGE_BASE_URL=https://github.com/conda-forge/miniforge/releases/download
 
 WORKDIR /work
 
 RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
     apt-get install -y --no-install-recommends --allow-unauthenticated \
-        python3-pip \
         python3-colcon-common-extensions \
         cmake \
         build-essential \
@@ -19,8 +21,40 @@ RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
         v4l-utils && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
-    pyyaml netifaces opencv-python-headless numpy pyrealsense2 sounddevice pyalsaaudio
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64) \
+            miniforge_arch="x86_64"; \
+            miniforge_sha256="636f7faca2d51ee42b4640ce160c751a46d57621ef4bf14378704c87c5db4fe3" \
+            ;; \
+        arm64) \
+            miniforge_arch="aarch64"; \
+            miniforge_sha256="7bf60bce50f57af7ea4500b45eeb401d9350011ab34c9c45f736647d8dba9021" \
+            ;; \
+        *) \
+            echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; \
+            exit 64 \
+            ;; \
+    esac; \
+    installer="/tmp/Miniforge3-${MINIFORGE_VERSION}-Linux-${miniforge_arch}.sh"; \
+    curl -fsSL \
+        "${MINIFORGE_BASE_URL}/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-${miniforge_arch}.sh" \
+        -o "${installer}"; \
+    echo "${miniforge_sha256}  ${installer}" | sha256sum -c -; \
+    /bin/bash "${installer}" -b -p /opt/miniforge3; \
+    rm -f "${installer}"
+
+COPY environment.teleop.yml /work/environment.teleop.yml
+COPY requirements.txt /work/requirements.txt
+RUN /opt/miniforge3/bin/conda env create \
+        --prefix /opt/g1-teleop \
+        --file /work/environment.teleop.yml && \
+    /opt/miniforge3/bin/conda clean --all --yes
+
+ENV PATH=/opt/g1-teleop/bin:${PATH}
+
+RUN /opt/g1-teleop/bin/python -m pip install --no-cache-dir -i ${PYPI_MIRROR} \
+    -r /work/requirements.txt pyalsaaudio
 
 # Build CycloneDDS 0.10.5 from source
 ARG CYCLONEDDS_URL=https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/cyclonedds-0.10.5.tar.gz
@@ -35,7 +69,9 @@ RUN curl -fsSL ${CYCLONEDDS_URL} \
 ENV CYCLONEDDS_HOME=/opt/cyclonedds
 ENV LD_LIBRARY_PATH=/opt/cyclonedds/lib:${LD_LIBRARY_PATH}
 
-RUN pip3 install --no-cache-dir --no-binary cyclonedds -i ${PYPI_MIRROR} cyclonedds==0.10.5
+RUN /opt/g1-teleop/bin/python -m pip install \
+    --no-cache-dir --no-binary cyclonedds \
+    -i ${PYPI_MIRROR} cyclonedds==0.10.5
 
 # Isolate rclpy topics (domain 42) from unitree_sdk2py's domain 0.
 # Force FastDDS to match agent-core (which has no CycloneDDS rmw installed).
@@ -45,6 +81,7 @@ ENV FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
 
 COPY unitree_sdk2py/ /work/unitree_sdk2py/
 COPY resource/       /work/resource/
+COPY teleop/         /work/teleop/
 COPY main.py   /work/main.py
 COPY device.py /work/device.py
 COPY rpc_proxy.py /work/rpc_proxy.py
@@ -56,9 +93,18 @@ COPY controlled_spatial_map.py /work/controlled_spatial_map.py
 COPY pointcloud_utils.py /work/pointcloud_utils.py
 COPY test_slam_rpc.py /work/test_slam_rpc.py
 COPY config.yaml /work/config.yaml
+COPY config.teleop-shadow.example.yaml /work/config.teleop-shadow.example.yaml
 COPY deploy/     /deploy/
 
-ENV PYTHONPATH=/work
+# Fail the target-architecture image build unless the exact G1_23 dependency
+# path can cold-load IPOPT and solve the bundled neutral end-effector target.
+RUN /bin/bash -c "source /opt/ros/humble/setup.bash && \
+    export PYTHONPATH=/opt/g1-teleop/lib/python3.10/site-packages:/work:\${PYTHONPATH:-} && \
+    export LD_LIBRARY_PATH=/opt/cyclonedds/lib:\${LD_LIBRARY_PATH:-} && \
+    PYTHONDONTWRITEBYTECODE=1 /opt/g1-teleop/bin/python -m teleop.preflight image \
+        --urdf /work/resource/g1_body23.urdf"
+
+ENV PYTHONPATH=/opt/g1-teleop/lib/python3.10/site-packages:/work
 ENV PYTHONUNBUFFERED=1
 
 # Suppress CycloneDDS tracing to stdout (prevent oversized log messages)
@@ -66,4 +112,4 @@ ENV CYCLONEDDS_URI='<CycloneDDS><Domain><Tracing><Verbosity>severe</Verbosity><O
 
 EXPOSE 15701
 
-CMD ["/bin/bash", "-c", "if command -v nvpmodel >/dev/null 2>&1; then nvpmodel -m 0 2>/dev/null; jetson_clocks 2>/dev/null; echo '[init] Jetson MAXN + clocks locked'; fi && source /opt/ros/humble/setup.bash && source /ros_ws/install/setup.bash && python3 /work/main.py ${NETWORK_INTERFACE:-eth0}"]
+CMD ["/bin/bash", "-c", "if command -v nvpmodel >/dev/null 2>&1; then nvpmodel -m 0 2>/dev/null; jetson_clocks 2>/dev/null; echo '[init] Jetson MAXN + clocks locked'; fi && source /opt/ros/humble/setup.bash && source /ros_ws/install/setup.bash && export PYTHONPATH=/opt/g1-teleop/lib/python3.10/site-packages:/work:${PYTHONPATH:-} && export LD_LIBRARY_PATH=/opt/cyclonedds/lib:${LD_LIBRARY_PATH:-} && exec /opt/g1-teleop/bin/python /work/main.py ${NETWORK_INTERFACE:-eth0}"]

--- a/unitree/g1/TELEOP.md
+++ b/unitree/g1/TELEOP.md
@@ -1,0 +1,52 @@
+# Unitree G1_23 teleoperation
+
+The root G1 Driver can expose `teleop_session` and `teleop_state` in the same
+MCP process and port as its other tools. V1 accepts Quest/OpenXR head and two
+controller poses, controls the ten G1_23 arm joints, and deliberately disables
+base and hand output. It never starts a second Driver or a second
+`rt/arm_sdk` publisher.
+
+The default `config.yaml` keeps teleoperation disabled and the legacy arm tool
+enabled. Copy `config.teleop-shadow.example.yaml` to the configured
+`CONFIG_PATH` to opt in. Shadow performs the real controller transform,
+Pinocchio/CasADi IK, and `rt/lowstate` comparison, but constructs no publisher.
+`plugins.arm.enabled` must remain false whenever teleoperation is enabled;
+startup rejects conflicting arm authorities.
+
+Live output is a separate explicit gate: set `teleop.mode: live` and
+`teleop.live.enabled: true` only after `docker build unitree/g1` (or
+`./build.sh unitree/g1`) passes on linux/amd64 or linux/arm64 and the robot reports
+`mode_machine=4`. The image build cold-loads IPOPT and solves the bundled
+G1_23 model; startup repeats a current-pose warm-up before constructing the
+sole publisher. A failed warm-up leaves the Driver unavailable rather than
+moving the solve into the first 150 ms control frame.
+
+The image owns one numerical ABI under `/opt/g1-teleop`, created from
+`environment.teleop.yml` with `conda-forge` plus `nodefaults`: Python 3.10,
+Pinocchio 3.1.0, CasADi 3.6.7, and NumPy 1.26.4. Pinocchio and CasADi are not
+mixed across ROS apt and pip. Miniforge 24.7.1-2 installers are checksum-pinned
+for linux/amd64 and linux/arm64; every other target architecture fails the
+build. The target-image preflight verifies all three numerical versions,
+imports `pinocchio.casadi`, and completes a real solve before the image can be
+published.
+
+The V1 joint-speed limit is intentionally fixed at `0.5 rad/s`. This can be a
+visible source of following delay; changing it requires a new calibrated
+profile rather than an untracked runtime tweak. Status exposes target,
+measured position, error, publisher weight, transport counters, and segmented
+receive/admit/mailbox/IK/publish/follow latency.
+
+When teleoperation is enabled, runtime secrets are supplied through
+`MOTUS_DRIVER_TOKEN` and `MOTUS_TELEOP_TICKET_SECRET`. Registration uses that
+Driver Bearer and the pinned Core CA mounted at
+`/etc/motus-core-certs/cert.pem`; TLS verification cannot be disabled. Legacy
+deployments may leave the secrets empty while teleoperation remains disabled.
+
+Offline fake validation from this directory:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 uv run --offline --python 3.10 \
+  --with 'aiohttp>=3.13,<3.15' --with 'aiortc>=1.14,<1.16' \
+  --with 'cryptography>=44,<47' --with 'PyYAML>=6.0' \
+  --with 'numpy==1.26.4' python -m unittest discover -s tests -v
+```

--- a/unitree/g1/config.teleop-shadow.example.yaml
+++ b/unitree/g1/config.teleop-shadow.example.yaml
@@ -1,5 +1,5 @@
 mcp_port: 15701
-ros_namespace: ""   # 留空则自动使用 hostname
+ros_namespace: ""
 
 plugins:
   mic:
@@ -12,8 +12,9 @@ plugins:
     enabled: true
   loco:
     enabled: true
+  # ArmActionPlugin and teleoperation are exclusive arm authorities.
   arm:
-    enabled: true
+    enabled: false
   state:
     enabled: true
   camera:
@@ -54,8 +55,7 @@ safety_harness:
   motor_temp_stop: 85
 
 teleop:
-  # Teleoperation is opt-in so existing G1 deployments retain ArmActionPlugin.
-  enabled: false
+  enabled: true
   mode: shadow
   profile_id: unitree_g1_23_dual_arm_controller_v1
   mode_machine: 4
@@ -67,8 +67,6 @@ teleop:
   dispatch_io_timeout_ms: 150
   dispatch_ack_timeout_ms: 200
   live:
-    # Set mode=live and this flag=true only after the image cold-IK smoke passes
-    # on the target G1 computer and the robot is in mode_machine=4.
     enabled: false
     control_hz: 250
     ramp_seconds: 2.0

--- a/unitree/g1/deploy/service.yml
+++ b/unitree/g1/deploy/service.yml
@@ -8,11 +8,19 @@ unitree-g1:
   volumes:
     - /dev:/dev
     - /opt/phanthy-motus/data:/opt/phanthy-motus/data
+    - /opt/phanthy-motus/data/certs:/etc/motus-core-certs:ro
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
     - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
     - PYTHONUNBUFFERED=1
+    - AGENT_CORE_URL=https://localhost:15678
+    - MOTUS_DRIVER_ID=${MOTUS_DRIVER_ID:-unitree-g1}
+    - MOTUS_ROBOT_ID=${MOTUS_ROBOT_ID:-unitree-g1}
+    # Legacy deployments keep working while teleop is disabled; the teleop
+    # factory rejects an empty token as soon as teleop.enabled=true.
+    - MOTUS_DRIVER_TOKEN=${MOTUS_DRIVER_TOKEN:-}
+    - MOTUS_TELEOP_TICKET_SECRET=${MOTUS_TELEOP_TICKET_SECRET:-}
   logging:
     driver: local
     options:

--- a/unitree/g1/environment.teleop.yml
+++ b/unitree/g1/environment.teleop.yml
@@ -1,0 +1,10 @@
+name: g1-teleop
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python=3.10
+  - pinocchio=3.1.0
+  - casadi=3.6.7
+  - numpy=1.26.4
+  - pip

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -21,22 +21,37 @@ import os
 import re
 import signal
 import socket
+import ssl
 import sys
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
-import yaml
-
 import rclpy
 import rclpy.executors
-
-from unitree_sdk2py.core.channel import ChannelFactoryInitialize
-from unitree_sdk2py.g1.audio.g1_audio_client import AudioClient
+import yaml
 from rpc_proxy import RpcProxy
+from unitree_sdk2py.comm.motion_switcher.motion_switcher_client import (
+    MotionSwitcherClient,
+)
+from unitree_sdk2py.core.channel import ChannelFactoryInitialize
 from unitree_sdk2py.g1.arm.g1_arm_action_client import G1ArmActionClient
+from unitree_sdk2py.g1.audio.g1_audio_client import AudioClient
 from unitree_sdk2py.g1.slam.slam_client import SlamClient
-from unitree_sdk2py.comm.motion_switcher.motion_switcher_client import MotionSwitcherClient
+
+
+# Kept lightweight until teleop is explicitly enabled. Ordinary legacy plugin
+# exceptions must not be mistaken for teleoperation protocol errors.
+class _TeleopDisabledProtocolError(Exception):
+    pass
+
+
+class _TeleopDisabledRtcError(Exception):
+    pass
+
+
+TeleopProtocolError = _TeleopDisabledProtocolError
+RtcRequestError = _TeleopDisabledRtcError
 
 
 # ── Config ────────────────────────────────────────────────────────────────────
@@ -54,6 +69,23 @@ def _resolve_namespace(cfg: dict) -> str:
     return re.sub(r"[^a-zA-Z0-9_]", "_", socket.gethostname())
 
 
+def _best_effort_cleanup(label: str, operation) -> bool:
+    """Run one shutdown operation without starving later safety cleanup."""
+
+    try:
+        operation()
+    except Exception as exc:  # noqa: BLE001 -- shutdown must isolate each owner
+        print(
+            f"[bundle] {label} cleanup FAILED: {type(exc).__name__}: {exc}",
+            flush=True,
+        )
+        import traceback
+
+        traceback.print_exc()
+        return False
+    return True
+
+
 # ── Bundle ────────────────────────────────────────────────────────────────────
 
 class G1DeviceBundle:
@@ -64,10 +96,21 @@ class G1DeviceBundle:
                  slam_client: SlamClient,
                  msc_client: MotionSwitcherClient,
                  smart_motion=None,
-                 network_iface: str = "eth0"):
+                 network_iface: str = "eth0",
+                 teleop_service=None):
         self._plugins: list = []
         self._smart_motion = smart_motion
+        self._teleop_service = teleop_service
+        self._stop_lock = threading.Lock()
+        self._stopped = False
         plugins_cfg = cfg.get("plugins", {})
+        if (
+            self._teleop_service is not None
+            and plugins_cfg.get("arm", {}).get("enabled") is True
+        ):
+            raise ValueError(
+                "teleoperation and ArmActionPlugin cannot share G1 arm authority"
+            )
 
         if plugins_cfg.get("mic", {}).get("enabled", False):
             from device import MicPlugin
@@ -90,12 +133,15 @@ class G1DeviceBundle:
             print("[bundle] LedPlugin loaded")
 
         if plugins_cfg.get("loco", {}).get("enabled", False):
-            from device import LocoStatePlugin, LocoPlugin
+            from device import LocoPlugin, LocoStatePlugin
             self._plugins.append(LocoStatePlugin(plugins_cfg["loco"], namespace, executor))
             self._plugins.append(LocoPlugin(plugins_cfg["loco"], namespace, executor, loco_client, slam_client=slam_client, smart_motion=smart_motion))
             print("[bundle] LocoStatePlugin + LocoPlugin loaded")
 
-        if plugins_cfg.get("arm", {}).get("enabled", False):
+        if (
+            plugins_cfg.get("arm", {}).get("enabled", False)
+            and self._teleop_service is None
+        ):
             from device import ArmActionPlugin
             self._plugins.append(ArmActionPlugin(plugins_cfg["arm"], namespace, executor, arm_client))
             print("[bundle] ArmActionPlugin loaded")
@@ -182,9 +228,21 @@ class G1DeviceBundle:
         print(f"[bundle] All {len(self._plugins)} plugins started", flush=True)
 
     def stop_all(self) -> None:
-        for p in self._plugins:
-            p.stop()
-        print("[bundle] All plugins stopped")
+        with self._stop_lock:
+            if self._stopped:
+                return
+            self._stopped = True
+            if self._teleop_service is not None:
+                _best_effort_cleanup(
+                    "teleop service",
+                    self._teleop_service.close,
+                )
+            for index, plugin in enumerate(self._plugins):
+                _best_effort_cleanup(
+                    f"plugin {index} ({type(plugin).__name__})",
+                    plugin.stop,
+                )
+            print("[bundle] All plugins stopped", flush=True)
 
     def get_all_tools(self) -> list:
         tools = []
@@ -193,9 +251,20 @@ class G1DeviceBundle:
                 tools.extend(p.get_tools())
             else:
                 tools.append(p.get_tool())
+        if self._teleop_service is not None:
+            tools.extend(self._teleop_service.get_tools())
         return tools
 
     def dispatch(self, tool_name: str, args: dict) -> dict | None:
+        if self._teleop_service is not None:
+            if tool_name in ("teleop_session", "teleop_state"):
+                return self._teleop_service.dispatch(tool_name, args)
+            if tool_name == "arm":
+                return {
+                    "ok": False,
+                    "code": "teleop_arm_unavailable",
+                    "error": "arm gestures are unavailable while teleoperation is enabled",
+                }
         for p in self._plugins:
             plugin_tools = p.get_tools() if hasattr(p, 'get_tools') else [p.get_tool()]
             for tool_def in plugin_tools:
@@ -212,6 +281,7 @@ class G1DeviceBundle:
 # ── MCP HTTP server ───────────────────────────────────────────────────────────
 
 _bundle: G1DeviceBundle | None = None
+_teleop_service = None
 
 
 def make_handler():
@@ -230,11 +300,17 @@ def make_handler():
             self.send_header("Content-Length", str(len(encoded)))
             self.send_header("Access-Control-Allow-Origin", "*")
             self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-            self.send_header("Access-Control-Allow-Headers", "Content-Type, Accept")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type, Accept, Authorization")
             self.end_headers()
             self.wfile.write(encoded)
 
         def do_GET(self):
+            if self.path == "/health" and _teleop_service is not None:
+                if not _teleop_service.authorized(self.headers.get("Authorization")):
+                    self._send(401, json.dumps({"error": "unauthorized"}))
+                    return
+                self._send(200, json.dumps(_teleop_service.health()))
+                return
             self.send_response(404)
             self.end_headers()
 
@@ -242,10 +318,15 @@ def make_handler():
             self.send_response(204)
             self.send_header("Access-Control-Allow-Origin", "*")
             self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-            self.send_header("Access-Control-Allow-Headers", "Content-Type, Accept")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type, Accept, Authorization")
             self.end_headers()
 
         def do_POST(self):
+            if _teleop_service is not None and not _teleop_service.authorized(
+                self.headers.get("Authorization")
+            ):
+                self._send(401, json.dumps({"error": "unauthorized"}))
+                return
             length = int(self.headers.get("Content-Length", 0))
             raw = self.rfile.read(length)
             try:
@@ -253,6 +334,22 @@ def make_handler():
             except Exception:
                 self._send(400, json.dumps({"jsonrpc": "2.0", "id": None,
                                              "error": {"code": -32700, "message": "Parse error"}}))
+                return
+
+            if self.path == "/offer":
+                if _teleop_service is None:
+                    self._send(404, json.dumps({"error": "teleop unavailable"}))
+                    return
+                try:
+                    self._send(200, json.dumps(_teleop_service.accept_offer(rpc)))
+                except RtcRequestError as exc:
+                    self._send(
+                        getattr(exc, "status", 400),
+                        json.dumps({"error": {"code": getattr(exc, "code", "rtc_error"), "message": str(exc)}}),
+                    )
+                return
+            if self.path != "/mcp":
+                self._send(404, json.dumps({"error": "not found"}))
                 return
 
             rid    = rpc.get("id")
@@ -267,9 +364,15 @@ def make_handler():
             def ok(result):
                 self._send(200, json.dumps({"jsonrpc": "2.0", "id": rid, "result": result}))
 
-            def err(code, msg):
-                self._send(200, json.dumps({"jsonrpc": "2.0", "id": rid,
-                                             "error": {"code": code, "message": msg}}))
+            def err(code, msg, data=None):
+                error = {"code": code, "message": msg}
+                if data is not None:
+                    error["data"] = data
+                self._send(200, json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": rid,
+                    "error": error,
+                }))
 
             try:
                 if method == "initialize":
@@ -290,6 +393,14 @@ def make_handler():
                         ok({"content": [{"type": "text", "text": json.dumps(result)}]})
                 else:
                     err(-32601, f"Method not found: {method}")
+            except TeleopProtocolError as e:
+                protocol_code = str(getattr(e, "code", "invalid_arguments"))[:64]
+                rpc_code = (
+                    -32601
+                    if protocol_code in {"unknown_tool", "unknown_action"}
+                    else -32602
+                )
+                err(rpc_code, str(e), {"code": protocol_code})
             except Exception as e:
                 err(-32603, str(e))
 
@@ -299,39 +410,182 @@ def make_handler():
 # ── Entry point ───────────────────────────────────────────────────────────────
 
 
-def _start_registration(mcp_port: int, name: str, category: str):
-    """Register this driver with agent-core in a background thread, then heartbeat every 30s."""
+def build_registration_ssl_context(registration: dict) -> ssl.SSLContext:
+    """Pin registration TLS to the deployed Agent Core certificate."""
+
+    if registration.get("verify_tls", True) is not True:
+        raise ValueError("G1 Driver registration requires TLS verification")
+    ca_file = Path(
+        str(registration.get("ca_file", "/etc/motus-core-certs/cert.pem"))
+    )
+    if not ca_file.is_file():
+        raise ValueError(f"Agent Core pinned CA file is missing: {ca_file}")
+    try:
+        context = ssl.create_default_context(
+            ssl.Purpose.SERVER_AUTH,
+            cafile=str(ca_file),
+        )
+    except (OSError, ssl.SSLError) as exc:
+        raise ValueError(f"Agent Core pinned CA file is invalid: {ca_file}") from exc
+    # Core's deployed certificate is issued to `phanthy-motus`, while this
+    # host-network Driver registers through localhost. Chain verification is
+    # mandatory; only the DNS-name check is disabled.
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_REQUIRED
+    return context
+
+
+def _start_registration(
+    mcp_port: int,
+    name: str,
+    category: str,
+    *,
+    cfg: dict,
+    teleop_service=None,
+):
+    """Register this Driver with pinned TLS and its per-Driver Bearer."""
+
     import urllib.request as _urllib
-    import ssl as _ssl
-    agent_core_url = os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
-    payload = json.dumps({
+    teleop_cfg = cfg.get("teleop", {})
+    registration = (
+        teleop_cfg.get("registration", {})
+        if isinstance(teleop_cfg, dict)
+        else {}
+    )
+    if not isinstance(registration, dict):
+        raise ValueError("teleop.registration config must be an object")
+    agent_core_url = str(
+        registration.get(
+            "agent_core_url",
+            os.environ.get("AGENT_CORE_URL", "https://localhost:15678"),
+        )
+    ).rstrip("/")
+    if not agent_core_url.startswith("https://"):
+        raise ValueError("Agent Core registration URL must use https")
+    advertise_url = str(
+        registration.get("advertise_url", f"http://localhost:{mcp_port}/mcp")
+    )
+    driver_id = (
+        teleop_service.runtime.driver_id
+        if teleop_service is not None
+        else os.environ.get("MOTUS_DRIVER_ID", "unitree-g1")
+    )
+    robot_id = (
+        teleop_service.runtime.robot_id
+        if teleop_service is not None
+        else os.environ.get("MOTUS_ROBOT_ID", driver_id)
+    )
+    payload_value = {
+        "id": driver_id,
+        "robot_id": robot_id,
         "name": name,
-        "url":  f"http://localhost:{mcp_port}/mcp",
+        "url": advertise_url,
+        "transport": "http",
         "category": category,
-    }).encode()
-    # agent-core uses self-signed cert, skip verification for localhost
-    _ctx = _ssl.create_default_context()
-    _ctx.check_hostname = False
-    _ctx.verify_mode = _ssl.CERT_NONE
+    }
+    payload = json.dumps(payload_value).encode()
+    headers = {"Content-Type": "application/json"}
+    token = (
+        teleop_service.driver_token
+        if teleop_service is not None
+        else os.environ.get("MOTUS_DRIVER_TOKEN")
+    )
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if teleop_service is not None and not token:
+        raise ValueError("teleoperation registration requires MOTUS_DRIVER_TOKEN")
+    try:
+        context = build_registration_ssl_context(registration)
+    except ValueError as exc:
+        if teleop_service is not None:
+            teleop_service.update_registration_status(
+                state="tls_error",
+                last_error=str(exc),
+            )
+            raise
+        print(f"[register] disabled: {exc}")
+        return {"state": "disabled_tls", "error": str(exc)[:256]}
+
     def _run():
-        import time as _t
         while True:
+            if teleop_service is not None:
+                status = teleop_service.registration_status
+                teleop_service.update_registration_status(
+                    state="registering",
+                    attempts=int(status["attempts"]) + 1,
+                    last_error=None,
+                )
             try:
                 req = _urllib.Request(
                     f"{agent_core_url}/api/mcp", data=payload,
-                    headers={"Content-Type": "application/json"}, method="POST",
+                    headers=headers, method="POST",
                 )
-                with _urllib.urlopen(req, timeout=3, context=_ctx):
-                    pass  # heartbeat ok, suppress log
-                _t.sleep(30)
+                with _urllib.urlopen(req, timeout=3, context=context) as response:
+                    http_status = int(getattr(response, "status", 200))
+                    response_body = response.read(64 * 1024 + 1)
+                if len(response_body) > 64 * 1024:
+                    raise ValueError("registration response exceeds 64 KiB")
+                if teleop_service is not None:
+                    try:
+                        decoded = json.loads(response_body)
+                        data = decoded["data"]
+                        trusted = (
+                            isinstance(decoded, dict)
+                            and isinstance(data, dict)
+                            and data.get("id") == driver_id
+                            and data.get("trust_state") == "trusted"
+                        )
+                    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+                        trusted = False
+                    if trusted:
+                        status = teleop_service.registration_status
+                        teleop_service.update_registration_status(
+                            state="registered",
+                            successes=int(status["successes"]) + 1,
+                            last_http_status=http_status,
+                            last_error=None,
+                        )
+                        wait_seconds = 30.0
+                    else:
+                        teleop_service.update_registration_status(
+                            state="trust_error",
+                            last_http_status=http_status,
+                            last_error="Agent Core did not confirm the requested trusted identity",
+                        )
+                        wait_seconds = 5.0
+                else:
+                    wait_seconds = 30.0
             except Exception as e:
                 print(f"[register] failed: {e}, retrying in 5s")
-                _t.sleep(5)
-    threading.Thread(target=_run, daemon=True, name="register").start()
+                if teleop_service is not None:
+                    status_code = getattr(e, "code", None)
+                    teleop_service.update_registration_status(
+                        state=("http_error" if status_code is not None else "connection_error"),
+                        last_http_status=(
+                            int(status_code) if isinstance(status_code, int) else None
+                        ),
+                        last_error=f"{type(e).__name__}: {e}",
+                    )
+                wait_seconds = 5.0
+            if teleop_service is not None:
+                if teleop_service.registration_wait(wait_seconds):
+                    return
+            else:
+                threading.Event().wait(wait_seconds)
+
+    if teleop_service is not None:
+        teleop_service.launch_registration_worker(_run)
+    else:
+        threading.Thread(target=_run, daemon=True, name="g1-register").start()
+    return {
+        "endpoint": f"{agent_core_url}/api/mcp",
+        "payload": payload_value,
+        "tls_verify_mode": context.verify_mode,
+    }
 
 
 def main():
-    global _bundle
+    global _bundle, _teleop_service, TeleopProtocolError, RtcRequestError
 
     if len(sys.argv) < 2:
         print(f"Usage: python3 {sys.argv[0]} <networkInterface>")
@@ -341,94 +595,189 @@ def main():
     cfg           = _load_config()
     namespace     = _resolve_namespace(cfg)
     mcp_port      = int(cfg.get("mcp_port", 15701))
-
-    print(f"[bundle] namespace={namespace} mcp_port={mcp_port}")
-
-    # DDS init
-    ChannelFactoryInitialize(0, network_iface)
-    print(f"[bundle] DDS initialized on interface: {network_iface}")
-
-    # Suppress C++ layer stdout (ClientStub recv/future logs) while keeping Python print working.
-    # C++ writes to fd 1 directly; we redirect fd 1 to /dev/null and give Python a dup of the original.
-    _orig_fd = os.dup(1)
-    _devnull = os.open(os.devnull, os.O_WRONLY)
-    os.dup2(_devnull, 1)
-    os.close(_devnull)
-    sys.stdout = os.fdopen(_orig_fd, 'w', buffering=1)
-
-    # AudioClient (shared by tts + led)
-    audio_client = AudioClient()
-    audio_client.SetTimeout(10.0)
-    audio_client.Init()
-    print("[bundle] AudioClient ready")
-
-    # LocoClient (locomotion control) — via subprocess proxy to avoid GIL contention
-    loco_client = RpcProxy(network_iface)
-    print("[bundle] LocoClient ready (subprocess proxy)")
-
-    # G1ArmActionClient (arm gestures)
-    arm_client = G1ArmActionClient()
-    arm_client.SetTimeout(10.0)
-    arm_client.Init()
-    print("[bundle] G1ArmActionClient ready")
-
-    # SlamClient (SLAM navigation)
-    slam_client = SlamClient()
-    slam_client.SetTimeout(5.0)
-    slam_client.Init()
-    print("[bundle] SlamClient ready")
-
-    # MotionSwitcherClient
-    msc_client = MotionSwitcherClient()
-    msc_client.SetTimeout(5.0)
-    msc_client.Init()
-    print("[bundle] MotionSwitcherClient ready")
-
-    # ROS2
-    rclpy.init()
-    executor = rclpy.executors.MultiThreadedExecutor()
-
-    # Safety Harness (SmartMotion) — independent subprocess
+    _bundle = None
+    _teleop_service = None
+    loco_client = None
+    executor = None
     smart_motion = None
-    harness_cfg = cfg.get("safety_harness", {})
-    if harness_cfg.get("enabled", True):
-        from safety_harness import SmartMotionProxy
-        smart_motion = SmartMotionProxy(namespace, harness_cfg, network_iface)
-        print("[bundle] SmartMotion safety harness active (subprocess)")
-
-    _bundle = G1DeviceBundle(cfg, namespace, executor, audio_client, loco_client, arm_client, slam_client, msc_client, smart_motion=smart_motion, network_iface=network_iface)
-    _bundle.start_all()
-
-    def _spin():
-        while rclpy.ok():
-            executor.spin_once(timeout_sec=0.1)
-
-    spin_thread = threading.Thread(target=_spin, daemon=True, name="bundle_spin")
-    spin_thread.start()
-
-    _start_registration(mcp_port, cfg.get("name", "Unitree G1"), "driver")
-
-    server = ThreadingHTTPServer(("", mcp_port), make_handler())
-    print(f"[bundle] MCP server → http://localhost:{mcp_port}")
-
-    def _shutdown(signum, frame):
-        print(f"[bundle] signal {signum}, shutting down")
-        if smart_motion:
-            smart_motion.shutdown()
-        _bundle.stop_all()
-        loco_client.stop()
-        threading.Thread(target=server.shutdown, daemon=True).start()
-
-    signal.signal(signal.SIGTERM, _shutdown)
-    signal.signal(signal.SIGINT, _shutdown)
+    server = None
+    ros_initialized = False
 
     try:
+        print(f"[bundle] namespace={namespace} mcp_port={mcp_port}")
+
+        # DDS init
+        ChannelFactoryInitialize(0, network_iface)
+        print(f"[bundle] DDS initialized on interface: {network_iface}")
+
+        teleop_cfg = cfg.get("teleop")
+        teleop_requested = (
+            isinstance(teleop_cfg, dict) and teleop_cfg.get("enabled") is True
+        )
+        if teleop_requested:
+            from teleop.factory import build_g1_teleop_service, project_preflight_error
+            from teleop.protocol import ProtocolError as _TeleopProtocolError
+            from teleop.rtc import RtcRequestError as _RtcRequestError
+
+            TeleopProtocolError = _TeleopProtocolError
+            RtcRequestError = _RtcRequestError
+            requested_mode = str(teleop_cfg.get("mode", "shadow"))
+            try:
+                _teleop_service = build_g1_teleop_service(cfg)
+                if _teleop_service is None:
+                    raise RuntimeError(
+                        "teleop was enabled but its factory returned no service"
+                    )
+            except Exception as exc:
+                print(
+                    "[teleop-preflight] "
+                    + json.dumps(
+                        project_preflight_error(exc, mode=requested_mode),
+                        allow_nan=False,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    ),
+                    flush=True,
+                )
+                return 1
+            print(
+                "[teleop-preflight] "
+                + json.dumps(
+                    _teleop_service.preflight_status(),
+                    allow_nan=False,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ),
+                flush=True,
+            )
+            print(
+                f"[bundle] G1 teleoperation initialized "
+                f"(mode={_teleop_service.runtime.mode}, "
+                f"profile={_teleop_service.runtime.profile_id})"
+            )
+
+        # Suppress C++ layer stdout (ClientStub recv/future logs) while keeping
+        # Python print working. C++ writes directly to fd 1.
+        original_fd = os.dup(1)
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, 1)
+        os.close(devnull)
+        sys.stdout = os.fdopen(original_fd, "w", buffering=1)
+
+        # AudioClient (shared by tts + led)
+        audio_client = AudioClient()
+        audio_client.SetTimeout(10.0)
+        audio_client.Init()
+        print("[bundle] AudioClient ready")
+
+        # LocoClient (locomotion control) — via subprocess proxy to avoid GIL contention
+        loco_client = RpcProxy(network_iface)
+        print("[bundle] LocoClient ready (subprocess proxy)")
+
+        # Firmware arm gestures and teleoperation are mutually exclusive owners.
+        arm_client = None
+        if (
+            _teleop_service is None
+            and cfg.get("plugins", {}).get("arm", {}).get("enabled", False)
+        ):
+            arm_client = G1ArmActionClient()
+            arm_client.SetTimeout(10.0)
+            arm_client.Init()
+            print("[bundle] G1ArmActionClient ready")
+
+        # SlamClient (SLAM navigation)
+        slam_client = SlamClient()
+        slam_client.SetTimeout(5.0)
+        slam_client.Init()
+        print("[bundle] SlamClient ready")
+
+        # MotionSwitcherClient
+        msc_client = MotionSwitcherClient()
+        msc_client.SetTimeout(5.0)
+        msc_client.Init()
+        print("[bundle] MotionSwitcherClient ready")
+
+        # ROS2
+        rclpy.init()
+        ros_initialized = True
+        executor = rclpy.executors.MultiThreadedExecutor()
+
+        # Safety Harness (SmartMotion) — independent subprocess
+        harness_cfg = cfg.get("safety_harness", {})
+        if harness_cfg.get("enabled", True):
+            from safety_harness import SmartMotionProxy
+
+            smart_motion = SmartMotionProxy(namespace, harness_cfg, network_iface)
+            print("[bundle] SmartMotion safety harness active (subprocess)")
+
+        _bundle = G1DeviceBundle(
+            cfg,
+            namespace,
+            executor,
+            audio_client,
+            loco_client,
+            arm_client,
+            slam_client,
+            msc_client,
+            smart_motion=smart_motion,
+            network_iface=network_iface,
+            teleop_service=_teleop_service,
+        )
+        _bundle.start_all()
+
+        def _spin():
+            while rclpy.ok():
+                executor.spin_once(timeout_sec=0.1)
+
+        spin_thread = threading.Thread(
+            target=_spin,
+            daemon=True,
+            name="bundle_spin",
+        )
+        spin_thread.start()
+
+        _start_registration(
+            mcp_port,
+            cfg.get("name", "Unitree G1"),
+            "driver",
+            cfg=cfg,
+            teleop_service=_teleop_service,
+        )
+
+        server = ThreadingHTTPServer(("", mcp_port), make_handler())
+        print(f"[bundle] MCP server → http://localhost:{mcp_port}")
+        shutdown_requested = threading.Event()
+
+        def _shutdown(signum, frame):
+            del frame
+            print(f"[bundle] signal {signum}, shutting down")
+            if shutdown_requested.is_set():
+                return
+            shutdown_requested.set()
+            threading.Thread(target=server.shutdown, daemon=True).start()
+
+        signal.signal(signal.SIGTERM, _shutdown)
+        signal.signal(signal.SIGINT, _shutdown)
         server.serve_forever()
     finally:
-        _bundle.stop_all()
-        executor.shutdown()
-        rclpy.shutdown()
+        # The teleop service owns the sole possible arm publisher. Close it
+        # independently and before every legacy subsystem, even when bundle or
+        # server construction never completed.
+        if _teleop_service is not None:
+            _best_effort_cleanup("teleop service", _teleop_service.close)
+        if _bundle is not None:
+            _best_effort_cleanup("device bundle", _bundle.stop_all)
+        if smart_motion is not None:
+            _best_effort_cleanup("SmartMotion", smart_motion.shutdown)
+        if loco_client is not None:
+            _best_effort_cleanup("LocoClient", loco_client.stop)
+        if server is not None:
+            _best_effort_cleanup("MCP server", server.server_close)
+        if executor is not None:
+            _best_effort_cleanup("ROS executor", executor.shutdown)
+        if ros_initialized:
+            _best_effort_cleanup("ROS", rclpy.shutdown)
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/unitree/g1/requirements.txt
+++ b/unitree/g1/requirements.txt
@@ -1,6 +1,9 @@
 netifaces>=0.11.0
 pyyaml>=6.0
 opencv-python-headless>=4.8
-numpy>=1.24
+numpy==1.26.4
 pyrealsense2>=2.54
 sounddevice>=0.4.6
+aiohttp>=3.13,<3.15
+aiortc>=1.14,<1.16
+cryptography>=44,<47

--- a/unitree/g1/resource/g1_body23.urdf
+++ b/unitree/g1/resource/g1_body23.urdf
@@ -1,0 +1,903 @@
+<robot name="g1_23dof">
+  <mujoco>
+    <compiler meshdir="meshes" discardvisual="false"/>
+  </mujoco>
+
+  <!-- [CAUTION] uncomment when convert to mujoco -->
+  <!-- <link name="world"></link>
+  <joint name="floating_base_joint" type="floating">
+    <parent link="world"/>
+    <child link="pelvis"/>
+  </joint> -->
+
+  <link name="pelvis">
+    <inertial>
+      <origin xyz="0 0 -0.07605" rpy="0 0 0"/>
+      <mass value="3.813"/>
+      <inertia ixx="0.010549" ixy="0" ixz="2.1E-06" iyy="0.0093089" iyz="0" izz="0.0079184"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/pelvis.STL"/>
+      </geometry>
+      <material name="dark">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+  </link>
+  <link name="pelvis_contour_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.001"/>
+      <inertia ixx="1e-7" ixy="0" ixz="0" iyy="1e-7" iyz="0" izz="1e-7"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/pelvis_contour_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/pelvis_contour_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="pelvis_contour_joint" type="fixed">
+    <parent link="pelvis"/>
+    <child link="pelvis_contour_link"/>
+  </joint>
+
+  <!-- Legs -->
+  <link name="left_hip_pitch_link">
+    <inertial>
+      <origin xyz="0.002741 0.047791 -0.02606" rpy="0 0 0"/>
+      <mass value="1.35"/>
+      <inertia ixx="0.001811" ixy="3.68E-05" ixz="-3.44E-05" iyy="0.0014193" iyz="0.000171" izz="0.0012812"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hip_pitch_link.STL"/>
+      </geometry>
+      <material name="dark">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hip_pitch_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hip_pitch_joint" type="revolute">
+    <origin xyz="0 0.064452 -0.1027" rpy="0 0 0"/>
+    <parent link="pelvis"/>
+    <child link="left_hip_pitch_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-2.5307" upper="2.8798" effort="88" velocity="32"/>
+  </joint>
+  <link name="left_hip_roll_link">
+    <inertial>
+      <origin xyz="0.029812 -0.001045 -0.087934" rpy="0 0 0"/>
+      <mass value="1.52"/>
+      <inertia ixx="0.0023773" ixy="-3.8E-06" ixz="-0.0003908" iyy="0.0024123" iyz="1.84E-05" izz="0.0016595"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hip_roll_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hip_roll_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hip_roll_joint" type="revolute">
+    <origin xyz="0 0.052 -0.030465" rpy="0 -0.1749 0"/>
+    <parent link="left_hip_pitch_link"/>
+    <child link="left_hip_roll_link"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-0.5236" upper="2.9671" effort="88" velocity="32"/>
+  </joint>
+  <link name="left_hip_yaw_link">
+    <inertial>
+      <origin xyz="-0.057709 -0.010981 -0.15078" rpy="0 0 0"/>
+      <mass value="1.702"/>
+      <inertia ixx="0.0057774" ixy="-0.0005411" ixz="-0.0023948" iyy="0.0076124" iyz="-0.0007072" izz="0.003149"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hip_yaw_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_hip_yaw_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_hip_yaw_joint" type="revolute">
+    <origin xyz="0.025001 0 -0.12412" rpy="0 0 0"/>
+    <parent link="left_hip_roll_link"/>
+    <child link="left_hip_yaw_link"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-2.7576" upper="2.7576" effort="88" velocity="32"/>
+  </joint>
+  <link name="left_knee_link">
+    <inertial>
+      <origin xyz="0.005457 0.003964 -0.12074" rpy="0 0 0"/>
+      <mass value="1.932"/>
+      <inertia ixx="0.011329" ixy="4.82E-05" ixz="-4.49E-05" iyy="0.011277" iyz="-0.0007146" izz="0.0015168"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_knee_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_knee_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_knee_joint" type="revolute">
+    <origin xyz="-0.078273 0.0021489 -0.17734" rpy="0 0.1749 0"/>
+    <parent link="left_hip_yaw_link"/>
+    <child link="left_knee_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-0.087267" upper="2.8798" effort="139" velocity="20"/>
+  </joint>
+  <link name="left_ankle_pitch_link">
+    <inertial>
+      <origin xyz="-0.007269 0 0.011137" rpy="0 0 0"/>
+      <mass value="0.074"/>
+      <inertia ixx="8.4E-06" ixy="0" ixz="-2.9E-06" iyy="1.89E-05" iyz="0" izz="1.26E-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_ankle_pitch_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_ankle_pitch_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_ankle_pitch_joint" type="revolute">
+    <origin xyz="0 -9.4445E-05 -0.30001" rpy="0 0 0"/>
+    <parent link="left_knee_link"/>
+    <child link="left_ankle_pitch_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-0.87267" upper="0.5236" effort="50" velocity="37"/>
+  </joint>
+  <link name="left_ankle_roll_link">
+    <inertial>
+      <origin xyz="0.026505 0 -0.016425" rpy="0 0 0"/>
+      <mass value="0.608"/>
+      <inertia ixx="0.0002231" ixy="2E-07" ixz="8.91E-05" iyy="0.0016161" iyz="-1E-07" izz="0.0016667"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_ankle_roll_link.STL"/>
+      </geometry>
+      <material name="dark">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.05 0.025 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="-0.05 -0.025 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="0.12 0.03 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="0.12 -0.03 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_ankle_roll_joint" type="revolute">
+    <origin xyz="0 0 -0.017558" rpy="0 0 0"/>
+    <parent link="left_ankle_pitch_link"/>
+    <child link="left_ankle_roll_link"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-0.2618" upper="0.2618" effort="50" velocity="37"/>
+  </joint>
+  <link name="right_hip_pitch_link">
+    <inertial>
+      <origin xyz="0.002741 -0.047791 -0.02606" rpy="0 0 0"/>
+      <mass value="1.35"/>
+      <inertia ixx="0.001811" ixy="-3.68E-05" ixz="-3.44E-05" iyy="0.0014193" iyz="-0.000171" izz="0.0012812"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hip_pitch_link.STL"/>
+      </geometry>
+      <material name="dark">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hip_pitch_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hip_pitch_joint" type="revolute">
+    <origin xyz="0 -0.064452 -0.1027" rpy="0 0 0"/>
+    <parent link="pelvis"/>
+    <child link="right_hip_pitch_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-2.5307" upper="2.8798" effort="88" velocity="32"/>
+  </joint>
+  <link name="right_hip_roll_link">
+    <inertial>
+      <origin xyz="0.029812 0.001045 -0.087934" rpy="0 0 0"/>
+      <mass value="1.52"/>
+      <inertia ixx="0.0023773" ixy="3.8E-06" ixz="-0.0003908" iyy="0.0024123" iyz="-1.84E-05" izz="0.0016595"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hip_roll_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hip_roll_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hip_roll_joint" type="revolute">
+    <origin xyz="0 -0.052 -0.030465" rpy="0 -0.1749 0"/>
+    <parent link="right_hip_pitch_link"/>
+    <child link="right_hip_roll_link"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-2.9671" upper="0.5236" effort="88" velocity="32"/>
+  </joint>
+  <link name="right_hip_yaw_link">
+    <inertial>
+      <origin xyz="-0.057709 0.010981 -0.15078" rpy="0 0 0"/>
+      <mass value="1.702"/>
+      <inertia ixx="0.0057774" ixy="0.0005411" ixz="-0.0023948" iyy="0.0076124" iyz="0.0007072" izz="0.003149"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hip_yaw_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_hip_yaw_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_hip_yaw_joint" type="revolute">
+    <origin xyz="0.025001 0 -0.12412" rpy="0 0 0"/>
+    <parent link="right_hip_roll_link"/>
+    <child link="right_hip_yaw_link"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-2.7576" upper="2.7576" effort="88" velocity="32"/>
+  </joint>
+  <link name="right_knee_link">
+    <inertial>
+      <origin xyz="0.005457 -0.003964 -0.12074" rpy="0 0 0"/>
+      <mass value="1.932"/>
+      <inertia ixx="0.011329" ixy="-4.82E-05" ixz="4.49E-05" iyy="0.011277" iyz="0.0007146" izz="0.0015168"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_knee_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_knee_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_knee_joint" type="revolute">
+    <origin xyz="-0.078273 -0.0021489 -0.17734" rpy="0 0.1749 0"/>
+    <parent link="right_hip_yaw_link"/>
+    <child link="right_knee_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-0.087267" upper="2.8798" effort="139" velocity="20"/>
+  </joint>
+  <link name="right_ankle_pitch_link">
+    <inertial>
+      <origin xyz="-0.007269 0 0.011137" rpy="0 0 0"/>
+      <mass value="0.074"/>
+      <inertia ixx="8.4E-06" ixy="0" ixz="-2.9E-06" iyy="1.89E-05" iyz="0" izz="1.26E-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_ankle_pitch_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_ankle_pitch_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_ankle_pitch_joint" type="revolute">
+    <origin xyz="0 9.4445E-05 -0.30001" rpy="0 0 0"/>
+    <parent link="right_knee_link"/>
+    <child link="right_ankle_pitch_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-0.87267" upper="0.5236" effort="50" velocity="37"/>
+  </joint>
+  <link name="right_ankle_roll_link">
+    <inertial>
+      <origin xyz="0.026505 0 -0.016425" rpy="0 0 0"/>
+      <mass value="0.608"/>
+      <inertia ixx="0.0002231" ixy="-2E-07" ixz="8.91E-05" iyy="0.0016161" iyz="1E-07" izz="0.0016667"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_ankle_roll_link.STL"/>
+      </geometry>
+      <material name="dark">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.05 0.025 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="-0.05 -0.025 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="0.12 0.03 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin xyz="0.12 -0.03 -0.03" rpy="0 0 0"/>
+      <geometry>
+        <sphere radius="0.005"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_ankle_roll_joint" type="revolute">
+    <origin xyz="0 0 -0.017558" rpy="0 0 0"/>
+    <parent link="right_ankle_pitch_link"/>
+    <child link="right_ankle_roll_link"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-0.2618" upper="0.2618" effort="50" velocity="37"/>
+  </joint>
+
+  <!-- Torso -->
+  <link name="waist_yaw_fixed_link">
+    <inertial>
+      <origin xyz="0.003964 0 0.018769" rpy="0 0 0"/>
+      <mass value="0.244"/>
+      <inertia ixx="9.9587E-05" ixy="-1.833E-06" ixz="-1.2617E-05" iyy="0.00012411" iyz="-1.18E-07" izz="0.00015586"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/waist_yaw_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+  </link>
+  <joint name="waist_yaw_fixed_joint" type="fixed">
+    <origin xyz="0.0039635 0 -0.054" rpy="0 0 0"/>
+    <parent link="torso_link"/>
+    <child link="waist_yaw_fixed_link"/>
+  </joint>
+  <joint name="waist_yaw_joint" type="revolute">
+    <origin xyz="-0.0039635 0 0.054" rpy="0 0 0"/>
+    <parent link="pelvis"/>
+    <child link="torso_link"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-2.618" upper="2.618" effort="88" velocity="32"/>
+  </joint>
+  <link name="torso_link">
+    <inertial>
+      <origin xyz="0.002601 0.000257 0.153719" rpy="0 0 0"/>
+      <mass value="8.562"/>
+      <inertia ixx="0.065674966" ixy="-8.597E-05" ixz="-0.001737252" iyy="0.053535188" iyz="8.6899E-05" izz="0.030808125"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/torso_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/torso_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <!-- LOGO -->
+  <joint name="logo_joint" type="fixed">
+    <origin xyz="0.0039635 0 -0.054" rpy="0 0 0"/>
+    <parent link="torso_link"/>
+    <child link="logo_link"/>
+  </joint>
+  <link name="logo_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.001"/>
+      <inertia ixx="1e-7" ixy="0" ixz="0" iyy="1e-7" iyz="0" izz="1e-7"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/logo_link.STL"/>
+      </geometry>
+      <material name="dark">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/logo_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <!-- Head -->
+  <link name="head_link">
+    <inertial>
+      <origin xyz="0.005267 0.000299 0.449869" rpy="0 0 0"/>
+      <mass value="1.036"/>
+      <inertia ixx="0.004085051" ixy="-2.543E-06" ixz="-6.9455E-05" iyy="0.004185212" iyz="-3.726E-06" izz="0.001807911"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/head_link.STL"/>
+      </geometry>
+      <material name="dark">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/head_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="head_joint" type="fixed">
+    <origin xyz="0.0039635 0 -0.054" rpy="0 0 0"/>
+    <parent link="torso_link"/>
+    <child link="head_link"/>
+  </joint>
+
+  <!-- Waist Support -->
+  <link name="waist_support_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.001"/>
+      <inertia ixx="1e-7" ixy="0" ixz="0" iyy="1e-7" iyz="0" izz="1e-7"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/waist_support_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/waist_support_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="waist_support_joint" type="fixed">
+    <origin xyz="0.0039635 0 -0.054" rpy="0 0 0"/>
+    <parent link="torso_link"/>
+    <child link="waist_support_link"/>
+  </joint>
+
+  <!-- IMU -->
+  <link name="imu_in_torso"></link>
+  <joint name="imu_in_torso_joint" type="fixed">
+    <origin xyz="-0.03959 -0.00224 0.13792" rpy="0 0 0"/>
+    <parent link="torso_link"/>
+    <child link="imu_in_torso"/>
+  </joint>
+
+  <link name="imu_in_pelvis"></link>
+  <joint name="imu_in_pelvis_joint" type="fixed">
+    <origin xyz="0.04525 0 -0.08339" rpy="0 0 0"/>
+    <parent link="pelvis"/>
+    <child link="imu_in_pelvis"/>
+  </joint>
+
+  <!-- d435 -->
+  <link name="d435_link"></link>
+  <joint name="d435_joint" type="fixed">
+    <origin xyz="0.0576235 0.01753 0.41987" rpy="0 0.8307767239493009 0"/>
+    <parent link="torso_link"/>
+    <child link="d435_link"/>
+  </joint>
+
+  <!-- mid360 -->
+  <link name="mid360_link"></link>
+  <joint name="mid360_joint" type="fixed">
+    <origin xyz="0.0002835 0.00003 0.40618" rpy="0 0.04014257279586953 0"/>
+    <parent link="torso_link"/>
+    <child link="mid360_link"/>
+  </joint>
+
+  <!-- Arm -->
+  <link name="left_shoulder_pitch_link">
+    <inertial>
+      <origin xyz="0 0.035892 -0.011628" rpy="0 0 0"/>
+      <mass value="0.718"/>
+      <inertia ixx="0.0004291" ixy="-9.2E-06" ixz="6.4E-06" iyy="0.000453" iyz="2.26E-05" izz="0.000423"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_shoulder_pitch_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0.04 -0.01" rpy="0 1.5707963267948966 0"/>
+      <geometry>
+        <cylinder radius="0.03" length="0.05"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_shoulder_pitch_joint" type="revolute">
+    <origin xyz="0.0039563 0.10022 0.23778" rpy="0.27931 5.4949E-05 -0.00019159"/>
+    <parent link="torso_link"/>
+    <child link="left_shoulder_pitch_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-3.0892" upper="2.6704" effort="25" velocity="37"/>
+  </joint>
+  <link name="left_shoulder_roll_link">
+    <inertial>
+      <origin xyz="-0.000227 0.00727 -0.063243" rpy="0 0 0"/>
+      <mass value="0.643"/>
+      <inertia ixx="0.0006177" ixy="-1E-06" ixz="8.7E-06" iyy="0.0006912" iyz="-5.3E-06" izz="0.0003894"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_shoulder_roll_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.004 0.006 -0.053" rpy="0 0 0"/>
+      <geometry>
+        <cylinder radius="0.03" length="0.03"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_shoulder_roll_joint" type="revolute">
+    <origin xyz="0 0.038 -0.013831" rpy="-0.27925 0 0"/>
+    <parent link="left_shoulder_pitch_link"/>
+    <child link="left_shoulder_roll_link"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-1.5882" upper="2.2515" effort="25" velocity="37"/>
+  </joint>
+  <link name="left_shoulder_yaw_link">
+    <inertial>
+      <origin xyz="0.010773 -0.002949 -0.072009" rpy="0 0 0"/>
+      <mass value="0.734"/>
+      <inertia ixx="0.0009988" ixy="7.9E-06" ixz="0.0001412" iyy="0.0010605" iyz="-2.86E-05" izz="0.0004354"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_shoulder_yaw_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_shoulder_yaw_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_shoulder_yaw_joint" type="revolute">
+    <origin xyz="0 0.00624 -0.1032" rpy="0 0 0"/>
+    <parent link="left_shoulder_roll_link"/>
+    <child link="left_shoulder_yaw_link"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-2.618" upper="2.618" effort="25" velocity="37"/>
+  </joint>
+  <link name="left_elbow_link">
+    <inertial>
+      <origin xyz="0.064956 0.004454 -0.010062" rpy="0 0 0"/>
+      <mass value="0.6"/>
+      <inertia ixx="0.0002891" ixy="6.53E-05" ixz="1.72E-05" iyy="0.0004152" iyz="-5.6E-06" izz="0.0004197"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_elbow_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_elbow_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="left_elbow_joint" type="revolute">
+    <origin xyz="0.015783 0 -0.080518" rpy="0 0 0"/>
+    <parent link="left_shoulder_yaw_link"/>
+    <child link="left_elbow_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-1.0472" upper="2.0944" effort="25" velocity="37"/>
+  </joint>
+  <joint name="left_wrist_roll_joint" type="revolute">
+    <origin xyz="0.100 0.00188791 -0.010" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/>
+    <parent link="left_elbow_link"/>
+    <child link="left_wrist_roll_rubber_hand"/>
+    <limit effort="25" velocity="37" lower="-1.972222054" upper="1.972222054"/>
+  </joint>
+  <link name="left_wrist_roll_rubber_hand">
+    <inertial>
+      <origin xyz="0.10794656650 0.00163511945 0.00202244863" rpy="0 0 0"/>
+      <mass value="0.35692864"/>
+      <inertia ixx="0.00019613494735" ixy="-0.00000419816908" ixz="-0.00003950860580" iyy="0.00200280358206" iyz="0.00000249774203" izz="0.00194181412808"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_wrist_roll_rubber_hand.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/left_wrist_roll_rubber_hand.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <link name="right_shoulder_pitch_link">
+    <inertial>
+      <origin xyz="0 -0.035892 -0.011628" rpy="0 0 0"/>
+      <mass value="0.718"/>
+      <inertia ixx="0.0004291" ixy="9.2E-06" ixz="6.4E-06" iyy="0.000453" iyz="-2.26E-05" izz="0.000423"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_shoulder_pitch_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 -0.04 -0.01" rpy="0 1.5707963267948966 0"/>
+      <geometry>
+        <cylinder radius="0.03" length="0.05"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_shoulder_pitch_joint" type="revolute">
+    <origin xyz="0.0039563 -0.10021 0.23778" rpy="-0.27931 5.4949E-05 0.00019159"/>
+    <parent link="torso_link"/>
+    <child link="right_shoulder_pitch_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-3.0892" upper="2.6704" effort="25" velocity="37"/>
+  </joint>
+  <link name="right_shoulder_roll_link">
+    <inertial>
+      <origin xyz="-0.000227 -0.00727 -0.063243" rpy="0 0 0"/>
+      <mass value="0.643"/>
+      <inertia ixx="0.0006177" ixy="1E-06" ixz="8.7E-06" iyy="0.0006912" iyz="5.3E-06" izz="0.0003894"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_shoulder_roll_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="-0.004 -0.006 -0.053" rpy="0 0 0"/>
+      <geometry>
+        <cylinder radius="0.03" length="0.03"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_shoulder_roll_joint" type="revolute">
+    <origin xyz="0 -0.038 -0.013831" rpy="0.27925 0 0"/>
+    <parent link="right_shoulder_pitch_link"/>
+    <child link="right_shoulder_roll_link"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-2.2515" upper="1.5882" effort="25" velocity="37"/>
+  </joint>
+  <link name="right_shoulder_yaw_link">
+    <inertial>
+      <origin xyz="0.010773 0.002949 -0.072009" rpy="0 0 0"/>
+      <mass value="0.734"/>
+      <inertia ixx="0.0009988" ixy="-7.9E-06" ixz="0.0001412" iyy="0.0010605" iyz="2.86E-05" izz="0.0004354"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_shoulder_yaw_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_shoulder_yaw_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_shoulder_yaw_joint" type="revolute">
+    <origin xyz="0 -0.00624 -0.1032" rpy="0 0 0"/>
+    <parent link="right_shoulder_roll_link"/>
+    <child link="right_shoulder_yaw_link"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-2.618" upper="2.618" effort="25" velocity="37"/>
+  </joint>
+  <link name="right_elbow_link">
+    <inertial>
+      <origin xyz="0.064956 -0.004454 -0.010062" rpy="0 0 0"/>
+      <mass value="0.6"/>
+      <inertia ixx="0.0002891" ixy="-6.53E-05" ixz="1.72E-05" iyy="0.0004152" iyz="5.6E-06" izz="0.0004197"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_elbow_link.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_elbow_link.STL"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="right_elbow_joint" type="revolute">
+    <origin xyz="0.015783 0 -0.080518" rpy="0 0 0"/>
+    <parent link="right_shoulder_yaw_link"/>
+    <child link="right_elbow_link"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-1.0472" upper="2.0944" effort="25" velocity="37"/>
+  </joint>
+  <joint name="right_wrist_roll_joint" type="revolute">
+    <origin xyz="0.100 -0.00188791 -0.010" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/>
+    <parent link="right_elbow_link"/>
+    <child link="right_wrist_roll_rubber_hand"/>
+    <limit effort="25" velocity="37" lower="-1.972222054" upper="1.972222054"/>
+  </joint>
+  <link name="right_wrist_roll_rubber_hand">
+    <inertial>
+      <origin xyz="0.10794656650 -0.00163511945 0.00202244863" rpy="0 0 0"/>
+      <mass value="0.35692864"/>
+      <inertia ixx="0.00019613494735" ixy="0.00000419816908" ixz="-0.00003950860580" iyy="0.00200280358206" iyz="-0.00000249774203" izz="0.00194181412808"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_wrist_roll_rubber_hand.STL"/>
+      </geometry>
+      <material name="white">
+        <color rgba="0.7 0.7 0.7 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="meshes/right_wrist_roll_rubber_hand.STL"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>

--- a/unitree/g1/teleop/NOTICE.md
+++ b/unitree/g1/teleop/NOTICE.md
@@ -1,0 +1,11 @@
+# Third-party source notice
+
+The G1_23 kinematics, controller-pose calibration, arm SDK lifecycle, and
+`resource/g1_body23.urdf` are focused ports from Unitree Robotics'
+`xr_teleoperate` project (local source revision
+`845b25a32f7febedf220e830952a7134897adb9d`) and its locally tested G1_23 safety
+corrections. Copyright 2025 HangZhou YuShu TECHNOLOGY CO.,LTD. Licensed under
+the Apache License, Version 2.0.
+
+No TeleVuer, Vuer, browser server, or image pipeline code is copied into this
+Driver. WebRTC is provided independently by the BSD-3-Clause `aiortc` package.

--- a/unitree/g1/teleop/__init__.py
+++ b/unitree/g1/teleop/__init__.py
@@ -1,0 +1,5 @@
+"""Unitree G1 teleoperation support owned by the root G1 Driver process."""
+
+from .descriptor import PROFILE_ID, tool_definitions
+
+__all__ = ["PROFILE_ID", "tool_definitions"]

--- a/unitree/g1/teleop/adapter.py
+++ b/unitree/g1/teleop/adapter.py
@@ -1,0 +1,502 @@
+"""G1_23 dual-arm pose projection and final output adapter.
+
+The module is robot-SDK free.  Production DDS objects and the Pinocchio IK
+solver are injected by :mod:`teleop.factory`; tests use deterministic fakes.
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+import threading
+import time
+from collections import deque
+from collections.abc import Callable, Mapping, Sequence
+from typing import Protocol
+
+import numpy as np
+
+from .descriptor import PROFILE_ID
+from .dispatch import AdapterAck, MotionIntent, StopRequest
+
+ARM_JOINT_COUNT = 10
+REQUIRED_MODE_MACHINE = 4
+_OPENXR_TO_ROBOT = np.array(
+    [[0.0, 0.0, -1.0], [-1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+    dtype=float,
+)
+_TO_UNITREE_LEFT_ARM = np.array(
+    [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, -1.0, 0.0],
+     [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]],
+    dtype=float,
+)
+_TO_UNITREE_RIGHT_ARM = np.array(
+    [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0],
+     [0.0, -1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]],
+    dtype=float,
+)
+
+
+class IkSolver(Protocol):
+    def solve(
+        self,
+        left_target: np.ndarray,
+        right_target: np.ndarray,
+        current_joint_positions: np.ndarray,
+        current_joint_velocities: np.ndarray,
+    ) -> tuple[Sequence[float], Sequence[float]]: ...
+
+    def reset(self, current_joint_positions: Sequence[float]) -> None: ...
+
+
+class LowStateReader(Protocol):
+    def read_arm_state(self) -> Mapping[str, object]: ...
+
+
+class ArmSdkPort(Protocol):
+    publisher_count: int
+
+    def startup_safe(self, deadline_monotonic: float) -> AdapterAck: ...
+
+    def apply_target(
+        self,
+        joint_positions: Sequence[float],
+        feedforward_torques: Sequence[float],
+        *,
+        expires_monotonic: float,
+        required_mode_machine: int,
+        allow_arm: bool = False,
+    ) -> AdapterAck: ...
+
+    def safe_stop(self, *, reason: str, deadline_monotonic: float) -> AdapterAck: ...
+
+    def snapshot(self) -> Mapping[str, object]: ...
+
+    def close(self) -> AdapterAck | None: ...
+
+
+class _LatencyWindow:
+    def __init__(self, maximum: int = 256):
+        self._samples: deque[float] = deque(maxlen=maximum)
+
+    def observe_seconds(self, seconds: float) -> None:
+        value = max(0.0, min(60_000.0, float(seconds) * 1000.0))
+        self._samples.append(value)
+
+    def snapshot(self) -> dict:
+        if not self._samples:
+            return {"last": None, "p50": None, "p95": None, "p99": None, "count": 0}
+        ordered = sorted(self._samples)
+
+        def percentile(fraction: float) -> float:
+            index = min(len(ordered) - 1, max(0, math.ceil(fraction * len(ordered)) - 1))
+            return round(ordered[index], 3)
+
+        return {
+            "last": round(self._samples[-1], 3),
+            "p50": percentile(0.50),
+            "p95": percentile(0.95),
+            "p99": percentile(0.99),
+            "count": len(self._samples),
+        }
+
+
+class G1ControllerPoseMapper:
+    """Map OpenXR head/controller poses into a pelvis-fixed G1 IK frame."""
+
+    def __init__(
+        self,
+    ):
+        # V1 is intentionally fixed to the Apache-2.0 upstream G1 controller
+        # calibration.  Any future calibration change requires a new profile.
+        self._waist_offset = np.array([0.15, 0.0, 0.45])
+
+    def map_frame(self, frame: Mapping[str, object]) -> tuple[np.ndarray, np.ndarray]:
+        head = self._pose_matrix(frame["head"])
+        left = self._pose_matrix(frame["left_controller"])
+        right = self._pose_matrix(frame["right_controller"])
+
+        head_robot = self._change_basis(head)
+        left_robot = self._change_basis(left) @ _TO_UNITREE_LEFT_ARM
+        right_robot = self._change_basis(right) @ _TO_UNITREE_RIGHT_ARM
+        yaw_inverse = self._head_yaw(head_robot).T
+        return (
+            self._head_relative(left_robot, head_robot, yaw_inverse),
+            self._head_relative(right_robot, head_robot, yaw_inverse),
+        )
+
+    def _head_relative(
+        self,
+        pose: np.ndarray,
+        head: np.ndarray,
+        yaw_inverse: np.ndarray,
+    ) -> np.ndarray:
+        # V1 is locked to xr_teleoperate's tested arm_reference_mode=head_yaw:
+        # express wrist rotation/translation in headset yaw, ignore pitch and
+        # roll, then translate the origin from head to the fixed IK waist.
+        result = np.eye(4)
+        result[:3, :3] = yaw_inverse @ pose[:3, :3]
+        relative = yaw_inverse @ (pose[:3, 3] - head[:3, 3])
+        result[:3, 3] = self._waist_offset + relative
+        if not np.all(np.isfinite(result)) or np.linalg.norm(relative) > 2.0:
+            raise ValueError("controller pose is outside the bounded G1 workspace")
+        return result
+
+    @staticmethod
+    def _head_yaw(head: np.ndarray) -> np.ndarray:
+        x_axis = head[:3, 0].copy()
+        x_axis[2] = 0.0
+        norm = float(np.linalg.norm(x_axis))
+        if not math.isfinite(norm) or norm <= 1e-6:
+            return np.eye(3)
+        x_axis /= norm
+        z_axis = np.array([0.0, 0.0, 1.0])
+        y_axis = np.cross(z_axis, x_axis)
+        y_norm = float(np.linalg.norm(y_axis))
+        if not math.isfinite(y_norm) or y_norm <= 1e-6:
+            return np.eye(3)
+        y_axis /= y_norm
+        return np.column_stack((x_axis, y_axis, z_axis))
+
+    @staticmethod
+    def _change_basis(pose: np.ndarray) -> np.ndarray:
+        result = np.eye(4)
+        result[:3, :3] = _OPENXR_TO_ROBOT @ pose[:3, :3] @ _OPENXR_TO_ROBOT.T
+        result[:3, 3] = _OPENXR_TO_ROBOT @ pose[:3, 3]
+        return result
+
+    @classmethod
+    def _pose_matrix(cls, value: object) -> np.ndarray:
+        if not isinstance(value, Mapping):
+            raise ValueError("pose must be an object")
+        position = np.asarray(value.get("position"), dtype=float)
+        quaternion = np.asarray(value.get("orientation"), dtype=float)
+        if position.shape != (3,) or quaternion.shape != (4,):
+            raise ValueError("pose position/quaternion dimensions are invalid")
+        if not np.all(np.isfinite(position)) or not np.all(np.isfinite(quaternion)):
+            raise ValueError("pose contains non-finite values")
+        norm = float(np.linalg.norm(quaternion))
+        if norm <= 0.0:
+            raise ValueError("pose quaternion is invalid")
+        x, y, z, w = quaternion / norm
+        rotation = np.array(
+            [
+                [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+                [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+                [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+            ],
+            dtype=float,
+        )
+        result = np.eye(4)
+        result[:3, :3] = rotation
+        result[:3, 3] = position
+        return result
+
+
+class G1DualArmAdapter:
+    """OutputAdapter that always runs mapping, IK and LowState observation.
+
+    Shadow mode deliberately has no ArmSdkPort, so construction cannot create a
+    publisher.  Live mode requires one injected port whose publisher_count is
+    exactly one.
+    """
+
+    def __init__(
+        self,
+        *,
+        mode: str,
+        pose_mapper: G1ControllerPoseMapper,
+        ik_solver: IkSolver,
+        low_state_reader: LowStateReader,
+        arm_sdk: ArmSdkPort | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        if mode not in ("shadow", "live"):
+            raise ValueError("mode must be 'shadow' or 'live'")
+        if mode == "shadow" and arm_sdk is not None:
+            raise ValueError("Shadow mode forbids an arm SDK port")
+        if mode == "live" and (
+            arm_sdk is None or getattr(arm_sdk, "publisher_count", None) != 1
+        ):
+            raise ValueError("Live mode requires exactly one arm_sdk publisher")
+        self.hardware_output = mode == "live"
+        self._mode = mode
+        self._mapper = pose_mapper
+        self._ik = ik_solver
+        self._low_state = low_state_reader
+        self._arm_sdk = arm_sdk
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._latency = {
+            "ik": _LatencyWindow(),
+            "adapter_apply": _LatencyWindow(),
+            "robot_follow": _LatencyWindow(),
+        }
+        self._closed = False
+        self._last_command_at: float | None = None
+        self._last_lowstate_at: float | None = None
+        self._output = self._empty_output("safe")
+
+    def startup_safe(self, deadline_monotonic: float) -> AdapterAck:
+        try:
+            state = self._read_state()
+            ready = getattr(self._ik, "ready", None)
+            if ready is not None and (not callable(ready) or ready() is not True):
+                return self._fault("ik_not_ready")
+            if not callable(getattr(self._ik, "solve", None)):
+                return self._fault("ik_not_ready")
+            if state["mode_machine"] != REQUIRED_MODE_MACHINE:
+                return self._fault("mode_machine_not_ai")
+        except (KeyError, TypeError, ValueError, RuntimeError, ArithmeticError):
+            return self._fault("startup_dependency_unavailable")
+        with self._lock:
+            measured = state["joint_positions"]
+            self._last_lowstate_at = state["sample_monotonic"]
+            self._output = self._make_output(
+                "stopped",
+                measured,
+                measured,
+                fault_reason=None,
+            )
+        reset = getattr(self._ik, "reset", None)
+        if callable(reset):
+            try:
+                reset(measured)
+            except (TypeError, ValueError, RuntimeError, ArithmeticError):
+                return self._fault("ik_reset_failed")
+        if self._arm_sdk is not None:
+            ack = self._arm_sdk.startup_safe(deadline_monotonic)
+            self._refresh_sdk_output()
+            return ack
+        if self._clock() >= deadline_monotonic:
+            return self._fault("startup_safe_deadline_missed")
+        return AdapterAck(True)
+
+    def apply(self, intent: MotionIntent) -> AdapterAck:
+        if self._clock() >= intent.expires_monotonic:
+            return AdapterAck(False, "intent_expired_at_adapter")
+        if intent.frame.get("deadman") is not True:
+            return AdapterAck(False, "unsafe_deadman")
+        tracking = intent.frame.get("tracking")
+        if not isinstance(tracking, Mapping) or not all(value is True for value in tracking.values()):
+            return AdapterAck(False, "unsafe_tracking")
+        try:
+            state = self._read_state()
+            left_target, right_target = self._mapper.map_frame(intent.frame)
+            ik_started = self._clock()
+            raw_target, raw_torques = self._ik.solve(
+                left_target,
+                right_target,
+                state["joint_positions"],
+                state["joint_velocities"],
+            )
+            target = np.asarray(raw_target, dtype=float)
+            torques = np.asarray(raw_torques, dtype=float)
+            self._latency["ik"].observe_seconds(self._clock() - ik_started)
+            if (
+                target.shape != (ARM_JOINT_COUNT,)
+                or torques.shape != (ARM_JOINT_COUNT,)
+                or not np.all(np.isfinite(target))
+                or not np.all(np.isfinite(torques))
+            ):
+                return self._fault("invalid_ik_result")
+            refreshed_state = self._read_state()
+            if self._clock() >= intent.expires_monotonic:
+                return self._fault("intent_expired_after_ik")
+            if self._mode == "live" and refreshed_state["mode_machine"] != REQUIRED_MODE_MACHINE:
+                return self._fault("mode_machine_not_ai")
+            apply_started = self._clock()
+            if self._arm_sdk is not None:
+                ack = self._arm_sdk.apply_target(
+                    target.tolist(),
+                    torques.tolist(),
+                    expires_monotonic=intent.expires_monotonic,
+                    required_mode_machine=REQUIRED_MODE_MACHINE,
+                    allow_arm=intent.allow_reclutch,
+                )
+                if not ack.ok:
+                    if ack.code in {"arm_sdk_reclutch_required", "arm_sdk_releasing"}:
+                        self._refresh_sdk_output()
+                        return ack
+                    return self._fault(ack.code)
+            self._latency["adapter_apply"].observe_seconds(self._clock() - apply_started)
+            now = self._clock()
+            with self._lock:
+                if (
+                    self.hardware_output
+                    and self._last_command_at is not None
+                    and state["sample_monotonic"] >= self._last_command_at
+                ):
+                    self._latency["robot_follow"].observe_seconds(
+                        state["sample_monotonic"] - self._last_command_at
+                    )
+                self._last_command_at = now
+                self._last_lowstate_at = refreshed_state["sample_monotonic"]
+                self._output = self._make_output(
+                    "published" if self.hardware_output else "would_apply",
+                    target,
+                    refreshed_state["joint_positions"],
+                    fault_reason=None,
+                )
+            self._refresh_sdk_output()
+            return AdapterAck(True)
+        except (KeyError, TypeError, ValueError, RuntimeError, ArithmeticError):
+            return self._fault("projection_or_ik_failed")
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck:
+        if self._arm_sdk is not None:
+            ack = self._arm_sdk.safe_stop(
+                reason=request.reason,
+                deadline_monotonic=request.deadline_monotonic,
+            )
+            if not ack.ok:
+                return self._fault(ack.code)
+        elif self._clock() >= request.deadline_monotonic:
+            return self._fault("adapter_stop_deadline_missed")
+        try:
+            state = self._read_state()
+            measured = state["joint_positions"]
+            reset = getattr(self._ik, "reset", None)
+            if callable(reset):
+                reset(measured)
+        except (KeyError, TypeError, ValueError, RuntimeError, ArithmeticError):
+            return self._fault("stop_dependency_unavailable")
+        with self._lock:
+            self._output = self._make_output(
+                "stopped",
+                measured,
+                measured,
+                fault_reason=None,
+            )
+        self._refresh_sdk_output()
+        return AdapterAck(True)
+
+    def snapshot(self) -> dict:
+        self._refresh_sdk_output()
+        with self._lock:
+            output = copy.deepcopy(self._output)
+            if self._last_command_at is not None:
+                output["command_age_ms"] = round(
+                    min(60_000.0, max(0.0, self._clock() - self._last_command_at) * 1000.0),
+                    3,
+                )
+            value = {
+                "kind": "hardware" if self.hardware_output else "recording",
+                "hardware_output": self.hardware_output,
+                "diagnostics": {
+                    "latency_ms": {
+                        name: window.snapshot() for name, window in self._latency.items()
+                    }
+                },
+                "output": output,
+            }
+            if not self.hardware_output:
+                operation = output.get("state")
+                if operation == "would_apply":
+                    current_kind = "would_apply"
+                elif operation in {"stopped", "releasing"}:
+                    current_kind = "would_stop"
+                else:
+                    current_kind = "safe"
+                value.update({
+                    "closed": self._closed,
+                    "current": {"kind": current_kind},
+                    "records": [],
+                })
+            return value
+
+    def external_fault_code(self) -> str | None:
+        probe = getattr(self._arm_sdk, "external_fault_code", None)
+        return probe() if callable(probe) else None
+
+    def external_release_signal(self) -> Mapping[str, object]:
+        probe = getattr(self._arm_sdk, "external_release_signal", None)
+        if callable(probe):
+            return probe()
+        return {"generation": 0, "reason": None, "acknowledged": True}
+
+    def close(self) -> AdapterAck | None:
+        with self._lock:
+            if self._closed:
+                return AdapterAck(True)
+            self._closed = True
+        ack = self._arm_sdk.close() if self._arm_sdk is not None else AdapterAck(True)
+        close_reader = getattr(self._low_state, "close", None)
+        if callable(close_reader):
+            close_reader()
+        return ack
+
+    def _read_state(self) -> dict:
+        raw = self._low_state.read_arm_state()
+        q = np.asarray(raw.get("joint_positions"), dtype=float)
+        dq = np.asarray(raw.get("joint_velocities"), dtype=float)
+        mode_machine = raw.get("mode_machine")
+        sampled = float(raw.get("sample_monotonic"))
+        if q.shape != (ARM_JOINT_COUNT,) or dq.shape != (ARM_JOINT_COUNT,):
+            raise ValueError("LowState arm vector shape is invalid")
+        if not np.all(np.isfinite(q)) or not np.all(np.isfinite(dq)) or not math.isfinite(sampled):
+            raise ValueError("LowState contains non-finite values")
+        if isinstance(mode_machine, bool) or not isinstance(mode_machine, int):
+            raise ValueError("LowState mode_machine is invalid")
+        age = self._clock() - sampled
+        if age < 0.0 or age > 0.1:
+            raise RuntimeError("LowState is stale")
+        return {
+            "joint_positions": q,
+            "joint_velocities": dq,
+            "mode_machine": mode_machine,
+            "sample_monotonic": sampled,
+        }
+
+    def _fault(self, reason: str) -> AdapterAck:
+        with self._lock:
+            self._output["state"] = "fault"
+            self._output["fault_reason"] = str(reason)[:128]
+        return AdapterAck(False, str(reason)[:64])
+
+    def _make_output(
+        self,
+        state: str,
+        target: Sequence[float] | None,
+        measured: Sequence[float] | None,
+        *,
+        fault_reason: str | None,
+    ) -> dict:
+        target_values = [] if target is None else [round(float(value), 6) for value in target]
+        measured_values = (
+            [] if measured is None else [round(float(value), 6) for value in measured]
+        )
+        error = None
+        if target_values and measured_values:
+            error = round(max(abs(a - b) for a, b in zip(target_values, measured_values)), 6)
+        return {
+            "profile_id": PROFILE_ID,
+            "hardware_output": self.hardware_output,
+            "state": state,
+            "target_joint_positions_rad": target_values,
+            "measured_joint_positions_rad": measured_values,
+            "max_abs_error_rad": error,
+            "arm_sdk_weight": 0.0 if self.hardware_output else None,
+            "command_age_ms": None,
+            "fault_reason": fault_reason,
+        }
+
+    def _empty_output(self, state: str) -> dict:
+        return self._make_output(state, None, None, fault_reason=None)
+
+    def _refresh_sdk_output(self) -> None:
+        if self._arm_sdk is None:
+            return
+        sdk = self._arm_sdk.snapshot()
+        weight = sdk.get("arm_sdk_weight")
+        if isinstance(weight, (int, float)) and not isinstance(weight, bool) and math.isfinite(weight):
+            with self._lock:
+                self._output["arm_sdk_weight"] = round(min(1.0, max(0.0, float(weight))), 6)
+
+
+__all__ = [
+    "ARM_JOINT_COUNT",
+    "G1ControllerPoseMapper",
+    "G1DualArmAdapter",
+    "REQUIRED_MODE_MACHINE",
+]

--- a/unitree/g1/teleop/control_safety.py
+++ b/unitree/g1/teleop/control_safety.py
@@ -1,0 +1,234 @@
+"""Deterministic lifecycle gating for arm SDK command publication.
+
+Ported from Unitree ``xr_teleoperate`` under Apache-2.0; see NOTICE.md.
+
+This module deliberately has no robot, DDS, or third-party dependencies.  It
+only decides whether a controller may publish and which SDK weight it should
+use.  Sending any final zero-weight frames remains the controller's job.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from dataclasses import dataclass
+from enum import Enum
+from numbers import Real
+from typing import Optional
+
+
+class ArmSdkState(str, Enum):
+    """States in the arm command publication lifecycle."""
+
+    DISARMED = "disarmed"
+    ARMING = "arming"
+    ARMED = "armed"
+    RELEASING = "releasing"
+    HARD_FAULT = "hard_fault"
+
+
+@dataclass(frozen=True)
+class ArmSdkSample:
+    """An immutable decision for one controller iteration."""
+
+    state: ArmSdkState
+    publish_allowed: bool
+    weight: float
+
+
+class ArmSdkGate:
+    """Thread-safe state machine for gradually taking and releasing arm control.
+
+    Time is supplied by the caller so the gate is deterministic and easy to
+    test.  All time-bearing calls must use a finite, nondecreasing clock.
+    ``hard_fault`` is intentionally latched and there is no reset operation;
+    recovery requires constructing a new gate as part of a deliberate restart.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._state = ArmSdkState.DISARMED
+        self._weight = 0.0
+        self._last_now: Optional[float] = None
+        self._transition_started_at = 0.0
+        self._transition_duration = 0.0
+        self._transition_start_weight = 0.0
+        self._release_reason: Optional[str] = None
+        self._fault_reason: Optional[str] = None
+
+    @property
+    def state(self) -> ArmSdkState:
+        with self._lock:
+            return self._state
+
+    @property
+    def release_reason(self) -> Optional[str]:
+        with self._lock:
+            return self._release_reason
+
+    @property
+    def fault_reason(self) -> Optional[str]:
+        with self._lock:
+            return self._fault_reason
+
+    def arm(self, now: float, ramp_s: float) -> ArmSdkSample:
+        """Begin taking control, ramping SDK weight from zero to one.
+
+        Arming is only valid while disarmed.  A zero-second ramp transitions
+        directly to ``ARMED``.
+        """
+
+        now_value = self._validate_finite_number(now, "now")
+        ramp_value = self._validate_ramp(ramp_s)
+
+        with self._lock:
+            self._observe(now_value)
+            if self._state is ArmSdkState.HARD_FAULT:
+                raise RuntimeError("cannot arm a hard-faulted gate")
+            if self._state is not ArmSdkState.DISARMED:
+                raise RuntimeError(f"cannot arm while gate is {self._state.value}")
+
+            self._release_reason = None
+            self._transition_started_at = now_value
+            self._transition_duration = ramp_value
+            self._transition_start_weight = 0.0
+            self._weight = 0.0
+
+            if ramp_value == 0.0:
+                self._state = ArmSdkState.ARMED
+                self._weight = 1.0
+            else:
+                self._state = ArmSdkState.ARMING
+
+            return self._snapshot()
+
+    def release(self, now: float, ramp_s: float, reason: str) -> ArmSdkSample:
+        """Release control, ramping from the current SDK weight to zero.
+
+        Release may interrupt an in-progress arm ramp.  Calling it while
+        already disarmed is a safe no-op.  Repeated calls while releasing are
+        idempotent and do not restart or lengthen the existing ramp.
+        """
+
+        now_value = self._validate_finite_number(now, "now")
+        ramp_value = self._validate_ramp(ramp_s)
+        reason_value = self._validate_reason(reason)
+
+        with self._lock:
+            self._observe(now_value)
+            if self._state is ArmSdkState.HARD_FAULT:
+                raise RuntimeError("cannot release a hard-faulted gate")
+            if self._state is ArmSdkState.DISARMED:
+                self._release_reason = reason_value
+                return self._snapshot()
+            if self._state is ArmSdkState.RELEASING:
+                return self._snapshot()
+
+            self._release_reason = reason_value
+            self._transition_started_at = now_value
+            self._transition_duration = ramp_value
+            self._transition_start_weight = self._weight
+
+            if ramp_value == 0.0 or self._weight == 0.0:
+                self._finish_release()
+            else:
+                self._state = ArmSdkState.RELEASING
+
+            return self._snapshot()
+
+    def hard_fault(self, reason: str) -> ArmSdkSample:
+        """Latch an unrecoverable fault and prohibit further publication.
+
+        The first fault reason is retained so a secondary cleanup failure
+        cannot hide the initiating fault.
+        """
+
+        reason_value = self._validate_reason(reason)
+
+        with self._lock:
+            if self._state is not ArmSdkState.HARD_FAULT:
+                self._fault_reason = reason_value
+                self._state = ArmSdkState.HARD_FAULT
+                self._weight = 0.0
+                self._transition_duration = 0.0
+                self._transition_start_weight = 0.0
+            return self._snapshot()
+
+    def sample(self, now: float) -> ArmSdkSample:
+        """Advance the state machine to ``now`` and return its decision."""
+
+        now_value = self._validate_finite_number(now, "now")
+        with self._lock:
+            self._observe(now_value)
+            return self._snapshot()
+
+    def _observe(self, now: float) -> None:
+        if self._last_now is not None and now < self._last_now:
+            raise ValueError(
+                f"now must be nondecreasing (received {now}, last {self._last_now})"
+            )
+        self._last_now = now
+        self._advance(now)
+
+    def _advance(self, now: float) -> None:
+        if self._state not in (ArmSdkState.ARMING, ArmSdkState.RELEASING):
+            return
+
+        elapsed = now - self._transition_started_at
+        progress = min(1.0, max(0.0, elapsed / self._transition_duration))
+
+        if self._state is ArmSdkState.ARMING:
+            self._weight = progress
+            if progress == 1.0:
+                self._state = ArmSdkState.ARMED
+                self._weight = 1.0
+            return
+
+        self._weight = self._transition_start_weight * (1.0 - progress)
+        if progress == 1.0:
+            self._finish_release()
+
+    def _finish_release(self) -> None:
+        self._state = ArmSdkState.DISARMED
+        self._weight = 0.0
+        self._transition_duration = 0.0
+        self._transition_start_weight = 0.0
+
+    def _snapshot(self) -> ArmSdkSample:
+        publish_allowed = self._state in (
+            ArmSdkState.ARMING,
+            ArmSdkState.ARMED,
+            ArmSdkState.RELEASING,
+        )
+        return ArmSdkSample(
+            state=self._state,
+            publish_allowed=publish_allowed,
+            weight=self._weight,
+        )
+
+    @staticmethod
+    def _validate_finite_number(value: float, name: str) -> float:
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise TypeError(f"{name} must be a real number")
+        result = float(value)
+        if not math.isfinite(result):
+            raise ValueError(f"{name} must be finite")
+        return result
+
+    @classmethod
+    def _validate_ramp(cls, ramp_s: float) -> float:
+        result = cls._validate_finite_number(ramp_s, "ramp_s")
+        if result < 0.0:
+            raise ValueError("ramp_s must be nonnegative")
+        return result
+
+    @staticmethod
+    def _validate_reason(reason: str) -> str:
+        if not isinstance(reason, str):
+            raise TypeError("reason must be a string")
+        if not reason.strip():
+            raise ValueError("reason must not be empty")
+        return reason
+
+
+__all__ = ["ArmSdkGate", "ArmSdkSample", "ArmSdkState"]

--- a/unitree/g1/teleop/descriptor.py
+++ b/unitree/g1/teleop/descriptor.py
@@ -1,0 +1,183 @@
+"""Pure, DDS-free descriptors for the G1 teleoperation tools."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from typing import Any
+
+PROFILE_ID = "unitree_g1_23_dual_arm_controller_v1"
+SHADOW_PROTOCOL = "motus.teleop.shadow.v1"
+LIVE_PROTOCOL = "motus.teleop.live.v1"
+RTC_FRAME_PROTOCOL = "motus.teleop.rtc-frame.v1"
+RTC_CONTROL_PROTOCOL = "motus.teleop.rtc-control.v1"
+SIGNALING_PROTOCOL = "motus.teleop.webrtc-offer-answer.v1"
+SIGNALING_AUDIENCE = "motus-teleop-rtc"
+PREFLIGHT_SCHEMA = "motus.teleop.g1-preflight.v1"
+RECORDING_DISPATCH = "motus.teleop.dispatch.recording.v1"
+HARDWARE_DISPATCH = "motus.teleop.dispatch.hardware.v1"
+MODES = frozenset({"shadow", "live"})
+
+CAPABILITIES = {
+    "profile_id": PROFILE_ID,
+    "input_bindings": {
+        "head": {"required": True, "role": "reference"},
+        "left_controller": {"required": True, "role": "left_end_effector"},
+        "right_controller": {"required": True, "role": "right_end_effector"},
+    },
+    "outputs": {
+        "dual_arm": {"enabled": True, "joint_count": 10},
+        "base": {"enabled": False},
+        "hands": {"enabled": False},
+    },
+    "effectors": ["dual_arm"],
+}
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def protocol_for_mode(mode: str) -> str:
+    _require_mode(mode)
+    return LIVE_PROTOCOL if mode == "live" else SHADOW_PROTOCOL
+
+
+def dispatch_for_mode(mode: str) -> str:
+    _require_mode(mode)
+    return HARDWARE_DISPATCH if mode == "live" else RECORDING_DISPATCH
+
+
+def capability_binding(mode: str) -> dict:
+    _require_mode(mode)
+    return {
+        "protocol": protocol_for_mode(mode),
+        "mode": mode,
+        "profile_id": PROFILE_ID,
+        "capabilities": copy.deepcopy(CAPABILITIES),
+        "dispatch_contract": dispatch_for_mode(mode),
+        "signaling": {
+            "protocol": SIGNALING_PROTOCOL,
+            "path": "/offer",
+            "access": "authenticated-core-proxy-only",
+            "audience": SIGNALING_AUDIENCE,
+        },
+    }
+
+
+def capability_digest(mode: str) -> str:
+    return hashlib.sha256(canonical_json(capability_binding(mode))).hexdigest()
+
+
+def tool_definitions(
+    *,
+    mode: str,
+    driver_id: str = "unitree-g1",
+    driver_name: str = "Unitree G1 Bundle",
+    robot_id: str | None = None,
+    signaling_enabled: bool = True,
+) -> list[dict]:
+    """Build descriptors without importing ROS, DDS, aiortc, NumPy or an IK solver."""
+
+    _require_mode(mode)
+    if not signaling_enabled:
+        raise ValueError("G1 teleoperation cannot be advertised without authenticated RTC signaling")
+    effective_robot_id = robot_id or driver_id
+    identity = {
+        "boot_id": {"type": "string", "format": "uuid"},
+        "session_id": {"type": "string", "format": "uuid"},
+        "epoch": {"type": "integer", "minimum": 1},
+        "fence": {"type": "string", "minLength": 24},
+    }
+    prepare_action = "prepare_live" if mode == "live" else "prepare_shadow"
+    actions = {
+        "stop": {"params": [], "description": "Release the teleoperation lifecycle safely"},
+        prepare_action: {
+            "params": ["session_id", "epoch", "fence"],
+            "description": (
+                "Prepare explicitly enabled G1 arm_sdk hardware control"
+                if mode == "live"
+                else "Prepare a zero-output G1 dual-arm Shadow session"
+            ),
+        },
+        "heartbeat": {"params": list(identity), "description": "Renew the Core-owned lease"},
+        "pause": {"params": list(identity), "description": "Pause and confirm safe output"},
+        "release": {"params": list(identity), "description": "Release authority and confirm safe output"},
+        "soft_stop": {"params": list(identity), "description": "Latch safe output until a newer prepare"},
+        "status": {"params": [], "description": "Read bounded session and output diagnostics"},
+    }
+    x_teleop = {
+        **capability_binding(mode),
+        "driver_id": driver_id,
+        "driver_name": driver_name,
+        "robot_id": effective_robot_id,
+        "actuation_enabled": mode == "live",
+        "capability_digest": capability_digest(mode),
+    }
+    session = {
+        "name": "teleop_session",
+        "type": "actuator",
+        "multiInstance": False,
+        "description": (
+            "Unitree G1_23 dual-arm controller teleoperation. Base and hands are disabled; "
+            "only the root G1 Driver may own the arm_sdk publisher."
+        ),
+        "annotations": {"destructiveHint": mode == "live", "idempotentHint": False},
+        "inputSchema": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "action": {"type": "string", "enum": list(actions)},
+                **identity,
+            },
+            "required": ["action"],
+            "x-action-params": actions,
+        },
+        "x-teleop": copy.deepcopy(x_teleop),
+    }
+    state = {
+        "name": "teleop_state",
+        "type": "resource",
+        "multiInstance": False,
+        "readOnly": True,
+        "description": "Read-only G1 teleoperation state, latency, target and measured joints",
+        "annotations": {
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+        "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+        "x-teleop": copy.deepcopy(x_teleop),
+    }
+    return [session, state]
+
+
+def _require_mode(mode: str) -> None:
+    if mode not in MODES:
+        raise ValueError(f"mode must be one of {sorted(MODES)}")
+
+
+__all__ = [
+    "CAPABILITIES",
+    "HARDWARE_DISPATCH",
+    "LIVE_PROTOCOL",
+    "MODES",
+    "PREFLIGHT_SCHEMA",
+    "PROFILE_ID",
+    "RECORDING_DISPATCH",
+    "SHADOW_PROTOCOL",
+    "SIGNALING_AUDIENCE",
+    "capability_binding",
+    "capability_digest",
+    "canonical_json",
+    "dispatch_for_mode",
+    "protocol_for_mode",
+    "tool_definitions",
+]

--- a/unitree/g1/teleop/dispatch.py
+++ b/unitree/g1/teleop/dispatch.py
@@ -1,0 +1,1037 @@
+"""Final-dispatch arbitration shared by G1 shadow and live modes.
+
+The adapter in this package records what a live adapter *would* receive.  It
+never imports a robot SDK or publishes a hardware command.  The arbiter is the
+executable reference for the safety boundary that later live adapters must
+implement: a one-slot motion mailbox, a non-droppable stop path, generation
+fencing, final deadline checks, and acknowledged startup/shutdown safety.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import hmac
+import json
+import math
+import re
+import threading
+import time
+from collections import Counter, deque
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .protocol import MAX_SEQUENCE
+
+_TRACKING_KEYS = frozenset({"head", "left_controller", "right_controller"})
+_ACK_CODE_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+
+def _tracking_ready(value: Any) -> bool:
+    return (
+        isinstance(value, Mapping)
+        and set(value) == _TRACKING_KEYS
+        and all(item is True for item in value.values())
+    )
+
+
+def _normalized_ack(value: Any, invalid_code: str) -> AdapterAck:
+    if not isinstance(value, AdapterAck) or not isinstance(value.ok, bool):
+        return AdapterAck(False, invalid_code)
+    if not isinstance(value.code, str) or not _ACK_CODE_RE.fullmatch(value.code):
+        return AdapterAck(False, invalid_code)
+    return value
+
+
+@dataclass(frozen=True)
+class AdapterAck:
+    """Bounded adapter acknowledgement with a stable, non-secret code."""
+
+    ok: bool
+    code: str = "ok"
+
+
+@dataclass(frozen=True)
+class MotionIntent:
+    """Sanitized motion intent delivered to an output adapter.
+
+    ``frame`` deliberately omits the fence.  Session and dispatch generations
+    are internal monotonic fences and are safe to expose to a test adapter.
+    """
+
+    session_generation: int
+    dispatch_generation: int
+    sequence: int
+    clutch_sequence: int
+    admitted_monotonic: float
+    expires_monotonic: float
+    frame: Mapping[str, Any]
+    allow_reclutch: bool = False
+    received_monotonic: float | None = None
+
+
+@dataclass(frozen=True)
+class StopRequest:
+    dispatch_generation: int
+    reason: str
+    requested_monotonic: float
+    deadline_monotonic: float
+
+
+class OutputAdapter(Protocol):
+    """Serial adapter contract used by the final-dispatch owner thread.
+
+    Implementations must enforce their deadline in the same critical section as
+    the real SDK write. ``apply`` may not leave an unbounded background output;
+    any asynchronous downstream work must carry the supplied generation and a
+    hardware-enforced TTL. A successful ``safe_stop`` ack means all older
+    generations are cancelled, drained, or made incapable of later output.
+    Adapter methods must also impose their own downstream I/O timeout: Python
+    can detect a stalled call and revoke authority, but cannot interrupt a
+    blocking vendor SDK call safely. Adapter methods must not re-enter the
+    arbiter; a defensive self-close rejection exists only to avoid deadlock.
+    """
+
+    hardware_output: bool
+
+    def startup_safe(self, deadline_monotonic: float) -> AdapterAck: ...
+
+    def apply(self, intent: MotionIntent) -> AdapterAck: ...
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck: ...
+
+    def snapshot(self) -> dict: ...
+
+    def close(self) -> AdapterAck | None: ...
+
+
+class StopHandle:
+    """Waitable result for one non-droppable safety request."""
+
+    def __init__(self, request: StopRequest, *, safety_deadline: float):
+        self.request = request
+        self.safety_deadline = safety_deadline
+        self._event = threading.Event()
+        self._ack: AdapterAck | None = None
+
+    def _finish(self, ack: AdapterAck) -> None:
+        self._ack = ack
+        self._event.set()
+
+    def wait(self, timeout: float) -> AdapterAck:
+        if not self._event.wait(timeout):
+            return AdapterAck(False, "stop_ack_timeout")
+        return self._ack or AdapterAck(False, "stop_ack_missing")
+
+    @property
+    def done(self) -> bool:
+        return self._event.is_set()
+
+
+@dataclass(frozen=True)
+class _PendingMotion:
+    intent: MotionIntent
+    authority_digest: str
+
+
+def _binding_digest(value: Mapping[str, Any]) -> str:
+    required = ("boot_id", "session_id", "epoch", "fence")
+    if any(key not in value for key in required):
+        raise ValueError("authority binding is incomplete")
+    encoded = json.dumps(
+        {key: value[key] for key in required},
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class RecordingAdapter:
+    """Bounded, thread-safe zero-actuation adapter for visible verification."""
+
+    hardware_output = False
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        max_records: int = 64,
+    ):
+        if max_records < 8 or max_records > 4096:
+            raise ValueError("max_records must be in [8, 4096]")
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._records: deque[dict] = deque(maxlen=max_records)
+        self._current = {"kind": "safe", "reason": "not_started"}
+        self._closed = False
+
+    def _record(self, value: dict) -> None:
+        record = {"recorded_monotonic": self._clock(), **copy.deepcopy(value)}
+        self._records.append(record)
+        self._current = copy.deepcopy(value)
+
+    def startup_safe(self, deadline_monotonic: float) -> AdapterAck:
+        with self._lock:
+            if self._closed:
+                return AdapterAck(False, "adapter_closed")
+            self._record({
+                "kind": "would_stop",
+                "reason": "startup_safe",
+                "dispatch_generation": 0,
+                "deadline_monotonic": deadline_monotonic,
+            })
+            if self._clock() >= deadline_monotonic:
+                return AdapterAck(False, "startup_safe_deadline_missed")
+            return AdapterAck(True)
+
+    def apply(self, intent: MotionIntent) -> AdapterAck:
+        with self._lock:
+            if self._closed:
+                return AdapterAck(False, "adapter_closed")
+            if self._clock() >= intent.expires_monotonic:
+                return AdapterAck(False, "intent_expired_at_adapter")
+            # The adapter contract itself refuses unsafe content even if a
+            # caller accidentally bypasses the runtime admission layer.
+            if intent.frame.get("deadman") is not True:
+                return AdapterAck(False, "unsafe_deadman")
+            if not _tracking_ready(intent.frame.get("tracking")):
+                return AdapterAck(False, "unsafe_tracking")
+            self._record({
+                "kind": "would_apply",
+                "sequence": intent.sequence,
+                "clutch_sequence": intent.clutch_sequence,
+                "session_generation": intent.session_generation,
+                "dispatch_generation": intent.dispatch_generation,
+                "base_twist": copy.deepcopy(intent.frame.get("base_twist")),
+            })
+            return AdapterAck(True)
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck:
+        with self._lock:
+            if self._closed:
+                return AdapterAck(False, "adapter_closed")
+            self._record({
+                "kind": "would_stop",
+                "reason": request.reason,
+                "dispatch_generation": request.dispatch_generation,
+                "deadline_monotonic": request.deadline_monotonic,
+            })
+            if self._clock() >= request.deadline_monotonic:
+                return AdapterAck(False, "adapter_stop_deadline_missed")
+            return AdapterAck(True)
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            return {
+                "kind": "recording",
+                "closed": self._closed,
+                "current": copy.deepcopy(self._current),
+                "records": copy.deepcopy(list(self._records)),
+            }
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+
+
+class FinalDispatchArbiter:
+    """Own all adapter I/O and enforce the last command authority check."""
+
+    _MOTION_STATES = frozenset({"safe_waiting_frame", "motion_eligible"})
+
+    def __init__(
+        self,
+        adapter: OutputAdapter,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        safety_clock: Callable[[], float] = time.monotonic,
+        io_timeout_ms: int = 250,
+    ):
+        if io_timeout_ms < 20 or io_timeout_ms > 5000:
+            raise ValueError("io_timeout_ms must be in [20, 5000]")
+        self._adapter = adapter
+        self._hardware_output = getattr(adapter, "hardware_output", None)
+        self._clock = clock
+        self._safety_clock = safety_clock
+        self._io_timeout = io_timeout_ms / 1000.0
+        self._condition = threading.Condition(threading.RLock())
+        self._stop_queue: deque[StopHandle] = deque()
+        self._mailbox: _PendingMotion | None = None
+        self._generation = 0
+        self._authority_digest: str | None = None
+        self._session_generation: int | None = None
+        self._state = "starting"
+        self._fault_code: str | None = None
+        self._stop_acknowledged = False
+        self._last_admitted_sequence: int | None = None
+        self._last_applied_sequence: int | None = None
+        self._last_decision = "starting"
+        self._external_release_generation = 0
+        self._external_release_reason: str | None = None
+        self._counters: Counter[str] = Counter()
+        self._latency_samples: dict[str, deque[float]] = {
+            "receive_to_admit": deque(maxlen=256),
+            "mailbox_wait": deque(maxlen=256),
+        }
+        self._shutdown = False
+        self._closed = False
+        self._close_lock = threading.Lock()
+        self._adapter_snapshot_lock = threading.Lock()
+        self._close_result: AdapterAck | None = None
+        self._adapter_close_ack: AdapterAck | None = None
+        self._adapter_snapshot: dict = {
+            "kind": "unavailable",
+            "reason": "startup_in_progress",
+        }
+        self._io_inflight_kind: str | None = None
+        self._io_deadline_safety: float | None = None
+        self._startup_done = threading.Event()
+        self._startup_decision = threading.Event()
+        self._startup_owner_done = threading.Event()
+        # Fail-safe default: unless the constructor explicitly hands the
+        # adapter to the final-dispatch worker, the startup owner closes it
+        # after startup_safe eventually returns.
+        self._startup_should_close = True
+
+        started_at = self._clock()
+        started_safety = self._safety_clock()
+        startup_result: list[AdapterAck] = []
+
+        def run_startup_safe() -> None:
+            try:
+                startup_result.append(_normalized_ack(
+                    adapter.startup_safe(started_at + self._io_timeout),
+                    "invalid_startup_ack",
+                ))
+            except Exception:  # noqa: BLE001 -- normalize adapter faults
+                startup_result.append(AdapterAck(False, "startup_safe_exception"))
+            finally:
+                self._capture_adapter_snapshot_owned()
+                self._startup_done.set()
+            # The startup call may outlive the constructor timeout.  It keeps
+            # exclusive adapter ownership until the constructor chooses either
+            # a worker hand-off or cleanup; close/snapshot never race it.
+            self._startup_decision.wait()
+            try:
+                if self._startup_should_close:
+                    self._close_adapter_owned()
+            finally:
+                self._startup_owner_done.set()
+
+        self._startup_thread = threading.Thread(
+            target=run_startup_safe,
+            daemon=True,
+            name="g1-teleop-startup-safe",
+        )
+        self._startup_thread.start()
+        completed = self._startup_done.wait(self._io_timeout)
+        elapsed_safety = self._safety_clock() - started_safety
+        ack = (
+            startup_result[0]
+            if completed and startup_result
+            else AdapterAck(False, "startup_safe_timeout")
+        )
+        if ack.ok and elapsed_safety <= self._io_timeout:
+            self._state = "safe_unarmed"
+            self._stop_acknowledged = True
+            self._last_decision = "startup_safe_ack"
+            self._counters["startup_safe_acks"] += 1
+        else:
+            self._state = "fault_latched"
+            self._fault_code = "startup_safe_timeout" if ack.ok else ack.code
+            self._last_decision = "startup_safe_failed"
+            self._counters["adapter_faults"] += 1
+
+        self._worker: threading.Thread | None = None
+        if self._fault_code is None:
+            self._startup_should_close = False
+        self._startup_decision.set()
+        if self._fault_code is None:
+            # The startup owner performs no adapter calls after hand-off.  This
+            # short wait also prevents successful starts from leaving a
+            # transient daemon behind in short-lived tests.
+            self._startup_owner_done.wait(self._io_timeout)
+            self._worker = threading.Thread(
+                target=self._worker_loop,
+                daemon=True,
+                name="g1-teleop-final-dispatch",
+            )
+            self._worker.start()
+
+    @property
+    def hardware_output(self) -> bool | None:
+        """Return the adapter's immutable output declaration for runtime gating."""
+
+        return self._hardware_output
+
+    @property
+    def ready(self) -> bool:
+        with self._condition:
+            self._refresh_io_stall_locked()
+            self._poll_adapter_signals_locked()
+            return self._fault_code is None and not self._closed
+
+    def begin_prepare(self, reason: str = "prepare") -> StopHandle:
+        return self.trip(
+            reason,
+            target_state="transitioning",
+            retain_authority=False,
+        )
+
+    def complete_prepare(
+        self,
+        handle: StopHandle,
+        binding: Mapping[str, Any],
+        session_generation: int,
+    ) -> AdapterAck:
+        digest = _binding_digest(binding)
+        with self._condition:
+            if self._closed:
+                return AdapterAck(False, "dispatch_closed")
+            if self._fault_code is not None:
+                return AdapterAck(False, self._fault_code)
+            if (
+                handle.request.dispatch_generation != self._generation
+                or not handle.done
+                or self._state != "transitioning"
+            ):
+                return AdapterAck(False, "prepare_superseded")
+            ack = handle.wait(0)
+            if not ack.ok:
+                return ack
+            self._authority_digest = digest
+            self._session_generation = session_generation
+            self._state = "safe_waiting_frame"
+            self._stop_acknowledged = True
+            self._last_admitted_sequence = None
+            self._last_applied_sequence = None
+            self._external_release_reason = None
+            self._last_decision = "prepared_after_stop_ack"
+            self._counters["sessions_armed"] += 1
+            return AdapterAck(True)
+
+    def publish_latest(
+        self,
+        frame: Mapping[str, Any],
+        *,
+        session_generation: int,
+        expires_monotonic: float,
+        allow_reclutch: bool = False,
+        received_monotonic: float | None = None,
+    ) -> AdapterAck:
+        if frame.get("deadman") is not True:
+            return AdapterAck(False, "unsafe_deadman")
+        if not _tracking_ready(frame.get("tracking")):
+            return AdapterAck(False, "unsafe_tracking")
+        admitted = self._clock()
+        try:
+            digest = _binding_digest(frame)
+            sequence = frame["sequence"]
+            clutch_sequence = frame["clutch_sequence"]
+            if (
+                isinstance(sequence, bool)
+                or not isinstance(sequence, int)
+                or sequence < 0
+                or sequence > MAX_SEQUENCE
+            ):
+                raise ValueError("invalid sequence")
+            if (
+                isinstance(clutch_sequence, bool)
+                or not isinstance(clutch_sequence, int)
+                or clutch_sequence < 0
+                or clutch_sequence > MAX_SEQUENCE
+            ):
+                raise ValueError("invalid clutch sequence")
+            expiry = float(expires_monotonic)
+            if not math.isfinite(expiry):
+                raise ValueError("invalid expiry")
+            received = admitted if received_monotonic is None else float(received_monotonic)
+            if not math.isfinite(received) or received > admitted:
+                raise ValueError("invalid receive time")
+        except (KeyError, TypeError, ValueError, OverflowError):
+            return AdapterAck(False, "invalid_intent")
+
+        sanitized = copy.deepcopy(dict(frame))
+        sanitized.pop("fence", None)
+        with self._condition:
+            self._poll_adapter_signals_locked()
+            if self._closed:
+                return AdapterAck(False, "dispatch_closed")
+            if self._fault_code is not None:
+                return AdapterAck(False, self._fault_code)
+            if self._session_generation != session_generation:
+                return AdapterAck(False, "stale_session_generation")
+            if self._authority_digest is None or not hmac.compare_digest(
+                digest, self._authority_digest
+            ):
+                return AdapterAck(False, "authority_mismatch")
+            if self._state == "safe_reclutch_required" and allow_reclutch:
+                self._state = "motion_eligible"
+                self._external_release_reason = None
+                self._counters["dispatch_reclutches"] += 1
+            elif self._state not in self._MOTION_STATES:
+                return AdapterAck(False, "motion_inhibited")
+            if expiry <= admitted:
+                return AdapterAck(False, "intent_expired")
+            if (
+                self._last_admitted_sequence is not None
+                and sequence <= self._last_admitted_sequence
+            ):
+                return AdapterAck(False, "sequence_not_increasing")
+            if self._mailbox is not None:
+                self._counters["mailbox_replacements"] += 1
+            intent = MotionIntent(
+                session_generation=session_generation,
+                dispatch_generation=self._generation,
+                sequence=sequence,
+                clutch_sequence=clutch_sequence,
+                admitted_monotonic=admitted,
+                expires_monotonic=expiry,
+                frame=sanitized,
+                allow_reclutch=bool(allow_reclutch),
+                received_monotonic=received,
+            )
+            self._mailbox = _PendingMotion(intent, digest)
+            self._state = "motion_eligible"
+            self._last_admitted_sequence = sequence
+            self._last_decision = "admitted"
+            self._counters["motion_admitted"] += 1
+            self._observe_latency_locked("receive_to_admit", admitted - received)
+            self._condition.notify_all()
+            return AdapterAck(True)
+
+    def trip(
+        self,
+        reason: str,
+        *,
+        target_state: str,
+        retain_authority: bool,
+    ) -> StopHandle:
+        if not isinstance(reason, str) or not reason:
+            raise ValueError("stop reason is required")
+        with self._condition:
+            self._generation += 1
+            now = self._clock()
+            request = StopRequest(
+                dispatch_generation=self._generation,
+                reason=reason,
+                requested_monotonic=now,
+                deadline_monotonic=now + self._io_timeout,
+            )
+            handle = StopHandle(
+                request,
+                safety_deadline=self._safety_clock() + self._io_timeout,
+            )
+            if self._mailbox is not None:
+                self._mailbox = None
+                self._counters["mailbox_cleared_by_stop"] += 1
+            self._state = target_state
+            self._stop_acknowledged = False
+            self._last_decision = f"stop_requested:{reason}"
+            if not retain_authority:
+                self._authority_digest = None
+                self._session_generation = None
+            if self._closed or self._shutdown:
+                handle._finish(AdapterAck(False, "dispatch_closed"))
+            elif self._worker is None:
+                handle._finish(AdapterAck(False, "dispatch_unavailable"))
+            else:
+                self._stop_queue.append(handle)
+                self._counters["stop_requests"] += 1
+                self._condition.notify_all()
+            return handle
+
+    @staticmethod
+    def wait_safe(handle: StopHandle, timeout: float = 0.5) -> AdapterAck:
+        return handle.wait(timeout)
+
+    def wait_dispatched(self, sequence: int, timeout: float = 1.0) -> bool:
+        deadline = time.monotonic() + timeout
+        with self._condition:
+            while self._last_applied_sequence != sequence:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or self._fault_code is not None or self._closed:
+                    return False
+                self._condition.wait(remaining)
+            return True
+
+    def snapshot(self) -> dict:
+        with self._condition:
+            self._refresh_io_stall_locked()
+            self._poll_adapter_signals_locked()
+            sequence_evidence = (
+                {"last_published_sequence": self._last_applied_sequence}
+                if self._hardware_output is True
+                else {"last_would_apply_sequence": self._last_applied_sequence}
+            )
+            state = {
+                "kind": "hardware" if self._hardware_output is True else "recording",
+                "state": self._state,
+                "ready": self._fault_code is None and not self._closed,
+                "generation": self._generation,
+                "mailbox_depth": int(self._mailbox is not None),
+                "stop_queue_depth": len(self._stop_queue),
+                "last_admitted_sequence": self._last_admitted_sequence,
+                **sequence_evidence,
+                "last_decision": self._last_decision,
+                "stop_acknowledged": self._stop_acknowledged,
+                "fault_code": self._fault_code,
+                "io_inflight": self._io_inflight_kind,
+                "counters": dict(sorted(self._counters.items())),
+                "latency_ms": {
+                    name: self._latency_summary(samples)
+                    for name, samples in self._latency_samples.items()
+                },
+                "external_release_reason": self._external_release_reason,
+            }
+        with self._adapter_snapshot_lock:
+            cached_adapter = self._adapter_snapshot
+        # Cache entries are replaced, never mutated.  Copying outside both
+        # arbiter locks prevents high-rate status reads from starving the I/O
+        # owner while still returning an isolated public value.
+        adapter = copy.deepcopy(cached_adapter)
+        if self._fault_code is not None and isinstance(adapter, dict):
+            output = adapter.get("output")
+            if isinstance(output, dict):
+                output["state"] = "fault"
+                output["arm_sdk_weight"] = (
+                    0.0 if self._hardware_output is True else None
+                )
+                output["fault_reason"] = self._fault_code
+        elif self._external_release_reason is not None and isinstance(adapter, dict):
+            output = adapter.get("output")
+            if isinstance(output, dict):
+                output["state"] = (
+                    "stopped" if self._stop_acknowledged else "releasing"
+                )
+                if self._stop_acknowledged:
+                    output["arm_sdk_weight"] = 0.0
+                output["fault_reason"] = None
+        state["adapter"] = adapter
+        return state
+
+    def _poll_adapter_signals_locked(self) -> None:
+        """Import asynchronous hardware state without invoking adapter I/O.
+
+        These optional probes are read-only and thread-safe. Polling avoids a
+        callback from the high-rate publisher into the dispatch lock and the
+        corresponding lock-order cycle.
+        """
+
+        fault_probe = getattr(self._adapter, "external_fault_code", None)
+        try:
+            external_fault = fault_probe() if callable(fault_probe) else None
+        except Exception:  # noqa: BLE001 -- diagnostics fail closed
+            external_fault = "adapter_fault_probe_failed"
+        if external_fault is not None:
+            code = str(external_fault)[:96]
+            if not _ACK_CODE_RE.fullmatch(code):
+                code = "adapter_async_fault"
+            self._latch_fault_locked(code, decision=f"async_fault:{code}")
+            return
+
+        release_probe = getattr(self._adapter, "external_release_signal", None)
+        if not callable(release_probe):
+            return
+        try:
+            signal = release_probe()
+            generation = signal.get("generation")
+            reason = signal.get("reason")
+            acknowledged = signal.get("acknowledged")
+            if (
+                isinstance(generation, bool)
+                or not isinstance(generation, int)
+                or generation < 0
+                or generation > MAX_SEQUENCE
+                or (
+                    reason is not None
+                    and reason not in {"command_timeout", "intent_expired"}
+                )
+                or not isinstance(acknowledged, bool)
+            ):
+                raise ValueError("invalid external release signal")
+        except Exception:  # noqa: BLE001 -- malformed safety signal is terminal
+            self._latch_fault_locked(
+                "adapter_release_probe_failed",
+                decision="async_fault:adapter_release_probe_failed",
+            )
+            return
+        if generation == 0 or reason is None:
+            return
+        if generation < self._external_release_generation:
+            self._latch_fault_locked(
+                "adapter_release_generation_regressed",
+                decision="async_fault:adapter_release_generation_regressed",
+            )
+            return
+        if generation > self._external_release_generation:
+            self._external_release_generation = generation
+            self._external_release_reason = reason
+            self._counters["autonomous_releases"] += 1
+            if self._state in self._MOTION_STATES:
+                self._generation += 1
+                self._mailbox = None
+                self._state = "safe_reclutch_required"
+                self._stop_acknowledged = acknowledged
+                self._last_decision = (
+                    f"safe_stop_ack:{reason}"
+                    if acknowledged
+                    else f"stop_requested:{reason}"
+                )
+                self._condition.notify_all()
+            else:
+                # An explicit Pause/Release/prepare transition is stronger
+                # than a concurrently observed hardware TTL release. Keep its
+                # state and acknowledgement evidence intact.
+                self._counters["autonomous_releases_merged"] += 1
+        elif (
+            acknowledged
+            and not self._stop_acknowledged
+            and self._state == "safe_reclutch_required"
+        ):
+            self._stop_acknowledged = True
+            self._state = "safe_reclutch_required"
+            self._last_decision = f"safe_stop_ack:{reason}"
+            self._counters["autonomous_release_acks"] += 1
+            self._condition.notify_all()
+
+    def _latch_fault_locked(self, code: str, *, decision: str) -> None:
+        if self._fault_code is not None:
+            return
+        self._generation += 1
+        self._fault_code = code
+        self._state = "fault_latched"
+        self._authority_digest = None
+        self._session_generation = None
+        self._mailbox = None
+        while self._stop_queue:
+            self._stop_queue.popleft()._finish(AdapterAck(False, code))
+        self._stop_acknowledged = False
+        self._io_inflight_kind = None
+        self._io_deadline_safety = None
+        self._last_decision = decision[:96]
+        self._counters["adapter_faults"] += 1
+        self._counters["adapter_async_faults"] += 1
+        self._condition.notify_all()
+
+    def _refresh_io_stall_locked(self) -> None:
+        if (
+            self._io_inflight_kind is None
+            or self._io_deadline_safety is None
+            or self._fault_code is not None
+            or self._safety_clock() < self._io_deadline_safety
+        ):
+            return
+        self._fault_code = "adapter_io_stalled"
+        self._state = "fault_latched"
+        self._authority_digest = None
+        self._session_generation = None
+        self._mailbox = None
+        self._stop_acknowledged = False
+        self._last_decision = f"io_stalled:{self._io_inflight_kind}"
+        self._counters["adapter_faults"] += 1
+        self._counters["adapter_io_stalls"] += 1
+        # The owner may currently be blocked, but the stop remains queued and
+        # will be its first operation if the vendor call ever returns.
+        self.trip(
+            "adapter_io_stalled",
+            target_state="fault_latched",
+            retain_authority=False,
+        )
+
+    def _observe_latency_locked(self, name: str, seconds: float) -> None:
+        milliseconds = max(0.0, min(60_000.0, float(seconds) * 1000.0))
+        self._latency_samples[name].append(milliseconds)
+
+    @staticmethod
+    def _latency_summary(samples: deque[float]) -> dict:
+        if not samples:
+            return {"last": None, "p50": None, "p95": None, "p99": None, "count": 0}
+        ordered = sorted(samples)
+
+        def percentile(value: float) -> float:
+            index = min(len(ordered) - 1, max(0, math.ceil(value * len(ordered)) - 1))
+            return round(ordered[index], 3)
+
+        return {
+            "last": round(samples[-1], 3),
+            "p50": percentile(0.50),
+            "p95": percentile(0.95),
+            "p99": percentile(0.99),
+            "count": len(samples),
+        }
+
+    def close(self, timeout: float = 0.5) -> AdapterAck:
+        if self._worker is threading.current_thread():
+            return AdapterAck(False, "owner_cannot_self_close")
+        with self._close_lock:
+            unavailable_result: AdapterAck | None = None
+            with self._condition:
+                if self._close_result is not None:
+                    return self._close_result
+                worker = self._worker
+                if worker is None:
+                    code = self._fault_code or "dispatch_unavailable"
+                    self._closed = True
+                    self._shutdown = True
+                    self._state = "fault_latched"
+                    self._stop_acknowledged = False
+                    self._close_result = AdapterAck(False, code)
+                    unavailable_result = self._close_result
+            if unavailable_result is not None:
+                # A timed-out startup call still owns the adapter.  It will
+                # close it serially if it ever returns; wait only within the
+                # caller's shutdown budget.
+                if self._startup_thread is not threading.current_thread():
+                    self._startup_owner_done.wait(timeout)
+                return unavailable_result
+
+            handle = self.trip(
+                "service_close",
+                target_state="closing",
+                retain_authority=False,
+            )
+            stop_ack = self.wait_safe(handle, timeout)
+            with self._condition:
+                self._closed = True
+                self._shutdown = True
+                self._mailbox = None
+                self._state = "closing" if stop_ack.ok else "fault_latched"
+                if not stop_ack.ok:
+                    self._fault_code = self._fault_code or stop_ack.code
+                self._condition.notify_all()
+            worker.join(timeout=max(timeout, self._io_timeout * 2))
+            with self._condition:
+                if worker.is_alive():
+                    result = AdapterAck(False, stop_ack.code if not stop_ack.ok else "owner_close_timeout")
+                elif not stop_ack.ok:
+                    result = stop_ack
+                elif self._adapter_close_ack is None:
+                    result = AdapterAck(False, "adapter_close_ack_missing")
+                else:
+                    result = self._adapter_close_ack
+                self._close_result = result
+                self._state = "closed" if result.ok else "fault_latched"
+                if not result.ok:
+                    self._fault_code = self._fault_code or result.code
+                    self._stop_acknowledged = False
+                return result
+
+    def _worker_loop(self) -> None:
+        try:
+            while True:
+                with self._condition:
+                    while not self._stop_queue and self._mailbox is None and not self._shutdown:
+                        self._condition.wait()
+                    if self._shutdown and not self._stop_queue:
+                        break
+                    if self._stop_queue:
+                        item: StopHandle | _PendingMotion = self._stop_queue.popleft()
+                        is_stop = True
+                    else:
+                        assert self._mailbox is not None
+                        item = self._mailbox
+                        self._mailbox = None
+                        is_stop = False
+                if is_stop:
+                    assert isinstance(item, StopHandle)
+                    self._perform_stop(item)
+                else:
+                    assert isinstance(item, _PendingMotion)
+                    self._perform_motion(item)
+        finally:
+            self._close_adapter_owned()
+
+    def _close_adapter_owned(self) -> None:
+        """Close the adapter from its sole current owner thread."""
+
+        try:
+            raw_ack = self._adapter.close()
+            close_ack = _normalized_ack(
+                AdapterAck(True) if raw_ack is None else raw_ack,
+                "invalid_close_ack",
+            )
+        except Exception:  # noqa: BLE001 -- normalize adapter close faults
+            close_ack = AdapterAck(False, "adapter_close_exception")
+        self._capture_adapter_snapshot_owned()
+        with self._condition:
+            self._adapter_close_ack = close_ack
+            self._condition.notify_all()
+
+    def _capture_adapter_snapshot_owned(self) -> None:
+        """Refresh public adapter evidence without crossing the owner boundary."""
+
+        try:
+            snapshot = self._adapter.snapshot()
+            if not isinstance(snapshot, dict):
+                snapshot = {
+                    "kind": "unavailable",
+                    "reason": "invalid_adapter_snapshot",
+                }
+            else:
+                snapshot = copy.deepcopy(snapshot)
+        except Exception:  # noqa: BLE001 -- status must survive adapter diagnostics
+            snapshot = {
+                "kind": "unavailable",
+                "reason": "adapter_snapshot_exception",
+            }
+        with self._adapter_snapshot_lock:
+            self._adapter_snapshot = snapshot
+
+    def _perform_stop(self, handle: StopHandle) -> None:
+        request = handle.request
+        started_safety = self._safety_clock()
+        with self._condition:
+            self._io_inflight_kind = "safe_stop"
+            self._io_deadline_safety = handle.safety_deadline
+        try:
+            ack = _normalized_ack(
+                self._adapter.safe_stop(request),
+                "invalid_stop_ack",
+            )
+            self._capture_adapter_snapshot_owned()
+        except Exception:  # noqa: BLE001 -- normalize adapter faults
+            ack = AdapterAck(False, "adapter_stop_exception")
+        finished_safety = self._safety_clock()
+        elapsed_safety = finished_safety - started_safety
+        if ack.ok:
+            if finished_safety >= handle.safety_deadline:
+                ack = AdapterAck(False, "adapter_stop_deadline_missed")
+            elif elapsed_safety > self._io_timeout:
+                ack = AdapterAck(False, "adapter_stop_timeout")
+        with self._condition:
+            self._io_inflight_kind = None
+            self._io_deadline_safety = None
+            handle._finish(ack)
+            if ack.ok:
+                self._counters["stop_acks"] += 1
+                if (
+                    request.dispatch_generation == self._generation
+                    and self._state != "fault_latched"
+                ):
+                    self._stop_acknowledged = True
+                    self._last_decision = (
+                        f"safe_stop_ack:{request.reason}"
+                        if self._hardware_output is True
+                        else f"would_stop:{request.reason}"
+                    )
+            else:
+                self._fault_code = self._fault_code or ack.code
+                self._state = "fault_latched"
+                self._authority_digest = None
+                self._session_generation = None
+                self._mailbox = None
+                self._stop_acknowledged = False
+                self._last_decision = f"stop_failed:{ack.code}"
+                self._counters["adapter_faults"] += 1
+            self._condition.notify_all()
+
+    def _perform_motion(self, pending: _PendingMotion) -> None:
+        intent = pending.intent
+        with self._condition:
+            self._poll_adapter_signals_locked()
+            now = self._clock()
+            valid = (
+                self._fault_code is None
+                and not self._closed
+                and self._state == "motion_eligible"
+                and intent.dispatch_generation == self._generation
+                and intent.session_generation == self._session_generation
+                and self._authority_digest is not None
+                and hmac.compare_digest(pending.authority_digest, self._authority_digest)
+            )
+            if not valid:
+                if (
+                    self._fault_code is None
+                    and self._state in self._MOTION_STATES
+                ):
+                    self._last_decision = "motion_dropped_stale"
+                self._counters["motion_dropped_stale"] += 1
+                self._condition.notify_all()
+                return
+            if now >= intent.expires_monotonic:
+                self._last_decision = "motion_dropped_expired"
+                self._counters["motion_dropped_expired"] += 1
+                self.trip(
+                    "pose_timeout",
+                    target_state="safe_reclutch_required",
+                    retain_authority=True,
+                )
+                self._condition.notify_all()
+                return
+            # This is the linearization point.  A concurrent trip after this
+            # commit is queued behind the bounded apply and cannot acknowledge
+            # until its safe-stop has executed.
+            self._last_decision = "motion_committed"
+            self._observe_latency_locked("mailbox_wait", now - intent.admitted_monotonic)
+            remaining = max(0.0, intent.expires_monotonic - now)
+            started_safety = self._safety_clock()
+            self._io_inflight_kind = "apply"
+            self._io_deadline_safety = started_safety + min(self._io_timeout, remaining)
+
+        try:
+            ack = _normalized_ack(
+                self._adapter.apply(intent),
+                "invalid_apply_ack",
+            )
+            self._capture_adapter_snapshot_owned()
+        except Exception:  # noqa: BLE001 -- normalize adapter faults
+            ack = AdapterAck(False, "adapter_apply_exception")
+        finished = self._clock()
+        finished_safety = self._safety_clock()
+        elapsed_safety = finished_safety - started_safety
+        if ack.ok:
+            if finished >= intent.expires_monotonic:
+                ack = AdapterAck(False, "adapter_apply_deadline_missed")
+            elif elapsed_safety > self._io_timeout:
+                ack = AdapterAck(False, "adapter_apply_timeout")
+        with self._condition:
+            self._io_inflight_kind = None
+            self._io_deadline_safety = None
+            if (
+                ack.ok
+                and self._fault_code is None
+                and not self._closed
+                and intent.dispatch_generation == self._generation
+            ):
+                self._last_applied_sequence = intent.sequence
+                self._last_decision = (
+                    "published" if self._hardware_output is True else "would_apply"
+                )
+                self._counters["motion_applied"] += 1
+            elif ack.ok:
+                self._counters["late_adapter_returns"] += 1
+            elif ack.code in {"arm_sdk_reclutch_required", "arm_sdk_releasing"}:
+                # A hardware TTL can expire between admission and apply. Import
+                # that fail-safe release as a recoverable HOLD, not a terminal
+                # adapter failure.
+                self._poll_adapter_signals_locked()
+                if self._state != "safe_reclutch_required":
+                    self._latch_fault_locked(
+                        "arm_sdk_release_unconfirmed",
+                        decision="async_fault:arm_sdk_release_unconfirmed",
+                    )
+            else:
+                already_faulted = self._fault_code is not None
+                self._fault_code = self._fault_code or ack.code
+                self._state = "fault_latched"
+                self._authority_digest = None
+                self._session_generation = None
+                self._mailbox = None
+                self._stop_acknowledged = False
+                self._last_decision = f"apply_failed:{self._fault_code}"
+                if not already_faulted:
+                    self._counters["adapter_faults"] += 1
+                # A failed motion write still schedules the independent safety
+                # path.  Its acknowledgement cannot clear the fault latch.
+                if not already_faulted:
+                    self.trip(
+                        "adapter_fault",
+                        target_state="fault_latched",
+                        retain_authority=False,
+                    )
+                    self._last_decision = f"apply_failed:{self._fault_code}"[:96]
+            self._condition.notify_all()

--- a/unitree/g1/teleop/factory.py
+++ b/unitree/g1/teleop/factory.py
@@ -1,0 +1,336 @@
+"""Production composition root for teleoperation inside the root G1 Driver."""
+
+from __future__ import annotations
+
+import math
+import os
+import time
+from pathlib import Path
+
+import numpy as np
+
+from .adapter import G1ControllerPoseMapper, G1DualArmAdapter
+from .descriptor import PREFLIGHT_SCHEMA, PROFILE_ID
+from .hardware import REQUIRED_MODE_MACHINE, G1ArmSdkPort, G1LowStateReader
+from .ik import G123PinocchioIk
+from .runtime import G1TeleopRuntime
+from .service import G1TeleopService
+
+_PREFLIGHT_STAGE_CODES = {
+    "low_state_init": "low_state_reader_unavailable",
+    "ik_init": "ik_dependencies_unavailable",
+    "low_state_probe": "low_state_preflight_failed",
+    "ik_warmup": "ik_warmup_failed",
+    "live_publisher_init": "arm_sdk_publisher_unavailable",
+    "runtime_startup": "final_dispatch_startup_failed",
+    "service_startup": "rtc_or_descriptor_startup_failed",
+}
+_PREFLIGHT_PUBLIC_MESSAGES = {
+    "low_state_reader_unavailable": "G1 LowState reader is unavailable",
+    "ik_dependencies_unavailable": "G1 teleoperation IK dependencies are unavailable",
+    "low_state_preflight_failed": "G1 LowState startup safety probe failed",
+    "ik_warmup_failed": "G1 teleoperation IK warm-up failed",
+    "arm_sdk_publisher_unavailable": "G1 arm publisher startup failed",
+    "final_dispatch_startup_failed": "G1 final dispatch did not start safe",
+    "rtc_or_descriptor_startup_failed": "G1 teleoperation service startup failed",
+    "startup_preflight_failed": "G1 teleoperation startup preflight failed",
+    "teleop_configuration_invalid": "G1 teleoperation configuration is invalid",
+}
+
+
+class G1TeleopPreflightError(RuntimeError):
+    """Startup failure with a bounded, operator-safe status projection."""
+
+    def __init__(
+        self,
+        *,
+        stage: str,
+        mode: str,
+        message: str,
+        publisher_created: bool = False,
+    ):
+        del message
+        code = _PREFLIGHT_STAGE_CODES.get(stage, "startup_preflight_failed")
+        public_message = _PREFLIGHT_PUBLIC_MESSAGES[code]
+        super().__init__(public_message)
+        self.preflight_status = {
+            "schema": PREFLIGHT_SCHEMA,
+            "ready": False,
+            "stage": stage,
+            "code": code,
+            "message": public_message,
+            "mode": mode,
+            "profile_id": PROFILE_ID,
+            "hardware_output": mode == "live",
+            "publisher_created": bool(publisher_created),
+        }
+
+
+def project_preflight_error(exc: BaseException, *, mode: str = "unknown") -> dict:
+    """Return JSON-safe startup evidence without exposing configuration secrets."""
+
+    projected = getattr(exc, "preflight_status", None)
+    if isinstance(projected, dict):
+        result = dict(projected)
+        result["message"] = _PREFLIGHT_PUBLIC_MESSAGES.get(
+            result.get("code"),
+            _PREFLIGHT_PUBLIC_MESSAGES["startup_preflight_failed"],
+        )
+        return result
+    return {
+        "schema": PREFLIGHT_SCHEMA,
+        "ready": False,
+        "stage": "configuration",
+        "code": "teleop_configuration_invalid",
+        "message": _PREFLIGHT_PUBLIC_MESSAGES["teleop_configuration_invalid"],
+        "mode": mode if mode in ("shadow", "live") else "unknown",
+        "profile_id": PROFILE_ID,
+        "hardware_output": mode == "live",
+        "publisher_created": False,
+    }
+
+
+def build_g1_teleop_service(config: dict) -> G1TeleopService | None:
+    """Build one embedded service after the root process initializes DDS.
+
+    Live output requires both ``mode: live`` and ``live.enabled: true``.  There
+    is no fallback from a requested live profile to Shadow.
+    """
+
+    teleop = config.get("teleop")
+    if teleop is None:
+        return None
+    if not isinstance(teleop, dict):
+        raise ValueError("teleop config must be an object")
+    if teleop.get("enabled") is not True:
+        return None
+    plugins = config.get("plugins", {})
+    if not isinstance(plugins, dict):
+        raise ValueError("plugins config must be an object")
+    if plugins.get("arm", {}).get("enabled") is True:
+        raise ValueError(
+            "teleop.enabled=true conflicts with plugins.arm.enabled=true; "
+            "the V1 arm authority must be exclusive"
+        )
+    mode = teleop.get("mode", "shadow")
+    if mode not in ("shadow", "live"):
+        raise ValueError("teleop.mode must be 'shadow' or 'live'")
+    if teleop.get("profile_id", PROFILE_ID) != PROFILE_ID:
+        raise ValueError(f"only teleop.profile_id={PROFILE_ID!r} is supported")
+    if int(teleop.get("mode_machine", REQUIRED_MODE_MACHINE)) != REQUIRED_MODE_MACHINE:
+        raise ValueError("G1_23 teleoperation requires mode_machine=4")
+    if bool(teleop.get("base_enabled", False)) or bool(teleop.get("hands_enabled", False)):
+        raise ValueError("G1_23 V1 is arm-only; base and hands must remain disabled")
+    lease_timeout_ms = int(teleop.get("lease_timeout_ms", 1000))
+    if not 750 <= lease_timeout_ms <= 10_000:
+        raise ValueError("teleop.lease_timeout_ms must be in Core's [750, 10000] range")
+    live = teleop.get("live", {})
+    if not isinstance(live, dict):
+        raise ValueError("teleop.live config must be an object")
+    if mode == "live" and live.get("enabled") is not True:
+        raise ValueError("teleop live output requires explicit teleop.live.enabled=true")
+    velocity_limit = float(live.get("velocity_limit_rad_s", 0.5))
+    if mode == "live" and not math.isclose(
+        velocity_limit,
+        0.5,
+        rel_tol=0.0,
+        abs_tol=1e-12,
+    ):
+        raise ValueError(
+            "unitree_g1_23_dual_arm_controller_v1 fixes "
+            "velocity_limit_rad_s=0.5"
+        )
+
+    driver_token = os.environ.get("MOTUS_DRIVER_TOKEN")
+    ticket_secret = os.environ.get("MOTUS_TELEOP_TICKET_SECRET")
+    if not driver_token:
+        raise ValueError("MOTUS_DRIVER_TOKEN is required when G1 teleoperation is enabled")
+    if ticket_secret is None:
+        raise ValueError(
+            "MOTUS_TELEOP_TICKET_SECRET is required when G1 teleoperation is enabled"
+        )
+
+    resource_root = Path(__file__).resolve().parents[1] / "resource"
+    urdf_path = Path(str(teleop.get("urdf_path", resource_root / "g1_body23.urdf")))
+    low_state = None
+    arm_sdk = None
+    runtime = None
+    stage = "low_state_init"
+    try:
+        low_state = G1LowStateReader(
+            ready_timeout_s=float(teleop.get("lowstate_ready_timeout_seconds", 2.0))
+        )
+        stage = "ik_init"
+        ik_solver = G123PinocchioIk(urdf_path)
+        stage = "low_state_probe"
+        initial_state = low_state.read_arm_state()
+        initial_q = np.asarray(initial_state.get("joint_positions"), dtype=float)
+        initial_dq = np.asarray(initial_state.get("joint_velocities"), dtype=float)
+        all_joint_q = np.asarray(
+            initial_state.get("all_joint_positions"),
+            dtype=float,
+        )
+        sampled = float(initial_state.get("sample_monotonic"))
+        mode_machine = initial_state.get("mode_machine")
+        age = time.monotonic() - sampled
+        if (
+            initial_q.shape != (10,)
+            or initial_dq.shape != (10,)
+            or all_joint_q.shape != (35,)
+            or not np.all(np.isfinite(initial_q))
+            or not np.all(np.isfinite(initial_dq))
+            or not np.all(np.isfinite(all_joint_q))
+            or not math.isfinite(sampled)
+            or age < 0.0
+            or age > 0.1
+            or mode_machine != REQUIRED_MODE_MACHINE
+        ):
+            raise RuntimeError("fresh G1 LowState mode_machine=4 is required")
+        stage = "ik_warmup"
+        warm_up = getattr(ik_solver, "warm_up", None)
+        if not callable(warm_up):
+            raise RuntimeError("G1_23 IK does not expose the required warm-up probe")
+        warmup_result = warm_up(
+            initial_q,
+            initial_dq,
+        )
+        warmup_ms = (
+            warmup_result.get("warmup_ms")
+            if isinstance(warmup_result, dict)
+            else None
+        )
+        if (
+            not isinstance(warmup_result, dict)
+            or warmup_result.get("ready") is not True
+            or isinstance(warmup_ms, bool)
+            or not isinstance(warmup_ms, (int, float))
+            or not math.isfinite(float(warmup_ms))
+            or float(warmup_ms) < 0.0
+            or float(warmup_ms) > 600_000.0
+            or ik_solver.ready() is not True
+        ):
+            raise RuntimeError("G1_23 IK warm-up did not establish readiness")
+        if mode == "live":
+            stage = "live_publisher_init"
+            arm_sdk = G1ArmSdkPort(
+                low_state,
+                control_hz=float(live.get("control_hz", 250.0)),
+                ramp_seconds=float(live.get("ramp_seconds", 2.0)),
+                release_seconds=float(live.get("release_seconds", 0.05)),
+                velocity_limit_rad_s=velocity_limit,
+                command_timeout_s=float(
+                    live.get(
+                        "command_timeout_seconds",
+                        int(teleop.get("pose_timeout_ms", 200)) / 1000.0,
+                    )
+                ),
+            )
+        adapter = G1DualArmAdapter(
+            mode=mode,
+            pose_mapper=G1ControllerPoseMapper(),
+            ik_solver=ik_solver,
+            low_state_reader=low_state,
+            arm_sdk=arm_sdk,
+        )
+        driver_id = str(
+            os.environ.get("MOTUS_DRIVER_ID", teleop.get("driver_id", "unitree-g1"))
+        )
+        driver_name = str(teleop.get("driver_name", "Unitree G1 Bundle"))
+        robot_id = str(
+            os.environ.get("MOTUS_ROBOT_ID", teleop.get("robot_id", driver_id))
+        )
+        stage = "runtime_startup"
+        runtime = G1TeleopRuntime(
+            mode=mode,
+            adapter=adapter,
+            driver_id=driver_id,
+            driver_name=driver_name,
+            robot_id=robot_id,
+            lease_timeout_ms=lease_timeout_ms,
+            pose_timeout_ms=int(teleop.get("pose_timeout_ms", 200)),
+            watchdog_interval_ms=int(teleop.get("watchdog_interval_ms", 25)),
+            dispatch_io_timeout_ms=int(teleop.get("dispatch_io_timeout_ms", 150)),
+            dispatch_ack_timeout_ms=int(teleop.get("dispatch_ack_timeout_ms", 200)),
+        )
+        startup = runtime.status()
+        if (
+            startup.get("state") != "idle"
+            or startup.get("dispatch", {}).get("ready") is not True
+            or startup.get("dispatch", {}).get("stop_acknowledged") is not True
+        ):
+            raise RuntimeError("G1 teleoperation final dispatch did not start safe")
+        startup_preflight = {
+            "schema": PREFLIGHT_SCHEMA,
+            "ready": False,
+            "stage": "service_startup",
+            "code": None,
+            "message": None,
+            "mode": mode,
+            "profile_id": PROFILE_ID,
+            "hardware_output": mode == "live",
+            "publisher_created": arm_sdk is not None,
+            "low_state": {
+                "ready": True,
+                "mode_machine": int(mode_machine),
+                "required_mode_machine": REQUIRED_MODE_MACHINE,
+                "sample_age_ms": round(age * 1000.0, 3),
+                "arm_joint_count": int(initial_q.size),
+                "motor_joint_count": int(all_joint_q.size),
+            },
+            "ik": {
+                "ready": True,
+                "warmup_ms": round(float(warmup_ms), 3),
+                "model": "g1_body23.urdf",
+                "solver": "pinocchio-casadi-ipopt",
+            },
+            "identity": {
+                "driver_id": driver_id,
+                "robot_id": robot_id,
+                "capability_digest": runtime.capability_digest,
+            },
+            "dispatch": {
+                "ready": True,
+                "kind": startup["dispatch"]["kind"],
+                "state": startup["dispatch"]["state"],
+                "stop_acknowledged": True,
+                "fault_code": None,
+            },
+        }
+        stage = "service_startup"
+        return G1TeleopService(
+            runtime,
+            driver_token=driver_token,
+            ticket_secret=ticket_secret,
+            startup_preflight=startup_preflight,
+            live_low_state_probe=(
+                low_state.read_arm_state if mode == "live" else None
+            ),
+            offer_timeout_s=float(teleop.get("offer_timeout_seconds", 5.0)),
+            ticket_ttl_max_seconds=int(teleop.get("ticket_ttl_max_seconds", 30)),
+            ticket_replay_cache_entries=int(
+                teleop.get("ticket_replay_cache_entries", 4096)
+            ),
+        )
+    except Exception as exc:
+        if runtime is not None:
+            runtime.close()
+        else:
+            if arm_sdk is not None:
+                arm_sdk.close()
+            if low_state is not None:
+                low_state.close()
+        if isinstance(exc, G1TeleopPreflightError):
+            raise
+        raise G1TeleopPreflightError(
+            stage=stage,
+            mode=mode,
+            message=str(exc),
+            publisher_created=arm_sdk is not None,
+        ) from exc
+
+
+__all__ = [
+    "G1TeleopPreflightError",
+    "build_g1_teleop_service",
+    "project_preflight_error",
+]

--- a/unitree/g1/teleop/hardware.py
+++ b/unitree/g1/teleop/hardware.py
@@ -1,0 +1,651 @@
+"""Production G1_23 LowState reader and sole ``rt/arm_sdk`` publisher.
+
+The lifecycle is a focused Apache-2.0 port of the tested G1_23 safety changes
+in Unitree ``xr_teleoperate``.  Construction never publishes.  One owner
+thread performs every DDS write and a stop ACK is returned only after five
+real, successful zero-weight frames.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from collections.abc import Callable, Mapping, Sequence
+
+import numpy as np
+
+from .control_safety import ArmSdkGate, ArmSdkState
+from .dispatch import AdapterAck
+
+ARM_INDICES = (15, 16, 17, 18, 19, 22, 23, 24, 25, 26)
+WRIST_INDICES = frozenset({19, 26})
+WEAK_INDICES = frozenset({4, 10, 15, 16, 17, 18, 22, 23, 24, 25})
+WEIGHT_INDEX = 29
+MOTOR_COUNT = 35
+ARM_SDK_TOPIC = "rt/arm_sdk"
+LOWSTATE_TOPIC = "rt/lowstate"
+REQUIRED_MODE_MACHINE = 4
+
+_publisher_guard = threading.Lock()
+_active_publishers = 0
+
+
+class G1LowStateReader:
+    """One callback-backed ``rt/lowstate`` reader shared by IK and publishing."""
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        ready_timeout_s: float = 2.0,
+        subscriber=None,
+    ):
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._ready = threading.Event()
+        self._closed = False
+        self._sample: dict | None = None
+        self._invalid_samples = 0
+        if subscriber is None:
+            try:
+                from unitree_sdk2py.core.channel import ChannelSubscriber
+                from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowState_
+            except (ImportError, OSError) as exc:
+                raise RuntimeError("Unitree LowState DDS dependencies are unavailable") from exc
+            subscriber = ChannelSubscriber(LOWSTATE_TOPIC, LowState_)
+        self._subscriber = subscriber
+        try:
+            self._subscriber.Init(self._on_sample, queueLen=1)
+        except TypeError:
+            # Minimal injected fakes may not expose the optional queue length.
+            self._subscriber.Init(self._on_sample)
+        if not self._ready.wait(float(ready_timeout_s)):
+            self.close()
+            raise RuntimeError(
+                f"no valid {LOWSTATE_TOPIC} sample within {float(ready_timeout_s):.3f}s"
+            )
+
+    def _on_sample(self, message) -> None:
+        try:
+            motors = message.motor_state
+            if len(motors) < MOTOR_COUNT:
+                raise ValueError("LowState motor vector is too short")
+            q = np.asarray([motors[index].q for index in range(MOTOR_COUNT)], dtype=float)
+            dq = np.asarray([motors[index].dq for index in range(MOTOR_COUNT)], dtype=float)
+            mode_machine = message.mode_machine
+            if (
+                q.shape != (MOTOR_COUNT,)
+                or dq.shape != (MOTOR_COUNT,)
+                or not np.all(np.isfinite(q))
+                or not np.all(np.isfinite(dq))
+                or isinstance(mode_machine, bool)
+                or not isinstance(mode_machine, int)
+            ):
+                raise ValueError("LowState sample is invalid")
+            sample = {
+                "joint_positions": q[list(ARM_INDICES)].copy(),
+                "joint_velocities": dq[list(ARM_INDICES)].copy(),
+                "all_joint_positions": q,
+                "mode_machine": int(mode_machine),
+                "sample_monotonic": self._clock(),
+            }
+        except (AttributeError, IndexError, TypeError, ValueError):
+            with self._lock:
+                self._invalid_samples += 1
+            return
+        with self._lock:
+            if self._closed:
+                return
+            self._sample = sample
+            self._ready.set()
+
+    def read_arm_state(self) -> Mapping[str, object]:
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("LowState reader is closed")
+            if self._sample is None:
+                raise RuntimeError("LowState has not been received")
+            return {
+                key: value.copy() if isinstance(value, np.ndarray) else value
+                for key, value in self._sample.items()
+            }
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            sampled = None if self._sample is None else self._sample["sample_monotonic"]
+            return {
+                "topic": LOWSTATE_TOPIC,
+                "ready": self._sample is not None and not self._closed,
+                "sample_age_ms": (
+                    None
+                    if sampled is None
+                    else round(min(60_000.0, max(0.0, self._clock() - sampled) * 1000.0), 3)
+                ),
+                "invalid_samples": self._invalid_samples,
+            }
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+        close = getattr(self._subscriber, "Close", None)
+        if callable(close):
+            close()
+
+
+class G1ArmSdkPort:
+    """Exactly-one, 250 Hz G1_23 arm SDK publication boundary."""
+
+    FINAL_ZERO_WEIGHT_FRAMES = 5
+    publisher_count = 1
+
+    def __init__(
+        self,
+        low_state_reader,
+        *,
+        control_hz: float = 250.0,
+        ramp_seconds: float = 2.0,
+        release_seconds: float = 0.05,
+        velocity_limit_rad_s: float = 0.5,
+        command_timeout_s: float = 0.2,
+        clock: Callable[[], float] = time.monotonic,
+        publisher=None,
+        message_factory=None,
+        crc=None,
+    ):
+        global _active_publishers
+        values = {
+            "control_hz": control_hz,
+            "ramp_seconds": ramp_seconds,
+            "release_seconds": release_seconds,
+            "velocity_limit_rad_s": velocity_limit_rad_s,
+            "command_timeout_s": command_timeout_s,
+        }
+        for name, value in values.items():
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be a finite number")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+        if not 50.0 <= float(control_hz) <= 500.0:
+            raise ValueError("control_hz must be in [50, 500]")
+        if float(ramp_seconds) < 0.0 or not 0.0 <= float(release_seconds) <= 0.1:
+            raise ValueError("ramp/release seconds are outside the bounded profile")
+        if float(velocity_limit_rad_s) <= 0.0 or not 0.05 <= float(command_timeout_s) <= 0.5:
+            raise ValueError("velocity limit/command timeout is outside the bounded profile")
+
+        with _publisher_guard:
+            if _active_publishers != 0:
+                raise RuntimeError("a G1 rt/arm_sdk publisher already exists in this process")
+            _active_publishers = 1
+        self._guard_owned = True
+        try:
+            if publisher is None or message_factory is None or crc is None:
+                try:
+                    from unitree_sdk2py.core.channel import ChannelPublisher
+                    from unitree_sdk2py.idl.default import unitree_hg_msg_dds__LowCmd_
+                    from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowCmd_
+                    from unitree_sdk2py.utils.crc import CRC
+                except (ImportError, OSError) as exc:
+                    raise RuntimeError("Unitree arm_sdk DDS dependencies are unavailable") from exc
+                publisher = publisher or ChannelPublisher(ARM_SDK_TOPIC, LowCmd_)
+                message_factory = message_factory or unitree_hg_msg_dds__LowCmd_
+                crc = crc or CRC()
+            self._publisher = publisher
+            self._publisher.Init()
+            self._message_factory = message_factory
+            self._crc = crc
+        except Exception:
+            self._release_publisher_guard()
+            raise
+
+        self._low_state = low_state_reader
+        self._clock = clock
+        self._period = 1.0 / float(control_hz)
+        self._ramp_seconds = float(ramp_seconds)
+        self._release_seconds = float(release_seconds)
+        self._velocity_limit = float(velocity_limit_rad_s)
+        self._command_timeout = float(command_timeout_s)
+        self._condition = threading.Condition(threading.RLock())
+        self._publish_lock = threading.RLock()
+        self._stop_event = threading.Event()
+        self._gate = ArmSdkGate()
+        self._last_gate_state = ArmSdkState.DISARMED
+        self._target_q = np.zeros(10)
+        self._target_tau = np.zeros(10)
+        self._target_generation = 0
+        self._last_published_generation = 0
+        self._target_expires = 0.0
+        self._required_mode = REQUIRED_MODE_MACHINE
+        self._last_target_update: float | None = None
+        self._last_published_at: float | None = None
+        self._writes = 0
+        self._arm_sdk_weight = 0.0
+        self._final_zero_remaining = 0
+        self._external_release_generation = 0
+        self._external_release_reason: str | None = None
+        self._external_release_acknowledged = True
+        self._fault_reason: str | None = None
+        self._closed = False
+        self._close_result: AdapterAck | None = None
+        self._thread = threading.Thread(
+            target=self._publisher_loop,
+            name="g1-arm-sdk-publisher",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def startup_safe(self, deadline_monotonic: float) -> AdapterAck:
+        try:
+            state = self._validated_lowstate(REQUIRED_MODE_MACHINE)
+        except (KeyError, TypeError, ValueError, RuntimeError, ArithmeticError):
+            return AdapterAck(False, "lowstate_not_ready")
+        with self._condition:
+            if self._fault_reason is not None:
+                return AdapterAck(False, "arm_sdk_fault")
+            safe = (
+                self._thread.is_alive()
+                and self._gate.state is ArmSdkState.DISARMED
+                and self._final_zero_remaining == 0
+                and state["mode_machine"] == REQUIRED_MODE_MACHINE
+                and self._clock() < float(deadline_monotonic)
+            )
+            return AdapterAck(safe, "ok" if safe else "startup_not_safe")
+
+    def apply_target(
+        self,
+        joint_positions: Sequence[float],
+        feedforward_torques: Sequence[float],
+        *,
+        expires_monotonic: float,
+        required_mode_machine: int,
+        allow_arm: bool = False,
+    ) -> AdapterAck:
+        try:
+            target = self._vector(joint_positions, "joint_positions")
+            torques = self._vector(feedforward_torques, "feedforward_torques")
+            expiry = float(expires_monotonic)
+            if not math.isfinite(expiry):
+                raise ValueError("expiry must be finite")
+            if required_mode_machine != REQUIRED_MODE_MACHINE:
+                raise ValueError("unsupported mode_machine")
+        except (TypeError, ValueError):
+            return AdapterAck(False, "invalid_arm_target")
+
+        with self._publish_lock:
+            try:
+                self._validated_lowstate(required_mode_machine)
+            except (KeyError, TypeError, ValueError, RuntimeError, ArithmeticError):
+                return AdapterAck(False, "lowstate_not_ready")
+            with self._condition:
+                now = self._clock()
+                if now >= expiry:
+                    return AdapterAck(False, "intent_expired_at_publisher")
+                if self._closed:
+                    return AdapterAck(False, "arm_sdk_closed")
+                if self._fault_reason is not None:
+                    return AdapterAck(False, "arm_sdk_fault")
+                if self._final_zero_remaining:
+                    return AdapterAck(False, "arm_sdk_releasing")
+                state = self._gate.state
+                if state is ArmSdkState.DISARMED:
+                    if allow_arm is not True:
+                        return AdapterAck(False, "arm_sdk_reclutch_required")
+                    armed = self._gate.arm(now, self._ramp_seconds)
+                    self._last_gate_state = armed.state
+                    self._arm_sdk_weight = armed.weight
+                elif state is ArmSdkState.RELEASING:
+                    return AdapterAck(False, "arm_sdk_releasing")
+                elif state is ArmSdkState.HARD_FAULT:
+                    return AdapterAck(False, "arm_sdk_fault")
+                self._target_q = target
+                self._target_tau = torques
+                self._target_generation += 1
+                generation = self._target_generation
+                self._target_expires = expiry
+                self._required_mode = required_mode_machine
+                self._last_target_update = now
+                self._condition.notify_all()
+
+        with self._condition:
+            while self._last_published_generation < generation:
+                if self._fault_reason is not None:
+                    return AdapterAck(False, "arm_sdk_fault")
+                remaining = expiry - self._clock()
+                if remaining <= 0.0:
+                    return AdapterAck(False, "publish_deadline_missed")
+                self._condition.wait(min(remaining, self._period * 2.0))
+            return AdapterAck(True)
+
+    def safe_stop(self, *, reason: str, deadline_monotonic: float) -> AdapterAck:
+        deadline = float(deadline_monotonic)
+        with self._publish_lock:
+            with self._condition:
+                if self._fault_reason is not None:
+                    return AdapterAck(False, "arm_sdk_fault")
+                if self._closed:
+                    return AdapterAck(False, "arm_sdk_closed")
+                if (
+                    self._gate.state is ArmSdkState.DISARMED
+                    and self._final_zero_remaining == 0
+                ):
+                    return AdapterAck(True)
+                now = self._clock()
+                remaining = deadline - now
+                final_budget = (self.FINAL_ZERO_WEIGHT_FRAMES + 1) * self._period
+                if remaining <= final_budget:
+                    return AdapterAck(False, "zero_weight_deadline_too_short")
+                release_duration = min(
+                    self._release_seconds,
+                    max(0.0, remaining - final_budget),
+                )
+                if self._gate.state is not ArmSdkState.RELEASING:
+                    previous = self._last_gate_state
+                    released = self._gate.release(
+                        now,
+                        release_duration,
+                        str(reason)[:128] or "safe_stop",
+                    )
+                    self._record_gate_sample_locked(previous, released)
+                self._condition.notify_all()
+
+        with self._condition:
+            while not (
+                self._gate.state is ArmSdkState.DISARMED
+                and self._final_zero_remaining == 0
+            ):
+                if self._fault_reason is not None:
+                    return AdapterAck(False, "arm_sdk_fault")
+                remaining = deadline - self._clock()
+                if remaining <= 0.0:
+                    return AdapterAck(False, "zero_weight_ack_timeout")
+                self._condition.wait(min(remaining, self._period * 2.0))
+            return AdapterAck(True)
+
+    def snapshot(self) -> Mapping[str, object]:
+        with self._condition:
+            return {
+                "topic": ARM_SDK_TOPIC,
+                "publisher_count": self.publisher_count,
+                "control_state": self._last_gate_state.value,
+                "arm_sdk_weight": float(self._arm_sdk_weight),
+                "writes": self._writes,
+                "final_zero_weight_frames_remaining": self._final_zero_remaining,
+                "last_published_monotonic": self._last_published_at,
+                "fault_reason": self._fault_reason,
+                "external_release_generation": self._external_release_generation,
+                "external_release_reason": self._external_release_reason,
+                "external_release_acknowledged": self._external_release_acknowledged,
+            }
+
+    def external_fault_code(self) -> str | None:
+        """Return a bounded asynchronous fault without performing I/O."""
+
+        with self._condition:
+            return None if self._fault_reason is None else "arm_sdk_async_fault"
+
+    def external_release_signal(self) -> Mapping[str, object]:
+        """Return the latest autonomous TTL release and its zero-frame ACK."""
+
+        with self._condition:
+            return {
+                "generation": self._external_release_generation,
+                "reason": self._external_release_reason,
+                "acknowledged": self._external_release_acknowledged,
+            }
+
+    def close(self) -> AdapterAck:
+        with self._condition:
+            if self._close_result is not None:
+                return self._close_result
+        stop_ack = self.safe_stop(
+            reason="arm_sdk_close",
+            deadline_monotonic=self._clock() + max(0.25, self._release_seconds + 0.1),
+        )
+        with self._publish_lock:
+            with self._condition:
+                self._closed = True
+                self._stop_event.set()
+                self._condition.notify_all()
+        if self._thread is not threading.current_thread():
+            self._thread.join(timeout=0.5)
+        if self._thread.is_alive():
+            result = AdapterAck(False, "publisher_close_timeout")
+            with self._condition:
+                self._close_result = result
+            return result
+        try:
+            close = getattr(self._publisher, "Close", None)
+            if callable(close):
+                close()
+        except Exception:  # noqa: BLE001 -- uncertain DDS close requires restart
+            result = AdapterAck(False, "publisher_dds_close_failed")
+            with self._condition:
+                self._close_result = result
+            return result
+        self._release_publisher_guard()
+        with self._condition:
+            self._close_result = stop_ack
+        return stop_ack
+
+    def _publisher_loop(self) -> None:
+        while not self._stop_event.is_set():
+            started = self._clock()
+            try:
+                self._publish_once()
+            except Exception as exc:  # noqa: BLE001 -- boundary must latch
+                self._latch_fault(f"publisher_cycle:{type(exc).__name__}")
+            elapsed = self._clock() - started
+            self._stop_event.wait(max(0.0, self._period - elapsed))
+
+    def _publish_once(self) -> None:
+        with self._publish_lock:
+            with self._condition:
+                if self._closed or self._fault_reason is not None:
+                    return
+                now = self._clock()
+                sample = self._sample_gate_locked(now)
+                if (
+                    sample.publish_allowed
+                    and self._last_target_update is not None
+                    and now - self._last_target_update > self._command_timeout
+                ):
+                    self._begin_autonomous_release_locked(
+                        now,
+                        self._release_seconds,
+                        "command_timeout",
+                    )
+                    sample = self._sample_gate_locked(now)
+                if sample.publish_allowed and now >= self._target_expires:
+                    self._begin_autonomous_release_locked(now, 0.0, "intent_expired")
+                    sample = self._sample_gate_locked(now)
+                publish_final_zero = self._final_zero_remaining > 0
+                if not sample.publish_allowed and not publish_final_zero:
+                    return
+                target = self._target_q.copy()
+                torques = self._target_tau.copy()
+                generation = self._target_generation
+                required_mode = self._required_mode
+                weight = 0.0 if publish_final_zero else sample.weight
+
+            # Final mode/freshness/deadline checks and the DDS write are under
+            # the same publish lock as stop/target transitions.
+            state = self._validated_lowstate(required_mode)
+            if not publish_final_zero and self._clock() >= self._target_expires:
+                return
+            current_q = np.asarray(state["joint_positions"], dtype=float)
+            clipped = self._clip_arm_target(target, current_q)
+            message = self._build_message(
+                state,
+                clipped,
+                torques,
+                weight,
+                required_mode,
+            )
+            write_timeout = self._period
+            if not publish_final_zero:
+                write_timeout = max(
+                    0.0,
+                    min(self._period, self._target_expires - self._clock()),
+                )
+                if write_timeout <= 0.0:
+                    return
+            try:
+                result = self._publisher.Write(message, timeout=write_timeout)
+            except TypeError:
+                result = self._publisher.Write(message)
+            if result is False:
+                raise RuntimeError("DDS Write returned false")
+
+            with self._condition:
+                self._writes += 1
+                self._last_published_at = self._clock()
+                if publish_final_zero:
+                    self._final_zero_remaining -= 1
+                    if (
+                        self._final_zero_remaining == 0
+                        and self._external_release_reason is not None
+                    ):
+                        self._external_release_acknowledged = True
+                else:
+                    self._last_published_generation = max(
+                        self._last_published_generation,
+                        generation,
+                    )
+                self._condition.notify_all()
+
+    def _begin_autonomous_release_locked(
+        self,
+        now: float,
+        duration: float,
+        reason: str,
+    ) -> None:
+        if self._gate.state in (ArmSdkState.DISARMED, ArmSdkState.RELEASING):
+            return
+        previous = self._last_gate_state
+        released = self._gate.release(now, duration, reason)
+        self._external_release_generation += 1
+        self._external_release_reason = reason
+        self._external_release_acknowledged = False
+        self._record_gate_sample_locked(previous, released)
+
+    def _sample_gate_locked(self, now: float):
+        previous = self._last_gate_state
+        sample = self._gate.sample(now)
+        return self._record_gate_sample_locked(previous, sample)
+
+    def _record_gate_sample_locked(self, previous, sample):
+        if (
+            previous in (ArmSdkState.ARMING, ArmSdkState.ARMED, ArmSdkState.RELEASING)
+            and sample.state is ArmSdkState.DISARMED
+        ):
+            self._final_zero_remaining = max(
+                self._final_zero_remaining,
+                self.FINAL_ZERO_WEIGHT_FRAMES,
+            )
+        self._last_gate_state = sample.state
+        self._arm_sdk_weight = sample.weight
+        return sample
+
+    def _validated_lowstate(self, required_mode: int) -> dict:
+        raw = dict(self._low_state.read_arm_state())
+        q = np.asarray(raw.get("joint_positions"), dtype=float)
+        dq = np.asarray(raw.get("joint_velocities"), dtype=float)
+        if "all_joint_positions" not in raw:
+            raise RuntimeError("LowState full motor vector is missing")
+        all_q = np.asarray(raw["all_joint_positions"], dtype=float)
+        sampled = float(raw.get("sample_monotonic"))
+        mode = raw.get("mode_machine")
+        if (
+            q.shape != (10,)
+            or dq.shape != (10,)
+            or all_q.shape != (MOTOR_COUNT,)
+            or not np.all(np.isfinite(q))
+            or not np.all(np.isfinite(dq))
+            or not np.all(np.isfinite(all_q))
+            or not math.isfinite(sampled)
+        ):
+            raise RuntimeError("LowState is invalid")
+        age = self._clock() - sampled
+        if age < 0.0 or age > 0.1:
+            raise RuntimeError("LowState is stale")
+        if mode != required_mode:
+            raise RuntimeError("mode_machine changed")
+        raw.update({
+            "joint_positions": q,
+            "joint_velocities": dq,
+            "all_joint_positions": all_q,
+            "sample_monotonic": sampled,
+            "mode_machine": mode,
+        })
+        return raw
+
+    def _build_message(self, state, arm_q, arm_tau, weight, required_mode):
+        message = self._message_factory()
+        all_q = state["all_joint_positions"]
+        for index in range(MOTOR_COUNT):
+            command = message.motor_cmd[index]
+            command.mode = 1
+            command.q = float(all_q[index])
+            command.dq = 0.0
+            command.tau = 0.0
+            if index in WRIST_INDICES:
+                command.kp, command.kd = 40.0, 1.5
+            elif index in WEAK_INDICES:
+                command.kp, command.kd = 80.0, 3.0
+            else:
+                command.kp, command.kd = 300.0, 3.0
+        for vector_index, motor_index in enumerate(ARM_INDICES):
+            command = message.motor_cmd[motor_index]
+            command.q = float(arm_q[vector_index])
+            command.tau = float(arm_tau[vector_index])
+        message.mode_pr = 0
+        message.mode_machine = required_mode
+        message.motor_cmd[WEIGHT_INDEX].q = float(min(1.0, max(0.0, weight)))
+        message.crc = self._crc.Crc(message)
+        return message
+
+    def _clip_arm_target(self, target: np.ndarray, current: np.ndarray) -> np.ndarray:
+        """Keep the ten-joint trajectory direction while limiting speed."""
+
+        delta = target - current
+        motion_scale = float(np.max(np.abs(delta))) / (
+            self._velocity_limit * self._period
+        )
+        return current + delta / max(motion_scale, 1.0)
+
+    def _latch_fault(self, reason: str) -> None:
+        with self._publish_lock:
+            with self._condition:
+                if self._fault_reason is None:
+                    self._fault_reason = str(reason)[:128]
+                    self._gate.hard_fault(self._fault_reason)
+                    self._last_gate_state = ArmSdkState.HARD_FAULT
+                    self._arm_sdk_weight = 0.0
+                self._condition.notify_all()
+
+    @staticmethod
+    def _vector(value, name: str) -> np.ndarray:
+        result = np.asarray(value, dtype=float)
+        if result.shape != (10,) or not np.all(np.isfinite(result)):
+            raise ValueError(f"{name} must be a finite ten-joint vector")
+        return result.copy()
+
+    def _release_publisher_guard(self) -> None:
+        global _active_publishers
+        if not self._guard_owned:
+            return
+        with _publisher_guard:
+            _active_publishers = max(0, _active_publishers - 1)
+            self._guard_owned = False
+
+
+__all__ = [
+    "ARM_INDICES",
+    "ARM_SDK_TOPIC",
+    "G1ArmSdkPort",
+    "G1LowStateReader",
+    "LOWSTATE_TOPIC",
+    "REQUIRED_MODE_MACHINE",
+]

--- a/unitree/g1/teleop/ik.py
+++ b/unitree/g1/teleop/ik.py
@@ -1,0 +1,283 @@
+"""Pinocchio/CasADi inverse kinematics for the fixed G1_23 V1 profile.
+
+This is a focused port of Unitree's Apache-2.0 ``G1_23_ArmIK`` algorithm in
+``xr_teleoperate``.  It deliberately excludes TeleVuer/Vuer and visualization.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from pathlib import Path
+
+import numpy as np
+
+ARM_JOINT_NAMES = (
+    "left_shoulder_pitch_joint",
+    "left_shoulder_roll_joint",
+    "left_shoulder_yaw_joint",
+    "left_elbow_joint",
+    "left_wrist_roll_joint",
+    "right_shoulder_pitch_joint",
+    "right_shoulder_roll_joint",
+    "right_shoulder_yaw_joint",
+    "right_elbow_joint",
+    "right_wrist_roll_joint",
+)
+
+LOCKED_JOINT_NAMES = (
+    "left_hip_pitch_joint",
+    "left_hip_roll_joint",
+    "left_hip_yaw_joint",
+    "left_knee_joint",
+    "left_ankle_pitch_joint",
+    "left_ankle_roll_joint",
+    "right_hip_pitch_joint",
+    "right_hip_roll_joint",
+    "right_hip_yaw_joint",
+    "right_knee_joint",
+    "right_ankle_pitch_joint",
+    "right_ankle_roll_joint",
+    "waist_yaw_joint",
+)
+
+
+class G123PinocchioIk:
+    """Ten-joint dual-arm IK with the upstream cost and torque model."""
+
+    def __init__(self, urdf_path: str | Path):
+        try:
+            import casadi
+            import pinocchio as pin
+            from pinocchio import casadi as cpin
+        except (ImportError, OSError) as exc:
+            raise RuntimeError(
+                "G1_23 IK requires the conda-forge ABI set "
+                "pinocchio==3.1.0, casadi==3.6.7, numpy==1.26.4"
+            ) from exc
+
+        path = Path(urdf_path).resolve()
+        if not path.is_file():
+            raise RuntimeError(f"G1_23 body23 URDF is missing: {path}")
+
+        try:
+            model = pin.buildModelFromUrdf(str(path))
+            missing = [name for name in LOCKED_JOINT_NAMES if not model.existJointName(name)]
+            if missing:
+                raise RuntimeError(f"G1_23 URDF is missing locked joints: {missing}")
+            lock_ids = [model.getJointId(name) for name in LOCKED_JOINT_NAMES]
+            reduced = pin.buildReducedModel(model, lock_ids, pin.neutral(model))
+            reduced.addFrame(pin.Frame(
+                "L_ee",
+                reduced.getJointId("left_wrist_roll_joint"),
+                pin.SE3(np.eye(3), np.array([0.20, 0.0, 0.0])),
+                pin.FrameType.OP_FRAME,
+            ))
+            reduced.addFrame(pin.Frame(
+                "R_ee",
+                reduced.getJointId("right_wrist_roll_joint"),
+                pin.SE3(np.eye(3), np.array([0.20, 0.0, 0.0])),
+                pin.FrameType.OP_FRAME,
+            ))
+        except RuntimeError:
+            raise
+        except Exception as exc:
+            raise RuntimeError(f"failed to load G1_23 IK model: {exc}") from exc
+
+        actual_names = tuple(str(name) for name in list(reduced.names)[1:])
+        if reduced.nq != 10 or reduced.nv != 10 or actual_names != ARM_JOINT_NAMES:
+            raise RuntimeError(
+                "G1_23 reduced model contract mismatch: "
+                f"nq={reduced.nq}, nv={reduced.nv}, joints={actual_names}"
+            )
+
+        self._pin = pin
+        self._casadi = casadi
+        self._model = reduced
+        self._data = reduced.createData()
+        self._lock = threading.Lock()
+        self._history: deque[np.ndarray] = deque(maxlen=4)
+        self._last_q = np.zeros(10)
+        self._ready = False
+        self._warmup_ms: float | None = None
+
+        cmodel = cpin.Model(reduced)
+        cdata = cmodel.createData()
+        cq = casadi.SX.sym("q", reduced.nq, 1)
+        ctf_l = casadi.SX.sym("tf_l", 4, 4)
+        ctf_r = casadi.SX.sym("tf_r", 4, 4)
+        cpin.framesForwardKinematics(cmodel, cdata, cq)
+        left_frame = reduced.getFrameId("L_ee")
+        right_frame = reduced.getFrameId("R_ee")
+        self._left_frame = left_frame
+        self._right_frame = right_frame
+        translation_error = casadi.Function(
+            "g1_23_translation_error",
+            [cq, ctf_l, ctf_r],
+            [casadi.vertcat(
+                cdata.oMf[left_frame].translation - ctf_l[:3, 3],
+                cdata.oMf[right_frame].translation - ctf_r[:3, 3],
+            )],
+        )
+        rotation_error = casadi.Function(
+            "g1_23_rotation_error",
+            [cq, ctf_l, ctf_r],
+            [casadi.vertcat(
+                cpin.log3(cdata.oMf[left_frame].rotation @ ctf_l[:3, :3].T),
+                cpin.log3(cdata.oMf[right_frame].rotation @ ctf_r[:3, :3].T),
+            )],
+        )
+
+        opti = casadi.Opti()
+        var_q = opti.variable(reduced.nq)
+        var_q_last = opti.parameter(reduced.nq)
+        param_left = opti.parameter(4, 4)
+        param_right = opti.parameter(4, 4)
+        opti.subject_to(opti.bounded(
+            reduced.lowerPositionLimit,
+            var_q,
+            reduced.upperPositionLimit,
+        ))
+        opti.minimize(
+            50.0 * casadi.sumsqr(translation_error(var_q, param_left, param_right))
+            + 0.5 * casadi.sumsqr(rotation_error(var_q, param_left, param_right))
+            + 0.02 * casadi.sumsqr(var_q)
+            + 0.1 * casadi.sumsqr(var_q - var_q_last)
+        )
+        opti.solver("ipopt", {
+            "expand": True,
+            "detect_simple_bounds": True,
+            "calc_lam_p": False,
+            "print_time": False,
+            "ipopt.sb": "yes",
+            "ipopt.print_level": 0,
+            "ipopt.max_iter": 30,
+            "ipopt.tol": 1e-4,
+            "ipopt.acceptable_tol": 5e-4,
+            "ipopt.acceptable_iter": 5,
+            "ipopt.warm_start_init_point": "yes",
+            "ipopt.derivative_test": "none",
+            "ipopt.jacobian_approximation": "exact",
+        })
+        self._opti = opti
+        self._var_q = var_q
+        self._var_q_last = var_q_last
+        self._param_left = param_left
+        self._param_right = param_right
+
+    def ready(self) -> bool:
+        """Return true only after one real IPOPT solve has succeeded."""
+
+        with self._lock:
+            return self._ready
+
+    def reset(self, current_joint_positions) -> None:
+        """Discard filter/seed state at every safe session boundary."""
+
+        current = self._validated_vector(current_joint_positions, "current q")
+        with self._lock:
+            self._history.clear()
+            self._last_q = current.copy()
+
+    def warm_up(self, current_joint_positions, current_joint_velocities) -> dict:
+        """Cold-load IPOPT by solving the measured current end-effector pose."""
+
+        current_q = self._validated_vector(current_joint_positions, "current q")
+        current_dq = self._validated_vector(current_joint_velocities, "current dq")
+        started = time.monotonic()
+        with self._lock:
+            self._ready = False
+            self._warmup_ms = None
+            self._pin.framesForwardKinematics(self._model, self._data, current_q)
+            left_pose = self._data.oMf[self._left_frame]
+            right_pose = self._data.oMf[self._right_frame]
+            left = np.eye(4)
+            right = np.eye(4)
+            left[:3, :3] = np.asarray(left_pose.rotation, dtype=float)
+            left[:3, 3] = np.asarray(left_pose.translation, dtype=float).reshape(3)
+            right[:3, :3] = np.asarray(right_pose.rotation, dtype=float)
+            right[:3, 3] = np.asarray(right_pose.translation, dtype=float).reshape(3)
+            self._history.clear()
+            self._last_q = current_q.copy()
+        try:
+            solved_q, _ = self.solve(left, right, current_q, current_dq)
+        except Exception:
+            with self._lock:
+                self._ready = False
+            raise
+        elapsed_ms = max(0.0, (time.monotonic() - started) * 1000.0)
+        if np.max(np.abs(np.asarray(solved_q) - current_q)) > 0.5:
+            raise RuntimeError("G1_23 IK warm-up diverged from measured posture")
+        with self._lock:
+            self._ready = True
+            self._warmup_ms = elapsed_ms
+            return {"ready": True, "warmup_ms": round(elapsed_ms, 3)}
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            return {
+                "ready": self._ready,
+                "warmup_ms": (
+                    None if self._warmup_ms is None else round(self._warmup_ms, 3)
+                ),
+                "history_depth": len(self._history),
+            }
+
+    def solve(self, left, right, current_q, current_dq):
+        left = self._validated_transform(left, "left target")
+        right = self._validated_transform(right, "right target")
+        current_q = self._validated_vector(current_q, "current q")
+        self._validated_vector(current_dq, "current dq")
+        with self._lock:
+            self._opti.set_initial(self._var_q, current_q)
+            self._opti.set_value(self._var_q_last, current_q)
+            self._opti.set_value(self._param_left, left)
+            self._opti.set_value(self._param_right, right)
+            try:
+                solution = self._opti.solve()
+                raw_q = np.asarray(solution.value(self._var_q), dtype=float).reshape(10)
+            except Exception as exc:
+                raise RuntimeError(f"G1_23 IK failed to converge: {exc}") from exc
+            if not np.all(np.isfinite(raw_q)):
+                raise RuntimeError("G1_23 IK returned non-finite joints")
+            self._history.append(raw_q.copy())
+            # Upstream WeightedMovingFilter weights newest→oldest as
+            # [0.4, 0.3, 0.2, 0.1].  During warm-up, normalize the prefix.
+            weights = np.array([0.4, 0.3, 0.2, 0.1])[: len(self._history)]
+            newest_first = np.stack(tuple(reversed(self._history)))
+            q = np.sum(newest_first * (weights / weights.sum())[:, None], axis=0)
+            tauff = self._pin.rnea(
+                self._model,
+                self._data,
+                q,
+                np.zeros(10),
+                np.zeros(10),
+            )
+            tauff = np.asarray(tauff, dtype=float).reshape(10)
+            if not np.all(np.isfinite(tauff)):
+                raise RuntimeError("G1_23 inverse dynamics returned non-finite torques")
+            self._last_q = q.copy()
+            return q, tauff
+
+    @staticmethod
+    def _validated_vector(value, name: str) -> np.ndarray:
+        result = np.asarray(value, dtype=float)
+        if result.shape != (10,) or not np.all(np.isfinite(result)):
+            raise ValueError(f"{name} must be a finite ten-joint vector")
+        return result
+
+    @staticmethod
+    def _validated_transform(value, name: str) -> np.ndarray:
+        result = np.asarray(value, dtype=float)
+        if result.shape != (4, 4) or not np.all(np.isfinite(result)):
+            raise ValueError(f"{name} must be a finite 4x4 transform")
+        if not np.allclose(result[3], [0.0, 0.0, 0.0, 1.0], atol=1e-8):
+            raise ValueError(f"{name} must be homogeneous")
+        determinant = float(np.linalg.det(result[:3, :3]))
+        if not np.isclose(determinant, 1.0, atol=1e-3):
+            raise ValueError(f"{name} rotation must have determinant one")
+        return result
+
+
+__all__ = ["ARM_JOINT_NAMES", "G123PinocchioIk", "LOCKED_JOINT_NAMES"]

--- a/unitree/g1/teleop/preflight.py
+++ b/unitree/g1/teleop/preflight.py
@@ -1,0 +1,327 @@
+"""Executable G1 target-image and zero-output Shadow startup probes."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import math
+import os
+import platform
+import time
+from pathlib import Path
+
+from .descriptor import PREFLIGHT_SCHEMA, PROFILE_ID
+
+EXPECTED_NUMPY_VERSION = "1.26.4"
+EXPECTED_CASADI_VERSION = "3.6.7"
+EXPECTED_PINOCCHIO_VERSION = "3.1.0"
+
+_PREFLIGHT_PUBLIC_MESSAGES = {
+    "target_dependency_import_failed": "Target image dependencies are unavailable",
+    "numpy_version_mismatch": "Target image NumPy version is incompatible",
+    "casadi_version_mismatch": "Target image CasADi version is incompatible",
+    "pinocchio_version_mismatch": "Target image Pinocchio version is incompatible",
+    "pinocchio_casadi_import_failed": "Target image Pinocchio/CasADi bridge is unavailable",
+    "target_ik_warmup_failed": "Target image IK warm-up failed",
+    "shadow_config_load_failed": "G1 Shadow configuration could not be loaded",
+    "shadow_config_invalid": "G1 Shadow configuration is invalid",
+    "shadow_mode_required": "G1 Shadow preflight requires Shadow mode",
+    "network_interface_required": "G1 network interface is required",
+    "shadow_dds_init_failed": "G1 Shadow DDS startup failed",
+    "shadow_startup_failed": "G1 Shadow startup failed",
+    "preflight_command_failed": "G1 teleoperation preflight command failed",
+}
+
+
+class PreflightCommandError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        stage: str,
+        code: str,
+        message: str,
+        mode: str = "image",
+    ):
+        del message
+        public_message = _PREFLIGHT_PUBLIC_MESSAGES.get(
+            code,
+            _PREFLIGHT_PUBLIC_MESSAGES["preflight_command_failed"],
+        )
+        super().__init__(public_message)
+        self.preflight_status = {
+            "schema": PREFLIGHT_SCHEMA,
+            "ready": False,
+            "stage": stage,
+            "code": code,
+            "message": public_message,
+            "mode": mode,
+            "profile_id": PROFILE_ID,
+            "hardware_output": False,
+            "publisher_created": False,
+        }
+
+
+def _initialize_dds(network_interface: str) -> None:
+    from unitree_sdk2py.core.channel import ChannelFactoryInitialize
+
+    ChannelFactoryInitialize(0, network_interface)
+
+
+def run_target_image_preflight(urdf_path: str | Path) -> dict:
+    """Cold-import target dependencies and execute one real G1_23 IPOPT solve."""
+
+    started = time.monotonic()
+    try:
+        dependencies = {
+            name: importlib.import_module(name)
+            for name in ("numpy", "casadi", "pinocchio")
+        }
+    except Exception as exc:
+        raise PreflightCommandError(
+            stage="target_dependencies",
+            code="target_dependency_import_failed",
+            message=f"{type(exc).__name__}: {exc}",
+        ) from exc
+
+    for dependency, expected, code in (
+        ("numpy", EXPECTED_NUMPY_VERSION, "numpy_version_mismatch"),
+        ("casadi", EXPECTED_CASADI_VERSION, "casadi_version_mismatch"),
+        ("pinocchio", EXPECTED_PINOCCHIO_VERSION, "pinocchio_version_mismatch"),
+    ):
+        actual = str(getattr(dependencies[dependency], "__version__", "unknown"))
+        if actual != expected:
+            raise PreflightCommandError(
+                stage="target_dependencies",
+                code=code,
+                message=f"expected {dependency}=={expected}, got {actual}",
+            )
+
+    try:
+        dependencies.update({
+            name: importlib.import_module(name)
+            for name in (
+                "aiortc",
+                "av",
+                "cryptography",
+                "teleop.factory",
+                "teleop.service",
+            )
+        })
+    except Exception as exc:
+        raise PreflightCommandError(
+            stage="target_dependencies",
+            code="target_dependency_import_failed",
+            message=f"{type(exc).__name__}: {exc}",
+        ) from exc
+
+    try:
+        from pinocchio import casadi as pinocchio_casadi  # noqa: F401
+    except Exception as exc:
+        raise PreflightCommandError(
+            stage="target_dependencies",
+            code="pinocchio_casadi_import_failed",
+            message=f"{type(exc).__name__}: {exc}",
+        ) from exc
+
+    try:
+        from .ik import G123PinocchioIk
+
+        solver = G123PinocchioIk(urdf_path)
+        numpy_module = dependencies["numpy"]
+        warmup = solver.warm_up(numpy_module.zeros(10), numpy_module.zeros(10))
+        warmup_ms = warmup.get("warmup_ms") if isinstance(warmup, dict) else None
+        if (
+            not isinstance(warmup, dict)
+            or warmup.get("ready") is not True
+            or solver.ready() is not True
+            or isinstance(warmup_ms, bool)
+            or not isinstance(warmup_ms, (int, float))
+            or not math.isfinite(float(warmup_ms))
+            or float(warmup_ms) < 0.0
+            or float(warmup_ms) > 600_000.0
+        ):
+            raise RuntimeError("G1_23 cold IPOPT solve did not establish readiness")
+    except Exception as exc:
+        if isinstance(exc, PreflightCommandError):
+            raise
+        raise PreflightCommandError(
+            stage="target_ik_warmup",
+            code="target_ik_warmup_failed",
+            message=f"{type(exc).__name__}: {exc}",
+        ) from exc
+
+    elapsed_ms = max(0.0, (time.monotonic() - started) * 1000.0)
+    return {
+        "schema": PREFLIGHT_SCHEMA,
+        "ready": True,
+        "stage": "complete",
+        "code": None,
+        "message": None,
+        "mode": "image",
+        "profile_id": PROFILE_ID,
+        "hardware_output": False,
+        "publisher_created": False,
+        "platform": {
+            "machine": platform.machine()[:64],
+            "python": platform.python_version()[:32],
+        },
+        "dependencies": {
+            name: str(getattr(module, "__version__", "available"))[:64]
+            for name, module in sorted(dependencies.items())
+        },
+        "ik": {
+            "ready": True,
+            "warmup_ms": round(float(warmup_ms), 3),
+            "total_preflight_ms": round(min(600_000.0, elapsed_ms), 3),
+            "model": "g1_body23.urdf",
+            "solver": "pinocchio-casadi-ipopt",
+        },
+    }
+
+
+def run_shadow_preflight(*, config_path: str | Path, network_interface: str) -> dict:
+    """Run the production Shadow factory once and return its startup evidence."""
+
+    try:
+        import yaml
+
+        with Path(config_path).open(encoding="utf-8") as handle:
+            config = yaml.safe_load(handle)
+    except Exception as exc:
+        raise PreflightCommandError(
+            stage="shadow_configuration",
+            code="shadow_config_load_failed",
+            message=f"{type(exc).__name__}: {exc}",
+            mode="shadow",
+        ) from exc
+    if not isinstance(config, dict):
+        raise PreflightCommandError(
+            stage="shadow_configuration",
+            code="shadow_config_invalid",
+            message="G1 config must be a YAML object",
+            mode="shadow",
+        )
+    teleop = config.get("teleop")
+    if (
+        not isinstance(teleop, dict)
+        or teleop.get("enabled") is not True
+        or teleop.get("mode", "shadow") != "shadow"
+    ):
+        raise PreflightCommandError(
+            stage="shadow_configuration",
+            code="shadow_mode_required",
+            message="preflight requires teleop.enabled=true and teleop.mode=shadow",
+            mode="shadow",
+        )
+    if not isinstance(network_interface, str) or not network_interface.strip():
+        raise PreflightCommandError(
+            stage="shadow_configuration",
+            code="network_interface_required",
+            message="a non-empty G1 network interface is required",
+            mode="shadow",
+        )
+
+    try:
+        _initialize_dds(network_interface.strip())
+    except Exception as exc:
+        raise PreflightCommandError(
+            stage="shadow_dds_init",
+            code="shadow_dds_init_failed",
+            message=f"{type(exc).__name__}: {exc}",
+            mode="shadow",
+        ) from exc
+
+    service = None
+    try:
+        from .factory import build_g1_teleop_service
+
+        service = build_g1_teleop_service(config)
+        if service is None:
+            raise RuntimeError("G1 Shadow factory returned no service")
+        status = service.preflight_status()
+        if (
+            status.get("ready") is not True
+            or status.get("mode") != "shadow"
+            or status.get("hardware_output") is not False
+            or status.get("publisher_created") is not False
+        ):
+            raise RuntimeError("G1 Shadow startup preflight did not reach zero-output readiness")
+        return status
+    except Exception as exc:
+        if isinstance(getattr(exc, "preflight_status", None), dict):
+            raise
+        raise PreflightCommandError(
+            stage="shadow_factory",
+            code="shadow_startup_failed",
+            message=f"{type(exc).__name__}: {exc}",
+            mode="shadow",
+        ) from exc
+    finally:
+        if service is not None:
+            service.close()
+
+
+def project_command_error(exc: BaseException) -> dict:
+    projected = getattr(exc, "preflight_status", None)
+    if isinstance(projected, dict):
+        result = dict(projected)
+        result["message"] = _PREFLIGHT_PUBLIC_MESSAGES.get(
+            result.get("code"),
+            _PREFLIGHT_PUBLIC_MESSAGES["preflight_command_failed"],
+        )
+        return result
+    return {
+        "schema": PREFLIGHT_SCHEMA,
+        "ready": False,
+        "stage": "preflight_command",
+        "code": "preflight_command_failed",
+        "message": _PREFLIGHT_PUBLIC_MESSAGES["preflight_command_failed"],
+        "mode": "unknown",
+        "profile_id": PROFILE_ID,
+        "hardware_output": False,
+        "publisher_created": False,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python3 -m teleop.preflight")
+    commands = parser.add_subparsers(dest="command", required=True)
+    image = commands.add_parser("image", help="cold-load target dependencies and IK")
+    image.add_argument(
+        "--urdf",
+        default=str(Path(__file__).resolve().parents[1] / "resource" / "g1_body23.urdf"),
+    )
+    shadow = commands.add_parser("shadow", help="probe production zero-output Shadow startup")
+    shadow.add_argument("--network-interface", required=True)
+    shadow.add_argument(
+        "--config",
+        default=os.environ.get("CONFIG_PATH", "/work/config.teleop-shadow.example.yaml"),
+    )
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "image":
+            result = run_target_image_preflight(args.urdf)
+        else:
+            result = run_shadow_preflight(
+                config_path=args.config,
+                network_interface=args.network_interface,
+            )
+    except Exception as exc:
+        print(json.dumps(project_command_error(exc), allow_nan=False, sort_keys=True))
+        return 1
+    print(json.dumps(result, allow_nan=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "PreflightCommandError",
+    "main",
+    "project_command_error",
+    "run_shadow_preflight",
+    "run_target_image_preflight",
+]

--- a/unitree/g1/teleop/protocol.py
+++ b/unitree/g1/teleop/protocol.py
@@ -1,0 +1,472 @@
+"""Pure Frame v1 validation and HMAC ticket helpers for G1 teleoperation.
+
+This module deliberately has no aiohttp or aiortc dependency.  It is shared by
+the HTTP/RTC adapters and the offline protocol tests.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import math
+import re
+import threading
+import time
+import uuid
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .descriptor import SIGNALING_AUDIENCE
+
+FRAME_SCHEMA_VERSION = 1
+MAX_FRAME_BYTES = 64 * 1024
+MAX_SEQUENCE = (1 << 63) - 1
+SUPPORTED_MODES = frozenset({"shadow", "live"})
+_TOKEN_ID_RE = re.compile(r"^[A-Za-z0-9_-]{16,128}$")
+_FENCE_RE = re.compile(r"^[A-Za-z0-9_-]{24,128}$")
+
+
+class ProtocolError(ValueError):
+    """A stable, user-visible protocol validation failure."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+class TicketError(ProtocolError):
+    """A ticket authentication or replay failure."""
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+FRAME_REQUIRED_FIELDS = frozenset({
+    "schema_version", "boot_id", "session_id", "epoch", "fence",
+    "sequence", "client_monotonic_ns", "mode", "deadman",
+    "clutch_sequence", "tracking", "head", "left_controller",
+    "right_controller", "controllers",
+})
+FRAME_OPTIONAL_FIELDS = frozenset({"base_twist"})
+RTC_PRIVATE_FIELDS = frozenset({"boot_id", "session_id", "epoch", "fence"})
+RTC_FRAME_REQUIRED_FIELDS = FRAME_REQUIRED_FIELDS - RTC_PRIVATE_FIELDS
+
+
+def _strict_object(value: Any, name: str, required: set[str], optional: set[str] | None = None) -> dict:
+    if not isinstance(value, dict):
+        raise ProtocolError("invalid_type", f"{name} must be an object")
+    optional = optional or set()
+    keys = set(value)
+    missing = required - keys
+    unknown = keys - required - optional
+    if missing:
+        raise ProtocolError("missing_field", f"{name} missing fields: {sorted(missing)}")
+    if unknown:
+        raise ProtocolError("unknown_field", f"{name} contains unknown fields: {sorted(unknown)}")
+    return value
+
+
+def _strict_int(
+    value: Any,
+    name: str,
+    *,
+    minimum: int = 0,
+    maximum: int | None = None,
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ProtocolError("invalid_type", f"{name} must be an integer")
+    if value < minimum:
+        raise ProtocolError("out_of_range", f"{name} must be >= {minimum}")
+    if maximum is not None and value > maximum:
+        raise ProtocolError("out_of_range", f"{name} must be <= {maximum}")
+    return value
+
+
+def _strict_bool(value: Any, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ProtocolError("invalid_type", f"{name} must be a boolean")
+    return value
+
+
+def _finite_number(value: Any, name: str, *, lower: float, upper: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ProtocolError("invalid_type", f"{name} must be a number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ProtocolError("non_finite", f"{name} must be finite")
+    if number < lower or number > upper:
+        raise ProtocolError("out_of_range", f"{name} must be in [{lower}, {upper}]")
+    return number
+
+
+def _float_array(value: Any, name: str, *, size: int | None, maximum_size: int | None,
+                 lower: float, upper: float) -> list[float]:
+    if not isinstance(value, list):
+        raise ProtocolError("invalid_type", f"{name} must be an array")
+    if size is not None and len(value) != size:
+        raise ProtocolError("invalid_length", f"{name} must contain exactly {size} values")
+    if maximum_size is not None and len(value) > maximum_size:
+        raise ProtocolError("invalid_length", f"{name} may contain at most {maximum_size} values")
+    return [
+        _finite_number(item, f"{name}[{index}]", lower=lower, upper=upper)
+        for index, item in enumerate(value)
+    ]
+
+
+def _validate_uuid(value: Any, name: str) -> str:
+    if not isinstance(value, str):
+        raise ProtocolError("invalid_type", f"{name} must be a UUID string")
+    try:
+        parsed = uuid.UUID(value)
+    except (ValueError, AttributeError) as exc:
+        raise ProtocolError("invalid_value", f"{name} must be a valid UUID") from exc
+    if str(parsed) != value.lower():
+        raise ProtocolError("invalid_value", f"{name} must use canonical UUID form")
+    return str(parsed)
+
+
+def _validate_fence(value: Any) -> str:
+    if not isinstance(value, str) or not _FENCE_RE.fullmatch(value):
+        raise ProtocolError("invalid_value", "fence must be a URL-safe token of 24-128 characters")
+    return value
+
+
+def _validate_pose(value: Any, name: str, tracking_valid: bool) -> dict | None:
+    if value is None:
+        if tracking_valid:
+            raise ProtocolError("tracking_mismatch", f"{name} is required while tracking is valid")
+        return None
+    if not tracking_valid:
+        raise ProtocolError("tracking_mismatch", f"{name} must be null while tracking is invalid")
+    pose = _strict_object(value, name, {"position", "orientation"})
+    position = _float_array(
+        pose["position"], f"{name}.position", size=3, maximum_size=None, lower=-100.0, upper=100.0
+    )
+    orientation = _float_array(
+        pose["orientation"], f"{name}.orientation", size=4, maximum_size=None, lower=-1.0, upper=1.0
+    )
+    norm = math.sqrt(sum(item * item for item in orientation))
+    if abs(norm - 1.0) > 0.02:
+        raise ProtocolError("invalid_quaternion", f"{name}.orientation must be normalized")
+    return {"position": position, "orientation": orientation}
+
+
+def _validate_controller(value: Any, name: str) -> dict:
+    controller = _strict_object(value, name, {"axes", "buttons"})
+    return {
+        "axes": _float_array(
+            controller["axes"], f"{name}.axes", size=None, maximum_size=8, lower=-1.0, upper=1.0
+        ),
+        "buttons": _float_array(
+            controller["buttons"], f"{name}.buttons", size=None, maximum_size=16, lower=0.0, upper=1.0
+        ),
+    }
+
+
+def _normalize_frame_v1(value: Any, *, expected_mode: str) -> dict:
+    if expected_mode not in SUPPORTED_MODES:
+        raise ValueError("expected_mode must be 'shadow' or 'live'")
+    frame = _strict_object(
+        value,
+        "frame",
+        set(FRAME_REQUIRED_FIELDS),
+        set(FRAME_OPTIONAL_FIELDS),
+    )
+    version = _strict_int(frame["schema_version"], "schema_version", minimum=1)
+    if version != FRAME_SCHEMA_VERSION:
+        raise ProtocolError("unsupported_version", f"schema_version must be {FRAME_SCHEMA_VERSION}")
+    if frame["mode"] != expected_mode:
+        raise ProtocolError("unsupported_mode", f"mode must be {expected_mode!r}")
+
+    tracking = _strict_object(
+        frame["tracking"], "tracking", {"head", "left_controller", "right_controller"}
+    )
+    normalized_tracking = {
+        key: _strict_bool(tracking[key], f"tracking.{key}")
+        for key in ("head", "left_controller", "right_controller")
+    }
+    controllers = _strict_object(frame["controllers"], "controllers", {"left", "right"})
+
+    normalized = {
+        "schema_version": version,
+        "boot_id": _validate_uuid(frame["boot_id"], "boot_id"),
+        "session_id": _validate_uuid(frame["session_id"], "session_id"),
+        "epoch": _strict_int(frame["epoch"], "epoch", minimum=1),
+        "fence": _validate_fence(frame["fence"]),
+        "sequence": _strict_int(
+            frame["sequence"], "sequence", minimum=0, maximum=MAX_SEQUENCE
+        ),
+        "client_monotonic_ns": _strict_int(
+            frame["client_monotonic_ns"], "client_monotonic_ns", minimum=0
+        ),
+        "mode": expected_mode,
+        "deadman": _strict_bool(frame["deadman"], "deadman"),
+        "clutch_sequence": _strict_int(
+            frame["clutch_sequence"],
+            "clutch_sequence",
+            minimum=0,
+            maximum=MAX_SEQUENCE,
+        ),
+        "tracking": normalized_tracking,
+        "head": _validate_pose(frame["head"], "head", normalized_tracking["head"]),
+        "left_controller": _validate_pose(
+            frame["left_controller"], "left_controller", normalized_tracking["left_controller"]
+        ),
+        "right_controller": _validate_pose(
+            frame["right_controller"], "right_controller", normalized_tracking["right_controller"]
+        ),
+        "controllers": {
+            "left": _validate_controller(controllers["left"], "controllers.left"),
+            "right": _validate_controller(controllers["right"], "controllers.right"),
+        },
+    }
+    if "base_twist" in frame:
+        twist = _strict_object(frame["base_twist"], "base_twist", {"linear", "angular"})
+        normalized["base_twist"] = {
+            "linear": _float_array(
+                twist["linear"], "base_twist.linear", size=3, maximum_size=None, lower=-20.0, upper=20.0
+            ),
+            "angular": _float_array(
+                twist["angular"], "base_twist.angular", size=3, maximum_size=None,
+                lower=-20.0, upper=20.0
+            ),
+        }
+    return normalized
+
+
+def validate_frame_v1(
+    value: Any,
+    *,
+    max_bytes: int = MAX_FRAME_BYTES,
+    expected_mode: str,
+) -> dict:
+    """Validate and normalize one authority-bearing Teleop Frame v1 object."""
+
+    try:
+        encoded_size = len(canonical_json(value))
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise ProtocolError("invalid_json", "frame must contain JSON-compatible finite values") from exc
+    if encoded_size > max_bytes:
+        raise ProtocolError("frame_too_large", f"frame exceeds {max_bytes} bytes")
+    return _normalize_frame_v1(value, expected_mode=expected_mode)
+
+
+def bind_rtc_frame_v1(
+    value: Any,
+    *,
+    authority: Mapping[str, Any],
+    max_bytes: int = MAX_FRAME_BYTES,
+    expected_mode: str,
+) -> dict:
+    """Bind a public RTC wire Frame to its ticket-authorized private identity.
+
+    The browser is deliberately forbidden from supplying any authority field.
+    The returned internal Frame can therefore use the same runtime and final
+    dispatch validation as authenticated MCP diagnostics without disclosing the
+    session fence to JavaScript.
+    """
+
+    try:
+        encoded_size = len(canonical_json(value))
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise ProtocolError("invalid_json", "RTC frame must contain JSON-compatible finite values") from exc
+    if encoded_size > max_bytes:
+        raise ProtocolError("frame_too_large", f"RTC frame exceeds {max_bytes} bytes")
+    wire = _strict_object(
+        value,
+        "RTC frame",
+        set(RTC_FRAME_REQUIRED_FIELDS),
+        set(FRAME_OPTIONAL_FIELDS),
+    )
+    if not isinstance(authority, Mapping):
+        raise ProtocolError("invalid_rtc_binding", "RTC authority binding is invalid")
+    try:
+        internal = {
+            "boot_id": authority["boot_id"],
+            "session_id": authority["session_id"],
+            "epoch": authority["epoch"],
+            "fence": authority["fence"],
+            **wire,
+        }
+    except KeyError as exc:
+        raise ProtocolError("invalid_rtc_binding", "RTC authority binding is incomplete") from exc
+    return _normalize_frame_v1(internal, expected_mode=expected_mode)
+
+
+def sdp_digest(sdp: str) -> str:
+    if not isinstance(sdp, str) or not sdp:
+        raise TicketError("invalid_sdp", "sdp must be a non-empty string")
+    return hashlib.sha256(sdp.encode("utf-8")).hexdigest()
+
+
+def _b64encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(value: str) -> bytes:
+    if not isinstance(value, str) or not value:
+        raise TicketError("malformed_ticket", "ticket segment is empty")
+    try:
+        return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+    except Exception as exc:
+        raise TicketError("malformed_ticket", "ticket is not valid base64url") from exc
+
+
+@dataclass(frozen=True)
+class TicketClaims:
+    boot_id: str
+    session_id: str
+    epoch: int
+    fence: str
+    capability_digest: str
+    sdp_sha256: str
+    iat: int
+    exp: int
+    jti: str
+    audience: str = SIGNALING_AUDIENCE
+
+    def as_dict(self) -> dict:
+        return {
+            "v": 1,
+            "aud": self.audience,
+            "boot_id": self.boot_id,
+            "session_id": self.session_id,
+            "epoch": self.epoch,
+            "fence": self.fence,
+            "capability_digest": self.capability_digest,
+            "sdp_sha256": self.sdp_sha256,
+            "iat": self.iat,
+            "exp": self.exp,
+            "jti": self.jti,
+        }
+
+
+class TicketCodec:
+    """Small HMAC-SHA256 token codec shared with Core-side integration tests."""
+
+    def __init__(self, secret: str | bytes):
+        if isinstance(secret, str):
+            try:
+                secret_bytes = secret.encode("utf-8")
+            except UnicodeEncodeError:
+                raise ValueError(
+                    "MOTUS_TELEOP_TICKET_SECRET must be valid UTF-8"
+                ) from None
+        else:
+            secret_bytes = bytes(secret)
+        if len(secret_bytes) < 32:
+            raise ValueError("MOTUS_TELEOP_TICKET_SECRET must contain at least 32 bytes")
+        self._secret = secret_bytes
+
+    def sign(self, claims: TicketClaims) -> str:
+        payload = _b64encode(canonical_json(claims.as_dict()))
+        signature = _b64encode(hmac.new(self._secret, payload.encode("ascii"), hashlib.sha256).digest())
+        return f"{payload}.{signature}"
+
+    def decode_and_verify_signature(self, token: str) -> dict:
+        if not isinstance(token, str) or token.count(".") != 1:
+            raise TicketError("malformed_ticket", "ticket must contain payload and signature")
+        payload, signature = token.split(".", 1)
+        expected = _b64encode(hmac.new(self._secret, payload.encode("ascii"), hashlib.sha256).digest())
+        if not hmac.compare_digest(signature, expected):
+            raise TicketError("invalid_signature", "ticket signature is invalid")
+        try:
+            decoded = json.loads(_b64decode(payload))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise TicketError("malformed_ticket", "ticket payload is not valid JSON") from exc
+        return _strict_object(
+            decoded,
+            "ticket",
+            {
+                "v", "aud", "boot_id", "session_id", "epoch", "fence",
+                "capability_digest", "sdp_sha256", "iat", "exp", "jti",
+            },
+        )
+
+
+class TicketVerifier:
+    """Verify binding, expiry and one-time use for RTC offers."""
+
+    def __init__(
+        self,
+        codec: TicketCodec,
+        *,
+        max_ttl_seconds: int = 30,
+        max_replay_entries: int = 4096,
+        wall_clock: Callable[[], float] = time.time,
+        audience: str = SIGNALING_AUDIENCE,
+    ):
+        self._codec = codec
+        self._max_ttl = int(max_ttl_seconds)
+        self._max_replay_entries = int(max_replay_entries)
+        self._wall_clock = wall_clock
+        self._audience = audience
+        self._used: dict[str, int] = {}
+        self._lock = threading.Lock()
+
+    def verify_and_consume(self, token: str, *, expected: Mapping[str, Any], sdp: str) -> dict:
+        claims = self._codec.decode_and_verify_signature(token)
+        now = int(self._wall_clock())
+        if claims["v"] != 1 or claims["aud"] != self._audience:
+            raise TicketError("invalid_audience", "ticket version or audience is invalid")
+        iat = _strict_int(claims["iat"], "ticket.iat", minimum=0)
+        exp = _strict_int(claims["exp"], "ticket.exp", minimum=1)
+        if iat > now + 5:
+            raise TicketError("ticket_not_yet_valid", "ticket issue time is in the future")
+        if exp <= now:
+            raise TicketError("ticket_expired", "ticket has expired")
+        if exp - iat <= 0 or exp - iat > self._max_ttl:
+            raise TicketError("invalid_ticket_ttl", f"ticket TTL must be <= {self._max_ttl} seconds")
+        jti = claims["jti"]
+        if not isinstance(jti, str) or not _TOKEN_ID_RE.fullmatch(jti):
+            raise TicketError("invalid_jti", "ticket jti is invalid")
+        if claims["sdp_sha256"] != sdp_digest(sdp):
+            raise TicketError("sdp_mismatch", "ticket is not bound to this SDP offer")
+        for key, value in expected.items():
+            if claims.get(key) != value:
+                raise TicketError("binding_mismatch", f"ticket {key} does not match the active session")
+
+        with self._lock:
+            self._used = {key: expiry for key, expiry in self._used.items() if expiry > now}
+            if jti in self._used:
+                raise TicketError("ticket_replayed", "ticket has already been used")
+            if len(self._used) >= self._max_replay_entries:
+                raise TicketError("replay_cache_full", "ticket replay cache is full")
+            self._used[jti] = exp
+        return claims
+
+
+def make_ticket_claims(
+    *,
+    session: Mapping[str, Any],
+    sdp: str,
+    ttl_seconds: int = 20,
+    wall_clock: Callable[[], float] = time.time,
+    jti: str | None = None,
+    audience: str = SIGNALING_AUDIENCE,
+) -> TicketClaims:
+    """Reference claim builder for Core integration and local tests."""
+
+    now = int(wall_clock())
+    return TicketClaims(
+        boot_id=str(session["boot_id"]),
+        session_id=str(session["session_id"]),
+        epoch=int(session["epoch"]),
+        fence=str(session["fence"]),
+        capability_digest=str(session["capability_digest"]),
+        sdp_sha256=sdp_digest(sdp),
+        iat=now,
+        exp=now + int(ttl_seconds),
+        jti=jti or _b64encode(uuid.uuid4().bytes),
+        audience=audience,
+    )

--- a/unitree/g1/teleop/rtc.py
+++ b/unitree/g1/teleop/rtc.py
@@ -1,0 +1,263 @@
+"""aiortc data-channel transport for the root G1 Driver."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from aiortc import RTCDataChannel, RTCPeerConnection, RTCSessionDescription
+
+from .protocol import ProtocolError, TicketError, TicketVerifier
+from .runtime import G1TeleopRuntime
+
+
+class RtcRequestError(RuntimeError):
+    def __init__(self, status: int, code: str, message: str):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+
+
+class RtcManager:
+    def __init__(self, runtime: G1TeleopRuntime, verifier: TicketVerifier | None):
+        self._runtime = runtime
+        self._verifier = verifier
+        self._peers: set[RTCPeerConnection] = set()
+        self._lock = asyncio.Lock()
+
+    @property
+    def enabled(self) -> bool:
+        return self._verifier is not None
+
+    async def accept_offer(self, payload: Any) -> dict:
+        if self._verifier is None:
+            raise RtcRequestError(
+                503,
+                "rtc_ticket_secret_missing",
+                "RTC is disabled until MOTUS_TELEOP_TICKET_SECRET is configured",
+            )
+        if not isinstance(payload, dict):
+            raise RtcRequestError(400, "invalid_offer", "offer body must be an object")
+        unknown = set(payload) - {"sdp", "type", "ticket"}
+        missing = {"sdp", "type", "ticket"} - set(payload)
+        if missing or unknown:
+            raise RtcRequestError(
+                400,
+                "invalid_offer",
+                f"offer fields invalid; missing={sorted(missing)}, unknown={sorted(unknown)}",
+            )
+        if payload["type"] != "offer" or not isinstance(payload["sdp"], str):
+            raise RtcRequestError(400, "invalid_offer", "type must be 'offer' and sdp must be a string")
+
+        try:
+            binding, generation = self._runtime.rtc_authority_snapshot()
+            self._verifier.verify_and_consume(
+                payload["ticket"],
+                expected=binding,
+                sdp=payload["sdp"],
+            )
+        except TicketError as exc:
+            self._runtime.record_protocol_error(exc.code)
+            raise RtcRequestError(401, exc.code, str(exc)) from exc
+        except ProtocolError as exc:
+            raise RtcRequestError(409, exc.code, str(exc)) from exc
+
+        async with self._lock:
+            # MCP may prepare a newer session while an offer is being verified.
+            # Never let a ticket for the old authority create a peer whose
+            # callbacks are accidentally bound to the new runtime generation.
+            try:
+                current_binding, current_generation = (
+                    self._runtime.rtc_authority_snapshot()
+                )
+                if current_binding != binding or current_generation != generation:
+                    raise RtcRequestError(
+                        409,
+                        "session_changed",
+                        "session changed while the RTC offer was being authorized",
+                    )
+            except ProtocolError as exc:
+                raise RtcRequestError(409, exc.code, str(exc)) from exc
+            await self._close_all_locked()
+            peer = RTCPeerConnection()
+            self._peers.add(peer)
+            self._install_peer_handlers(peer, generation, binding)
+            try:
+                await peer.setRemoteDescription(
+                    RTCSessionDescription(sdp=payload["sdp"], type=payload["type"])
+                )
+                answer = await peer.createAnswer()
+                await peer.setLocalDescription(answer)
+            except Exception as exc:
+                self._peers.discard(peer)
+                await peer.close()
+                self._runtime.record_protocol_error("invalid_sdp")
+                raise RtcRequestError(400, "invalid_sdp", f"failed to negotiate offer: {exc}") from exc
+
+        local = peer.localDescription
+        return {
+            "sdp": local.sdp,
+            "type": local.type,
+            "boot_id": binding["boot_id"],
+            "session_id": binding["session_id"],
+            "epoch": binding["epoch"],
+            "capability_digest": binding["capability_digest"],
+            "mode": self._runtime.mode,
+            "actuation_enabled": self._runtime.actuation_enabled,
+        }
+
+    async def close_all(self) -> None:
+        async with self._lock:
+            await self._close_all_locked()
+
+    async def _close_all_locked(self) -> None:
+        peers = list(self._peers)
+        self._peers.clear()
+        if peers:
+            await asyncio.gather(*(peer.close() for peer in peers), return_exceptions=True)
+
+    def _install_peer_handlers(
+        self,
+        peer: RTCPeerConnection,
+        generation: int,
+        authority: dict,
+    ) -> None:
+        accepted_labels: set[str] = set()
+
+        @peer.on("datachannel")
+        def on_datachannel(channel: RTCDataChannel) -> None:
+            label = channel.label
+            if label in accepted_labels or not self._channel_contract_valid(channel):
+                self._runtime.record_protocol_error("invalid_data_channel")
+                channel.close()
+                return
+            accepted_labels.add(label)
+
+            @channel.on("open")
+            def on_open() -> None:
+                self._runtime.mark_channel(generation, label, True)
+
+            @channel.on("close")
+            def on_close() -> None:
+                self._runtime.mark_channel(generation, label, False)
+
+            @channel.on("message")
+            def on_message(message: str | bytes) -> None:
+                if label == "teleop-pose":
+                    self._handle_pose_message(message, generation, authority)
+                else:
+                    if not self._runtime.generation_matches(generation):
+                        self._runtime.record_protocol_error("stale_rtc_message")
+                        return
+                    self._handle_control_message(channel, message)
+
+            # aiortc emits the remote `datachannel` event after moving the
+            # channel to open, so its earlier `open` event is not observable
+            # from this callback.  Record that already-open state explicitly.
+            if channel.readyState == "open":
+                self._runtime.mark_channel(generation, label, True)
+
+        @peer.on("connectionstatechange")
+        async def on_connectionstatechange() -> None:
+            if peer.connectionState in ("failed", "closed", "disconnected"):
+                self._runtime.mark_rtc_disconnected(generation, f"rtc_{peer.connectionState}")
+                self._peers.discard(peer)
+                if peer.connectionState != "closed":
+                    await peer.close()
+
+    @staticmethod
+    def _channel_contract_valid(channel: RTCDataChannel) -> bool:
+        if channel.label == "teleop-control":
+            return (
+                channel.ordered is True
+                and channel.maxRetransmits is None
+                and channel.maxPacketLifeTime is None
+            )
+        if channel.label == "teleop-pose":
+            return (
+                channel.ordered is False
+                and channel.maxRetransmits == 0
+                and channel.maxPacketLifeTime is None
+            )
+        return False
+
+    def _decode_message(self, message: str | bytes, *, maximum: int) -> Any:
+        if isinstance(message, bytes):
+            if len(message) > maximum:
+                raise ProtocolError("message_too_large", f"RTC message exceeds {maximum} bytes")
+            try:
+                message = message.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ProtocolError("invalid_encoding", "RTC message must be UTF-8 JSON") from exc
+        if not isinstance(message, str):
+            raise ProtocolError("invalid_encoding", "RTC message must be UTF-8 JSON")
+        try:
+            encoded_size = len(message.encode("utf-8"))
+        except UnicodeEncodeError as exc:
+            raise ProtocolError("invalid_encoding", "RTC message must be UTF-8 JSON") from exc
+        if encoded_size > maximum:
+            raise ProtocolError("message_too_large", f"RTC message exceeds {maximum} bytes")
+        try:
+            return json.loads(message)
+        except (json.JSONDecodeError, ValueError, RecursionError) as exc:
+            raise ProtocolError("invalid_json", "RTC message must be valid JSON") from exc
+
+    def _handle_pose_message(
+        self,
+        message: str | bytes,
+        generation: int,
+        authority: dict,
+    ) -> None:
+        try:
+            self._runtime.submit_rtc_frame(
+                self._decode_message(message, maximum=64 * 1024),
+                authority=authority,
+                rtc_generation=generation,
+            )
+        except ProtocolError as exc:
+            self._runtime.record_protocol_error(exc.code)
+
+    def _handle_control_message(
+        self,
+        channel: RTCDataChannel,
+        message: str | bytes,
+    ) -> None:
+        try:
+            payload = self._decode_message(message, maximum=8 * 1024)
+            if not isinstance(payload, dict) or set(payload) - {"type", "request_id"}:
+                raise ProtocolError(
+                    "invalid_control",
+                    "control message contains invalid or private authority fields",
+                )
+            message_type = payload.get("type")
+            if message_type in ("peer_ping", "status"):
+                result = self._runtime.status()
+            elif message_type == "heartbeat":
+                raise ProtocolError(
+                    "rtc_cannot_renew_lease",
+                    "RTC control messages never renew the Core-owned lease",
+                )
+            elif message_type in ("pause", "soft_stop", "release"):
+                raise ProtocolError(
+                    "rtc_control_requires_core",
+                    "session mutations must use the authenticated Core REST API",
+                )
+            else:
+                raise ProtocolError("invalid_control", f"unsupported control message type: {message_type}")
+            channel.send(json.dumps({
+                "type": "response",
+                "request_id": payload.get("request_id"),
+                "ok": True,
+                "state": result["state"],
+                "lease_renewed": False,
+            }, separators=(",", ":")))
+        except ProtocolError as exc:
+            self._runtime.record_protocol_error(exc.code)
+            if channel.readyState == "open":
+                channel.send(json.dumps({
+                    "type": "response",
+                    "ok": False,
+                    "error": {"code": exc.code, "message": str(exc)},
+                    "lease_renewed": False,
+                }, separators=(",", ":")))

--- a/unitree/g1/teleop/runtime.py
+++ b/unitree/g1/teleop/runtime.py
@@ -1,0 +1,869 @@
+"""Thread-safe G1 teleoperation session runtime."""
+
+from __future__ import annotations
+
+import copy
+import re
+import secrets
+import threading
+import time
+import uuid
+from collections import Counter, deque
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from .descriptor import CAPABILITIES, PROFILE_ID, capability_digest
+from .dispatch import FinalDispatchArbiter, OutputAdapter, StopHandle
+from .protocol import (
+    ProtocolError,
+    bind_rtc_frame_v1,
+    validate_frame_v1,
+)
+
+SESSION_STATES = {
+    "idle",
+    "prepared_shadow",
+    "active_shadow",
+    "prepared_live",
+    "active_live",
+    "hold",
+    "paused",
+    "released",
+    "fault",
+}
+class G1TeleopRuntime:
+    """Own fencing, watchdogs and the sole G1 final-dispatch boundary."""
+
+    def __init__(
+        self,
+        *,
+        lease_timeout_ms: int = 1000,
+        pose_timeout_ms: int = 200,
+        watchdog_interval_ms: int = 25,
+        driver_id: str = "unitree-g1",
+        driver_name: str = "Unitree G1 Bundle",
+        robot_id: str | None = None,
+        clock: Callable[[], float] = time.monotonic,
+        auto_watchdog: bool = True,
+        dispatch_io_timeout_ms: int = 100,
+        dispatch_ack_timeout_ms: int = 200,
+        mode: str,
+        adapter: OutputAdapter,
+    ):
+        if lease_timeout_ms < 100:
+            raise ValueError("lease_timeout_ms must be >= 100")
+        if pose_timeout_ms < 20:
+            raise ValueError("pose_timeout_ms must be >= 20")
+        if watchdog_interval_ms < 5:
+            raise ValueError("watchdog_interval_ms must be >= 5")
+        if dispatch_io_timeout_ms < 20 or dispatch_io_timeout_ms > 150:
+            raise ValueError("dispatch_io_timeout_ms must be in [20, 150]")
+        if (
+            dispatch_ack_timeout_ms < dispatch_io_timeout_ms
+            or dispatch_ack_timeout_ms > 200
+        ):
+            raise ValueError(
+                "dispatch_ack_timeout_ms must be >= dispatch_io_timeout_ms and <= 200"
+            )
+        if mode not in ("shadow", "live"):
+            raise ValueError("mode must be 'shadow' or 'live'")
+        expected_hardware = mode == "live"
+        if getattr(adapter, "hardware_output", None) is not expected_hardware:
+            raise ValueError("adapter hardware_output must match the configured session mode")
+        self.boot_id = str(uuid.uuid4())
+        self.driver_id = driver_id
+        self.driver_name = driver_name
+        self.robot_id = robot_id or driver_id
+        self.mode = mode
+        self.profile_id = PROFILE_ID
+        self.capabilities = copy.deepcopy(CAPABILITIES)
+        self.capability_digest = capability_digest(mode)
+        self.actuation_enabled = expected_hardware
+        self._prepared_state = f"prepared_{mode}"
+        self._active_state = f"active_{mode}"
+        self._prepare_action = f"prepare_{mode}"
+        self._lease_timeout = lease_timeout_ms / 1000.0
+        self._pose_timeout = pose_timeout_ms / 1000.0
+        self._watchdog_interval = watchdog_interval_ms / 1000.0
+        self._clock = clock
+        self._lock = threading.RLock()
+        self._transition_lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._watchdog_thread: threading.Thread | None = None
+        self._dispatch_ack_timeout = dispatch_ack_timeout_ms / 1000.0
+        self._dispatcher = FinalDispatchArbiter(
+            adapter,
+            clock=clock,
+            io_timeout_ms=dispatch_io_timeout_ms,
+        )
+        self._closed = False
+
+        self._epoch = 0
+        self._generation = 0
+        self._state = "idle"
+        self._reason: str | None = None
+        self._session_id: str | None = None
+        self._fence: str | None = None
+        self._prepared_at: float | None = None
+        self._last_lease_at: float | None = None
+        self._authority_valid = False
+        self._authority_invalid_reason: str | None = "not_prepared"
+        self._last_pose_at: float | None = None
+        self._latest_frame: dict | None = None
+        self._last_sequence: int | None = None
+        self._hold_clutch_sequence = -1
+        self._neutral_required = True
+        self._rtc_connected = False
+        self._channels = {"teleop-control": False, "teleop-pose": False}
+        self._counters: Counter[str] = Counter()
+        self._frame_times: deque[float] = deque(maxlen=256)
+        self._sequence_gaps = 0
+        self._rtc_rtt_ms: float | None = None
+        if auto_watchdog:
+            self.start()
+
+    def start(self) -> None:
+        """Start one long-lived watchdog thread; calling twice is harmless."""
+
+        with self._lock:
+            if self._closed:
+                return
+            if self._watchdog_thread and self._watchdog_thread.is_alive():
+                return
+            self._stop_event.clear()
+            self._watchdog_thread = threading.Thread(
+                target=self._watchdog_loop,
+                daemon=True,
+                name="g1-teleop-watchdog",
+            )
+            self._watchdog_thread.start()
+
+    def close(self) -> None:
+        self._stop_event.set()
+        thread = self._watchdog_thread
+        if thread and thread is not threading.current_thread():
+            thread.join(timeout=max(1.0, self._watchdog_interval * 4))
+        with self._transition_lock:
+            with self._lock:
+                if self._closed:
+                    return
+                self._closed = True
+                if self._authority_valid:
+                    self._generation += 1
+                self._authority_valid = False
+                self._authority_invalid_reason = "service_close"
+                self._state = "released"
+                self._reason = "service_close"
+                self._clear_session_locked()
+            ack = self._dispatcher.close(self._dispatch_ack_timeout)
+            if not ack.ok:
+                with self._lock:
+                    self._latch_dispatch_fault_locked(ack.code)
+
+    def prepare(self, requested_mode: str, args: dict) -> dict:
+        if requested_mode != self.mode:
+            raise ProtocolError(
+                "mode_not_configured",
+                f"Driver is configured for {self.mode!r}; {requested_mode!r} prepare is unavailable",
+            )
+        session_id = self._canonical_uuid(args.get("session_id"), "session_id")
+        epoch = args.get("epoch")
+        if isinstance(epoch, bool) or not isinstance(epoch, int) or epoch < 1:
+            raise ProtocolError("invalid_epoch", "epoch must be an integer >= 1")
+        fence = args.get("fence")
+        if not isinstance(fence, str) or not re.fullmatch(r"[A-Za-z0-9_-]{24,128}", fence):
+            raise ProtocolError("invalid_fence", "fence must be a URL-safe token of 24-128 characters")
+        binding = {
+            "boot_id": self.boot_id,
+            "session_id": session_id,
+            "epoch": epoch,
+            "fence": fence,
+        }
+        with self._transition_lock:
+            with self._lock:
+                self._require_open_locked()
+                if epoch <= self._epoch:
+                    raise ProtocolError("stale_epoch", f"epoch must be greater than {self._epoch}")
+                # Fence RTC and Frame callbacks before the safe-stop leaves the
+                # runtime lock.  The new authority is installed only after the
+                # final adapter has acknowledged that stop.
+                self._generation += 1
+                generation = self._generation
+                self._authority_valid = False
+                self._authority_invalid_reason = self._prepare_action
+                self._state = "hold"
+                self._reason = self._prepare_action
+                self._clear_session_locked()
+                handle = self._dispatcher.begin_prepare(self._prepare_action)
+            ack = self._dispatcher.wait_safe(handle, self._dispatch_ack_timeout)
+            if not ack.ok:
+                with self._lock:
+                    self._latch_dispatch_fault_locked(ack.code)
+                raise ProtocolError(
+                    "dispatch_stop_unconfirmed",
+                    "final output adapter did not acknowledge prepare safe-stop",
+                )
+            with self._lock:
+                self._require_open_locked()
+                dispatch_ack = self._dispatcher.complete_prepare(handle, binding, generation)
+                if not dispatch_ack.ok:
+                    self._latch_dispatch_fault_locked(dispatch_ack.code)
+                    raise ProtocolError(
+                        "dispatch_prepare_failed",
+                        "final output adapter could not arm the configured teleoperation session",
+                    )
+                now = self._clock()
+                self._epoch = epoch
+                self._state = self._prepared_state
+                self._reason = None
+                self._session_id = session_id
+                self._fence = fence
+                self._prepared_at = now
+                self._last_lease_at = now
+                self._authority_valid = True
+                self._authority_invalid_reason = None
+                self._last_pose_at = None
+                self._latest_frame = None
+                self._last_sequence = None
+                self._hold_clutch_sequence = -1
+                self._neutral_required = True
+                self._rtc_connected = False
+                self._channels = {"teleop-control": False, "teleop-pose": False}
+                self._counters["sessions_prepared"] += 1
+                return self._public_snapshot_locked(now)
+
+    def heartbeat(self, args: dict) -> dict:
+        now = self._clock()
+        with self._lock:
+            self._require_open_locked()
+            self._require_session_live_locked()
+            self._require_identity_locked(args)
+            self._require_authority_valid_locked(now)
+            self._last_lease_at = now
+            self._counters["lease_heartbeats"] += 1
+            return self._public_snapshot_locked(now)
+
+    def pause(self, args: dict) -> dict:
+        with self._transition_lock:
+            now = self._clock()
+            with self._lock:
+                self._require_open_locked()
+                self._require_session_live_locked()
+                self._require_identity_locked(args)
+                self._require_authority_valid_locked(now)
+                handle = self._enter_hold_locked("operator_pause", target_state="paused")
+            self._wait_for_transition_stop(handle, "pause")
+            with self._lock:
+                return self._public_snapshot_locked(self._clock())
+
+    def soft_stop(self, args: dict) -> dict:
+        with self._transition_lock:
+            now = self._clock()
+            with self._lock:
+                self._require_open_locked()
+                self._require_session_live_locked()
+                self._require_identity_locked(args)
+                self._require_authority_valid_locked(now)
+                if self._state == "paused":
+                    raise ProtocolError(
+                        "session_paused",
+                        f"a paused session requires a new {self._prepare_action}",
+                    )
+                handle = self._enter_hold_locked("soft_stop")
+                self._counters["soft_stops"] += 1
+            self._wait_for_transition_stop(handle, "soft_stop")
+            with self._lock:
+                return self._public_snapshot_locked(self._clock())
+
+    def release(self, args: dict | None = None, *, lifecycle: bool = False) -> dict:
+        with self._transition_lock:
+            with self._lock:
+                self._require_open_locked()
+                if not lifecycle:
+                    self._require_session_live_locked()
+                    self._require_identity_locked(args or {})
+                reason = "lifecycle_stop" if lifecycle else "operator_release"
+                handle = self._invalidate_authority_locked(reason, target_state="released")
+                self._counters["sessions_released"] += 1
+            self._wait_for_transition_stop(handle, "release")
+            with self._lock:
+                return self._public_snapshot_locked(self._clock())
+
+    def submit_frame(
+        self,
+        raw_frame: Any,
+        *,
+        source: str,
+        rtc_generation: int | None = None,
+    ) -> dict:
+        received_at = self._clock()
+        with self._lock:
+            self._counters["frames_received"] += 1
+        try:
+            frame = validate_frame_v1(raw_frame, expected_mode=self.mode)
+        except ProtocolError as exc:
+            with self._lock:
+                self._counters["frames_rejected"] += 1
+                self._counters[f"reject_{exc.code}"] += 1
+            raise
+
+        now = self._clock()
+        with self._lock:
+            try:
+                self._require_open_locked()
+                self._require_session_live_locked()
+                self._require_identity_locked(frame)
+                self._require_authority_valid_locked(now)
+                if source == "rtc":
+                    if rtc_generation != self._generation:
+                        raise ProtocolError(
+                            "stale_rtc_generation",
+                            "RTC Pose belongs to a stale session generation",
+                        )
+                    if not self._rtc_connected or not all(self._channels.values()):
+                        if self._state in (self._prepared_state, self._active_state):
+                            self._enter_hold_locked("rtc_not_ready")
+                        raise ProtocolError(
+                            "rtc_not_ready",
+                            "both teleop-control and teleop-pose must be open for RTC Pose",
+                        )
+                if self._state == "paused":
+                    raise ProtocolError("session_inactive", f"cannot accept frames in state {self._state}")
+                sequence = frame["sequence"]
+                if self._last_sequence is not None and sequence <= self._last_sequence:
+                    raise ProtocolError(
+                        "sequence_not_increasing",
+                        f"sequence must be greater than {self._last_sequence}",
+                    )
+            except ProtocolError as exc:
+                self._counters["frames_rejected"] += 1
+                self._counters[f"reject_{exc.code}"] += 1
+                raise
+
+            if self._last_sequence is not None and sequence > self._last_sequence + 1:
+                self._sequence_gaps += sequence - self._last_sequence - 1
+            self._latest_frame = frame
+            self._last_sequence = sequence
+            self._last_pose_at = now
+            self._counters["frames_accepted"] += 1
+            self._counters[f"frames_from_{source}"] += 1
+            self._frame_times.append(now)
+
+            tracking_ok = all(frame["tracking"].values())
+            dispatch_frame = False
+            allow_reclutch = False
+            if self._state == "hold" and self._reason == "soft_stop":
+                # Core has no resume/rearm action.  An operator soft-stop is a
+                # latch: only release followed by a newer prepare can re-arm.
+                self._counters["frames_held_after_soft_stop"] += 1
+            elif not tracking_ok:
+                self._enter_hold_locked("tracking_lost")
+            elif self._neutral_required:
+                if frame["deadman"]:
+                    self._counters["frames_held_neutral_required"] += 1
+                    if self._state == self._active_state:
+                        self._enter_hold_locked("neutral_required")
+                else:
+                    self._neutral_required = False
+                    self._hold_clutch_sequence = max(
+                        self._hold_clutch_sequence,
+                        int(frame["clutch_sequence"]),
+                    )
+                    self._counters["neutral_observations"] += 1
+            elif not frame["deadman"]:
+                self._enter_hold_locked("deadman_released")
+            elif self._state == self._prepared_state:
+                if frame["clutch_sequence"] > self._hold_clutch_sequence:
+                    self._state = self._active_state
+                    self._reason = None
+                    dispatch_frame = True
+                    allow_reclutch = True
+                else:
+                    self._counters["frames_held_without_reclutch"] += 1
+            elif self._state == "hold":
+                if frame["clutch_sequence"] > self._hold_clutch_sequence:
+                    self._state = self._active_state
+                    self._reason = None
+                    self._counters["explicit_reclutches"] += 1
+                    dispatch_frame = True
+                    allow_reclutch = True
+                else:
+                    self._counters["frames_held_without_reclutch"] += 1
+            elif self._state == self._active_state:
+                dispatch_frame = True
+
+            if dispatch_frame:
+                lease_started = (
+                    self._last_lease_at if self._last_lease_at is not None else now
+                )
+                dispatch_ack = self._dispatcher.publish_latest(
+                    frame,
+                    session_generation=self._generation,
+                    expires_monotonic=min(
+                        now + self._pose_timeout,
+                        lease_started + self._lease_timeout,
+                    ),
+                    allow_reclutch=allow_reclutch,
+                    received_monotonic=received_at,
+                )
+                if not dispatch_ack.ok:
+                    self._counters["dispatch_rejections"] += 1
+                    self._counters[f"dispatch_reject_{dispatch_ack.code}"] += 1
+                    dispatch_state = self._dispatcher.snapshot()["state"]
+                    if dispatch_ack.code == "intent_expired" or (
+                        dispatch_ack.code == "motion_inhibited"
+                        and dispatch_state == "safe_reclutch_required"
+                    ):
+                        self._enter_hold_locked("pose_timeout")
+                    else:
+                        self._dispatcher.trip(
+                            "dispatch_fault",
+                            target_state="fault_latched",
+                            retain_authority=False,
+                        )
+                        self._latch_dispatch_fault_locked(dispatch_ack.code)
+                        raise ProtocolError(
+                            "dispatch_fault",
+                            "final output authority check failed; a new Driver process is required",
+                        )
+
+            result = self._public_snapshot_locked(now)
+            result["accepted_sequence"] = sequence
+            return result
+
+    def mark_channel(self, generation: int, label: str, opened: bool) -> dict:
+        now = self._clock()
+        with self._lock:
+            if generation != self._generation:
+                self._counters["stale_rtc_callbacks"] += 1
+                return self._public_snapshot_locked(now)
+            if self._state in ("idle", "released"):
+                self._counters["terminal_rtc_callbacks_ignored"] += 1
+                return self._public_snapshot_locked(now)
+            if not self._authority_valid or self._lease_deadline_passed_locked(now):
+                if self._authority_valid:
+                    self._invalidate_authority_locked("lease_timeout", target_state="hold")
+                self._counters["expired_rtc_callbacks_ignored"] += 1
+                return self._public_snapshot_locked(now)
+            was_connected = self._rtc_connected
+            if label in self._channels:
+                self._channels[label] = bool(opened)
+            self._rtc_connected = all(self._channels.values())
+            if self._rtc_connected and not was_connected:
+                self._neutral_required = True
+                self._counters["rtc_neutral_resets"] += 1
+            if not opened and self._state in (self._prepared_state, self._active_state):
+                self._enter_hold_locked("rtc_disconnected")
+            return self._public_snapshot_locked(now)
+
+    def submit_rtc_frame(
+        self,
+        raw_frame: Any,
+        *,
+        authority: Mapping[str, Any],
+        rtc_generation: int,
+    ) -> dict:
+        """Bind one public RTC frame before entering the common safety path."""
+
+        try:
+            frame = bind_rtc_frame_v1(
+                raw_frame,
+                authority=authority,
+                expected_mode=self.mode,
+            )
+        except ProtocolError as exc:
+            with self._lock:
+                self._counters["frames_rejected"] += 1
+                self._counters[f"reject_{exc.code}"] += 1
+            raise
+        return self.submit_frame(
+            frame,
+            source="rtc",
+            rtc_generation=rtc_generation,
+        )
+
+    def mark_rtc_disconnected(self, generation: int, reason: str = "rtc_disconnected") -> dict:
+        now = self._clock()
+        with self._lock:
+            if generation != self._generation:
+                self._counters["stale_rtc_callbacks"] += 1
+                return self._public_snapshot_locked(now)
+            if self._state in ("idle", "released"):
+                self._counters["terminal_rtc_callbacks_ignored"] += 1
+                return self._public_snapshot_locked(now)
+            if not self._authority_valid or self._lease_deadline_passed_locked(now):
+                if self._authority_valid:
+                    self._invalidate_authority_locked("lease_timeout", target_state="hold")
+                self._counters["expired_rtc_callbacks_ignored"] += 1
+                return self._public_snapshot_locked(now)
+            self._rtc_connected = False
+            self._channels = {"teleop-control": False, "teleop-pose": False}
+            if self._state in (self._prepared_state, self._active_state):
+                self._enter_hold_locked(reason)
+            self._counters["rtc_disconnects"] += 1
+            return self._public_snapshot_locked(now)
+
+    def record_protocol_error(self, code: str) -> None:
+        with self._lock:
+            self._counters["protocol_errors"] += 1
+            self._counters[f"protocol_{code}"] += 1
+
+    def record_rtc_rtt(self, milliseconds: float | None) -> None:
+        with self._lock:
+            if milliseconds is None:
+                self._rtc_rtt_ms = None
+                return
+            value = float(milliseconds)
+            if value < 0.0 or value > 60_000.0:
+                raise ValueError("RTC RTT must be in [0, 60000] milliseconds")
+            self._rtc_rtt_ms = round(value, 3)
+
+    def status(self) -> dict:
+        with self._lock:
+            now = self._clock()
+            if self._authority_valid and self._lease_deadline_passed_locked(now):
+                self._invalidate_authority_locked("lease_timeout", target_state="hold")
+            return self._public_snapshot_locked(now)
+
+    def ticket_binding(self) -> dict:
+        with self._lock:
+            self._require_open_locked()
+            self._require_session_live_locked()
+            self._require_authority_valid_locked(self._clock())
+            return self._ticket_binding_locked()
+
+    def rtc_authority_snapshot(self) -> tuple[dict, int]:
+        """Capture one immutable RTC authority tuple under the runtime lock."""
+
+        with self._lock:
+            self._require_open_locked()
+            self._require_session_live_locked()
+            self._require_authority_valid_locked(self._clock())
+            return self._ticket_binding_locked(), self._generation
+
+    def session_generation(self) -> int:
+        """Return the opaque internal generation used only to fence RTC callbacks."""
+
+        with self._lock:
+            return self._generation
+
+    def generation_matches(self, generation: int) -> bool:
+        with self._lock:
+            self._sync_dispatch_fault_locked()
+            if generation != self._generation:
+                return False
+            if not self._authority_valid:
+                return False
+            if self._lease_deadline_passed_locked(self._clock()):
+                self._invalidate_authority_locked("lease_timeout", target_state="hold")
+                return False
+            return True
+
+    def watchdog_tick(self) -> dict:
+        now = self._clock()
+        with self._lock:
+            self._sync_dispatch_fault_locked()
+            if self._authority_valid and self._state in (
+                self._prepared_state, self._active_state, "hold", "paused"
+            ):
+                if self._lease_deadline_passed_locked(now):
+                    self._invalidate_authority_locked("lease_timeout", target_state="hold")
+                elif (
+                    self._state == self._active_state
+                    and self._last_pose_at is not None
+                    and now - self._last_pose_at > self._pose_timeout
+                ):
+                    self._enter_hold_locked("pose_timeout")
+                    self._counters["pose_timeouts"] += 1
+            return self._public_snapshot_locked(now)
+
+    def _watchdog_loop(self) -> None:
+        while not self._stop_event.wait(self._watchdog_interval):
+            self.watchdog_tick()
+
+    def _enter_hold_locked(
+        self,
+        reason: str,
+        *,
+        target_state: str = "hold",
+    ) -> StopHandle | None:
+        changed = self._state != target_state or self._reason != reason
+        self._state = target_state
+        self._reason = reason
+        if self._latest_frame is not None:
+            self._hold_clutch_sequence = max(
+                self._hold_clutch_sequence,
+                int(self._latest_frame["clutch_sequence"]),
+            )
+        if not changed:
+            return None
+        dispatch_state = (
+            "safe_latched"
+            if target_state == "paused" or reason == "soft_stop"
+            else "safe_reclutch_required"
+        )
+        return self._dispatcher.trip(
+            reason,
+            target_state=dispatch_state,
+            retain_authority=True,
+        )
+
+    def _lease_deadline_passed_locked(self, now: float) -> bool:
+        return self._last_lease_at is None or now - self._last_lease_at > self._lease_timeout
+
+    def _invalidate_authority_locked(
+        self,
+        reason: str,
+        *,
+        target_state: str,
+    ) -> StopHandle:
+        was_valid = self._authority_valid
+        self._authority_valid = False
+        self._authority_invalid_reason = reason
+        if was_valid:
+            self._generation += 1
+        self._state = target_state
+        self._reason = reason
+        self._clear_session_locked()
+        handle = self._dispatcher.trip(
+            reason,
+            target_state="safe_revoked",
+            retain_authority=False,
+        )
+        if was_valid and reason == "lease_timeout":
+            self._counters["lease_timeouts"] += 1
+        return handle
+
+    def _clear_session_locked(self) -> None:
+        self._session_id = None
+        self._fence = None
+        self._prepared_at = None
+        self._last_lease_at = None
+        self._last_pose_at = None
+        self._latest_frame = None
+        self._last_sequence = None
+        self._hold_clutch_sequence = -1
+        self._neutral_required = True
+        self._frame_times.clear()
+        self._sequence_gaps = 0
+        self._rtc_connected = False
+        self._channels = {"teleop-control": False, "teleop-pose": False}
+
+    def _wait_for_transition_stop(
+        self,
+        handle: StopHandle | None,
+        operation: str,
+    ) -> None:
+        if handle is None:
+            return
+        ack = self._dispatcher.wait_safe(handle, self._dispatch_ack_timeout)
+        if ack.ok:
+            return
+        with self._lock:
+            self._latch_dispatch_fault_locked(ack.code)
+        raise ProtocolError(
+            "dispatch_stop_unconfirmed",
+            f"final output adapter did not acknowledge {operation} safe-stop",
+        )
+
+    def _latch_dispatch_fault_locked(self, code: str) -> None:
+        if self._authority_valid:
+            self._generation += 1
+        self._authority_valid = False
+        self._authority_invalid_reason = "dispatch_fault"
+        self._state = "fault"
+        self._reason = "dispatch_fault"
+        self._clear_session_locked()
+        self._counters["dispatch_faults"] += 1
+        self._counters[f"dispatch_fault_{code}"] += 1
+
+    def _sync_dispatch_fault_locked(self) -> None:
+        dispatch = self._dispatcher.snapshot()
+        code = dispatch.get("fault_code")
+        if code is not None and self._authority_invalid_reason != "dispatch_fault":
+            self._latch_dispatch_fault_locked(str(code))
+            return
+        release_reason = dispatch.get("external_release_reason")
+        dispatch_state = dispatch.get("state")
+        if (
+            (
+                release_reason in {"command_timeout", "intent_expired"}
+                or dispatch_state == "safe_reclutch_required"
+            )
+            and self._authority_valid
+            and self._state == self._active_state
+        ):
+            self._state = "hold"
+            self._reason = (
+                str(release_reason)
+                if release_reason in {"command_timeout", "intent_expired"}
+                else "pose_timeout"
+            )
+            self._neutral_required = True
+            if self._latest_frame is not None:
+                self._hold_clutch_sequence = max(
+                    self._hold_clutch_sequence,
+                    int(self._latest_frame["clutch_sequence"]),
+                )
+            self._counters["hardware_ttl_holds"] += 1
+
+    def _require_open_locked(self) -> None:
+        if self._closed:
+            raise ProtocolError("service_closed", "the Driver process is closing")
+        self._sync_dispatch_fault_locked()
+
+    def _require_authority_valid_locked(self, now: float) -> None:
+        if not self._authority_valid:
+            self._raise_invalid_authority_locked()
+        if self._lease_deadline_passed_locked(now):
+            self._invalidate_authority_locked("lease_timeout", target_state="hold")
+            raise ProtocolError(
+                "session_expired",
+                f"Core MCP heartbeat lease expired; a new {self._prepare_action} is required",
+            )
+
+    def _require_session_live_locked(self) -> None:
+        if not self._authority_valid:
+            self._raise_invalid_authority_locked()
+
+    def _raise_invalid_authority_locked(self) -> None:
+        if self._authority_invalid_reason == "lease_timeout":
+            raise ProtocolError(
+                "session_expired",
+                f"Core MCP heartbeat lease expired; a new {self._prepare_action} is required",
+            )
+        raise ProtocolError(
+            "session_inactive",
+            f"a new {self._prepare_action} session is required",
+        )
+
+    def _require_identity_locked(self, value: dict) -> None:
+        required = ("boot_id", "session_id", "epoch", "fence")
+        missing = [key for key in required if key not in value]
+        if missing:
+            raise ProtocolError("missing_identity", f"missing session identity fields: {missing}")
+        if value["boot_id"] != self.boot_id:
+            raise ProtocolError("boot_mismatch", "boot_id does not match this Driver process")
+        if value["session_id"] != self._session_id:
+            raise ProtocolError("session_mismatch", "session_id does not match the active session")
+        if isinstance(value["epoch"], bool) or value["epoch"] != self._epoch:
+            raise ProtocolError("epoch_mismatch", "epoch does not match the active session")
+        if not isinstance(value["fence"], str) or not secrets.compare_digest(value["fence"], self._fence or ""):
+            raise ProtocolError("fence_mismatch", "fence does not match the active session")
+
+    def _ticket_binding_locked(self) -> dict:
+        assert self._session_id is not None and self._fence is not None
+        return {
+            "boot_id": self.boot_id,
+            "session_id": self._session_id,
+            "epoch": self._epoch,
+            "fence": self._fence,
+            "capability_digest": self.capability_digest,
+        }
+
+    @staticmethod
+    def _canonical_uuid(value: Any, name: str) -> str:
+        if not isinstance(value, str):
+            raise ProtocolError("invalid_session_id", f"{name} must be a canonical UUID")
+        try:
+            parsed = uuid.UUID(value)
+        except ValueError as exc:
+            raise ProtocolError("invalid_session_id", f"{name} must be a canonical UUID") from exc
+        if str(parsed) != value.lower():
+            raise ProtocolError("invalid_session_id", f"{name} must be a canonical UUID")
+        return str(parsed)
+
+    def _public_snapshot_locked(self, now: float) -> dict:
+        self._sync_dispatch_fault_locked()
+        lease_age = None if self._last_lease_at is None else max(0.0, now - self._last_lease_at)
+        pose_age = None if self._last_pose_at is None else max(0.0, now - self._last_pose_at)
+        latest = copy.deepcopy(self._latest_frame)
+        if latest is not None:
+            latest.pop("fence", None)
+        dispatch = self._dispatcher.snapshot()
+        adapter_snapshot = dispatch.get("adapter", {})
+        adapter_diagnostics = (
+            adapter_snapshot.get("diagnostics", {})
+            if isinstance(adapter_snapshot, dict)
+            else {}
+        )
+        adapter_latency = adapter_diagnostics.get("latency_ms", {})
+        dispatch_latency = dispatch.get("latency_ms", {})
+        empty_latency = {"last": None, "p50": None, "p95": None, "p99": None, "count": 0}
+        latency = {
+            "receive_to_admit": copy.deepcopy(
+                dispatch_latency.get("receive_to_admit", empty_latency)
+            ),
+            "mailbox_wait": copy.deepcopy(
+                dispatch_latency.get("mailbox_wait", empty_latency)
+            ),
+            "ik": copy.deepcopy(adapter_latency.get("ik", empty_latency)),
+            "adapter_apply": copy.deepcopy(
+                adapter_latency.get("adapter_apply", empty_latency)
+            ),
+            "robot_follow": copy.deepcopy(
+                adapter_latency.get("robot_follow", empty_latency)
+            ),
+        }
+        if len(self._frame_times) >= 2:
+            span = self._frame_times[-1] - self._frame_times[0]
+            frame_rate_hz = 0.0 if span <= 0.0 else (len(self._frame_times) - 1) / span
+        else:
+            frame_rate_hz = 0.0
+        transport = {
+            "rtc_rtt_ms": self._rtc_rtt_ms,
+            "pose_age_ms": None if pose_age is None else round(pose_age * 1000, 3),
+            "frame_rate_hz": round(min(1000.0, max(0.0, frame_rate_hz)), 3),
+            "frames_received": int(self._counters.get("frames_received", 0)),
+            "frames_rejected": int(self._counters.get("frames_rejected", 0)),
+            "sequence_gaps": int(self._sequence_gaps),
+            "mailbox_replacements": int(
+                dispatch.get("counters", {}).get("mailbox_replacements", 0)
+            ),
+        }
+        output = copy.deepcopy(adapter_snapshot.get("output", {}))
+        return {
+            "driver": self.driver_id,
+            "driver_id": self.driver_id,
+            "driver_name": self.driver_name,
+            "driver_type": "teleop",
+            "robot_id": self.robot_id,
+            "profile_id": self.profile_id,
+            "mode": self.mode,
+            "actuation_enabled": self.actuation_enabled,
+            "boot_id": self.boot_id,
+            "session_id": self._session_id,
+            "epoch": self._epoch,
+            "state": self._state,
+            "reason": self._reason,
+            "authority_valid": self._authority_valid,
+            "capability_digest": self.capability_digest,
+            "capabilities": copy.deepcopy(self.capabilities),
+            "lease": {
+                "source": "agent-core-mcp-heartbeat-only",
+                "timeout_ms": round(self._lease_timeout * 1000),
+                "age_ms": None if lease_age is None else round(lease_age * 1000, 3),
+                "fresh": lease_age is not None and lease_age <= self._lease_timeout,
+                "authority_valid": self._authority_valid,
+                "expired_latched": self._authority_invalid_reason == "lease_timeout",
+            },
+            "pose": {
+                "timeout_ms": round(self._pose_timeout * 1000),
+                "age_ms": None if pose_age is None else round(pose_age * 1000, 3),
+                "fresh": pose_age is not None and pose_age <= self._pose_timeout,
+                "latest_sequence": self._last_sequence,
+                "latest": latest,
+            },
+            "rtc": {
+                "connected": self._rtc_connected,
+                "channels": dict(self._channels),
+                "renews_lease": False,
+            },
+            "dispatch": dispatch,
+            "diagnostics": {
+                "transport": transport,
+                "latency_ms": latency,
+            },
+            "output": output,
+            "counters": dict(sorted(self._counters.items())),
+        }

--- a/unitree/g1/teleop/service.py
+++ b/unitree/g1/teleop/service.py
@@ -1,0 +1,604 @@
+"""G1 teleoperation MCP facade and in-process aiortc event loop."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import hmac
+import json
+import math
+import re
+import threading
+import time
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from .descriptor import (
+    PREFLIGHT_SCHEMA,
+    PROFILE_ID,
+    SIGNALING_AUDIENCE,
+    tool_definitions,
+)
+from .protocol import ProtocolError, TicketCodec, TicketVerifier
+from .rtc import RtcManager, RtcRequestError
+from .runtime import G1TeleopRuntime
+
+_IDENTITY_KEYS = {"boot_id", "session_id", "epoch", "fence"}
+_DRIVER_BEARER_RE = re.compile(r"^[A-Za-z0-9._~+/=-]{24,4096}$")
+_REQUIRED_MODE_MACHINE = 4
+_LIVE_LOWSTATE_MAX_AGE_S = 0.1
+
+
+class G1TeleopService:
+    """One teleoperation service embedded in the existing root G1 Driver."""
+
+    def __init__(
+        self,
+        runtime: G1TeleopRuntime,
+        *,
+        driver_token: str,
+        ticket_secret: str,
+        startup_preflight: dict,
+        live_low_state_probe: Callable[[], Mapping[str, object]] | None = None,
+        offer_timeout_s: float = 5.0,
+        ticket_ttl_max_seconds: int = 30,
+        ticket_replay_cache_entries: int = 4096,
+    ):
+        if not isinstance(driver_token, str) or not _DRIVER_BEARER_RE.fullmatch(driver_token):
+            raise ValueError(
+                "MOTUS_DRIVER_TOKEN must contain 24-4096 restricted ASCII Bearer characters"
+            )
+        self.runtime = runtime
+        if runtime.actuation_enabled:
+            if not callable(live_low_state_probe):
+                raise ValueError("Live service requires a read-only LowState health probe")
+        elif live_low_state_probe is not None:
+            raise ValueError("Shadow service forbids a hardware LowState health probe")
+        self._live_low_state_probe = live_low_state_probe
+        self._driver_token = driver_token
+        self._offer_timeout = float(offer_timeout_s)
+        validated_preflight = self._validate_factory_preflight(startup_preflight)
+        verifier = TicketVerifier(
+            TicketCodec(ticket_secret),
+            audience=SIGNALING_AUDIENCE,
+            max_ttl_seconds=int(ticket_ttl_max_seconds),
+            max_replay_entries=int(ticket_replay_cache_entries),
+        )
+        self.rtc = RtcManager(runtime, verifier)
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            name="g1-teleop-rtc",
+            daemon=True,
+        )
+        self._closed = False
+        self._close_lock = threading.Lock()
+        self._registration_lock = threading.Lock()
+        self._registration_stop = threading.Event()
+        self._registration_thread: threading.Thread | None = None
+        self._registration_status = {
+            "state": "not_started",
+            "attempts": 0,
+            "successes": 0,
+            "last_http_status": None,
+            "last_error": None,
+            "tls_verification": "pinned_certificate",
+        }
+        self._startup_preflight = validated_preflight
+        self._rtc_loop_ready = False
+        self._thread.start()
+        loop_probe = threading.Event()
+        self._loop.call_soon_threadsafe(loop_probe.set)
+        if not loop_probe.wait(timeout=2.0):
+            self._stop_failed_loop_start()
+            raise RuntimeError("G1 teleoperation RTC event loop failed its startup probe")
+        self._rtc_loop_ready = True
+        try:
+            self._startup_preflight = self._complete_startup_preflight(
+                self._startup_preflight
+            )
+        except Exception:
+            self._stop_failed_loop_start()
+            raise
+
+    @property
+    def driver_token(self) -> str:
+        """Bearer credential used by Core for this embedded Driver."""
+
+        return self._driver_token
+
+    @property
+    def registration_status(self) -> dict:
+        with self._registration_lock:
+            return dict(self._registration_status)
+
+    def update_registration_status(self, **updates) -> None:
+        allowed = {
+            "state",
+            "attempts",
+            "successes",
+            "last_http_status",
+            "last_error",
+            "tls_verification",
+        }
+        if set(updates) - allowed:
+            raise ValueError("invalid registration status field")
+        bounded = dict(updates)
+        error = bounded.get("last_error")
+        if error is not None:
+            bounded["last_error"] = str(error)[:256]
+        with self._registration_lock:
+            self._registration_status.update(bounded)
+
+    def launch_registration_worker(self, target) -> None:
+        with self._registration_lock:
+            if self._registration_thread is not None:
+                raise RuntimeError("registration worker already exists")
+            thread = threading.Thread(
+                target=target,
+                daemon=True,
+                name="g1-register",
+            )
+            self._registration_thread = thread
+        thread.start()
+
+    def registration_wait(self, timeout: float) -> bool:
+        return self._registration_stop.wait(timeout)
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def authorized(self, authorization_header: str | None) -> bool:
+        if not isinstance(authorization_header, str) or not authorization_header.startswith("Bearer "):
+            return False
+        return hmac.compare_digest(authorization_header[7:], self._driver_token)
+
+    def get_tools(self) -> list[dict]:
+        return tool_definitions(
+            mode=self.runtime.mode,
+            driver_id=self.runtime.driver_id,
+            driver_name=self.runtime.driver_name,
+            robot_id=self.runtime.robot_id,
+            signaling_enabled=self.rtc.enabled,
+        )
+
+    def preflight_status(self) -> dict:
+        """Return bounded startup evidence plus current RTC-loop liveness."""
+
+        result = copy.deepcopy(self._startup_preflight)
+        loop_running = bool(
+            self._rtc_loop_ready
+            and not self._closed
+            and self._thread.is_alive()
+            and self._loop.is_running()
+        )
+        result["rtc"]["event_loop_running"] = loop_running
+        result["rtc"]["ready"] = bool(self.rtc.enabled and loop_running)
+        result["ready"] = bool(result["ready"] and result["rtc"]["ready"])
+        if not result["ready"]:
+            result["stage"] = "service_runtime"
+            result["code"] = "rtc_event_loop_unavailable"
+            result["message"] = "RTC event loop is not running"
+        return result
+
+    def dispatch(self, tool_name: str, arguments: Any) -> dict:
+        if not isinstance(arguments, dict):
+            raise ProtocolError("invalid_arguments", "tool arguments must be an object")
+        args = dict(arguments)
+        if tool_name == "teleop_state":
+            if args:
+                raise ProtocolError("invalid_arguments", "teleop_state accepts no arguments")
+            return self.runtime.status()
+        if tool_name != "teleop_session":
+            raise ProtocolError("unknown_tool", f"unknown tool: {tool_name}")
+        action = args.pop("action", None)
+        if not isinstance(action, str):
+            raise ProtocolError("missing_action", "teleop_session requires an action")
+        if action in ("prepare_shadow", "prepare_live"):
+            self._require_exact(args, {"session_id", "epoch", "fence"}, action)
+            result = self.runtime.prepare(action.removeprefix("prepare_"), args)
+            self._close_all_rtc()
+            return result
+        if action in ("heartbeat", "pause", "release", "soft_stop"):
+            self._require_exact(args, _IDENTITY_KEYS, action)
+            operation = getattr(self.runtime, action)
+            result = operation(args)
+            if action in ("pause", "release", "soft_stop"):
+                self._close_all_rtc()
+            return result
+        if action == "status":
+            self._require_exact(args, set(), action)
+            return self.runtime.status()
+        if action == "stop":
+            self._require_exact(args, set(), action)
+            result = self.runtime.release(lifecycle=True)
+            self._close_all_rtc()
+            return result
+        raise ProtocolError("unknown_action", f"unknown teleop_session action: {action}")
+
+    def accept_offer(self, payload: Any) -> dict:
+        if self._closed:
+            raise RtcRequestError(503, "service_closed", "teleoperation service is closed")
+        future = asyncio.run_coroutine_threadsafe(self.rtc.accept_offer(payload), self._loop)
+        try:
+            return future.result(timeout=self._offer_timeout)
+        except TimeoutError as exc:
+            future.cancel()
+            raise RtcRequestError(504, "offer_timeout", "RTC negotiation timed out") from exc
+
+    def blocks_arm_gesture(self) -> bool:
+        state = self.runtime.status()["state"]
+        return state in {
+            "prepared_shadow",
+            "active_shadow",
+            "prepared_live",
+            "active_live",
+            "hold",
+            "paused",
+        }
+
+    def health(self) -> dict:
+        status = self.runtime.status()
+        registration = self.registration_status
+        preflight = self.preflight_status()
+        live_low_state = self._live_low_state_health()
+        # Do not hold the lifecycle lock across the potentially blocking
+        # LowState read: final-dispatch close must never wait for diagnostics.
+        # This short final section makes the result linearizable with close().
+        # If close finishes during the probe, this response is red; if this
+        # response is green, close cannot finish until it has returned.
+        with self._close_lock:
+            if self._closed:
+                preflight = self.preflight_status()
+                if live_low_state is not None:
+                    live_low_state = self._live_low_state_result(
+                        code="service_closed"
+                    )
+            return {
+                "ready": bool(
+                    not self._closed
+                    and preflight["ready"]
+                    and status["dispatch"]["ready"]
+                    and registration["state"] == "registered"
+                    and (
+                        live_low_state is None
+                        or live_low_state["ready"] is True
+                    )
+                ),
+                "mode": status["mode"],
+                "actuation_enabled": status["actuation_enabled"],
+                "profile_id": status["profile_id"],
+                "capability_digest": status["capability_digest"],
+                "state": status["state"],
+                "dispatch": {
+                    "kind": status["dispatch"]["kind"],
+                    "state": status["dispatch"]["state"],
+                    "stop_acknowledged": status["dispatch"]["stop_acknowledged"],
+                    "fault_code": status["dispatch"]["fault_code"],
+                },
+                "preflight": preflight,
+                "live_low_state": live_low_state,
+                "registration": registration,
+            }
+
+    def close(self) -> None:
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._registration_stop.set()
+
+            def cleanup(label: str, operation) -> None:
+                try:
+                    operation()
+                except Exception as exc:  # noqa: BLE001 -- keep safety cleanup independent
+                    print(
+                        f"[teleop] {label} cleanup FAILED: "
+                        f"{type(exc).__name__}: {exc}",
+                        flush=True,
+                    )
+
+            registration_thread = self._registration_thread
+            if (
+                registration_thread is not None
+                and registration_thread is not threading.current_thread()
+            ):
+                cleanup(
+                    "registration worker",
+                    lambda: registration_thread.join(timeout=3.5),
+                )
+            cleanup("RTC peers", self._close_all_rtc)
+            # Runtime close owns the final-dispatch safe-stop and sole possible
+            # arm publisher. It must run even if RTC/registration cleanup fails.
+            cleanup("runtime", self.runtime.close)
+            if not self._loop.is_closed():
+                cleanup(
+                    "RTC event-loop stop",
+                    lambda: self._loop.call_soon_threadsafe(self._loop.stop),
+                )
+            if self._thread is not threading.current_thread():
+                cleanup("RTC event-loop thread", lambda: self._thread.join(timeout=1.0))
+            if not self._thread.is_alive() and not self._loop.is_closed():
+                cleanup("RTC event loop", self._loop.close)
+
+    def _live_low_state_health(self) -> dict | None:
+        """Read current Live LowState without touching the output adapter."""
+
+        probe = self._live_low_state_probe
+        if probe is None:
+            return None
+        if self._closed:
+            return self._live_low_state_result(code="service_closed")
+        try:
+            sample = probe()
+        except Exception:  # noqa: BLE001 -- a health probe must fail closed
+            return self._live_low_state_result(code="low_state_unavailable")
+        if not isinstance(sample, Mapping):
+            return self._live_low_state_result(code="low_state_invalid")
+
+        mode_machine = sample.get("mode_machine")
+        sampled = sample.get("sample_monotonic")
+        arm_joint_count = self._finite_vector_count(
+            sample.get("joint_positions"),
+            expected=10,
+        )
+        velocity_count = self._finite_vector_count(
+            sample.get("joint_velocities"),
+            expected=10,
+        )
+        motor_joint_count = self._finite_vector_count(
+            sample.get("all_joint_positions"),
+            expected=35,
+        )
+        if (
+            isinstance(mode_machine, bool)
+            or not isinstance(mode_machine, int)
+            or isinstance(sampled, bool)
+            or not isinstance(sampled, (int, float))
+            or not math.isfinite(float(sampled))
+            or arm_joint_count is None
+            or velocity_count is None
+            or motor_joint_count is None
+        ):
+            return self._live_low_state_result(code="low_state_invalid")
+
+        age_s = time.monotonic() - float(sampled)
+        age_ms = round(min(60_000.0, max(0.0, age_s * 1000.0)), 3)
+        if not math.isfinite(age_s) or age_s < 0.0 or age_s > _LIVE_LOWSTATE_MAX_AGE_S:
+            return self._live_low_state_result(
+                code="low_state_stale",
+                mode_machine=mode_machine,
+                sample_age_ms=age_ms,
+                arm_joint_count=arm_joint_count,
+                motor_joint_count=motor_joint_count,
+            )
+        if mode_machine != _REQUIRED_MODE_MACHINE:
+            return self._live_low_state_result(
+                code="mode_machine_not_ai",
+                mode_machine=mode_machine,
+                sample_age_ms=age_ms,
+                arm_joint_count=arm_joint_count,
+                motor_joint_count=motor_joint_count,
+            )
+        return self._live_low_state_result(
+            code=None,
+            mode_machine=mode_machine,
+            sample_age_ms=age_ms,
+            arm_joint_count=arm_joint_count,
+            motor_joint_count=motor_joint_count,
+        )
+
+    @staticmethod
+    def _finite_vector_count(value: object, *, expected: int) -> int | None:
+        if isinstance(value, (str, bytes, bytearray)):
+            return None
+        try:
+            values = list(value)
+        except (TypeError, ValueError):
+            return None
+        if len(values) != expected:
+            return None
+        for item in values:
+            if (
+                isinstance(item, bool)
+                or not isinstance(item, (int, float))
+                or not math.isfinite(float(item))
+            ):
+                return None
+        return len(values)
+
+    @staticmethod
+    def _live_low_state_result(
+        *,
+        code: str | None,
+        mode_machine: int | None = None,
+        sample_age_ms: float | None = None,
+        arm_joint_count: int | None = None,
+        motor_joint_count: int | None = None,
+    ) -> dict:
+        return {
+            "ready": code is None,
+            "code": code,
+            "mode_machine": mode_machine,
+            "required_mode_machine": _REQUIRED_MODE_MACHINE,
+            "sample_age_ms": sample_age_ms,
+            "arm_joint_count": arm_joint_count,
+            "motor_joint_count": motor_joint_count,
+        }
+
+    def _validate_factory_preflight(self, preflight: dict) -> dict:
+        if not isinstance(preflight, dict):
+            raise ValueError("startup_preflight must be an object")
+        result = copy.deepcopy(preflight)
+        required = {
+            "schema",
+            "ready",
+            "stage",
+            "code",
+            "message",
+            "mode",
+            "profile_id",
+            "hardware_output",
+            "publisher_created",
+            "low_state",
+            "ik",
+            "identity",
+            "dispatch",
+        }
+        if set(result) != required:
+            raise ValueError("startup_preflight fields do not match the V1 contract")
+        if (
+            result["schema"] != PREFLIGHT_SCHEMA
+            or result["mode"] != self.runtime.mode
+            or result["profile_id"] != PROFILE_ID
+            or result["hardware_output"] is not self.runtime.actuation_enabled
+            or result["publisher_created"] is not self.runtime.actuation_enabled
+            or result["ready"] is not False
+            or result["stage"] != "service_startup"
+            or result["code"] is not None
+            or result["message"] is not None
+        ):
+            raise ValueError("startup_preflight factory binding is invalid")
+        low_state = result["low_state"]
+        ik = result["ik"]
+        identity = result["identity"]
+        dispatch = result["dispatch"]
+        sample_age_ms = (
+            low_state.get("sample_age_ms") if isinstance(low_state, dict) else None
+        )
+        warmup_ms = ik.get("warmup_ms") if isinstance(ik, dict) else None
+        expected_dispatch_kind = (
+            "hardware" if self.runtime.actuation_enabled else "recording"
+        )
+        if (
+            not isinstance(low_state, dict)
+            or set(low_state) != {
+                "ready",
+                "mode_machine",
+                "required_mode_machine",
+                "sample_age_ms",
+                "arm_joint_count",
+                "motor_joint_count",
+            }
+            or low_state.get("ready") is not True
+            or low_state.get("mode_machine") != 4
+            or low_state.get("required_mode_machine") != 4
+            or low_state.get("arm_joint_count") != 10
+            or low_state.get("motor_joint_count") != 35
+            or isinstance(sample_age_ms, bool)
+            or not isinstance(sample_age_ms, (int, float))
+            or not math.isfinite(float(sample_age_ms))
+            or not 0.0 <= float(sample_age_ms) <= 100.0
+            or not isinstance(ik, dict)
+            or set(ik) != {"ready", "warmup_ms", "model", "solver"}
+            or ik.get("ready") is not True
+            or ik.get("model") != "g1_body23.urdf"
+            or ik.get("solver") != "pinocchio-casadi-ipopt"
+            or isinstance(warmup_ms, bool)
+            or not isinstance(warmup_ms, (int, float))
+            or not math.isfinite(float(warmup_ms))
+            or not 0.0 <= float(warmup_ms) <= 600_000.0
+            or not isinstance(identity, dict)
+            or set(identity) != {"driver_id", "robot_id", "capability_digest"}
+            or identity.get("driver_id") != self.runtime.driver_id
+            or identity.get("robot_id") != self.runtime.robot_id
+            or identity.get("capability_digest") != self.runtime.capability_digest
+            or not isinstance(dispatch, dict)
+            or set(dispatch) != {
+                "ready",
+                "kind",
+                "state",
+                "stop_acknowledged",
+                "fault_code",
+            }
+            or dispatch.get("ready") is not True
+            or dispatch.get("kind") != expected_dispatch_kind
+            or dispatch.get("state") != "safe_unarmed"
+            or dispatch.get("stop_acknowledged") is not True
+            or dispatch.get("fault_code") is not None
+        ):
+            raise ValueError("startup_preflight safety evidence is invalid")
+        try:
+            json.dumps(result, allow_nan=False)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("startup_preflight must be bounded JSON data") from exc
+        return result
+
+    def _complete_startup_preflight(self, preflight: dict) -> dict:
+        tools = self.get_tools()
+        if [tool.get("name") for tool in tools] != ["teleop_session", "teleop_state"]:
+            raise RuntimeError("G1 teleoperation descriptor tools are incomplete")
+        expected_identity = {
+            "driver_id": self.runtime.driver_id,
+            "robot_id": self.runtime.robot_id,
+            "profile_id": self.runtime.profile_id,
+            "capability_digest": self.runtime.capability_digest,
+            "mode": self.runtime.mode,
+            "actuation_enabled": self.runtime.actuation_enabled,
+        }
+        for tool in tools:
+            x_teleop = tool.get("x-teleop")
+            if not isinstance(x_teleop, dict):
+                raise RuntimeError("G1 teleoperation descriptor binding is missing")
+            if any(x_teleop.get(key) != value for key, value in expected_identity.items()):
+                raise RuntimeError("G1 teleoperation descriptor identity is inconsistent")
+            signaling = x_teleop.get("signaling")
+            if (
+                not isinstance(signaling, dict)
+                or signaling.get("audience") != SIGNALING_AUDIENCE
+                or signaling.get("path") != "/offer"
+            ):
+                raise RuntimeError("G1 teleoperation RTC descriptor is inconsistent")
+        result = copy.deepcopy(preflight)
+        result["descriptor"] = {
+            "ready": True,
+            "tool_names": ["teleop_session", "teleop_state"],
+            **expected_identity,
+        }
+        result["rtc"] = {
+            "ready": True,
+            "ticket_verifier": self.rtc.enabled,
+            "event_loop_running": True,
+            "audience": SIGNALING_AUDIENCE,
+            "offer_path": "/offer",
+        }
+        result["ready"] = True
+        result["stage"] = "complete"
+        result["code"] = None
+        result["message"] = None
+        try:
+            json.dumps(result, allow_nan=False)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("completed startup preflight is not JSON-safe") from exc
+        return result
+
+    def _stop_failed_loop_start(self) -> None:
+        self._closed = True
+        self._registration_stop.set()
+        if self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._thread.is_alive() and self._thread is not threading.current_thread():
+            self._thread.join(timeout=1.0)
+        if not self._thread.is_alive() and not self._loop.is_closed():
+            self._loop.close()
+
+    def _close_all_rtc(self) -> None:
+        if self._loop.is_closed():
+            return
+        future = asyncio.run_coroutine_threadsafe(self.rtc.close_all(), self._loop)
+        try:
+            future.result(timeout=self._offer_timeout)
+        except TimeoutError:
+            future.cancel()
+
+    @staticmethod
+    def _require_exact(args: dict, expected: set[str], action: str) -> None:
+        if set(args) != expected:
+            raise ProtocolError(
+                "invalid_arguments",
+                f"{action} requires exactly {sorted(expected)}",
+            )
+
+
+__all__ = ["PREFLIGHT_SCHEMA", "G1TeleopService"]

--- a/unitree/g1/tests/__init__.py
+++ b/unitree/g1/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Offline tests for the G1 Driver."""

--- a/unitree/g1/tests/helpers.py
+++ b/unitree/g1/tests/helpers.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import time
+import uuid
+
+import numpy as np
+from teleop.descriptor import PREFLIGHT_SCHEMA
+
+
+class FakeLowStateReader:
+    def __init__(self, *, mode_machine: int = 4):
+        self.mode_machine = mode_machine
+        self.q = np.linspace(-0.2, 0.2, 10)
+        self.dq = np.zeros(10)
+        self.reads = 0
+
+    def read_arm_state(self):
+        self.reads += 1
+        all_q = np.zeros(35)
+        all_q[[15, 16, 17, 18, 19, 22, 23, 24, 25, 26]] = self.q
+        return {
+            "joint_positions": self.q.copy(),
+            "joint_velocities": self.dq.copy(),
+            "all_joint_positions": all_q,
+            "mode_machine": self.mode_machine,
+            "sample_monotonic": time.monotonic(),
+        }
+
+
+class FakeIkSolver:
+    def __init__(self):
+        self.calls = []
+        self.resets = []
+
+    def reset(self, current_q):
+        self.resets.append(np.asarray(current_q, dtype=float).copy())
+
+    def solve(self, left, right, current_q, current_dq):
+        self.calls.append((left.copy(), right.copy(), current_q.copy(), current_dq.copy()))
+        return current_q + 0.1, np.zeros(10)
+
+
+def startup_preflight(runtime, *, warmup_ms: float = 1.0) -> dict:
+    status = runtime.status()
+    return {
+        "schema": PREFLIGHT_SCHEMA,
+        "ready": False,
+        "stage": "service_startup",
+        "code": None,
+        "message": None,
+        "mode": runtime.mode,
+        "profile_id": runtime.profile_id,
+        "hardware_output": runtime.actuation_enabled,
+        "publisher_created": runtime.actuation_enabled,
+        "low_state": {
+            "ready": True,
+            "mode_machine": 4,
+            "required_mode_machine": 4,
+            "sample_age_ms": 1.0,
+            "arm_joint_count": 10,
+            "motor_joint_count": 35,
+        },
+        "ik": {
+            "ready": True,
+            "warmup_ms": warmup_ms,
+            "model": "g1_body23.urdf",
+            "solver": "pinocchio-casadi-ipopt",
+        },
+        "identity": {
+            "driver_id": runtime.driver_id,
+            "robot_id": runtime.robot_id,
+            "capability_digest": runtime.capability_digest,
+        },
+        "dispatch": {
+            "ready": status["dispatch"]["ready"],
+            "kind": status["dispatch"]["kind"],
+            "state": status["dispatch"]["state"],
+            "stop_acknowledged": status["dispatch"]["stop_acknowledged"],
+            "fault_code": status["dispatch"]["fault_code"],
+        },
+    }
+
+
+def session():
+    return {
+        "session_id": str(uuid.uuid4()),
+        "epoch": 1,
+        "fence": "f" * 32,
+    }
+
+
+def frame(runtime, identity, *, sequence: int, clutch_sequence: int, deadman: bool):
+    return {
+        "schema_version": 1,
+        "boot_id": runtime.boot_id,
+        "session_id": identity["session_id"],
+        "epoch": identity["epoch"],
+        "fence": identity["fence"],
+        "sequence": sequence,
+        "client_monotonic_ns": 123,
+        "mode": runtime.mode,
+        "deadman": deadman,
+        "clutch_sequence": clutch_sequence,
+        "tracking": {
+            "head": True,
+            "left_controller": True,
+            "right_controller": True,
+        },
+        "head": {
+            "position": [0.0, 1.6, 0.0],
+            "orientation": [0.0, 0.0, 0.0, 1.0],
+        },
+        "left_controller": {
+            "position": [-0.2, 1.2, -0.4],
+            "orientation": [0.0, 0.0, 0.0, 1.0],
+        },
+        "right_controller": {
+            "position": [0.2, 1.2, -0.4],
+            "orientation": [0.0, 0.0, 0.0, 1.0],
+        },
+        "controllers": {
+            "left": {"axes": [], "buttons": []},
+            "right": {"axes": [], "buttons": []},
+        },
+    }
+
+
+def rtc_frame(runtime, identity, *, sequence: int, clutch_sequence: int, deadman: bool):
+    """Build the public RTC frame; session authority is peer-bound, not sent by Quest."""
+
+    value = frame(
+        runtime,
+        identity,
+        sequence=sequence,
+        clutch_sequence=clutch_sequence,
+        deadman=deadman,
+    )
+    for private_key in ("boot_id", "session_id", "epoch", "fence"):
+        value.pop(private_key)
+    return value

--- a/unitree/g1/tests/test_teleop_bundle.py
+++ b/unitree/g1/tests/test_teleop_bundle.py
@@ -1,0 +1,612 @@
+import contextlib
+import importlib.util
+import io
+import json
+import ssl
+import subprocess
+import sys
+import threading
+import types
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+from unittest.mock import patch
+
+from teleop.descriptor import tool_definitions
+
+
+class FakeTeleopService:
+    def __init__(self):
+        self.blocked = False
+        self.closed = False
+        self.close_calls = 0
+        self.dispatch_error = None
+        self.runtime = types.SimpleNamespace(
+            driver_id="unitree-g1",
+            robot_id="unitree-g1",
+            mode="shadow",
+            profile_id="unitree_g1_23_dual_arm_controller_v1",
+        )
+        self._registration_status = {
+            "state": "not_started",
+            "attempts": 0,
+            "successes": 0,
+            "last_http_status": None,
+            "last_error": None,
+            "tls_verification": "pinned_certificate",
+        }
+
+    def get_tools(self):
+        return [{"name": "teleop_session"}, {"name": "teleop_state"}]
+
+    def dispatch(self, name, args):
+        if self.dispatch_error is not None:
+            raise self.dispatch_error
+        return {"tool": name, "arguments": dict(args)}
+
+    def blocks_arm_gesture(self):
+        return self.blocked
+
+    def close(self):
+        self.close_calls += 1
+        self.closed = True
+
+    def preflight_status(self):
+        return self.health()["preflight"]
+
+    @property
+    def driver_token(self):
+        return "driver-token-123456789012"
+
+    def authorized(self, header):
+        return header == f"Bearer {self.driver_token}"
+
+    def health(self):
+        return {
+            "ready": False,
+            "preflight": {
+                "schema": "motus.teleop.g1-preflight.v1",
+                "ready": True,
+                "mode": "shadow",
+                "hardware_output": False,
+                "publisher_created": False,
+            },
+        }
+
+    @property
+    def registration_status(self):
+        return dict(self._registration_status)
+
+    def update_registration_status(self, **updates):
+        self._registration_status.update(updates)
+
+    def launch_registration_worker(self, target):
+        target()
+
+    def registration_wait(self, timeout):
+        return True
+
+
+class FakeArmPlugin:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get_tool(self):
+        return {"name": "arm", "type": "actuator"}
+
+    def dispatch(self, action, args):
+        return {"action": action, **args}
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+def load_main_module():
+    modules = {
+        "yaml": types.SimpleNamespace(safe_load=lambda handle: {}),
+        "rclpy": types.ModuleType("rclpy"),
+        "rclpy.executors": types.ModuleType("rclpy.executors"),
+        "unitree_sdk2py.core.channel": types.SimpleNamespace(ChannelFactoryInitialize=lambda *args: None),
+        "unitree_sdk2py.g1.audio.g1_audio_client": types.SimpleNamespace(AudioClient=object),
+        "rpc_proxy": types.SimpleNamespace(RpcProxy=object),
+        "unitree_sdk2py.g1.arm.g1_arm_action_client": types.SimpleNamespace(G1ArmActionClient=object),
+        "unitree_sdk2py.g1.slam.slam_client": types.SimpleNamespace(SlamClient=object),
+        "unitree_sdk2py.comm.motion_switcher.motion_switcher_client": types.SimpleNamespace(MotionSwitcherClient=object),
+    }
+    old = {name: sys.modules.get(name) for name in modules}
+    sys.modules.update(modules)
+    try:
+        path = Path(__file__).parents[1] / "main.py"
+        spec = importlib.util.spec_from_file_location("g1_main_under_test", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, previous in old.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+
+class G1BundleTeleopTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.main = load_main_module()
+
+    def setUp(self):
+        self.teleop = FakeTeleopService()
+        self.bundle = self.main.G1DeviceBundle(
+            {"plugins": {
+                "arm": {"enabled": False},
+                "smart_motion": {"enabled": False},
+            }},
+            "test",
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            teleop_service=self.teleop,
+        )
+
+    def test_tools_list_exposes_teleop_on_the_existing_root_bundle(self):
+        names = [tool["name"] for tool in self.bundle.get_all_tools()]
+        self.assertEqual(names, ["teleop_session", "teleop_state"])
+        self.assertEqual(
+            self.bundle.dispatch("teleop_session", {"action": "status"}),
+            {"tool": "teleop_session", "arguments": {"action": "status"}},
+        )
+
+    def test_teleop_enabled_never_constructs_or_exposes_arm_gesture(self):
+        result = self.bundle.dispatch("arm", {"action": "wave"})
+        self.assertEqual(result["code"], "teleop_arm_unavailable")
+
+    def test_conflicting_teleop_and_arm_plugin_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "cannot share G1 arm authority"):
+            self.main.G1DeviceBundle(
+                {"plugins": {
+                    "arm": {"enabled": True},
+                    "smart_motion": {"enabled": False},
+                }},
+                "test",
+                object(),
+                object(),
+                object(),
+                object(),
+                object(),
+                object(),
+                teleop_service=self.teleop,
+            )
+
+    def test_stop_all_closes_teleop_first_and_isolates_legacy_failures(self):
+        events = []
+
+        class OrderedTeleop(FakeTeleopService):
+            def close(service_self):
+                events.append("teleop")
+                super().close()
+
+        class Plugin:
+            def __init__(self, name, *, fail=False):
+                self.name = name
+                self.fail = fail
+                self.calls = 0
+
+            def stop(self):
+                self.calls += 1
+                events.append(self.name)
+                if self.fail:
+                    raise RuntimeError("legacy stop failed")
+
+        teleop = OrderedTeleop()
+        bundle = self.main.G1DeviceBundle(
+            {"plugins": {"smart_motion": {"enabled": False}}},
+            "test",
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            teleop_service=teleop,
+        )
+        failing = Plugin("failing", fail=True)
+        healthy = Plugin("healthy")
+        bundle._plugins = [failing, healthy]
+
+        with (
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            bundle.stop_all()
+            bundle.stop_all()
+
+        self.assertEqual(["teleop", "failing", "healthy"], events)
+        self.assertEqual(1, teleop.close_calls)
+        self.assertEqual(1, failing.calls)
+        self.assertEqual(1, healthy.calls)
+
+    def test_main_closes_teleop_when_later_audio_initialization_fails(self):
+        class FailingAudioClient:
+            def SetTimeout(self, timeout):
+                self.timeout = timeout
+
+            def Init(self):
+                raise RuntimeError("audio initialization failed")
+
+        teleop = FakeTeleopService()
+        config = {
+            "teleop": {"enabled": True, "mode": "shadow"},
+            "plugins": {"smart_motion": {"enabled": False}},
+            "safety_harness": {"enabled": False},
+        }
+        previous_bundle = self.main._bundle
+        previous_service = self.main._teleop_service
+        try:
+            with (
+                patch.object(self.main, "_load_config", return_value=config),
+                patch.object(self.main.sys, "argv", ["main.py", "eth0"]),
+                patch(
+                    "teleop.factory.build_g1_teleop_service",
+                    return_value=teleop,
+                ),
+                patch.object(self.main, "AudioClient", FailingAudioClient),
+                patch.object(self.main.os, "dup", return_value=100),
+                patch.object(self.main.os, "open", return_value=101),
+                patch.object(self.main.os, "dup2"),
+                patch.object(self.main.os, "close"),
+                patch.object(self.main.os, "fdopen", return_value=sys.stdout),
+                self.assertRaisesRegex(RuntimeError, "audio initialization failed"),
+            ):
+                self.main.main()
+        finally:
+            self.main._bundle = previous_bundle
+            self.main._teleop_service = previous_service
+
+        self.assertTrue(teleop.closed)
+        self.assertEqual(1, teleop.close_calls)
+
+    def test_process_preflight_failure_is_nonzero_without_secret_in_either_stream(self):
+        secret = "operator-secret-never-public"
+        private_path = "/private/operator/g1-live.yaml"
+        script = f'''\
+from unittest.mock import patch
+from tests.test_teleop_bundle import load_main_module
+
+module = load_main_module()
+config = {{"teleop": {{"enabled": True, "mode": "live"}}}}
+with (
+    patch.object(module, "_load_config", return_value=config),
+    patch.object(module.sys, "argv", ["main.py", "eth0"]),
+    patch(
+        "teleop.factory.build_g1_teleop_service",
+        side_effect=RuntimeError("failed at {private_path} token={secret}"),
+    ),
+):
+    raise SystemExit(module.main())
+'''
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=Path(__file__).parents[1],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=10,
+        )
+
+        self.assertEqual(1, completed.returncode)
+        projected_line = next(
+            line
+            for line in completed.stdout.splitlines()
+            if line.startswith("[teleop-preflight] ")
+        )
+        projected = json.loads(projected_line.removeprefix("[teleop-preflight] "))
+        self.assertEqual("teleop_configuration_invalid", projected["code"])
+        self.assertEqual(
+            "G1 teleoperation configuration is invalid",
+            projected["message"],
+        )
+        combined = completed.stdout + completed.stderr
+        self.assertNotIn(secret, combined)
+        self.assertNotIn(private_path, combined)
+        self.assertEqual("", completed.stderr)
+
+    def test_teleop_disabled_preserves_legacy_arm_tool(self):
+        previous = sys.modules.get("device")
+        sys.modules["device"] = types.SimpleNamespace(ArmActionPlugin=FakeArmPlugin)
+        try:
+            bundle = self.main.G1DeviceBundle(
+                {"plugins": {
+                    "arm": {"enabled": True},
+                    "smart_motion": {"enabled": False},
+                }},
+                "test",
+                object(),
+                object(),
+                object(),
+                object(),
+                object(),
+                object(),
+                teleop_service=None,
+            )
+        finally:
+            if previous is None:
+                sys.modules.pop("device", None)
+            else:
+                sys.modules["device"] = previous
+        self.assertEqual(["arm"], [tool["name"] for tool in bundle.get_all_tools()])
+        self.assertEqual("wave", bundle.dispatch("arm", {"action": "wave"})["action"])
+
+    def test_same_origin_mcp_requires_exact_driver_bearer(self):
+        previous_bundle = self.main._bundle
+        previous_service = self.main._teleop_service
+        self.main._bundle = self.bundle
+        self.main._teleop_service = self.teleop
+        server = self.main.ThreadingHTTPServer(
+            ("127.0.0.1", 0),
+            self.main.make_handler(),
+        )
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        endpoint = f"http://127.0.0.1:{server.server_port}/mcp"
+        body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize"}).encode()
+        try:
+            for header in (None, "Bearer wrong-token-123456789"):
+                headers = {"Content-Type": "application/json"}
+                if header is not None:
+                    headers["Authorization"] = header
+                request = urllib.request.Request(endpoint, data=body, headers=headers)
+                with self.assertRaises(urllib.error.HTTPError) as caught:
+                    urllib.request.urlopen(request, timeout=1)
+                self.assertEqual(401, caught.exception.code)
+                caught.exception.read()
+                caught.exception.close()
+
+            request = urllib.request.Request(
+                endpoint,
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {self.teleop.driver_token}",
+                },
+            )
+            with urllib.request.urlopen(request, timeout=1) as response:
+                self.assertEqual(200, response.status)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=1)
+            self.main._bundle = previous_bundle
+            self.main._teleop_service = previous_service
+
+    def test_authenticated_health_exposes_zero_output_preflight(self):
+        previous_service = self.main._teleop_service
+        self.main._teleop_service = self.teleop
+        server = self.main.ThreadingHTTPServer(
+            ("127.0.0.1", 0),
+            self.main.make_handler(),
+        )
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        endpoint = f"http://127.0.0.1:{server.server_port}/health"
+        try:
+            unauthorized = urllib.request.Request(endpoint)
+            with self.assertRaises(urllib.error.HTTPError) as caught:
+                urllib.request.urlopen(unauthorized, timeout=1)
+            self.assertEqual(401, caught.exception.code)
+            caught.exception.close()
+
+            request = urllib.request.Request(
+                endpoint,
+                headers={"Authorization": f"Bearer {self.teleop.driver_token}"},
+            )
+            with urllib.request.urlopen(request, timeout=1) as response:
+                payload = json.load(response)
+            self.assertTrue(payload["preflight"]["ready"])
+            self.assertEqual("shadow", payload["preflight"]["mode"])
+            self.assertFalse(payload["preflight"]["hardware_output"])
+            self.assertFalse(payload["preflight"]["publisher_created"])
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=1)
+            self.main._teleop_service = previous_service
+
+    def test_registration_tls_is_pinned_and_cannot_be_disabled(self):
+        with self.assertRaisesRegex(ValueError, "requires TLS verification"):
+            self.main.build_registration_ssl_context({"verify_tls": False})
+        with self.assertRaisesRegex(ValueError, "pinned CA file is missing"):
+            self.main.build_registration_ssl_context({"ca_file": "/missing/core-ca.pem"})
+        ca_file = ssl.get_default_verify_paths().cafile
+        if not ca_file or not Path(ca_file).is_file():
+            self.skipTest("system CA bundle unavailable")
+        context = self.main.build_registration_ssl_context({"ca_file": ca_file})
+        self.assertEqual(ssl.CERT_REQUIRED, context.verify_mode)
+        self.assertFalse(context.check_hostname)
+
+    def test_registration_echoes_descriptor_identity_and_uses_bearer(self):
+        ca_file = ssl.get_default_verify_paths().cafile
+        if not ca_file or not Path(ca_file).is_file():
+            self.skipTest("system CA bundle unavailable")
+
+        class Response:
+            status = 200
+
+            def read(self, maximum):
+                return json.dumps({
+                    "code": 200,
+                    "data": {"id": "unitree-g1", "trust_state": "trusted"},
+                }).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        with patch("urllib.request.urlopen", return_value=Response()) as opened:
+            evidence = self.main._start_registration(
+                15701,
+                "Unitree G1 Bundle",
+                "driver",
+                cfg={
+                    "teleop": {
+                        "registration": {
+                            "agent_core_url": "https://localhost:15678",
+                            "ca_file": ca_file,
+                        }
+                    }
+                },
+                teleop_service=self.teleop,
+            )
+        self.assertEqual("unitree-g1", evidence["payload"]["id"])
+        self.assertEqual("unitree-g1", evidence["payload"]["robot_id"])
+        for tool in tool_definitions(mode="shadow"):
+            self.assertEqual(evidence["payload"]["id"], tool["x-teleop"]["driver_id"])
+            self.assertEqual(
+                evidence["payload"]["robot_id"],
+                tool["x-teleop"]["robot_id"],
+            )
+        request = opened.call_args.args[0]
+        self.assertEqual(
+            f"Bearer {self.teleop.driver_token}",
+            request.get_header("Authorization"),
+        )
+        self.assertEqual(ssl.CERT_REQUIRED, evidence["tls_verify_mode"])
+        self.assertEqual("registered", self.teleop.registration_status["state"])
+        self.assertEqual(1, self.teleop.registration_status["attempts"])
+        self.assertEqual(1, self.teleop.registration_status["successes"])
+
+    def test_registration_http_200_without_trust_never_turns_health_green(self):
+        ca_file = ssl.get_default_verify_paths().cafile
+        if not ca_file or not Path(ca_file).is_file():
+            self.skipTest("system CA bundle unavailable")
+
+        class Response:
+            status = 200
+
+            def read(self, maximum):
+                return json.dumps({
+                    "code": 200,
+                    "data": {"id": "unitree-g1", "trust_state": "untrusted"},
+                }).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        with patch("urllib.request.urlopen", return_value=Response()):
+            self.main._start_registration(
+                15701,
+                "Unitree G1 Bundle",
+                "driver",
+                cfg={"teleop": {"registration": {"ca_file": ca_file}}},
+                teleop_service=self.teleop,
+            )
+        self.assertEqual("trust_error", self.teleop.registration_status["state"])
+        self.assertEqual(1, self.teleop.registration_status["attempts"])
+        self.assertEqual(0, self.teleop.registration_status["successes"])
+
+    def test_mcp_protocol_error_preserves_stable_code_in_jsonrpc_data(self):
+        class FakeProtocolError(ValueError):
+            def __init__(self, code, message):
+                super().__init__(message)
+                self.code = code
+
+        previous_bundle = self.main._bundle
+        previous_service = self.main._teleop_service
+        previous_error = self.main.TeleopProtocolError
+        self.main._bundle = self.bundle
+        self.main._teleop_service = self.teleop
+        self.main.TeleopProtocolError = FakeProtocolError
+        self.teleop.dispatch_error = FakeProtocolError(
+            "session_inactive",
+            "a new prepare_shadow session is required",
+        )
+        server = self.main.ThreadingHTTPServer(
+            ("127.0.0.1", 0),
+            self.main.make_handler(),
+        )
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        endpoint = f"http://127.0.0.1:{server.server_port}/mcp"
+        request = urllib.request.Request(
+            endpoint,
+            data=json.dumps({
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "tools/call",
+                "params": {
+                    "name": "teleop_session",
+                    "arguments": {"action": "heartbeat"},
+                },
+            }).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.teleop.driver_token}",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=1) as response:
+                payload = json.load(response)
+            self.assertEqual(-32602, payload["error"]["code"])
+            self.assertEqual(
+                {"code": "session_inactive"},
+                payload["error"]["data"],
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=1)
+            self.main._bundle = previous_bundle
+            self.main._teleop_service = previous_service
+            self.main.TeleopProtocolError = previous_error
+
+    def test_legacy_plugin_value_error_remains_internal_error(self):
+        class FailingBundle:
+            def dispatch(self, name, args):
+                raise ValueError("legacy plugin bug")
+
+        previous_bundle = self.main._bundle
+        previous_service = self.main._teleop_service
+        self.main._bundle = FailingBundle()
+        self.main._teleop_service = None
+        server = self.main.ThreadingHTTPServer(
+            ("127.0.0.1", 0),
+            self.main.make_handler(),
+        )
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{server.server_port}/mcp",
+            data=json.dumps({
+                "jsonrpc": "2.0",
+                "id": 8,
+                "method": "tools/call",
+                "params": {"name": "arm", "arguments": {"action": "wave"}},
+            }).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=1) as response:
+                payload = json.load(response)
+            self.assertEqual(-32603, payload["error"]["code"])
+            self.assertNotIn("data", payload["error"])
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=1)
+            self.main._bundle = previous_bundle
+            self.main._teleop_service = previous_service
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_teleop_descriptor.py
+++ b/unitree/g1/tests/test_teleop_descriptor.py
@@ -1,0 +1,86 @@
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from teleop.descriptor import (
+    PROFILE_ID,
+    canonical_json,
+    capability_binding,
+    tool_definitions,
+)
+
+
+class TeleopDescriptorTests(unittest.TestCase):
+    def test_descriptor_import_is_hardware_free_and_mode_specific(self):
+        forbidden = {"rclpy", "cyclonedds", "aiortc", "pinocchio", "casadi"}
+        # Discovery imports every test module, including the aiortc scenario.
+        # Prove the descriptor boundary in a fresh interpreter instead of
+        # relying on suite execution order.
+        probe = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import json,sys; import teleop.descriptor; "
+                    f"print(json.dumps(sorted(set({sorted(forbidden)!r}) & set(sys.modules))))"
+                ),
+            ],
+            cwd=Path(__file__).resolve().parents[1],
+            env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual([], json.loads(probe.stdout))
+        for mode, prepare, protocol, dispatch in (
+            (
+                "shadow",
+                "prepare_shadow",
+                "motus.teleop.shadow.v1",
+                "motus.teleop.dispatch.recording.v1",
+            ),
+            (
+                "live",
+                "prepare_live",
+                "motus.teleop.live.v1",
+                "motus.teleop.dispatch.hardware.v1",
+            ),
+        ):
+            session_tool, state_tool = tool_definitions(mode=mode, robot_id="g1-test")
+            self.assertEqual([session_tool["name"], state_tool["name"]], ["teleop_session", "teleop_state"])
+            self.assertFalse(session_tool["multiInstance"])
+            x_teleop = session_tool["x-teleop"]
+            self.assertEqual(x_teleop["protocol"], protocol)
+            self.assertEqual(x_teleop["dispatch_contract"], dispatch)
+            self.assertEqual(x_teleop["profile_id"], PROFILE_ID)
+            self.assertEqual(x_teleop["signaling"]["audience"], "motus-teleop-rtc")
+            self.assertEqual(
+                set(x_teleop),
+                {
+                    "protocol", "mode", "profile_id", "capabilities",
+                    "dispatch_contract", "signaling", "driver_id", "driver_name",
+                    "robot_id", "actuation_enabled", "capability_digest",
+                },
+            )
+            capabilities = x_teleop["capabilities"]
+            self.assertEqual(set(capabilities), {"profile_id", "input_bindings", "outputs", "effectors"})
+            self.assertEqual(capabilities["outputs"]["dual_arm"]["joint_count"], 10)
+            self.assertFalse(capabilities["outputs"]["base"]["enabled"])
+            self.assertFalse(capabilities["outputs"]["hands"]["enabled"])
+            actions = session_tool["inputSchema"]["properties"]["action"]["enum"]
+            self.assertIn(prepare, actions)
+            self.assertNotIn("prepare_live" if mode == "shadow" else "prepare_shadow", actions)
+            expected_digest = hashlib.sha256(canonical_json(capability_binding(mode))).hexdigest()
+            self.assertEqual(x_teleop["capability_digest"], expected_digest)
+
+    def test_signaling_cannot_be_advertised_when_unavailable(self):
+        with self.assertRaisesRegex(ValueError, "cannot be advertised"):
+            tool_definitions(mode="shadow", signaling_enabled=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_teleop_factory.py
+++ b/unitree/g1/tests/test_teleop_factory.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+import unittest
+from collections import deque
+from unittest.mock import patch
+
+import numpy as np
+from teleop.dispatch import AdapterAck
+from teleop.factory import (
+    G1TeleopPreflightError,
+    build_g1_teleop_service,
+    project_preflight_error,
+)
+from teleop.ik import G123PinocchioIk
+
+
+class FactoryLowState:
+    def __init__(self, *args, **kwargs):
+        self.closed = False
+
+    def read_arm_state(self):
+        return {
+            "joint_positions": np.zeros(10),
+            "joint_velocities": np.zeros(10),
+            "all_joint_positions": np.zeros(35),
+            "mode_machine": 4,
+            "sample_monotonic": time.monotonic(),
+        }
+
+    def close(self):
+        self.closed = True
+
+
+class FactoryIk:
+    instances = []
+
+    def __init__(self, path):
+        self.warmed = False
+        self.resets = []
+        type(self).instances.append(self)
+
+    def warm_up(self, q, dq):
+        self.warmed = True
+        return {"ready": True, "warmup_ms": 1.0}
+
+    def ready(self):
+        return self.warmed
+
+    def reset(self, q):
+        self.resets.append(np.asarray(q).copy())
+
+    def solve(self, left, right, q, dq):
+        return np.asarray(q).copy(), np.zeros(10)
+
+
+class FactoryPort:
+    publisher_count = 1
+    constructed_after_warmup = False
+
+    def __init__(self, low_state, *args, **kwargs):
+        type(self).constructed_after_warmup = bool(
+            FactoryIk.instances and FactoryIk.instances[-1].warmed
+        )
+
+    def startup_safe(self, deadline):
+        return AdapterAck(True)
+
+    def apply_target(self, *args, **kwargs):
+        return AdapterAck(True)
+
+    def safe_stop(self, *args, **kwargs):
+        return AdapterAck(True)
+
+    def snapshot(self):
+        return {"arm_sdk_weight": 0.0, "fault_reason": None}
+
+    def external_fault_code(self):
+        return None
+
+    def external_release_signal(self):
+        return {"generation": 0, "reason": None, "acknowledged": True}
+
+    def close(self):
+        return AdapterAck(True)
+
+
+class CapturingService:
+    def __init__(self, runtime, **kwargs):
+        self.runtime = runtime
+        self.startup_preflight = kwargs["startup_preflight"]
+        self.live_low_state_probe = kwargs["live_low_state_probe"]
+
+    def close(self):
+        self.runtime.close()
+
+
+class G1TeleopFactoryTests(unittest.TestCase):
+    def setUp(self):
+        FactoryIk.instances.clear()
+        FactoryPort.constructed_after_warmup = False
+        self.env = patch.dict(
+            "os.environ",
+            {
+                "MOTUS_DRIVER_TOKEN": "d" * 32,
+                "MOTUS_TELEOP_TICKET_SECRET": "t" * 32,
+            },
+            clear=False,
+        )
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
+
+    def test_missing_or_disabled_teleop_is_a_noop(self):
+        with patch("teleop.factory.G1LowStateReader") as low_state:
+            self.assertIsNone(build_g1_teleop_service({}))
+            self.assertIsNone(build_g1_teleop_service({"teleop": {}}))
+            self.assertIsNone(
+                build_g1_teleop_service({"teleop": {"enabled": False}})
+            )
+        low_state.assert_not_called()
+
+    def test_shadow_warms_real_ik_boundary_without_constructing_publisher(self):
+        config = {"teleop": {"enabled": True, "mode": "shadow"}}
+        with (
+            patch("teleop.factory.G1LowStateReader", FactoryLowState),
+            patch("teleop.factory.G123PinocchioIk", FactoryIk),
+            patch("teleop.factory.G1ArmSdkPort") as publisher,
+            patch("teleop.factory.G1TeleopService", CapturingService),
+        ):
+            service = build_g1_teleop_service(config)
+        try:
+            self.assertTrue(FactoryIk.instances[-1].warmed)
+            publisher.assert_not_called()
+            self.assertFalse(service.runtime.actuation_enabled)
+            self.assertIsNone(service.live_low_state_probe)
+            self.assertEqual("shadow", service.startup_preflight["mode"])
+            self.assertFalse(service.startup_preflight["hardware_output"])
+            self.assertFalse(service.startup_preflight["publisher_created"])
+            self.assertEqual(4, service.startup_preflight["low_state"]["mode_machine"])
+            self.assertLessEqual(
+                service.startup_preflight["low_state"]["sample_age_ms"],
+                100.0,
+            )
+            self.assertEqual(1.0, service.startup_preflight["ik"]["warmup_ms"])
+            self.assertEqual(
+                service.runtime.capability_digest,
+                service.startup_preflight["identity"]["capability_digest"],
+            )
+        finally:
+            service.close()
+
+    def test_arm_gesture_configuration_conflict_fails_before_dependencies(self):
+        config = {
+            "teleop": {"enabled": True, "mode": "shadow"},
+            "plugins": {"arm": {"enabled": True}},
+        }
+        with patch("teleop.factory.G1LowStateReader") as low_state:
+            with self.assertRaisesRegex(ValueError, "arm authority must be exclusive"):
+                build_g1_teleop_service(config)
+        low_state.assert_not_called()
+
+    def test_core_lease_and_fixed_velocity_contracts_fail_before_dependencies(self):
+        invalid = (
+            {"teleop": {"enabled": True, "mode": "shadow", "lease_timeout_ms": 749}},
+            {
+                "teleop": {
+                    "enabled": True,
+                    "mode": "live",
+                    "live": {"enabled": True, "velocity_limit_rad_s": 0.6},
+                }
+            },
+        )
+        for config in invalid:
+            with self.subTest(config=config):
+                with patch("teleop.factory.G1LowStateReader") as low_state:
+                    with self.assertRaises(ValueError):
+                        build_g1_teleop_service(config)
+                low_state.assert_not_called()
+
+    def test_wrong_mode_and_failed_startup_never_return_a_ready_service(self):
+        class WrongModeLowState(FactoryLowState):
+            def read_arm_state(self):
+                value = dict(super().read_arm_state())
+                value["mode_machine"] = 3
+                return value
+
+        class ChangesModeAfterProbe(FactoryLowState):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.reads = 0
+
+            def read_arm_state(self):
+                self.reads += 1
+                value = dict(super().read_arm_state())
+                value["mode_machine"] = 4 if self.reads == 1 else 3
+                return value
+
+        config = {"teleop": {"enabled": True, "mode": "shadow"}}
+        for low_state_type, expected_stage in (
+            (WrongModeLowState, "low_state_probe"),
+            (ChangesModeAfterProbe, "runtime_startup"),
+        ):
+            with self.subTest(low_state=low_state_type.__name__):
+                with (
+                    patch("teleop.factory.G1LowStateReader", low_state_type),
+                    patch("teleop.factory.G123PinocchioIk", FactoryIk),
+                    patch("teleop.factory.G1ArmSdkPort") as publisher,
+                    patch("teleop.factory.G1TeleopService", CapturingService),
+                ):
+                    with self.assertRaises(G1TeleopPreflightError) as caught:
+                        build_g1_teleop_service(config)
+                self.assertEqual(
+                    expected_stage,
+                    caught.exception.preflight_status["stage"],
+                )
+                publisher.assert_not_called()
+
+    def test_failed_shadow_preflight_has_stable_operator_projection(self):
+        class StaleLowState(FactoryLowState):
+            def read_arm_state(self):
+                value = dict(super().read_arm_state())
+                value["sample_monotonic"] = time.monotonic() - 1.0
+                return value
+
+        config = {"teleop": {"enabled": True, "mode": "shadow"}}
+        with (
+            patch("teleop.factory.G1LowStateReader", StaleLowState),
+            patch("teleop.factory.G123PinocchioIk", FactoryIk),
+            patch("teleop.factory.G1ArmSdkPort") as publisher,
+        ):
+            with self.assertRaises(G1TeleopPreflightError) as caught:
+                build_g1_teleop_service(config)
+        publisher.assert_not_called()
+        projected = project_preflight_error(caught.exception, mode="shadow")
+        self.assertFalse(projected["ready"])
+        self.assertEqual("low_state_probe", projected["stage"])
+        self.assertEqual("low_state_preflight_failed", projected["code"])
+        self.assertEqual(
+            "G1 LowState startup safety probe failed",
+            projected["message"],
+        )
+        self.assertFalse(projected["hardware_output"])
+        self.assertNotIn("d" * 32, projected["message"])
+
+    def test_arbitrary_configuration_error_is_not_reflected_publicly(self):
+        secret = "driver-secret-that-must-not-be-reflected"
+        projected = project_preflight_error(
+            ValueError(f"invalid /private/operator/config.yaml token={secret}"),
+            mode="live",
+        )
+        self.assertEqual("teleop_configuration_invalid", projected["code"])
+        self.assertEqual(
+            "G1 teleoperation configuration is invalid",
+            projected["message"],
+        )
+        self.assertNotIn(secret, json.dumps(projected, sort_keys=True))
+        self.assertNotIn("/private/operator", json.dumps(projected, sort_keys=True))
+
+    def test_live_publisher_is_constructed_only_after_successful_warmup(self):
+        config = {
+            "teleop": {
+                "enabled": True,
+                "mode": "live",
+                "live": {"enabled": True},
+            }
+        }
+        with (
+            patch("teleop.factory.G1LowStateReader", FactoryLowState),
+            patch("teleop.factory.G123PinocchioIk", FactoryIk),
+            patch("teleop.factory.G1ArmSdkPort", FactoryPort),
+            patch("teleop.factory.G1TeleopService", CapturingService),
+        ):
+            service = build_g1_teleop_service(config)
+        try:
+            self.assertTrue(FactoryPort.constructed_after_warmup)
+            self.assertTrue(service.runtime.actuation_enabled)
+            self.assertTrue(callable(service.live_low_state_probe))
+            self.assertTrue(service.startup_preflight["hardware_output"])
+            self.assertTrue(service.startup_preflight["publisher_created"])
+        finally:
+            service.close()
+
+    def test_real_ik_reset_discards_previous_session_filter_history(self):
+        solver = object.__new__(G123PinocchioIk)
+        solver._lock = threading.Lock()
+        solver._history = deque(
+            [np.full(10, -1.0), np.full(10, 1.0)],
+            maxlen=4,
+        )
+        solver._last_q = np.full(10, 1.0)
+        measured = np.linspace(-0.2, 0.2, 10)
+        solver.reset(measured)
+        self.assertEqual(0, len(solver._history))
+        np.testing.assert_array_equal(measured, solver._last_q)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_teleop_live.py
+++ b/unitree/g1/tests/test_teleop_live.py
@@ -1,0 +1,516 @@
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+import uuid
+
+import numpy as np
+from teleop.adapter import G1ControllerPoseMapper, G1DualArmAdapter
+from teleop.hardware import ARM_INDICES, G1ArmSdkPort
+from teleop.protocol import ProtocolError
+from teleop.runtime import G1TeleopRuntime
+
+from tests.helpers import FakeIkSolver, FakeLowStateReader, frame, session
+
+
+class FakeMotorCommand:
+    def __init__(self):
+        self.mode = 0
+        self.q = 0.0
+        self.dq = 0.0
+        self.tau = 0.0
+        self.kp = 0.0
+        self.kd = 0.0
+
+
+class FakeLowCommand:
+    def __init__(self):
+        self.mode_pr = 0
+        self.mode_machine = 0
+        self.motor_cmd = [FakeMotorCommand() for _ in range(35)]
+        self.crc = 0
+
+
+class FakeCrc:
+    def Crc(self, message):
+        return 1234
+
+
+class FakePublisher:
+    def __init__(self):
+        self.initialized = 0
+        self.closed = 0
+        self._lock = threading.Lock()
+        self.records = []
+
+    def Init(self):
+        self.initialized += 1
+
+    def Write(self, message, timeout=None):
+        with self._lock:
+            self.records.append({
+                "weight": message.motor_cmd[29].q,
+                "q": [message.motor_cmd[index].q for index in ARM_INDICES],
+                "tau": [message.motor_cmd[index].tau for index in ARM_INDICES],
+                "mode_machine": message.mode_machine,
+                "crc": message.crc,
+            })
+        return True
+
+    def Close(self):
+        self.closed += 1
+
+    def snapshot(self):
+        with self._lock:
+            return list(self.records)
+
+
+class FailingZeroPublisher(FakePublisher):
+    def __init__(self):
+        super().__init__()
+        self.fail_zero = False
+
+    def Write(self, message, timeout=None):
+        if self.fail_zero and message.motor_cmd[29].q == 0.0:
+            return False
+        return super().Write(message, timeout=timeout)
+
+
+class StaleableLowState(FakeLowStateReader):
+    def __init__(self):
+        super().__init__()
+        self.stale = False
+
+    def read_arm_state(self):
+        state = dict(super().read_arm_state())
+        if self.stale:
+            state["sample_monotonic"] = time.monotonic() - 1.0
+        return state
+
+
+class G1LiveRuntimeTests(unittest.TestCase):
+    def setUp(self):
+        self.lowstate = FakeLowStateReader()
+        self.publisher = FakePublisher()
+        self.port = G1ArmSdkPort(
+            self.lowstate,
+            control_hz=250.0,
+            ramp_seconds=0.0,
+            release_seconds=0.0,
+            velocity_limit_rad_s=30.0,
+            command_timeout_s=0.2,
+            publisher=self.publisher,
+            message_factory=FakeLowCommand,
+            crc=FakeCrc(),
+        )
+        self.adapter = G1DualArmAdapter(
+            mode="live",
+            pose_mapper=G1ControllerPoseMapper(),
+            ik_solver=FakeIkSolver(),
+            low_state_reader=self.lowstate,
+            arm_sdk=self.port,
+        )
+        self.runtime = G1TeleopRuntime(
+            mode="live",
+            adapter=self.adapter,
+            pose_timeout_ms=1000,
+            dispatch_io_timeout_ms=150,
+            dispatch_ack_timeout_ms=200,
+            auto_watchdog=False,
+        )
+        self.identity = session()
+
+    def tearDown(self):
+        self.runtime.close()
+
+    def _wait_until(self, predicate, timeout=1.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            result = predicate()
+            if result:
+                return result
+            time.sleep(0.002)
+        self.fail("timed out waiting for live output")
+
+    def test_one_publisher_publish_ack_and_five_zero_weight_stop_frames(self):
+        prepared = self.runtime.prepare("live", self.identity)
+        self.assertEqual("prepared_live", prepared["state"])
+        self.assertTrue(prepared["actuation_enabled"])
+        self.assertEqual(10, len(prepared["output"]["target_joint_positions_rad"]))
+        self.assertEqual(1, self.publisher.initialized)
+
+        with self.assertRaisesRegex(RuntimeError, "already exists"):
+            G1ArmSdkPort(
+                FakeLowStateReader(),
+                publisher=FakePublisher(),
+                message_factory=FakeLowCommand,
+                crc=FakeCrc(),
+            )
+
+        self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=1, clutch_sequence=7, deadman=False),
+            source="test",
+        )
+        active = self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=2, clutch_sequence=8, deadman=True),
+            source="test",
+        )
+        self.assertEqual("active_live", active["state"])
+        published = self._wait_until(
+            lambda: (
+                state
+                if (state := self.runtime.status())["dispatch"].get(
+                    "last_published_sequence"
+                ) == 2
+                else None
+            )
+        )
+        self.assertEqual("published", published["output"]["state"])
+        self.assertTrue(published["output"]["hardware_output"])
+        self.assertNotIn("last_would_apply_sequence", published["dispatch"])
+        records_before_stop = self.publisher.snapshot()
+        self.assertGreaterEqual(len(records_before_stop), 1)
+        self.assertEqual(1.0, records_before_stop[-1]["weight"])
+        self.assertEqual(4, records_before_stop[-1]["mode_machine"])
+        self.assertEqual(1234, records_before_stop[-1]["crc"])
+        self.assertEqual(10, len(records_before_stop[-1]["q"]))
+        self.assertEqual(10, len(records_before_stop[-1]["tau"]))
+
+        paused = self.runtime.pause({
+            "boot_id": self.runtime.boot_id,
+            **self.identity,
+        })
+        self.assertEqual("paused", paused["state"])
+        self.assertTrue(paused["dispatch"]["stop_acknowledged"])
+        records = self.publisher.snapshot()
+        self.assertGreaterEqual(len(records), len(records_before_stop) + 5)
+        self.assertEqual([0.0] * 5, [record["weight"] for record in records[-5:]])
+        self.assertEqual(0.0, paused["output"]["arm_sdk_weight"])
+        self.assertEqual(10, len(paused["output"]["target_joint_positions_rad"]))
+        self.assertEqual(
+            len(paused["output"]["target_joint_positions_rad"]),
+            len(paused["output"]["measured_joint_positions_rad"]),
+        )
+
+        writes_after_pause = len(records)
+        repeated = self.port.safe_stop(
+            reason="repeated_safe_stop",
+            deadline_monotonic=time.monotonic() + 0.15,
+        )
+        self.assertTrue(repeated.ok)
+        self.assertEqual(writes_after_pause, len(self.publisher.snapshot()))
+
+        # A completed zero-weight release may be deliberately prepared again;
+        # historical writes never make startup/current safety fail.
+        second = {
+            "session_id": str(uuid.uuid4()),
+            "epoch": 2,
+            "fence": "s" * 32,
+        }
+        prepared_again = self.runtime.prepare("live", second)
+        self.assertEqual("prepared_live", prepared_again["state"])
+        self.runtime.submit_frame(
+            frame(self.runtime, second, sequence=1, clutch_sequence=1, deadman=False),
+            source="test",
+        )
+        self.runtime.submit_frame(
+            frame(self.runtime, second, sequence=2, clutch_sequence=2, deadman=True),
+            source="test",
+        )
+        self._wait_until(
+            lambda: self.runtime.status()["dispatch"].get("last_published_sequence") == 2
+        )
+        released = self.runtime.release({
+            "boot_id": self.runtime.boot_id,
+            **second,
+        })
+        self.assertEqual("released", released["state"])
+        self.assertTrue(released["dispatch"]["stop_acknowledged"])
+
+    def test_mode_change_latches_fault_and_no_write_occurs_after_fault(self):
+        self.runtime.prepare("live", self.identity)
+        rtc_generation = self.runtime.session_generation()
+        self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=1, clutch_sequence=1, deadman=False),
+            source="test",
+        )
+        self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=2, clutch_sequence=2, deadman=True),
+            source="test",
+        )
+        self._wait_until(lambda: len(self.publisher.snapshot()) >= 1)
+        self.lowstate.mode_machine = 3
+        fault = self._wait_until(
+            lambda: (
+                snapshot
+                if (snapshot := self.port.snapshot())["fault_reason"] is not None
+                else None
+            )
+        )
+        self.assertEqual("hard_fault", fault["control_state"])
+        terminal = self.runtime.watchdog_tick()
+        self.assertEqual("fault", terminal["state"])
+        self.assertEqual("dispatch_fault", terminal["reason"])
+        self.assertFalse(terminal["authority_valid"])
+        self.assertIsNone(terminal["session_id"])
+        self.assertIsNone(terminal["lease"]["age_ms"])
+        self.assertFalse(terminal["lease"]["fresh"])
+        self.assertFalse(terminal["rtc"]["connected"])
+        self.assertEqual("fault_latched", terminal["dispatch"]["state"])
+        self.assertFalse(terminal["dispatch"]["ready"])
+        self.assertFalse(terminal["dispatch"]["stop_acknowledged"])
+        self.assertEqual("arm_sdk_async_fault", terminal["dispatch"]["fault_code"])
+        self.assertEqual("fault", terminal["output"]["state"])
+        self.assertEqual(0.0, terminal["output"]["arm_sdk_weight"])
+        self.assertFalse(self.runtime.generation_matches(rtc_generation))
+        with self.assertRaises(ProtocolError):
+            self.runtime.submit_frame(
+                frame(
+                    self.runtime,
+                    self.identity,
+                    sequence=3,
+                    clutch_sequence=3,
+                    deadman=True,
+                ),
+                source="test",
+            )
+        writes_at_fault = len(self.publisher.snapshot())
+        time.sleep(0.03)
+        self.assertEqual(writes_at_fault, len(self.publisher.snapshot()))
+
+    def test_autonomous_timeout_requires_neutral_then_new_clutch(self):
+        self.runtime.prepare("live", self.identity)
+        self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=1, clutch_sequence=1, deadman=False),
+            source="test",
+        )
+        self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=2, clutch_sequence=2, deadman=True),
+            source="test",
+        )
+        self._wait_until(
+            lambda: self.runtime.status()["dispatch"].get("last_published_sequence") == 2
+        )
+        released = self._wait_until(
+            lambda: (
+                snapshot
+                if (snapshot := self.port.external_release_signal())["acknowledged"]
+                and snapshot["generation"] == 1
+                else None
+            ),
+            timeout=1.0,
+        )
+        self.assertEqual("command_timeout", released["reason"])
+        hold = self.runtime.watchdog_tick()
+        self.assertEqual("hold", hold["state"])
+        self.assertEqual("command_timeout", hold["reason"])
+        self.assertEqual("safe_reclutch_required", hold["dispatch"]["state"])
+        self.assertTrue(hold["dispatch"]["stop_acknowledged"])
+        writes_at_release = len(self.publisher.snapshot())
+
+        still_held = self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=3, clutch_sequence=3, deadman=True),
+            source="test",
+        )
+        self.assertEqual("hold", still_held["state"])
+        time.sleep(0.02)
+        self.assertEqual(writes_at_release, len(self.publisher.snapshot()))
+
+        neutral = self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=4, clutch_sequence=3, deadman=False),
+            source="test",
+        )
+        self.assertEqual("hold", neutral["state"])
+        resumed = self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=5, clutch_sequence=4, deadman=True),
+            source="test",
+        )
+        self.assertEqual("active_live", resumed["state"])
+        self._wait_until(
+            lambda: self.runtime.status()["dispatch"].get("last_published_sequence") == 5
+        )
+        self.assertGreater(len(self.publisher.snapshot()), writes_at_release)
+
+    def test_late_timeout_signal_cannot_weaken_pause_or_release(self):
+        self.runtime.prepare("live", self.identity)
+        paused = self.runtime.pause({"boot_id": self.runtime.boot_id, **self.identity})
+        self.assertEqual("paused", paused["state"])
+        with self.port._condition:
+            self.port._external_release_generation += 1
+            self.port._external_release_reason = "command_timeout"
+            self.port._external_release_acknowledged = True
+        still_paused = self.runtime.status()
+        self.assertEqual("paused", still_paused["state"])
+        self.assertEqual("safe_latched", still_paused["dispatch"]["state"])
+
+        second = {
+            "session_id": str(uuid.uuid4()),
+            "epoch": 2,
+            "fence": "r" * 32,
+        }
+        self.runtime.prepare("live", second)
+        released = self.runtime.release({"boot_id": self.runtime.boot_id, **second})
+        self.assertEqual("released", released["state"])
+        with self.port._condition:
+            self.port._external_release_generation += 1
+            self.port._external_release_reason = "intent_expired"
+            self.port._external_release_acknowledged = True
+        still_released = self.runtime.status()
+        self.assertEqual("released", still_released["state"])
+        self.assertEqual("safe_revoked", still_released["dispatch"]["state"])
+
+    def test_missing_or_short_full_lowstate_never_writes(self):
+        self.runtime.close()
+
+        class InvalidFullState(FakeLowStateReader):
+            def __init__(self, *, missing):
+                super().__init__()
+                self.missing = missing
+
+            def read_arm_state(self):
+                value = dict(super().read_arm_state())
+                if self.missing:
+                    value.pop("all_joint_positions")
+                else:
+                    value["all_joint_positions"] = np.zeros(34)
+                return value
+
+        for missing in (True, False):
+            with self.subTest(missing=missing):
+                publisher = FakePublisher()
+                port = G1ArmSdkPort(
+                    InvalidFullState(missing=missing),
+                    ramp_seconds=0.0,
+                    release_seconds=0.0,
+                    publisher=publisher,
+                    message_factory=FakeLowCommand,
+                    crc=FakeCrc(),
+                )
+                try:
+                    self.assertFalse(port.startup_safe(time.monotonic() + 0.1).ok)
+                    ack = port.apply_target(
+                        np.zeros(10),
+                        np.zeros(10),
+                        expires_monotonic=time.monotonic() + 0.1,
+                        required_mode_machine=4,
+                        allow_arm=True,
+                    )
+                    self.assertFalse(ack.ok)
+                    self.assertEqual([], publisher.snapshot())
+                finally:
+                    port.close()
+
+    def test_velocity_limit_preserves_whole_vector_direction(self):
+        self.runtime.close()
+        lowstate = FakeLowStateReader()
+        publisher = FakePublisher()
+        port = G1ArmSdkPort(
+            lowstate,
+            control_hz=100.0,
+            ramp_seconds=0.0,
+            release_seconds=0.0,
+            velocity_limit_rad_s=0.5,
+            publisher=publisher,
+            message_factory=FakeLowCommand,
+            crc=FakeCrc(),
+        )
+        try:
+            delta = np.linspace(0.1, 1.0, 10)
+            ack = port.apply_target(
+                lowstate.q + delta,
+                np.zeros(10),
+                expires_monotonic=time.monotonic() + 0.2,
+                required_mode_machine=4,
+                allow_arm=True,
+            )
+            self.assertTrue(ack.ok)
+            actual_delta = np.asarray(publisher.snapshot()[-1]["q"]) - lowstate.q
+            np.testing.assert_allclose(actual_delta / delta, np.full(10, 0.005), atol=1e-8)
+        finally:
+            port.close()
+
+    def test_stale_lowstate_latches_fault_before_another_write(self):
+        self.runtime.close()
+        self.lowstate = StaleableLowState()
+        self.publisher = FakePublisher()
+        self.port = G1ArmSdkPort(
+            self.lowstate,
+            ramp_seconds=0.0,
+            release_seconds=0.0,
+            velocity_limit_rad_s=30.0,
+            publisher=self.publisher,
+            message_factory=FakeLowCommand,
+            crc=FakeCrc(),
+        )
+        self.adapter = G1DualArmAdapter(
+            mode="live",
+            pose_mapper=G1ControllerPoseMapper(),
+            ik_solver=FakeIkSolver(),
+            low_state_reader=self.lowstate,
+            arm_sdk=self.port,
+        )
+        self.runtime = G1TeleopRuntime(
+            mode="live",
+            adapter=self.adapter,
+            pose_timeout_ms=1000,
+            dispatch_io_timeout_ms=150,
+            dispatch_ack_timeout_ms=200,
+            auto_watchdog=False,
+        )
+        self.identity = session()
+        self.runtime.prepare("live", self.identity)
+        self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=1, clutch_sequence=1, deadman=False),
+            source="test",
+        )
+        self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=2, clutch_sequence=2, deadman=True),
+            source="test",
+        )
+        self._wait_until(lambda: len(self.publisher.snapshot()) >= 1)
+        self.lowstate.stale = True
+        self._wait_until(lambda: self.port.snapshot()["fault_reason"] is not None)
+        writes_at_fault = len(self.publisher.snapshot())
+        time.sleep(0.03)
+        self.assertEqual(writes_at_fault, len(self.publisher.snapshot()))
+
+    def test_failed_zero_weight_write_is_not_counted_as_confirmed(self):
+        self.runtime.close()
+        lowstate = FakeLowStateReader()
+        publisher = FailingZeroPublisher()
+        port = G1ArmSdkPort(
+            lowstate,
+            ramp_seconds=0.0,
+            release_seconds=0.0,
+            velocity_limit_rad_s=30.0,
+            publisher=publisher,
+            message_factory=FakeLowCommand,
+            crc=FakeCrc(),
+        )
+        try:
+            self.assertTrue(port.startup_safe(time.monotonic() + 0.1).ok)
+            applied = port.apply_target(
+                np.linspace(-0.1, 0.1, 10),
+                np.zeros(10),
+                expires_monotonic=time.monotonic() + 0.5,
+                required_mode_machine=4,
+                allow_arm=True,
+            )
+            self.assertTrue(applied.ok)
+            publisher.fail_zero = True
+            stopped = port.safe_stop(
+                reason="test_failed_zero",
+                deadline_monotonic=time.monotonic() + 0.15,
+            )
+            self.assertFalse(stopped.ok)
+            snapshot = port.snapshot()
+            self.assertEqual("hard_fault", snapshot["control_state"])
+            self.assertEqual(5, snapshot["final_zero_weight_frames_remaining"])
+            self.assertNotEqual(0.0, publisher.snapshot()[-1]["weight"])
+        finally:
+            port.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_teleop_preflight.py
+++ b/unitree/g1/tests/test_teleop_preflight.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import teleop.factory as factory_module
+import teleop.ik as ik_module
+import teleop.service as service_module
+import yaml
+from teleop.descriptor import PREFLIGHT_SCHEMA, PROFILE_ID
+from teleop.preflight import (
+    EXPECTED_CASADI_VERSION,
+    EXPECTED_NUMPY_VERSION,
+    EXPECTED_PINOCCHIO_VERSION,
+    PreflightCommandError,
+    main,
+    run_shadow_preflight,
+    run_target_image_preflight,
+)
+
+
+class ImageIk:
+    def __init__(self, urdf_path):
+        self.urdf_path = str(urdf_path)
+        self.warmed = False
+
+    def warm_up(self, q, dq):
+        self.warmed = True
+        return {"ready": True, "warmup_ms": 12.5}
+
+    def ready(self):
+        return self.warmed
+
+
+class ShadowService:
+    def __init__(self):
+        self.closed = False
+
+    def preflight_status(self):
+        return {
+            "schema": PREFLIGHT_SCHEMA,
+            "ready": True,
+            "stage": "complete",
+            "code": None,
+            "message": None,
+            "mode": "shadow",
+            "profile_id": PROFILE_ID,
+            "hardware_output": False,
+            "publisher_created": False,
+        }
+
+    def close(self):
+        self.closed = True
+
+
+class G1PreflightCommandTests(unittest.TestCase):
+    def _dependency_modules(
+        self,
+        *,
+        numpy_version="1.26.4",
+        casadi_version="3.6.7",
+        pinocchio_version="3.1.0",
+    ):
+        pinocchio = types.ModuleType("pinocchio")
+        pinocchio.__version__ = pinocchio_version
+        pinocchio.casadi = types.SimpleNamespace()
+        return {
+            "aiortc": types.SimpleNamespace(__version__="1.14.0"),
+            "av": types.SimpleNamespace(__version__="14.0.0"),
+            "casadi": types.SimpleNamespace(__version__=casadi_version),
+            "cryptography": types.SimpleNamespace(__version__="46.0.0"),
+            "numpy": types.SimpleNamespace(
+                __version__=numpy_version,
+                zeros=lambda size: [0.0] * size,
+            ),
+            "pinocchio": pinocchio,
+            "teleop.factory": factory_module,
+            "teleop.service": service_module,
+        }
+
+    def test_target_image_entry_runs_cold_ik_and_returns_json_safe_evidence(self):
+        modules = self._dependency_modules()
+        with (
+            patch.dict(sys.modules, {"pinocchio": modules["pinocchio"]}),
+            patch.object(ik_module, "G123PinocchioIk", ImageIk),
+            patch("teleop.preflight.importlib.import_module", side_effect=modules.__getitem__),
+        ):
+            result = run_target_image_preflight("/work/resource/g1_body23.urdf")
+        self.assertTrue(result["ready"])
+        self.assertEqual("image", result["mode"])
+        self.assertFalse(result["hardware_output"])
+        self.assertFalse(result["publisher_created"])
+        self.assertEqual(12.5, result["ik"]["warmup_ms"])
+        self.assertEqual(EXPECTED_NUMPY_VERSION, result["dependencies"]["numpy"])
+        self.assertEqual(EXPECTED_CASADI_VERSION, result["dependencies"]["casadi"])
+        self.assertEqual(
+            EXPECTED_PINOCCHIO_VERSION,
+            result["dependencies"]["pinocchio"],
+        )
+        json.dumps(result, allow_nan=False)
+
+    def test_target_image_rejects_casadi_372_before_pinocchio_casadi_import(self):
+        modules = self._dependency_modules(casadi_version="3.7.2")
+        pinocchio = modules["pinocchio"]
+        del pinocchio.casadi
+        bridge_accesses = []
+
+        def reject_bridge_import(name):
+            if name == "casadi":
+                bridge_accesses.append(name)
+                raise RuntimeError("incompatible pinocchio.casadi ABI")
+            raise AttributeError(name)
+
+        pinocchio.__getattr__ = reject_bridge_import
+        with (
+            patch.dict(sys.modules, {"pinocchio": pinocchio}),
+            patch("teleop.preflight.importlib.import_module", side_effect=modules.__getitem__),
+        ):
+            with self.assertRaises(PreflightCommandError) as caught:
+                run_target_image_preflight("unused.urdf")
+        self.assertEqual("casadi_version_mismatch", caught.exception.preflight_status["code"])
+        self.assertEqual(
+            "Target image CasADi version is incompatible",
+            caught.exception.preflight_status["message"],
+        )
+        self.assertEqual([], bridge_accesses)
+
+    def test_target_image_other_numeric_mismatches_have_stable_public_codes(self):
+        for kwargs, code, message in (
+            (
+                {"numpy_version": "2.2.6"},
+                "numpy_version_mismatch",
+                "Target image NumPy version is incompatible",
+            ),
+            (
+                {"pinocchio_version": "3.2.0"},
+                "pinocchio_version_mismatch",
+                "Target image Pinocchio version is incompatible",
+            ),
+        ):
+            with self.subTest(code=code):
+                modules = self._dependency_modules(**kwargs)
+                with (
+                    patch.dict(sys.modules, {"pinocchio": modules["pinocchio"]}),
+                    patch(
+                        "teleop.preflight.importlib.import_module",
+                        side_effect=modules.__getitem__,
+                    ),
+                ):
+                    with self.assertRaises(PreflightCommandError) as caught:
+                        run_target_image_preflight("unused.urdf")
+                self.assertEqual(code, caught.exception.preflight_status["code"])
+                self.assertEqual(message, caught.exception.preflight_status["message"])
+
+    def test_target_image_bridge_import_failure_has_stable_dependency_code(self):
+        modules = self._dependency_modules()
+        del modules["pinocchio"].casadi
+        with (
+            patch.dict(sys.modules, {"pinocchio": modules["pinocchio"]}),
+            patch("teleop.preflight.importlib.import_module", side_effect=modules.__getitem__),
+        ):
+            with self.assertRaises(PreflightCommandError) as caught:
+                run_target_image_preflight("unused.urdf")
+        self.assertEqual(
+            "pinocchio_casadi_import_failed",
+            caught.exception.preflight_status["code"],
+        )
+        self.assertEqual(
+            "Target image Pinocchio/CasADi bridge is unavailable",
+            caught.exception.preflight_status["message"],
+        )
+
+    def test_shadow_entry_reuses_factory_and_closes_without_hardware_output(self):
+        service = ShadowService()
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml") as config:
+            config.write("teleop:\n  enabled: true\n  mode: shadow\n")
+            config.flush()
+            with (
+                patch(
+                    "teleop.preflight._initialize_dds"
+                ) as initialize_dds,
+                patch(
+                    "teleop.factory.build_g1_teleop_service",
+                    return_value=service,
+                ) as build_service,
+            ):
+                result = run_shadow_preflight(
+                    config_path=config.name,
+                    network_interface="eth0",
+                )
+        initialize_dds.assert_called_once_with("eth0")
+        build_service.assert_called_once()
+        self.assertTrue(service.closed)
+        self.assertTrue(result["ready"])
+        self.assertFalse(result["publisher_created"])
+
+    def test_shadow_entry_rejects_live_before_initializing_dds(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml") as config:
+            config.write("teleop:\n  enabled: true\n  mode: live\n  live:\n    enabled: true\n")
+            config.flush()
+            with patch(
+                "teleop.preflight._initialize_dds"
+            ) as initialize_dds:
+                with self.assertRaises(PreflightCommandError) as caught:
+                    run_shadow_preflight(
+                        config_path=config.name,
+                        network_interface="eth0",
+                    )
+        initialize_dds.assert_not_called()
+        self.assertEqual("shadow_mode_required", caught.exception.preflight_status["code"])
+
+    def test_cli_projects_failure_as_one_json_object(self):
+        secret = "operator-secret-in-private-path"
+        failure = PreflightCommandError(
+            stage="target_dependencies",
+            code="target_dependency_import_failed",
+            message=f"pinocchio unavailable at /private/{secret}",
+        )
+        output = io.StringIO()
+        with (
+            patch("teleop.preflight.run_target_image_preflight", side_effect=failure),
+            contextlib.redirect_stdout(output),
+        ):
+            exit_code = main(["image", "--urdf", "unused.urdf"])
+        self.assertEqual(1, exit_code)
+        payload = json.loads(output.getvalue())
+        self.assertFalse(payload["ready"])
+        self.assertEqual("target_dependency_import_failed", payload["code"])
+        self.assertEqual(
+            "Target image dependencies are unavailable",
+            payload["message"],
+        )
+        self.assertNotIn(secret, output.getvalue())
+        self.assertNotIn("/private/", output.getvalue())
+
+    def test_docker_build_uses_the_executable_target_image_smoke(self):
+        dockerfile = (Path(__file__).parents[1] / "Dockerfile").read_text()
+        self.assertIn(
+            "/opt/g1-teleop/bin/python -m teleop.preflight image",
+            dockerfile,
+        )
+        self.assertIn("--urdf /work/resource/g1_body23.urdf", dockerfile)
+        self.assertNotIn("solver = G123PinocchioIk", dockerfile)
+
+    def test_disabled_teleop_keeps_legacy_compose_secret_optional(self):
+        service = (Path(__file__).parents[1] / "deploy" / "service.yml").read_text()
+        self.assertIn("MOTUS_DRIVER_TOKEN=${MOTUS_DRIVER_TOKEN:-}", service)
+        self.assertNotIn("MOTUS_DRIVER_TOKEN is required", service)
+
+    def test_target_image_manifest_owns_the_supported_numeric_abi(self):
+        environment = yaml.safe_load(
+            (Path(__file__).parents[1] / "environment.teleop.yml").read_text()
+        )
+        self.assertEqual("g1-teleop", environment["name"])
+        self.assertEqual(["conda-forge", "nodefaults"], environment["channels"])
+        self.assertEqual(
+            [
+                "python=3.10",
+                "pinocchio=3.1.0",
+                "casadi=3.6.7",
+                "numpy=1.26.4",
+                "pip",
+            ],
+            environment["dependencies"],
+        )
+
+        requirements = {
+            line.strip()
+            for line in (Path(__file__).parents[1] / "requirements.txt")
+            .read_text()
+            .splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        }
+        self.assertIn("numpy==1.26.4", requirements)
+        self.assertFalse(any(line.startswith("casadi") for line in requirements))
+        self.assertFalse(any(line.startswith("pinocchio") for line in requirements))
+
+    def test_docker_uses_only_the_pinned_conda_numeric_runtime(self):
+        dockerfile = (Path(__file__).parents[1] / "Dockerfile").read_text()
+        self.assertIn("ARG MINIFORGE_VERSION=24.7.1-2", dockerfile)
+        self.assertIn("amd64)", dockerfile)
+        self.assertIn('miniforge_arch="x86_64"', dockerfile)
+        self.assertIn("arm64)", dockerfile)
+        self.assertIn('miniforge_arch="aarch64"', dockerfile)
+        self.assertIn(
+            "636f7faca2d51ee42b4640ce160c751a46d57621ef4bf14378704c87c5db4fe3",
+            dockerfile,
+        )
+        self.assertIn(
+            "7bf60bce50f57af7ea4500b45eeb401d9350011ab34c9c45f736647d8dba9021",
+            dockerfile,
+        )
+        self.assertIn('echo "unsupported TARGETARCH: ${TARGETARCH}"', dockerfile)
+        self.assertIn("exit 64", dockerfile)
+        self.assertIn("/opt/miniforge3/bin/conda env create", dockerfile)
+        self.assertIn("--prefix /opt/g1-teleop", dockerfile)
+        self.assertNotIn("ros-humble-pinocchio", dockerfile)
+        self.assertNotIn("pip3 install", dockerfile)
+        self.assertNotIn("python3 -m pip", dockerfile)
+        self.assertEqual(
+            2,
+            dockerfile.count("/opt/g1-teleop/bin/python -m pip install"),
+        )
+        self.assertEqual(
+            2,
+            dockerfile.count(
+                "export PYTHONPATH=/opt/g1-teleop/lib/python3.10/site-packages:/work:"
+            ),
+        )
+        self.assertNotIn("LD_LIBRARY_PATH=/opt/g1-teleop/lib", dockerfile)
+        self.assertEqual(
+            2,
+            dockerfile.count("export LD_LIBRARY_PATH=/opt/cyclonedds/lib:"),
+        )
+        self.assertIn(
+            "exec /opt/g1-teleop/bin/python /work/main.py",
+            dockerfile,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_teleop_rtc.py
+++ b/unitree/g1/tests/test_teleop_rtc.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+import unittest
+
+from aiortc import RTCPeerConnection, RTCSessionDescription
+from teleop.adapter import G1ControllerPoseMapper, G1DualArmAdapter
+from teleop.descriptor import SIGNALING_AUDIENCE
+from teleop.dispatch import AdapterAck
+from teleop.protocol import (
+    ProtocolError,
+    TicketCodec,
+    TicketError,
+    TicketVerifier,
+    bind_rtc_frame_v1,
+    make_ticket_claims,
+)
+from teleop.rtc import RtcManager, RtcRequestError
+from teleop.runtime import G1TeleopRuntime
+from teleop.service import G1TeleopService
+
+from tests.helpers import (
+    FakeIkSolver,
+    FakeLowStateReader,
+    rtc_frame,
+    session,
+    startup_preflight,
+)
+
+DRIVER_TOKEN = "driver-token-for-local-g1-rtc-tests"
+TICKET_SECRET = "ticket-secret-for-local-g1-rtc-tests-0123456789"
+
+
+class HealthArmSdk:
+    publisher_count = 1
+
+    def __init__(self):
+        self.output_calls = []
+
+    def startup_safe(self, deadline):
+        self.output_calls.append("startup_safe")
+        return AdapterAck(True)
+
+    def apply_target(self, *args, **kwargs):
+        self.output_calls.append("apply_target")
+        return AdapterAck(True)
+
+    def safe_stop(self, *args, **kwargs):
+        self.output_calls.append("safe_stop")
+        return AdapterAck(True)
+
+    def snapshot(self):
+        return {"arm_sdk_weight": 0.0, "fault_reason": None}
+
+    def external_fault_code(self):
+        return None
+
+    def external_release_signal(self):
+        return {"generation": 0, "reason": None, "acknowledged": True}
+
+    def close(self):
+        self.output_calls.append("close")
+        return AdapterAck(True)
+
+
+class G1LocalAiortcTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.low_state = FakeLowStateReader()
+        adapter = G1DualArmAdapter(
+            mode="shadow",
+            pose_mapper=G1ControllerPoseMapper(),
+            ik_solver=FakeIkSolver(),
+            low_state_reader=self.low_state,
+        )
+        self.runtime = G1TeleopRuntime(
+            mode="shadow",
+            adapter=adapter,
+            lease_timeout_ms=15_000,
+            pose_timeout_ms=1_000,
+            auto_watchdog=False,
+        )
+        self.service = G1TeleopService(
+            self.runtime,
+            driver_token=DRIVER_TOKEN,
+            ticket_secret=TICKET_SECRET,
+            startup_preflight=startup_preflight(self.runtime),
+            offer_timeout_s=10.0,
+        )
+        self.peer = RTCPeerConnection()
+
+    async def asyncTearDown(self):
+        await self.peer.close()
+        await asyncio.to_thread(self.service.close)
+
+    async def _wait_until(self, predicate, *, timeout: float = 10.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            value = predicate()
+            if value:
+                return value
+            await asyncio.sleep(0.01)
+        self.fail("timed out waiting for RTC state")
+
+    async def test_startup_preflight_binds_descriptor_identity_and_running_rtc(self):
+        preflight = self.service.preflight_status()
+        self.assertTrue(preflight["ready"])
+        self.assertEqual("complete", preflight["stage"])
+        self.assertEqual("shadow", preflight["mode"])
+        self.assertFalse(preflight["hardware_output"])
+        self.assertFalse(preflight["publisher_created"])
+        self.assertTrue(preflight["low_state"]["ready"])
+        self.assertTrue(preflight["ik"]["ready"])
+        self.assertTrue(preflight["descriptor"]["ready"])
+        self.assertEqual(
+            self.runtime.capability_digest,
+            preflight["descriptor"]["capability_digest"],
+        )
+        self.assertEqual("unitree-g1", preflight["descriptor"]["driver_id"])
+        self.assertTrue(preflight["rtc"]["event_loop_running"])
+        self.assertEqual("motus-teleop-rtc", preflight["rtc"]["audience"])
+        health = self.service.health()
+        self.assertTrue(health["preflight"]["ready"])
+        self.assertFalse(health["ready"])
+        self.assertEqual("not_started", health["registration"]["state"])
+        self.assertIsNone(health["live_low_state"])
+        reads_before = self.low_state.reads
+        self.service.health()
+        self.assertEqual(reads_before, self.low_state.reads)
+
+    async def test_authenticated_offer_ticket_replay_and_neutral_reclutch(self):
+        identity = session()
+        prepared = self.service.dispatch(
+            "teleop_session",
+            {"action": "prepare_shadow", **identity},
+        )
+        self.assertFalse(self.service.authorized(None))
+        self.assertFalse(self.service.authorized("Bearer wrong"))
+        self.assertTrue(self.service.authorized(f"Bearer {DRIVER_TOKEN}"))
+
+        control_open = asyncio.Event()
+        pose_open = asyncio.Event()
+        control = self.peer.createDataChannel("teleop-control", ordered=True)
+        pose = self.peer.createDataChannel(
+            "teleop-pose",
+            ordered=False,
+            maxRetransmits=0,
+        )
+
+        @control.on("open")
+        def on_control_open():
+            control_open.set()
+
+        @pose.on("open")
+        def on_pose_open():
+            pose_open.set()
+
+        await self.peer.setLocalDescription(await self.peer.createOffer())
+        offer_sdp = self.peer.localDescription.sdp
+        claims = make_ticket_claims(
+            session={
+                "boot_id": self.runtime.boot_id,
+                "session_id": identity["session_id"],
+                "epoch": identity["epoch"],
+                "fence": identity["fence"],
+                "capability_digest": prepared["capability_digest"],
+            },
+            sdp=offer_sdp,
+            jti="g1_local_rtc_ticket_1234",
+        )
+        offer = {
+            "type": "offer",
+            "sdp": offer_sdp,
+            "ticket": TicketCodec(TICKET_SECRET).sign(claims),
+        }
+        answer = await asyncio.to_thread(self.service.accept_offer, offer)
+        self.assertEqual("shadow", answer["mode"])
+        self.assertFalse(answer["actuation_enabled"])
+        self.assertNotIn("fence", answer)
+
+        with self.assertRaises(RtcRequestError) as replay:
+            await asyncio.to_thread(self.service.accept_offer, offer)
+        self.assertEqual(401, replay.exception.status)
+        self.assertEqual("ticket_replayed", replay.exception.code)
+
+        await self.peer.setRemoteDescription(
+            RTCSessionDescription(sdp=answer["sdp"], type=answer["type"])
+        )
+        await asyncio.wait_for(
+            asyncio.gather(control_open.wait(), pose_open.wait()),
+            timeout=10.0,
+        )
+        await self._wait_until(lambda: self.runtime.status()["rtc"]["connected"])
+
+        # A newly prepared or reconnected peer must first show both grips
+        # released; an already-held grip can never activate hardware output.
+        pose.send(json.dumps(rtc_frame(
+            self.runtime,
+            identity,
+            sequence=1,
+            clutch_sequence=7,
+            deadman=True,
+        )))
+        await self._wait_until(
+            lambda: self.runtime.status()["pose"]["latest_sequence"] == 1
+        )
+        self.assertEqual("prepared_shadow", self.runtime.status()["state"])
+
+        pose.send(json.dumps(rtc_frame(
+            self.runtime,
+            identity,
+            sequence=2,
+            clutch_sequence=7,
+            deadman=False,
+        )))
+        await self._wait_until(
+            lambda: self.runtime.status()["pose"]["latest_sequence"] == 2
+        )
+        self.assertEqual("prepared_shadow", self.runtime.status()["state"])
+
+        pose.send(json.dumps(rtc_frame(
+            self.runtime,
+            identity,
+            sequence=3,
+            clutch_sequence=8,
+            deadman=True,
+        )))
+        state = await self._wait_until(
+            lambda: (
+                snapshot
+                if (snapshot := self.runtime.status())["dispatch"].get(
+                    "last_would_apply_sequence"
+                ) == 3
+                else None
+            )
+        )
+        self.assertEqual("active_shadow", state["state"])
+        self.assertEqual("would_apply", state["output"]["state"])
+        self.assertFalse(state["output"]["hardware_output"])
+
+
+class G1RtcNegativeContractTests(unittest.TestCase):
+    def test_ticket_audience_sdp_and_session_binding_are_independent(self):
+        identity = session()
+        expected = {
+            "boot_id": "00000000-0000-0000-0000-000000000001",
+            **identity,
+            "capability_digest": "a" * 64,
+        }
+        codec = TicketCodec(TICKET_SECRET)
+
+        cases = (
+            (
+                "invalid_audience",
+                make_ticket_claims(
+                    session=expected,
+                    sdp="offer-a",
+                    audience="teleop-shadow-rtc",
+                    jti="wrong_audience_001",
+                ),
+                expected,
+                "offer-a",
+            ),
+            (
+                "sdp_mismatch",
+                make_ticket_claims(
+                    session=expected,
+                    sdp="offer-a",
+                    audience=SIGNALING_AUDIENCE,
+                    jti="wrong_sdp_value_01",
+                ),
+                expected,
+                "offer-b",
+            ),
+            (
+                "binding_mismatch",
+                make_ticket_claims(
+                    session=expected,
+                    sdp="offer-a",
+                    audience=SIGNALING_AUDIENCE,
+                    jti="wrong_binding_0001",
+                ),
+                {**expected, "session_id": session()["session_id"]},
+                "offer-a",
+            ),
+        )
+        for code, claims, binding, sdp in cases:
+            with self.subTest(code=code):
+                verifier = TicketVerifier(codec, audience=SIGNALING_AUDIENCE)
+                with self.assertRaises(TicketError) as caught:
+                    verifier.verify_and_consume(
+                        codec.sign(claims),
+                        expected=binding,
+                        sdp=sdp,
+                    )
+                self.assertEqual(code, caught.exception.code)
+
+    def test_browser_frame_cannot_supply_private_authority(self):
+        adapter = G1DualArmAdapter(
+            mode="shadow",
+            pose_mapper=G1ControllerPoseMapper(),
+            ik_solver=FakeIkSolver(),
+            low_state_reader=FakeLowStateReader(),
+        )
+        runtime = G1TeleopRuntime(mode="shadow", adapter=adapter, auto_watchdog=False)
+        identity = session()
+        try:
+            public = rtc_frame(
+                runtime,
+                identity,
+                sequence=1,
+                clutch_sequence=1,
+                deadman=False,
+            )
+            public["session_id"] = identity["session_id"]
+            authority = {
+                "boot_id": runtime.boot_id,
+                **identity,
+            }
+            with self.assertRaises(ProtocolError) as caught:
+                bind_rtc_frame_v1(
+                    public,
+                    authority=authority,
+                    expected_mode="shadow",
+                )
+            self.assertEqual("unknown_field", caught.exception.code)
+        finally:
+            runtime.close()
+
+
+    def test_rtc_heartbeat_never_renews_core_lease(self):
+        class Clock:
+            def __init__(self):
+                self.value = time.monotonic()
+
+            def __call__(self):
+                return self.value
+
+        class Channel:
+            readyState = "open"
+
+            def __init__(self):
+                self.sent = []
+
+            def send(self, value):
+                self.sent.append(json.loads(value))
+
+        clock = Clock()
+
+        class ClockedLowState(FakeLowStateReader):
+            def read_arm_state(self):
+                value = dict(super().read_arm_state())
+                value["sample_monotonic"] = clock()
+                return value
+
+        adapter = G1DualArmAdapter(
+            mode="shadow",
+            pose_mapper=G1ControllerPoseMapper(),
+            ik_solver=FakeIkSolver(),
+            low_state_reader=ClockedLowState(),
+            clock=clock,
+        )
+        runtime = G1TeleopRuntime(
+            mode="shadow",
+            adapter=adapter,
+            lease_timeout_ms=100,
+            clock=clock,
+            auto_watchdog=False,
+        )
+        identity = session()
+        channel = Channel()
+        try:
+            runtime.prepare("shadow", identity)
+            RtcManager(runtime, None)._handle_control_message(
+                channel,
+                json.dumps({"type": "heartbeat", "request_id": "rtc-heartbeat"}),
+            )
+            self.assertFalse(channel.sent[-1]["ok"])
+            self.assertEqual(
+                "rtc_cannot_renew_lease",
+                channel.sent[-1]["error"]["code"],
+            )
+            self.assertFalse(channel.sent[-1]["lease_renewed"])
+            clock.value += 0.101
+            expired = runtime.watchdog_tick()
+            self.assertFalse(expired["authority_valid"])
+            self.assertIsNone(expired["session_id"])
+            self.assertEqual("lease_timeout", expired["reason"])
+        finally:
+            runtime.close()
+
+
+class G1LiveHealthTests(unittest.TestCase):
+    def setUp(self):
+        class HealthLowState(FakeLowStateReader):
+            stale = False
+
+            def read_arm_state(low_state_self):
+                sample = super().read_arm_state()
+                if low_state_self.stale:
+                    sample["sample_monotonic"] = time.monotonic() - 1.0
+                return sample
+
+        self.low_state = HealthLowState()
+        self.arm_sdk = HealthArmSdk()
+        adapter = G1DualArmAdapter(
+            mode="live",
+            pose_mapper=G1ControllerPoseMapper(),
+            ik_solver=FakeIkSolver(),
+            low_state_reader=self.low_state,
+            arm_sdk=self.arm_sdk,
+        )
+        self.runtime = G1TeleopRuntime(
+            mode="live",
+            adapter=adapter,
+            auto_watchdog=False,
+        )
+        self.service = G1TeleopService(
+            self.runtime,
+            driver_token=DRIVER_TOKEN,
+            ticket_secret=TICKET_SECRET,
+            startup_preflight=startup_preflight(self.runtime),
+            live_low_state_probe=self.low_state.read_arm_state,
+        )
+        self.service.update_registration_status(state="registered")
+
+    def tearDown(self):
+        self.service.close()
+
+    def test_live_health_turns_red_when_mode_machine_leaves_ai_without_output(self):
+        before = self.service.health()
+        self.assertTrue(before["ready"])
+        self.assertTrue(before["live_low_state"]["ready"])
+        output_calls = list(self.arm_sdk.output_calls)
+
+        self.low_state.mode_machine = 3
+        after = self.service.health()
+
+        self.assertFalse(after["ready"])
+        self.assertEqual("mode_machine_not_ai", after["live_low_state"]["code"])
+        self.assertEqual(3, after["live_low_state"]["mode_machine"])
+        self.assertEqual(output_calls, self.arm_sdk.output_calls)
+
+    def test_live_health_turns_red_for_stale_low_state_without_output(self):
+        self.low_state.stale = True
+        output_calls = list(self.arm_sdk.output_calls)
+
+        health = self.service.health()
+
+        self.assertFalse(health["ready"])
+        self.assertEqual("low_state_stale", health["live_low_state"]["code"])
+        self.assertGreaterEqual(health["live_low_state"]["sample_age_ms"], 999.0)
+        self.assertEqual(output_calls, self.arm_sdk.output_calls)
+
+    def test_live_health_cannot_return_green_after_concurrent_close(self):
+        probe_entered = threading.Event()
+        release_probe = threading.Event()
+        original_read = self.low_state.read_arm_state
+
+        def blocked_read():
+            probe_entered.set()
+            if not release_probe.wait(1.0):
+                raise RuntimeError("test probe was not released")
+            return original_read()
+
+        self.service._live_low_state_probe = blocked_read
+        results = []
+        worker = threading.Thread(target=lambda: results.append(self.service.health()))
+        worker.start()
+        self.assertTrue(probe_entered.wait(1.0))
+
+        # close() must not wait for a diagnostics read; once it has returned,
+        # the blocked health call may only publish a red service_closed result.
+        self.service.close()
+        output_calls_after_close = list(self.arm_sdk.output_calls)
+        release_probe.set()
+        worker.join(1.0)
+
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(1, len(results))
+        self.assertFalse(results[0]["ready"])
+        self.assertEqual(
+            "service_closed",
+            results[0]["live_low_state"]["code"],
+        )
+        self.assertEqual(output_calls_after_close, self.arm_sdk.output_calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_teleop_shadow.py
+++ b/unitree/g1/tests/test_teleop_shadow.py
@@ -1,0 +1,297 @@
+import threading
+import time
+import unittest
+
+import numpy as np
+from teleop.adapter import G1ControllerPoseMapper, G1DualArmAdapter
+from teleop.dispatch import AdapterAck
+from teleop.protocol import ProtocolError
+from teleop.runtime import G1TeleopRuntime
+
+from tests.helpers import FakeIkSolver, FakeLowStateReader, frame, session
+
+
+class G1ShadowRuntimeTests(unittest.TestCase):
+    def setUp(self):
+        self.lowstate = FakeLowStateReader()
+        self.ik = FakeIkSolver()
+        self.adapter = G1DualArmAdapter(
+            mode="shadow",
+            pose_mapper=G1ControllerPoseMapper(),
+            ik_solver=self.ik,
+            low_state_reader=self.lowstate,
+        )
+        self.runtime = G1TeleopRuntime(
+            mode="shadow",
+            adapter=self.adapter,
+            auto_watchdog=False,
+        )
+        self.identity = session()
+
+    def tearDown(self):
+        self.runtime.close()
+
+    def _wait_for_output(self, state, timeout=1.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            snapshot = self.runtime.status()
+            if snapshot["output"]["state"] == state:
+                return snapshot
+            time.sleep(0.002)
+        self.fail(f"output did not reach {state}")
+
+    def _assert_joint_shape(self, snapshot, expected=10):
+        target = snapshot["output"]["target_joint_positions_rad"]
+        measured = snapshot["output"]["measured_joint_positions_rad"]
+        self.assertEqual(expected, len(target), snapshot["state"])
+        self.assertEqual(len(target), len(measured), snapshot["state"])
+
+    def test_pose_mapper_matches_g1_23_controller_profile_golden_pose(self):
+        raw = frame(self.runtime, self.identity, sequence=0, clutch_sequence=0, deadman=False)
+        left, right = G1ControllerPoseMapper().map_frame(raw)
+        np.testing.assert_allclose(left[:3, 3], [0.55, 0.2, 0.05], atol=1e-9)
+        np.testing.assert_allclose(right[:3, 3], [0.55, -0.2, 0.05], atol=1e-9)
+        np.testing.assert_allclose(left[:3, :3], [
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, -1.0],
+            [0.0, 1.0, 0.0],
+        ], atol=1e-9)
+        np.testing.assert_allclose(right[:3, :3], [
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.0, -1.0, 0.0],
+        ], atol=1e-9)
+
+        # The deployed G1 path explicitly uses arm_reference_mode=head_yaw.
+        raw["head"]["orientation"] = [0.0, 2 ** -0.5, 0.0, 2 ** -0.5]
+        yawed_left, yawed_right = G1ControllerPoseMapper().map_frame(raw)
+        np.testing.assert_allclose(yawed_left[:3, 3], [0.35, -0.4, 0.05], atol=1e-9)
+        np.testing.assert_allclose(yawed_right[:3, 3], [-0.05, -0.4, 0.05], atol=1e-9)
+        np.testing.assert_allclose(yawed_left[:3, :3], [
+            [0.0, 0.0, -1.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ], atol=1e-9)
+        np.testing.assert_allclose(yawed_right[:3, :3], [
+            [0.0, 0.0, 1.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+        ], atol=1e-9)
+
+    def test_shadow_requires_neutral_then_reclutch_and_never_has_publisher(self):
+        self._assert_joint_shape(self.runtime.status())
+        prepared = self.runtime.prepare("shadow", self.identity)
+        self.assertEqual(prepared["state"], "prepared_shadow")
+        self.assertFalse(prepared["actuation_enabled"])
+        self.assertFalse(prepared["output"]["hardware_output"])
+        self._assert_joint_shape(prepared)
+
+        held = self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=0, clutch_sequence=7, deadman=True),
+            source="test",
+        )
+        self.assertEqual(held["state"], "prepared_shadow")
+        self.assertEqual(len(self.ik.calls), 0)
+
+        neutral = self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=1, clutch_sequence=7, deadman=False),
+            source="test",
+        )
+        self.assertEqual(neutral["state"], "prepared_shadow")
+
+        active = self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=2, clutch_sequence=8, deadman=True),
+            source="test",
+        )
+        self.assertEqual(active["state"], "active_shadow")
+        snapshot = self._wait_for_output("would_apply")
+        self.assertEqual(snapshot["dispatch"]["last_would_apply_sequence"], 2)
+        self.assertNotIn("last_published_sequence", snapshot["dispatch"])
+        self.assertGreaterEqual(self.lowstate.reads, 4)
+        self.assertEqual(len(self.ik.calls), 1)
+        self.assertEqual(len(snapshot["output"]["target_joint_positions_rad"]), 10)
+        self.assertEqual(len(snapshot["output"]["measured_joint_positions_rad"]), 10)
+        self.assertAlmostEqual(snapshot["output"]["max_abs_error_rad"], 0.1)
+        self.assertEqual(
+            set(snapshot["diagnostics"]["latency_ms"]),
+            {"receive_to_admit", "mailbox_wait", "ik", "adapter_apply", "robot_follow"},
+        )
+
+        paused = self.runtime.pause({
+            "boot_id": self.runtime.boot_id,
+            **self.identity,
+        })
+        self.assertEqual(paused["state"], "paused")
+        self.assertTrue(paused["dispatch"]["stop_acknowledged"])
+        self.assertEqual(paused["output"]["state"], "stopped")
+        self._assert_joint_shape(paused)
+
+        released = self.runtime.release({
+            "boot_id": self.runtime.boot_id,
+            **self.identity,
+        })
+        self.assertEqual("released", released["state"])
+        self._assert_joint_shape(released)
+
+    def test_hold_and_fault_preserve_equal_ten_joint_vectors(self):
+        self.runtime.prepare("shadow", self.identity)
+        self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=1, clutch_sequence=1, deadman=False),
+            source="test",
+        )
+        self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=2, clutch_sequence=2, deadman=True),
+            source="test",
+        )
+        self._wait_for_output("would_apply")
+        held = self.runtime.submit_frame(
+            frame(self.runtime, self.identity, sequence=3, clutch_sequence=2, deadman=False),
+            source="test",
+        )
+        self.assertEqual("hold", held["state"])
+        stopped = self._wait_for_output("stopped")
+        self._assert_joint_shape(stopped)
+
+        class FailingIk(FakeIkSolver):
+            def solve(self, *args):
+                raise RuntimeError("deterministic IK failure")
+
+        failing_adapter = G1DualArmAdapter(
+            mode="shadow",
+            pose_mapper=G1ControllerPoseMapper(),
+            ik_solver=FailingIk(),
+            low_state_reader=FakeLowStateReader(),
+        )
+        failing = G1TeleopRuntime(
+            mode="shadow",
+            adapter=failing_adapter,
+            auto_watchdog=False,
+        )
+        failing_identity = session()
+        try:
+            failing.prepare("shadow", failing_identity)
+            failing.submit_frame(
+                frame(failing, failing_identity, sequence=1, clutch_sequence=1, deadman=False),
+                source="test",
+            )
+            failing.submit_frame(
+                frame(failing, failing_identity, sequence=2, clutch_sequence=2, deadman=True),
+                source="test",
+            )
+            deadline = time.monotonic() + 1.0
+            while time.monotonic() < deadline:
+                fault = failing.status()
+                if fault["state"] == "fault":
+                    break
+                time.sleep(0.002)
+            else:
+                self.fail("IK failure did not latch the runtime fault")
+            self._assert_joint_shape(fault)
+        finally:
+            failing.close()
+
+    def test_mode_mismatch_fails_before_mapping_or_ik(self):
+        self.runtime.prepare("shadow", self.identity)
+        wrong = frame(self.runtime, self.identity, sequence=0, clutch_sequence=0, deadman=False)
+        wrong["mode"] = "live"
+        with self.assertRaisesRegex(ProtocolError, "mode must be 'shadow'"):
+            self.runtime.submit_frame(wrong, source="test")
+        self.assertEqual(len(self.ik.calls), 0)
+
+    def test_mailbox_expiry_is_projected_to_runtime_hold_without_new_frame(self):
+        class Clock:
+            def __init__(self):
+                self.value = 0.0
+
+            def __call__(self):
+                return self.value
+
+        class BlockingRecordingAdapter:
+            hardware_output = False
+
+            def __init__(self):
+                self.entered = threading.Event()
+                self.release = threading.Event()
+
+            def startup_safe(self, deadline):
+                return AdapterAck(True)
+
+            def apply(self, intent):
+                if intent.sequence == 2:
+                    self.entered.set()
+                    self.release.wait(1.0)
+                return AdapterAck(True)
+
+            def safe_stop(self, request):
+                return AdapterAck(True)
+
+            def snapshot(self):
+                output = {
+                    "profile_id": "unitree_g1_23_dual_arm_controller_v1",
+                    "hardware_output": False,
+                    "state": "safe",
+                    "target_joint_positions_rad": [0.0] * 10,
+                    "measured_joint_positions_rad": [0.0] * 10,
+                    "max_abs_error_rad": 0.0,
+                    "arm_sdk_weight": None,
+                    "command_age_ms": None,
+                    "fault_reason": None,
+                }
+                return {
+                    "kind": "recording",
+                    "closed": False,
+                    "current": {"kind": "safe"},
+                    "records": [],
+                    "diagnostics": {"latency_ms": {}},
+                    "output": output,
+                }
+
+            def close(self):
+                return AdapterAck(True)
+
+        clock = Clock()
+        adapter = BlockingRecordingAdapter()
+        runtime = G1TeleopRuntime(
+            mode="shadow",
+            adapter=adapter,
+            clock=clock,
+            pose_timeout_ms=1000,
+            auto_watchdog=False,
+        )
+        identity = session()
+        try:
+            runtime.prepare("shadow", identity)
+            runtime.submit_frame(
+                frame(runtime, identity, sequence=1, clutch_sequence=1, deadman=False),
+                source="test",
+            )
+            runtime.submit_frame(
+                frame(runtime, identity, sequence=2, clutch_sequence=2, deadman=True),
+                source="test",
+            )
+            self.assertTrue(adapter.entered.wait(1.0))
+            runtime._pose_timeout = 0.2
+            runtime.submit_frame(
+                frame(runtime, identity, sequence=3, clutch_sequence=2, deadman=True),
+                source="test",
+            )
+            clock.value = 0.3
+            adapter.release.set()
+            deadline = time.monotonic() + 1.0
+            while time.monotonic() < deadline:
+                status = runtime.status()
+                if status["state"] == "hold":
+                    break
+                time.sleep(0.002)
+            else:
+                self.fail("expired mailbox intent was not projected to HOLD")
+            self.assertEqual("pose_timeout", status["reason"])
+            self.assertEqual("safe_reclutch_required", status["dispatch"]["state"])
+            self.assertTrue(status["dispatch"]["stop_acknowledged"])
+        finally:
+            adapter.release.set()
+            runtime.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 交付结果

本 PR 在现有 Unitree G1 根 Driver 中新增可选启用的 G1_23 双臂 OpenXR 遥操作适配器。Shadow 模式会运行真实姿态变换、十关节 IK 和 LowState 对比，但不会创建 Publisher；Live 模式是独立的双重显式启用路径，并且只允许创建一个 `rt/arm_sdk` Publisher。

## 包含内容

- 版本化的 G1_23 Shadow/Live 描述符与状态证据
- OpenXR 头部和控制器姿态到 G1 头部偏航相对坐标系的双臂映射
- 基于 Pinocchio 3.1.0、CasADi 3.6.7 和随附 body23 URDF 的十关节 IK
- LowState 新鲜度、运控模式检查和基于当前姿态的 IK 预热
- 只保留最新帧的 RTC 调度、速度限制、deadman、中立重握和指令过期处理
- 单一 `rt/arm_sdk` Publisher、权重渐变和五帧零权重释放
- 异步 Publisher 故障投影、故障关闭生命周期清理和带认证的健康检查与预检
- Docker/Conda 数值 ABI 门禁和目标镜像冷启动求解预检

## 安全边界

- 默认配置保持遥操作关闭，并保留原有手臂手势插件。
- 启用遥操作时，会禁用与其竞争控制权的手臂手势插件。
- Live 必须同时设置 `teleop.mode=live` 和 `teleop.live.enabled=true`。
- V1 只控制 G1_23 的十个手臂关节；底盘和塑胶假手保持禁用。
- 在遥操作未启用时，旧部署可以继续把遥操作密钥留空。

## 验证结果

- 在当前 `origin/main` 上独立运行 G1 测试：**57 项通过**
- 本地真实 `aiortc` 双 DataChannel 场景：通过
- Shadow 零 Publisher、Live 唯一 Publisher、五帧释放、模式与新鲜度故障、超时重握和生命周期清理合同：通过
- 导入描述符时不会访问硬件
- `git diff --check`：通过

## 依赖与转为可评审状态前的条件

- 配套 Core 控制面见 [phanthymotus#84](https://github.com/4paradigm/phanthymotus/pull/84)。
- 本 PR 独立于 Generic Shadow Driver PR，不导入其中任何内容。
- 尚未在 G1 电脑上执行目标 Linux/ARM64 镜像的冷启动构建。
- G1 当前关机；本 PR 不声明 Shadow 或小幅 Live 真机验收完成。
