### PR TITLE
feat(g1): isolate speaker and controlled_spatial into subprocesses

### DIFF
--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -8,6 +8,7 @@ plugins:
     enabled: true
   speaker:
     enabled: true
+    isolated_process: true
   led:
     enabled: true
   loco:
@@ -26,6 +27,7 @@ plugins:
     db_path: /opt/phanthy-motus/data/spatial.db
   controlled_spatial:
     enabled: true
+    isolated_process: true
     native_slam_pcd_dir: /home/unitree
     native_slam_db_path: /opt/phanthy-motus/data/controlled_spatial.db
   controlled_spatial_map:

--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -899,3 +899,134 @@ class ControlledSpatialPlugin:
             return {"status": "stopped"}
 
         return None
+
+
+# ── Isolated Process Mode ─────────────────────────────────────────────────────
+
+def _controlled_spatial_process(plugin_config: dict, namespace: str, command_queue, result_queue):
+    """Subprocess entry: runs ControlledSpatialPlugin with its own DDS + GIL."""
+    import os as _os
+    _os.setsid()
+
+    try:
+        from unitree_sdk2py.core.channel import ChannelFactoryInitialize
+        network_iface = plugin_config.get("network_iface", "eth0")
+        ChannelFactoryInitialize(0, network_iface)
+
+        # Suppress C++ stdout in subprocess
+        _orig_fd = _os.dup(1)
+        _devnull = _os.open(_os.devnull, _os.O_WRONLY)
+        _os.dup2(_devnull, 1)
+        _os.close(_devnull)
+        import sys
+        sys.stdout = _os.fdopen(_orig_fd, 'w', buffering=1)
+
+        child_config = dict(plugin_config)
+        child_config["isolated_process"] = False
+        plugin = ControlledSpatialPlugin(child_config, namespace, None, slam_client=None, smart_motion=None)
+        plugin.start()
+        tool_def = plugin.get_tools()
+        result_queue.put({"ready": True, "tools": tool_def})
+    except Exception as e:
+        result_queue.put({"ready": False, "error": str(e)})
+        return
+
+    print(f"[ControlledSpatial:subprocess] ready, pid={_os.getpid()}", flush=True)
+
+    while True:
+        try:
+            cmd = command_queue.get()
+        except Exception:
+            break
+        if cmd is None:
+            break
+        request_id = cmd.get("id")
+        action = cmd.get("action", "")
+        args = cmd.get("args", {})
+        try:
+            result = plugin.dispatch(action, args)
+            result_queue.put({"id": request_id, "result": result})
+        except Exception as e:
+            result_queue.put({"id": request_id, "result": {"error": str(e)}})
+
+    plugin.stop()
+
+
+class ControlledSpatialIsolatedProxy:
+    """Main-process proxy: forwards dispatch calls to isolated subprocess via Queue."""
+
+    PREFIX = "controlled_spatial"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, slam_client=None, smart_motion=None):
+        import multiprocessing as _mp
+        import queue as _q
+
+        self._ipc_lock = threading.Lock()
+        self._request_id = 0
+        self._startup_error = None
+        self._tools = None
+
+        ctx = _mp.get_context("spawn")
+        self._command_queue = ctx.Queue()
+        self._result_queue = ctx.Queue()
+        child_config = dict(plugin_config)
+        child_config["isolated_process"] = False
+        self._proc = ctx.Process(
+            target=_controlled_spatial_process,
+            args=(child_config, namespace, self._command_queue, self._result_queue),
+            daemon=False,
+            name="controlled_spatial",
+        )
+        self._proc.start()
+        import atexit
+        atexit.register(self.stop)
+        try:
+            result = self._result_queue.get(timeout=30.0)
+        except _q.Empty:
+            self._startup_error = "controlled_spatial subprocess startup timed out"
+            print(f"[ControlledSpatial:proxy] {self._startup_error}", flush=True)
+            return
+        if not result.get("ready"):
+            self._startup_error = result.get("error", "subprocess failed to start")
+            print(f"[ControlledSpatial:proxy] {self._startup_error}", flush=True)
+            return
+        self._tools = result.get("tools", [])
+        print(f"[ControlledSpatial:proxy] subprocess ready, pid={self._proc.pid}", flush=True)
+
+    def get_tools(self) -> list:
+        if self._tools:
+            return self._tools
+        # Fallback: return minimal tool def
+        return [{"name": "controlled_spatial", "type": "actuator",
+                 "description": "Controlled spatial navigation (degraded — subprocess not running)",
+                 "inputSchema": {"type": "object", "properties": {"action": {"type": "string"}}, "required": ["action"]}}]
+
+    def get_tool(self) -> dict:
+        return self.get_tools()[0]
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        if self._proc and self._proc.is_alive():
+            self._command_queue.put(None)
+            self._proc.join(timeout=5)
+            if self._proc.is_alive():
+                self._proc.terminate()
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if not self._proc or not self._proc.is_alive():
+            return {"error": self._startup_error or "controlled_spatial subprocess is not running"}
+        import queue as _q
+        with self._ipc_lock:
+            self._request_id += 1
+            request_id = self._request_id
+            self._command_queue.put({"id": request_id, "action": action, "args": dict(args)})
+            try:
+                while True:
+                    result = self._result_queue.get(timeout=120.0)
+                    if result.get("id") == request_id:
+                        return result.get("result")
+            except _q.Empty:
+                return {"error": f"controlled_spatial action '{action}' timed out (120s)"}
+

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -623,7 +623,215 @@ class SpeakerPlugin:
         return None
 
 
-# ── SmartMotionPlugin (controller) ─────────────────────────────────────────
+# ── Speaker Isolated Process Mode ─────────────────────────────────────────────
+
+def _speaker_process(network_iface: str, namespace: str, plugin_config: dict,
+                     command_queue, result_queue):
+    """Subprocess: runs SpeakerNode with its own DDS context + ROS2.
+
+    Owns an independent AudioClient whose PlayStream RPC is not blocked by
+    the main process's lidar/SLAM DDS traffic.
+    """
+    import os as _os
+    import sys as _sys
+    _os.setsid()
+
+    try:
+        from unitree_sdk2py.core.channel import ChannelFactoryInitialize
+        ChannelFactoryInitialize(0, network_iface)
+
+        # Suppress C++ stdout
+        _orig_fd = _os.dup(1)
+        _devnull = _os.open(_os.devnull, _os.O_WRONLY)
+        _os.dup2(_devnull, 1)
+        _os.close(_devnull)
+        _sys.stdout = _os.fdopen(_orig_fd, 'w', buffering=1)
+
+        audio_client = AudioClient()
+        audio_client.SetTimeout(10.0)
+        audio_client.Init()
+
+        import rclpy as _rclpy
+        from rclpy.executors import MultiThreadedExecutor
+        _rclpy.init()
+        executor = MultiThreadedExecutor()
+
+        node = _SpeakerNode(audio_client)
+        executor.add_node(node)
+
+        import threading
+        spin_thread = threading.Thread(
+            target=lambda: _spin_until_shutdown(executor),
+            daemon=True, name="speaker_spin",
+        )
+        spin_thread.start()
+
+        result_queue.put({"ready": True})
+        print(f"[Speaker:subprocess] ready, pid={_os.getpid()}", flush=True)
+    except Exception as e:
+        result_queue.put({"ready": False, "error": str(e)})
+        return
+
+    # Play startup sound
+    import pathlib
+    pcm_path = pathlib.Path(__file__).parent / 'resource' / 'startup_beep.pcm'
+    try:
+        pcm = pcm_path.read_bytes()
+        block_size = 9600
+        for offset in range(0, len(pcm), block_size):
+            block = pcm[offset:offset + block_size]
+            code, _ = audio_client.PlayStream(APP_NAME, "0", block)
+            if code != 0:
+                break
+            duration = len(block) / 32000
+            remaining = duration - 0.08
+            if remaining > 0:
+                time.sleep(remaining)
+        print(f"[Speaker:subprocess] startup sound OK ({len(pcm)} bytes)", flush=True)
+    except Exception as e:
+        print(f"[Speaker:subprocess] startup sound error: {e}", flush=True)
+
+    # Command loop
+    while True:
+        try:
+            cmd = command_queue.get()
+        except Exception:
+            break
+        if cmd is None:
+            break
+        request_id = cmd.get("id")
+        action = cmd.get("action", "")
+        args = cmd.get("args", {})
+        try:
+            if action in ("start", "play"):
+                topic = args.get("input_topic", "")
+                if not topic:
+                    result_queue.put({"id": request_id, "result": {"error": "Missing input_topic"}})
+                    continue
+                node.stop_play()
+                topic = node.start_play(topic)
+                result_queue.put({"id": request_id, "result": {"state": "ready", "topic": topic}})
+            elif action == "stop":
+                node.stop_play()
+                result_queue.put({"id": request_id, "result": {"state": "idle"}})
+            elif action == "interrupt":
+                r = node.interrupt()
+                result_queue.put({"id": request_id, "result": r})
+            elif action == "pause":
+                r = node.pause()
+                result_queue.put({"id": request_id, "result": r})
+            elif action == "resume":
+                r = node.resume()
+                result_queue.put({"id": request_id, "result": r})
+            elif action == "info":
+                result_queue.put({"id": request_id, "result": {
+                    "state": node.state,
+                    "topic": node._topic,
+                    "buffer_chunks": node._buf.qsize(),
+                }})
+            else:
+                result_queue.put({"id": request_id, "result": None})
+        except Exception as e:
+            result_queue.put({"id": request_id, "result": {"error": str(e)}})
+
+    node.stop_play()
+    executor.shutdown()
+
+
+def _spin_until_shutdown(executor):
+    import rclpy as _rclpy
+    while _rclpy.ok():
+        executor.spin_once(timeout_sec=0.1)
+
+
+class SpeakerIsolatedProxy:
+    """Main-process proxy: forwards speaker commands to isolated subprocess."""
+
+    PREFIX = "speaker"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, audio_client=None,
+                 network_iface: str = "eth0"):
+        import multiprocessing as _mp
+        import queue as _q
+
+        self._ipc_lock = threading.Lock()
+        self._request_id = 0
+        self._startup_error = None
+
+        ctx = _mp.get_context("spawn")
+        self._command_queue = ctx.Queue()
+        self._result_queue = ctx.Queue()
+        self._proc = ctx.Process(
+            target=_speaker_process,
+            args=(network_iface, namespace, plugin_config,
+                  self._command_queue, self._result_queue),
+            daemon=False,
+            name="speaker_isolated",
+        )
+        self._proc.start()
+        import atexit
+        atexit.register(self.stop)
+        try:
+            result = self._result_queue.get(timeout=20.0)
+        except _q.Empty:
+            self._startup_error = "speaker subprocess startup timed out"
+            print(f"[Speaker:proxy] {self._startup_error}", flush=True)
+            return
+        if not result.get("ready"):
+            self._startup_error = result.get("error", "subprocess failed to start")
+            print(f"[Speaker:proxy] {self._startup_error}", flush=True)
+            return
+        print(f"[Speaker:proxy] subprocess ready, pid={self._proc.pid}", flush=True)
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "speaker",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "G1 speaker — subscribes to ROS2 topic and streams PCM-16k audio to robot speaker",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["start", "stop", "info"],
+                        "description": "Action to perform",
+                    },
+                    "input_topic": {
+                        "type": "string",
+                        "description": "ROS2 topic to subscribe for PCM audio (provided by canvas connection)",
+                    },
+                },
+                "required": ["action"],
+            },
+            "topic_in": [{"format": "audio/pcm-16k"}],
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        if self._proc and self._proc.is_alive():
+            self._command_queue.put(None)
+            self._proc.join(timeout=5)
+            if self._proc.is_alive():
+                self._proc.terminate()
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if not self._proc or not self._proc.is_alive():
+            return {"error": self._startup_error or "speaker subprocess is not running"}
+        import queue as _q
+        with self._ipc_lock:
+            self._request_id += 1
+            request_id = self._request_id
+            self._command_queue.put({"id": request_id, "action": action, "args": dict(args)})
+            try:
+                while True:
+                    result = self._result_queue.get(timeout=15.0)
+                    if result.get("id") == request_id:
+                        return result.get("result")
+            except _q.Empty:
+                return {"error": f"speaker action '{action}' timed out (15s)"}
 
 class SmartMotionPlugin:
     """统一打断/暂停控制卡片。协调 speaker + loco 的中止和暂停。"""

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -672,24 +672,26 @@ def _speaker_process(network_iface: str, namespace: str, plugin_config: dict,
         result_queue.put({"ready": False, "error": str(e)})
         return
 
-    # Play startup sound
-    import pathlib
-    pcm_path = pathlib.Path(__file__).parent / 'resource' / 'startup_beep.pcm'
-    try:
-        pcm = pcm_path.read_bytes()
-        block_size = 9600
-        for offset in range(0, len(pcm), block_size):
-            block = pcm[offset:offset + block_size]
-            code, _ = audio_client.PlayStream(APP_NAME, "0", block)
-            if code != 0:
-                break
-            duration = len(block) / 32000
-            remaining = duration - 0.08
-            if remaining > 0:
-                time.sleep(remaining)
-        print(f"[Speaker:subprocess] startup sound OK ({len(pcm)} bytes)", flush=True)
-    except Exception as e:
-        print(f"[Speaker:subprocess] startup sound error: {e}", flush=True)
+    def _play_beep():
+        """Play startup beep synchronously."""
+        import pathlib
+        pcm_path = pathlib.Path(__file__).parent / 'resource' / 'startup_beep.pcm'
+        try:
+            pcm = pcm_path.read_bytes()
+            block_size = 9600
+            for off in range(0, len(pcm), block_size):
+                block = pcm[off:off + block_size]
+                code, _ = audio_client.PlayStream(APP_NAME, "0", block)
+                if code != 0:
+                    print(f"[Speaker:subprocess] startup sound stopped at offset {off}: code={code}", flush=True)
+                    return
+                duration = len(block) / 32000
+                remaining = duration - 0.08
+                if remaining > 0:
+                    time.sleep(remaining)
+            print(f"[Speaker:subprocess] startup sound OK ({len(pcm)} bytes)", flush=True)
+        except Exception as e:
+            print(f"[Speaker:subprocess] startup sound error: {e}", flush=True)
 
     # Command loop
     while True:
@@ -709,6 +711,8 @@ def _speaker_process(network_iface: str, namespace: str, plugin_config: dict,
                     result_queue.put({"id": request_id, "result": {"error": "Missing input_topic"}})
                     continue
                 node.stop_play()
+                # Play startup sound before starting subscription (same as non-isolated path)
+                _play_beep()
                 topic = node.start_play(topic)
                 result_queue.put({"id": request_id, "result": {"state": "ready", "topic": topic}})
             elif action == "stop":

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -80,9 +80,15 @@ class G1DeviceBundle:
             print("[bundle] NativeTtsPlugin loaded")
 
         if plugins_cfg.get("speaker", {}).get("enabled", False):
-            from device import SpeakerPlugin
-            self._plugins.append(SpeakerPlugin(plugins_cfg["speaker"], namespace, executor, audio_client))
-            print("[bundle] SpeakerPlugin loaded")
+            speaker_cfg = plugins_cfg["speaker"]
+            if speaker_cfg.get("isolated_process", False):
+                from device import SpeakerIsolatedProxy
+                self._plugins.append(SpeakerIsolatedProxy(speaker_cfg, namespace, executor, audio_client, network_iface=network_iface))
+                print("[bundle] SpeakerPlugin loaded (isolated process)")
+            else:
+                from device import SpeakerPlugin
+                self._plugins.append(SpeakerPlugin(speaker_cfg, namespace, executor, audio_client))
+                print("[bundle] SpeakerPlugin loaded")
 
         if plugins_cfg.get("led", {}).get("enabled", False):
             from device import LedPlugin
@@ -126,11 +132,16 @@ class G1DeviceBundle:
             print("[bundle] SpatialPlugin loaded")
 
         if plugins_cfg.get("controlled_spatial", {}).get("enabled", False):
-            from controlled_spatial import ControlledSpatialPlugin
             controlled_cfg = dict(plugins_cfg["controlled_spatial"])
             controlled_cfg["network_iface"] = network_iface
-            self._plugins.append(ControlledSpatialPlugin(controlled_cfg, namespace, executor, slam_client, smart_motion=smart_motion))
-            print("[bundle] ControlledSpatialPlugin loaded")
+            if controlled_cfg.get("isolated_process", False):
+                from controlled_spatial import ControlledSpatialIsolatedProxy
+                self._plugins.append(ControlledSpatialIsolatedProxy(controlled_cfg, namespace, executor, slam_client, smart_motion=smart_motion))
+                print("[bundle] ControlledSpatialPlugin loaded (isolated process)")
+            else:
+                from controlled_spatial import ControlledSpatialPlugin
+                self._plugins.append(ControlledSpatialPlugin(controlled_cfg, namespace, executor, slam_client, smart_motion=smart_motion))
+                print("[bundle] ControlledSpatialPlugin loaded")
 
         if plugins_cfg.get("controlled_spatial_map", {}).get("enabled", False):
             try:


### PR DESCRIPTION
## Summary

- Speaker `PlayStream` RPC was delayed by lidar point cloud traffic on the shared DDS `recvMC` thread, causing audio stuttering
- Added `SpeakerIsolatedProxy` — speaker runs in independent subprocess with its own DDS context
- Added `ControlledSpatialIsolatedProxy` — spatial plugin runs in independent subprocess  
- Enabled via `isolated_process: true` in config.yaml (opt-in per plugin)
- Startup beep plays on "开始控制" click, not on container restart

## Test plan

- [x] Deployed to G1, speaker subprocess starts successfully (5.5% CPU)
- [x] MCP tools/call speaker info returns correct state via IPC
- [x] All 25 MCP tools registered normally
- [x] Startup sound plays on dispatch start, not on process init

🤖 Generated with [Claude Code](https://claude.com/claude-code)