### PR TITLE
feat(g1): add network DDS health sensor

### DIFF
--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -16,6 +16,9 @@ plugins:
     enabled: true
   state:
     enabled: true
+  network_dds_health:
+    enabled: true
+    publish_hz: 2.0
   camera:
     enabled: true
   lidar:

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -18,6 +18,9 @@ drivers/unitree/g1/device.py — Unitree G1 设备插件（重构版）。
   StatePlugin        (sensor)    — DDS LowState → IMU/battery ROS2 topic
 """
 
+from __future__ import annotations
+
+from collections import deque
 import json
 import queue
 import socket
@@ -1815,6 +1818,313 @@ class StatePlugin:
             if urdf_path.exists():
                 return {"urdf": urdf_path.read_text()}
             return {"error": "URDF model file not found"}
+        return None
+
+
+# ── NetworkDdsHealthPlugin (sensor) ──────────────────────────────────────────
+
+class _TopicHealth:
+    def __init__(self, name: str, topic: str, group: str, expected_hz: float, stale_after_s: float, required: bool):
+        self.name = name
+        self.topic = topic
+        self.group = group
+        self.required = bool(required)
+        self.expected_hz = float(expected_hz)
+        self.stale_after_s = float(stale_after_s)
+        self.sample_count = 0
+        self.estimated_missed = 0
+        self.first_time: float | None = None
+        self.last_time: float | None = None
+        self._last_interval_time: float | None = None
+        self._intervals = deque(maxlen=30)
+        self.last_latency_ms: float | None = None
+        self.max_latency_ms: float | None = None
+        self.last_payload: dict = {}
+
+    def record(self, msg, now: float, clock_ns: int | None) -> None:
+        if self.first_time is None:
+            self.first_time = now
+        if self._last_interval_time is not None:
+            interval = now - self._last_interval_time
+            if interval > 0:
+                self._intervals.append(interval)
+                self._record_gap(interval)
+        self._last_interval_time = now
+        self.last_time = now
+        self.sample_count += 1
+        self._record_latency(msg, clock_ns)
+
+    def _record_gap(self, interval: float) -> None:
+        if self.expected_hz <= 0:
+            return
+        period = 1.0 / self.expected_hz
+        if interval <= period * 1.5:
+            return
+        self.estimated_missed += max(0, int(interval / period) - 1)
+
+    def _record_latency(self, msg, clock_ns: int | None) -> None:
+        if clock_ns is None:
+            return
+        header = getattr(msg, "header", None)
+        stamp = getattr(header, "stamp", None)
+        if stamp is None:
+            return
+        try:
+            stamp_ns = int(stamp.sec) * 1_000_000_000 + int(stamp.nanosec)
+        except Exception:
+            return
+        if stamp_ns <= 0:
+            return
+        latency_ms = max(0.0, (clock_ns - stamp_ns) / 1_000_000.0)
+        self.last_latency_ms = latency_ms
+        if self.max_latency_ms is None or latency_ms > self.max_latency_ms:
+            self.max_latency_ms = latency_ms
+
+    def hz(self) -> float | None:
+        if not self._intervals:
+            return None
+        avg = sum(self._intervals) / len(self._intervals)
+        if avg <= 0:
+            return None
+        return 1.0 / avg
+
+    def payload(self, now: float) -> dict:
+        if self.last_time is None:
+            state = "no_data"
+            age_ms = None
+            fresh = False
+        else:
+            age = now - self.last_time
+            age_ms = round(age * 1000.0, 1)
+            fresh = age <= self.stale_after_s
+            state = "fresh" if fresh else "stale"
+
+        out = {
+            "name": self.name,
+            "status": state,
+            "fresh": fresh,
+            "required": self.required,
+            "age_ms": age_ms,
+            "samples": self.sample_count,
+            "missed": self.estimated_missed,
+        }
+        hz = self.hz()
+        if hz is not None:
+            out["hz"] = round(hz, 2)
+        if self.last_latency_ms is not None:
+            out["latency_ms"] = round(self.last_latency_ms, 1)
+        if self.max_latency_ms is not None:
+            out["max_latency_ms"] = round(self.max_latency_ms, 1)
+        return out
+
+
+class _NetworkDdsHealthNode(Node):
+    """Aggregates ROS2 topic freshness and transport health into one JSON status topic."""
+
+    _TOPIC_SPECS = (
+        ("loco_state", "loco/state", "dds", "json", 10.0, 1.0, True),
+        ("loco_motion_state", "loco/motion_state", "dds", "json", 10.0, 1.0, False),
+        ("imu", "state/imu", "dds", "json", 20.0, 0.5, True),
+        ("battery", "state/battery", "dds", "json", 1.0, 3.0, True),
+        ("joints", "state/joints", "dds", "json", 10.0, 1.0, True),
+        ("mainboard", "state/mainboard", "dds", "json", 0.5, 5.0, True),
+        ("lidar_cloud", "lidar/cloud", "lidar", "bytes", 10.0, 1.0, True),
+    )
+
+    def __init__(self, health_topic: str, namespace: str, mcp_port: int | None, publish_hz: float = 2.0):
+        super().__init__("g1_network_dds_health")
+        from std_msgs.msg import UInt8MultiArray
+
+        self._health_topic = health_topic
+        self._namespace = namespace
+        self._mcp_port = mcp_port
+        self._pub = self.create_publisher(String, health_topic, _LOW_LAT_QOS)
+        self._lock = threading.Lock()
+        self._stats: dict[str, _TopicHealth] = {}
+        self._subscriptions = []
+
+        msg_types = {
+            "json": String,
+            "bytes": UInt8MultiArray,
+        }
+        for name, path, group, msg_kind, expected_hz, stale_after_s, required in self._TOPIC_SPECS:
+            topic = f"/{namespace}/{path}"
+            self._stats[name] = _TopicHealth(name, topic, group, expected_hz, stale_after_s, required)
+            sub = self.create_subscription(
+                msg_types[msg_kind],
+                topic,
+                lambda msg, topic_name=name: self._on_topic(topic_name, msg),
+                _LOW_LAT_QOS,
+            )
+            self._subscriptions.append(sub)
+
+        period = 1.0 / max(0.1, float(publish_hz))
+        self._timer = self.create_timer(period, self._publish)
+        self.get_logger().info(f"NetworkDdsHealthNode ready — topic: {health_topic}")
+
+    def _clock_ns(self) -> int | None:
+        try:
+            return int(self.get_clock().now().nanoseconds)
+        except Exception:
+            return None
+
+    def _on_topic(self, name: str, msg) -> None:
+        now = time.monotonic()
+        with self._lock:
+            stat = self._stats.get(name)
+            if stat is None:
+                return
+            stat.record(msg, now, self._clock_ns())
+
+    def current_state(self) -> dict:
+        return self._build_state(time.monotonic())
+
+    def _build_state(self, now: float) -> dict:
+        with self._lock:
+            stats = {name: stat for name, stat in self._stats.items()}
+            topics = {name: stat.payload(now) for name, stat in stats.items()}
+
+        counts = {
+            "fresh": sum(1 for item in topics.values() if item["status"] == "fresh"),
+            "stale": sum(1 for item in topics.values() if item["status"] == "stale"),
+            "no_data": sum(1 for item in topics.values() if item["status"] == "no_data"),
+        }
+        required_topics = {name: item for name, item in topics.items() if item["required"]}
+        required_problem_topics = [
+            name for name, item in required_topics.items()
+            if item["status"] != "fresh"
+        ]
+
+        if counts["fresh"] == 0:
+            state = "no_data"
+        elif required_problem_topics:
+            state = "degraded"
+        else:
+            state = "healthy"
+
+        def group_state(group_name: str) -> str:
+            group_items = [
+                topics[name] for name, stat in stats.items()
+                if stat.group == group_name and topics[name]["required"]
+            ]
+            if not group_items:
+                return "healthy"
+            fresh = sum(1 for item in group_items if item["status"] == "fresh")
+            bad = sum(1 for item in group_items if item["status"] != "fresh")
+            if fresh == 0:
+                return "no_data"
+            if bad:
+                return "degraded"
+            return "healthy"
+
+        dds_state = group_state("dds")
+        lidar_state = group_state("lidar")
+
+        latency_values = [
+            item["latency_ms"]
+            for item in topics.values()
+            if "latency_ms" in item
+        ]
+        issues = [
+            {"name": name, "status": topics[name]["status"]}
+            for name in required_problem_topics
+        ]
+        dds = [topics[name] for name, stat in stats.items() if stat.group == "dds" and topics[name]["required"]]
+        lidar = [topics[name] for name, stat in stats.items() if stat.group == "lidar" and topics[name]["required"]]
+        optional = [topics[name] for name, stat in stats.items() if not topics[name]["required"]]
+        return {
+            "state": state,
+            "checks": {
+                "dds": dds_state == "healthy",
+                "lidar": lidar_state == "healthy",
+                "mcp": True,
+            },
+            "metrics": {
+                "fresh_topics": counts["fresh"],
+                "stale_topics": counts["stale"],
+                "no_data_topics": counts["no_data"],
+                "missed_samples": sum(item["missed"] for item in topics.values()),
+                "max_latency_ms": round(max(latency_values), 1) if latency_values else None,
+            },
+            "issues": issues,
+            "dds": dds,
+            "lidar": lidar,
+            "optional": optional,
+        }
+
+    def _publish(self) -> None:
+        out = String()
+        out.data = json.dumps(self.current_state(), separators=(",", ":"))
+        self._pub.publish(out)
+
+
+class NetworkDdsHealthPlugin:
+    PREFIX = "network_dds_health"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor):
+        self._topic = f"/{namespace}/state/network_dds_health"
+        publish_hz = float(plugin_config.get("publish_hz", 2.0))
+        mcp_port = plugin_config.get("mcp_port")
+        self._node = _NetworkDdsHealthNode(self._topic, namespace, mcp_port, publish_hz=publish_hz)
+        executor.add_node(self._node)
+
+    def get_tools(self) -> list:
+        return [{
+            "name": "network_dds_health",
+            "type": "sensor",
+            "multiInstance": False,
+            "description": (
+                "G1 Network & DDS Health — aggregates DDS topic freshness, estimated missed samples, "
+                "message latency where headers are available, and LiDAR/MCP communication state. "
+                f"Publishes status JSON to {self._topic}"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["current_frame"],
+                        "description": "Return the latest in-memory network health frame",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "current_frame": {
+                        "description": "查看当前帧数据",
+                    },
+                },
+            },
+            "configSchema": {
+                "type": "object",
+                "properties": {
+                    "publish_hz": {
+                        "type": "number",
+                        "title": "Status publish rate in Hz",
+                        "description": "Frequency for publishing network health status JSON",
+                        "default": 2.0,
+                        "minimum": 0.2,
+                        "maximum": 10.0,
+                    },
+                },
+            },
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+        }]
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "running"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "current_frame":
+            return self._node.current_state()
+        if action in ("info", "network_dds_health"):
+            return {"state": "running"}
         return None
 
 

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -110,6 +110,13 @@ class G1DeviceBundle:
             self._plugins.append(StatePlugin(plugins_cfg["state"], namespace, executor))
             print("[bundle] StatePlugin loaded")
 
+        if plugins_cfg.get("network_dds_health", {}).get("enabled", False):
+            from device import NetworkDdsHealthPlugin
+            health_cfg = dict(plugins_cfg["network_dds_health"])
+            health_cfg["mcp_port"] = cfg.get("mcp_port")
+            self._plugins.append(NetworkDdsHealthPlugin(health_cfg, namespace, executor))
+            print("[bundle] NetworkDdsHealthPlugin loaded")
+
         if plugins_cfg.get("camera", {}).get("enabled", False):
             from device import RealSensePlugin
             self._plugins.append(RealSensePlugin(plugins_cfg["camera"], namespace, executor))

--- a/unitree/g1/tests/test_network_dds_health.py
+++ b/unitree/g1/tests/test_network_dds_health.py
@@ -1,0 +1,280 @@
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+G1_DIR = REPO_ROOT / "unitree" / "g1"
+
+
+class _FakeLogger:
+    def info(self, *_args, **_kwargs):
+        pass
+
+    def warn(self, *_args, **_kwargs):
+        pass
+
+
+class _FakeClock:
+    def __init__(self, node):
+        self._node = node
+
+    def now(self):
+        return types.SimpleNamespace(nanoseconds=self._node._fake_clock_ns)
+
+
+class _FakePublisher:
+    def __init__(self):
+        self.messages = []
+
+    def publish(self, msg):
+        self.messages.append(msg)
+
+
+class _FakeNode:
+    def __init__(self, *_args, **_kwargs):
+        self._fake_clock_ns = 2_000_000_000
+        self._created_subscriptions = []
+        self._created_timers = []
+        self._created_publishers = []
+
+    def create_publisher(self, msg_type, topic, qos):
+        pub = _FakePublisher()
+        self._created_publishers.append((msg_type, topic, qos, pub))
+        return pub
+
+    def create_subscription(self, msg_type, topic, callback, qos):
+        sub = types.SimpleNamespace(msg_type=msg_type, topic=topic, callback=callback, qos=qos)
+        self._created_subscriptions.append(sub)
+        return sub
+
+    def create_timer(self, period, callback):
+        timer = types.SimpleNamespace(period=period, callback=callback)
+        self._created_timers.append(timer)
+        return timer
+
+    def get_clock(self):
+        return _FakeClock(self)
+
+    def get_logger(self):
+        return _FakeLogger()
+
+
+class _FakeQoSProfile:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _String:
+    def __init__(self, data=""):
+        self.data = data
+
+
+class _Header:
+    pass
+
+
+class _UInt8MultiArray:
+    def __init__(self):
+        self.data = []
+
+
+class _CompressedImage:
+    def __init__(self, sec=0, nanosec=0):
+        self.header = types.SimpleNamespace(stamp=types.SimpleNamespace(sec=sec, nanosec=nanosec))
+
+
+class _Image(_CompressedImage):
+    pass
+
+
+def _install_import_stubs():
+    rclpy = types.ModuleType("rclpy")
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_qos = types.ModuleType("rclpy.qos")
+    rclpy_node.Node = _FakeNode
+    rclpy_qos.QoSProfile = _FakeQoSProfile
+    rclpy_qos.ReliabilityPolicy = types.SimpleNamespace(BEST_EFFORT="best_effort")
+    rclpy_qos.HistoryPolicy = types.SimpleNamespace(KEEP_LAST="keep_last")
+    rclpy_qos.DurabilityPolicy = types.SimpleNamespace(VOLATILE="volatile")
+
+    std_msgs = types.ModuleType("std_msgs")
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    std_msgs_msg.Header = _Header
+    std_msgs_msg.String = _String
+    std_msgs_msg.UInt8MultiArray = _UInt8MultiArray
+
+    sensor_msgs = types.ModuleType("sensor_msgs")
+    sensor_msgs_msg = types.ModuleType("sensor_msgs.msg")
+    sensor_msgs_msg.CompressedImage = _CompressedImage
+    sensor_msgs_msg.Image = _Image
+
+    audio_msgs = types.ModuleType("audio_msgs")
+    audio_msgs_msg = types.ModuleType("audio_msgs.msg")
+    audio_msgs_msg.AudioChunk = type("AudioChunk", (), {})
+
+    pointcloud_utils = types.ModuleType("pointcloud_utils")
+    pointcloud_utils.gravity_align_inplace = lambda *_args, **_kwargs: None
+
+    numpy = types.ModuleType("numpy")
+
+    audio_client_mod = types.ModuleType("unitree_sdk2py.g1.audio.g1_audio_client")
+    audio_client_mod.AudioClient = type("AudioClient", (), {})
+
+    modules = {
+        "rclpy": rclpy,
+        "rclpy.node": rclpy_node,
+        "rclpy.qos": rclpy_qos,
+        "std_msgs": std_msgs,
+        "std_msgs.msg": std_msgs_msg,
+        "sensor_msgs": sensor_msgs,
+        "sensor_msgs.msg": sensor_msgs_msg,
+        "audio_msgs": audio_msgs,
+        "audio_msgs.msg": audio_msgs_msg,
+        "pointcloud_utils": pointcloud_utils,
+        "numpy": numpy,
+        "unitree_sdk2py": types.ModuleType("unitree_sdk2py"),
+        "unitree_sdk2py.g1": types.ModuleType("unitree_sdk2py.g1"),
+        "unitree_sdk2py.g1.audio": types.ModuleType("unitree_sdk2py.g1.audio"),
+        "unitree_sdk2py.g1.audio.g1_audio_client": audio_client_mod,
+    }
+    sys.modules.update(modules)
+
+
+def _load_device_module():
+    _install_import_stubs()
+    spec = importlib.util.spec_from_file_location("g1_device_under_test", G1_DIR / "device.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeExecutor:
+    def __init__(self):
+        self.nodes = []
+
+    def add_node(self, node):
+        self.nodes.append(node)
+
+
+class NetworkDdsHealthTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.device = _load_device_module()
+
+    def test_tool_schema_is_sensor_only(self):
+        executor = _FakeExecutor()
+        plugin = self.device.NetworkDdsHealthPlugin({"publish_hz": 2.0, "mcp_port": 15701}, "g1", executor)
+
+        tool = plugin.get_tools()[0]
+        self.assertEqual(tool["name"], "network_dds_health")
+        self.assertEqual(tool["type"], "sensor")
+        self.assertEqual(
+            tool["inputSchema"]["properties"]["action"]["enum"],
+            ["current_frame"],
+        )
+        self.assertIn("current_frame", tool["inputSchema"]["x-action-params"])
+        self.assertEqual(tool["topic_out"], [{"topic": "/g1/state/network_dds_health", "format": "data/json"}])
+        self.assertEqual(tool["configSchema"]["properties"]["publish_hz"]["default"], 2.0)
+        self.assertNotIn("read", json.dumps(tool).lower())
+        self.assertNotIn("snapshot", json.dumps(tool).lower())
+        self.assertEqual(len(executor.nodes), 1)
+
+    def test_publish_rate_config_controls_timer_period(self):
+        node = self.device._NetworkDdsHealthNode("/g1/state/network_dds_health", "g1", 15701, publish_hz=5.0)
+
+        self.assertAlmostEqual(node._created_timers[0].period, 0.2)
+
+    def test_current_frame_action_returns_latest_state_without_topic_metadata(self):
+        executor = _FakeExecutor()
+        plugin = self.device.NetworkDdsHealthPlugin({"publish_hz": 2.0, "mcp_port": 15701}, "g1", executor)
+        executor.nodes[0]._on_topic("battery", _String("{}"))
+
+        frame = plugin.dispatch("current_frame", {})
+
+        self.assertIn("checks", frame)
+        self.assertIn("metrics", frame)
+        self.assertNotIn("source_topic", frame)
+        self.assertNotIn("topic_out", frame)
+        self.assertNotIn("snapshot", json.dumps(frame).lower())
+
+    def test_subscribes_to_existing_driver_topics(self):
+        node = self.device._NetworkDdsHealthNode("/g1/state/network_dds_health", "g1", 15701)
+
+        topics = {sub.topic for sub in node._created_subscriptions}
+        self.assertIn("/g1/loco/state", topics)
+        self.assertIn("/g1/state/imu", topics)
+        self.assertIn("/g1/state/battery", topics)
+        self.assertIn("/g1/lidar/cloud", topics)
+
+    def test_freshness_and_optional_motion_topic(self):
+        node = self.device._NetworkDdsHealthNode("/g1/state/network_dds_health", "g1", 15701)
+        node._fake_clock_ns = 2_050_000_000
+
+        node._on_topic("loco_state", _String("{}"))
+        node._on_topic("lidar_cloud", _UInt8MultiArray())
+
+        state = node.current_state()
+        self.assertTrue(state["checks"]["mcp"])
+        self.assertTrue(next(item for item in state["dds"] if item["name"] == "loco_state")["fresh"])
+        self.assertTrue(state["lidar"][0]["fresh"])
+        self.assertFalse(state["optional"][0]["required"])
+        self.assertNotIn("camera_ok", state)
+        self.assertNotIn("source_topic", state)
+        self.assertNotIn("topic_out", state)
+
+    def test_stale_and_estimated_missed_samples(self):
+        stat = self.device._TopicHealth("imu", "/g1/state/imu", "dds", expected_hz=20.0, stale_after_s=0.5, required=True)
+        stat.record(_String("{}"), now=10.0, clock_ns=None)
+        stat.record(_String("{}"), now=10.5, clock_ns=None)
+
+        payload = stat.payload(now=11.2)
+        self.assertEqual(payload["status"], "stale")
+        self.assertGreaterEqual(payload["missed"], 9)
+
+    def test_optional_motion_topic_does_not_fail_dds_group(self):
+        node = self.device._NetworkDdsHealthNode("/g1/state/network_dds_health", "g1", 15701)
+        for name in ("loco_state", "imu", "battery", "joints", "mainboard"):
+            node._on_topic(name, _String("{}"))
+
+        state = node.current_state()
+        self.assertTrue(state["checks"]["dds"])
+        self.assertEqual(state["optional"][0]["status"], "no_data")
+        self.assertFalse(state["optional"][0]["required"])
+
+    def test_publish_outputs_json_status_without_internal_fields(self):
+        node = self.device._NetworkDdsHealthNode("/g1/state/network_dds_health", "g1", 15701)
+        node._on_topic("battery", _String("{}"))
+        node._publish()
+
+        published = json.loads(node._pub.messages[-1].data)
+        self.assertIn("checks", published)
+        self.assertIn("metrics", published)
+        self.assertIn("dds", published)
+        self.assertIn("lidar", published)
+        self.assertNotIn("camera_ok", published)
+        self.assertNotIn("source_topic", published)
+        self.assertNotIn("topic_out", published)
+
+
+class NetworkDdsHealthWiringTests(unittest.TestCase):
+    def test_config_enables_plugin(self):
+        config_text = (G1_DIR / "config.yaml").read_text()
+        self.assertIn("network_dds_health:", config_text)
+        self.assertIn("publish_hz: 2.0", config_text)
+
+    def test_bundle_loads_plugin_after_state_before_camera(self):
+        main_text = (G1_DIR / "main.py").read_text()
+        state_idx = main_text.index("StatePlugin loaded")
+        health_idx = main_text.index("NetworkDdsHealthPlugin loaded")
+        camera_idx = main_text.index("RealSensePlugin loaded")
+        self.assertLess(state_idx, health_idx)
+        self.assertLess(health_idx, camera_idx)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a G1 `network_dds_health` sensor card that publishes DDS/topic freshness, missed sample estimates, latency where available, and LiDAR/MCP health into one status JSON stream.
- Keep the runtime payload compact with `checks`, `metrics`, `issues`, `dds`, `lidar`, and `optional` groups so the canvas and LLM can read it directly.
- Add a configurable `publish_hz` and a `current_frame` action button for viewing the latest in-memory frame without using snapshot/read mode.

## Validation
- `python3 -m unittest unitree/g1/tests/test_network_dds_health.py -v`
- `PYTHONPYCACHEPREFIX=/private/tmp/network-health-pycache python3 -m py_compile unitree/g1/device.py unitree/g1/main.py`
- `git diff --check`
- Deployed on Shanghai G1 for smoke validation: plugin loaded, MCP schema exposed `publish_hz` and `current_frame`, and `current_frame` returned health data without `source_topic`, `topic_out`, or `snapshot` fields.

望陈总review
