### PR TITLE
fix(tianyi2.0): improve ext_mic remote audio_sender reliability

### DIFF
--- a/x-humanoid/tianyi2.0/audio_sender.py
+++ b/x-humanoid/tianyi2.0/audio_sender.py
@@ -14,6 +14,7 @@ Clients (e.g. ext_mic plugin on another host) connect and receive raw PCM-16k.
 
 import argparse
 import numpy as np
+import os
 import re
 import select
 import socket
@@ -80,6 +81,9 @@ def _capture_loop(card_idx: int, clients: list, clients_lock: threading.Lock):
 
     print(f"[audio_sender] capturing card {card_idx}, {native_rate}Hz → {target_rate}Hz")
 
+    last_success = time.time()
+    MAX_FAIL_DURATION = 10  # exit if no successful read for 10s
+
     while True:
         try:
             length, data = pcm.read()
@@ -105,10 +109,19 @@ def _capture_loop(card_idx: int, clients: list, clients_lock: threading.Lock):
                     )
             except Exception:
                 time.sleep(3)
+            # Watchdog: exit if stuck too long
+            if time.time() - last_success > MAX_FAIL_DURATION:
+                print(f"[audio_sender] FATAL: no successful read for {MAX_FAIL_DURATION}s, exiting", flush=True)
+                os._exit(1)
             continue
 
         if length <= 0:
+            if time.time() - last_success > MAX_FAIL_DURATION:
+                print(f"[audio_sender] FATAL: no successful read for {MAX_FAIL_DURATION}s, exiting", flush=True)
+                os._exit(1)
             continue
+
+        last_success = time.time()
 
         # Convert S24_3LE stereo → S16_LE mono
         if is_s24_stereo:

--- a/x-humanoid/tianyi2.0/ext_devices.py
+++ b/x-humanoid/tianyi2.0/ext_devices.py
@@ -462,7 +462,15 @@ class _NetworkMicNode(Node):
 
     def start(self) -> dict:
         if self.state == "running":
-            return self._status_dict()
+            # Check if capture thread is actually alive
+            if self._thread and self._thread.is_alive():
+                return self._status_dict()
+            # Thread died — reset and restart
+            self._running = False
+            self._thread = None
+            self.state = "idle"
+            log.warning(f"[ext_mic/net] thread was dead for {self._device_name}, restarting")
+
         self._running = True
         self._thread = threading.Thread(target=self._capture_loop, daemon=True)
         self._thread.start()
@@ -726,26 +734,27 @@ class _NetworkMicNode(Node):
                 time.sleep(2)
                 self._ensure_remote_ready(host, port)
 
-    def _ensure_remote_ready(self, host: str, port: int):
+    def _ensure_remote_ready(self, host: str, port: int, force_restart: bool = False):
         """Check remote audio_sender health; restart via SSH if unhealthy."""
         import socket as _socket
         import subprocess as _subprocess
 
         # Step 1: probe — connect and try to read data within 3s
-        healthy = False
-        try:
-            sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
-            sock.settimeout(3.0)
-            sock.connect((host, port))
-            sock.settimeout(3.0)
-            data = sock.recv(1024)
-            healthy = len(data) > 0
-            sock.close()
-        except Exception:
-            pass
+        if not force_restart:
+            healthy = False
+            try:
+                sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+                sock.settimeout(3.0)
+                sock.connect((host, port))
+                sock.settimeout(3.0)
+                data = sock.recv(1024)
+                healthy = len(data) > 0
+                sock.close()
+            except Exception:
+                pass
 
-        if healthy:
-            return
+            if healthy:
+                return
 
         # Step 2: unhealthy — SSH restart if config available
         if not self._ssh_user or not self._ssh_script:
@@ -753,24 +762,34 @@ class _NetworkMicNode(Node):
             return
 
         print(f"[ext_mic/tcp] remote unhealthy, restarting via SSH...", flush=True)
-        restart_cmd = (
-            f"pkill -f '{self._ssh_script}' 2>/dev/null; sleep 1; "
+        # Use SIGKILL to ensure immediate termination
+        kill_cmd = f"pkill -9 -f '{self._ssh_script}' 2>/dev/null"
+        ssh_base = [
+            "sshpass", "-p", self._ssh_pass,
+            "ssh", "-o", "StrictHostKeyChecking=no", "-o", "ConnectTimeout=5",
+            f"{self._ssh_user}@{host}",
+        ]
+        try:
+            _subprocess.run(ssh_base + [kill_cmd], capture_output=True, timeout=10)
+        except Exception as e:
+            print(f"[ext_mic/tcp] SSH kill failed: {e}", flush=True)
+
+        # Wait for ALSA device to be fully released
+        time.sleep(3)
+
+        # Start fresh audio_sender
+        start_cmd = (
             f"nohup python3 {self._ssh_script} --port {port} --card {self._ssh_card} "
             f"> /tmp/audio_sender.log 2>&1 &"
         )
-        ssh_cmd = [
-            "sshpass", "-p", self._ssh_pass,
-            "ssh", "-o", "StrictHostKeyChecking=no", "-o", "ConnectTimeout=5",
-            f"{self._ssh_user}@{host}", restart_cmd,
-        ]
         try:
-            _subprocess.run(ssh_cmd, capture_output=True, timeout=15)
+            _subprocess.run(ssh_base + [start_cmd], capture_output=True, timeout=10)
         except Exception as e:
-            print(f"[ext_mic/tcp] SSH restart failed: {e}", flush=True)
+            print(f"[ext_mic/tcp] SSH start failed: {e}", flush=True)
             return
 
-        # Step 3: wait for ready — poll TCP until data received (max ~8s)
-        for i in range(4):
+        # Step 3: wait for ready — poll TCP until data received (max ~10s)
+        for i in range(5):
             time.sleep(2)
             try:
                 sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -113,8 +113,8 @@ def _probe_remote_mics(cfg: dict) -> list[dict]:
 
         # Step 1: Probe remote audio devices
         try:
-            result = _ssh("arecord -l")
-            devices = _parse_arecord_output(result.stdout + result.stderr)
+            result = _ssh("arecord -l 2>&1")
+            devices = _parse_arecord_output(result.stdout)
         except Exception as e:
             print(f"[ext_mic/probe] {ssh_host}: SSH probe failed: {e}")
             continue
@@ -149,25 +149,59 @@ def _probe_remote_mics(cfg: dict) -> list[dict]:
         except Exception as e:
             print(f"[ext_mic/probe] {ssh_host}: deploy failed: {e}")
 
-        # Step 3: Start audio_sender if not running (use first detected card)
+        # Step 3: Verify audio_sender is healthy (not just alive) via TCP data probe
         primary_card = devices[0]["card"]
+        healthy = False
         try:
-            check = _ssh("pgrep -f audio_sender.py")
-            if check.returncode != 0 or not check.stdout.strip():
-                _ssh(f"nohup python3 {sender_path} --port {port} --card {primary_card} "
-                     f"> /tmp/audio_sender.log 2>&1 &")
-                time.sleep(1)
-                verify = _ssh("pgrep -f audio_sender.py")
-                if verify.returncode == 0 and verify.stdout.strip():
-                    pid = verify.stdout.strip().splitlines()[0]
-                    print(f"[ext_mic/probe] {ssh_host}: started audio_sender (pid={pid}, card={primary_card}, port={port})")
-                else:
-                    print(f"[ext_mic/probe] {ssh_host}: WARNING: audio_sender did not start")
+            probe_cmd = (
+                f"python3 -c \""
+                f"import socket,sys;"
+                f"s=socket.socket();"
+                f"s.settimeout(3);"
+                f"s.connect(('127.0.0.1',{port}));"
+                f"d=s.recv(1024);"
+                f"s.close();"
+                f"sys.exit(0 if len(d)>0 else 1)\""
+            )
+            check = _ssh(probe_cmd, timeout=10)
+            healthy = (check.returncode == 0)
+        except Exception:
+            pass
+
+        if not healthy:
+            # Kill existing (might be zombie) + restart
+            try:
+                _ssh("pkill -9 -f audio_sender.py 2>/dev/null")
+            except Exception:
+                pass
+            time.sleep(3)  # wait for ALSA device release
+            # Deploy audio_sender.py if missing
+            try:
+                check = _ssh(f"test -f {sender_path} && echo EXISTS")
+                if "EXISTS" not in (check.stdout or ""):
+                    local_src = str(Path(__file__).parent / "audio_sender.py")
+                    subprocess.run(
+                        ["sshpass", "-p", ssh_pass, "scp",
+                         "-o", "StrictHostKeyChecking=no",
+                         local_src, f"{ssh_user}@{ssh_host}:{sender_path}"],
+                        check=True, timeout=15)
+                    print(f"[ext_mic/probe] {ssh_host}: deployed audio_sender.py")
+            except Exception as e:
+                print(f"[ext_mic/probe] {ssh_host}: deploy failed: {e}")
+            # Start fresh
+            _ssh(f"nohup python3 {sender_path} --port {port} --card {primary_card} "
+                 f"> /tmp/audio_sender.log 2>&1 &")
+            time.sleep(2)
+            verify = _ssh("pgrep -f audio_sender.py")
+            if verify.returncode == 0 and verify.stdout.strip():
+                pid = verify.stdout.strip().splitlines()[0]
+                print(f"[ext_mic/probe] {ssh_host}: restarted audio_sender (pid={pid}, card={primary_card}, port={port})")
             else:
-                pid = check.stdout.strip().splitlines()[0]
-                print(f"[ext_mic/probe] {ssh_host}: audio_sender already running (pid={pid})")
-        except Exception as e:
-            print(f"[ext_mic/probe] {ssh_host}: start failed: {e}")
+                print(f"[ext_mic/probe] {ssh_host}: WARNING: audio_sender did not start")
+        else:
+            check = _ssh("pgrep -f audio_sender.py")
+            pid = check.stdout.strip().splitlines()[0] if check.stdout.strip() else "?"
+            print(f"[ext_mic/probe] {ssh_host}: audio_sender healthy (pid={pid})")
 
         # Step 4: Build device list entries (name includes format info)
         for dev in devices:


### PR DESCRIPTION
## Summary
- Add 10s watchdog to `audio_sender.py` — self-exits when ALSA capture is stuck, enabling external restart
- Improve `_ensure_remote_ready()` — SIGKILL + 3s ALSA release wait + 5 verification rounds
- Fix `_NetworkMicNode.start()` — detect dead capture thread and restart instead of returning stale status
- Fix `_probe_remote_mics()` — TCP data probe replaces pgrep (detects zombie processes); merge arecord stderr to fix duplicate device listing

## Test plan
- [x] Deployed to Tianyi 2.0, verified audio_sender healthy after restart
- [x] Confirmed duplicate device listing resolved (1 entry instead of 2)
- [x] Verified continuous TCP audio data flow (~30KB/s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)