### PR TITLE
修复 G1：增强导航速度提案执行与可恢复停车

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ python main.py
 4. Tools become available to the LLM agent and appear in the Web Dashboard
 5. The LLM agent can invoke tools via MCP `tools/call`
 
+### G1 Controlled Navigation Velocity
+
+The G1 `loco` actuator accepts a lease-bound
+`phanthy.navigation.velocity_proposal.v1` input. Valid proposals are executed
+through a capacity-one latest-only queue, so an older pending velocity is
+coalesced instead of backlogged. A proposal TTL lapse immediately triggers
+`StopMove`; only a successful post-call zero-odometry confirmation keeps the
+same navigation lease recoverable for the next fresh proposal. Hard safety,
+identity, sequence, RPC, and stop-confirmation faults still disarm the lease.
+
+`loco info` exposes proposal counters, the coalesced count, measured RPC and
+queue latency, rolling RPC p50/p95/p99/max values, rejection reasons, and the
+last confirmed proposal stop. The `last_set_velocity_duration_ms` value is
+measured RPC time, not the proposal TTL budget.
+
 ## Writing a New Driver
 
 Want to add support for new hardware? See the **[Driver Development Guide](README_dev.md)** for the full specification, including:

--- a/README_zh.md
+++ b/README_zh.md
@@ -62,6 +62,19 @@ python main.py
 4. 工具对 LLM Agent 可用，并显示在 Web Dashboard 中
 5. LLM Agent 通过 MCP `tools/call` 调用工具
 
+### G1 受控导航速度执行
+
+G1 `loco` actuator 接收由导航 lease 约束的
+`phanthy.navigation.velocity_proposal.v1` 输入。有效 proposal 通过容量为 1
+的 latest-only 队列执行：已等待的旧速度会被新速度合并替换，不会积压。
+proposal TTL 失效会立即触发 `StopMove`；只有在返回后用新的 odometry
+样本确认零速，同一导航 lease 才能保留并接受下一条新鲜 proposal。安全、
+身份、序列、RPC 和停车确认类硬故障仍会解除武装。
+
+`loco info` 会返回 proposal 计数、合并数、实测 RPC/队列时延、滚动
+RPC p50/p95/p99/max、逐原因拒绝统计及最近一次已确认停车。
+`last_set_velocity_duration_ms` 表示实测 RPC 耗时，不是 proposal TTL 余量。
+
 ## 开发新驱动
 
 想要为新硬件添加驱动？请参阅 **[驱动开发指南](README_dev.md)** 获取完整规范，包括：

--- a/unitree/g1/Dockerfile
+++ b/unitree/g1/Dockerfile
@@ -50,6 +50,7 @@ COPY device.py /work/device.py
 COPY rpc_proxy.py /work/rpc_proxy.py
 COPY ext_devices.py /work/ext_devices.py
 COPY safety_harness.py /work/safety_harness.py
+COPY velocity_proposal.py /work/velocity_proposal.py
 COPY scan_context.py /work/scan_context.py
 COPY controlled_spatial.py /work/controlled_spatial.py
 COPY controlled_spatial_map.py /work/controlled_spatial_map.py

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -13,6 +13,29 @@ plugins:
     enabled: true
   loco:
     enabled: true
+    # N5 canvas input. Driver startup is disarmed until loco action=start binds
+    # the one authoritative proposal topic.
+    velocity_proposal_enabled: true
+    velocity_proposal_driver_authorized: true
+    velocity_proposal_max_ttl_ms: 250
+    velocity_proposal_min_x: -0.05
+    velocity_proposal_max_x: 0.15
+    velocity_proposal_max_abs_y: 0.12
+    velocity_proposal_max_abs_yaw: 0.35
+    velocity_proposal_max_planar_speed: 0.18
+    velocity_proposal_odom_timeout: 0.5
+    velocity_proposal_scan_timeout: 0.5
+    velocity_proposal_fsm_check_interval: 0.2
+    velocity_proposal_fsm_timeout: 0.5
+    velocity_proposal_nav_status_timeout: 0.25
+    velocity_proposal_watchdog_hz: 40
+    velocity_proposal_rpc_timeout: 0.1
+    velocity_proposal_stop_rpc_timeout: 0.1
+    velocity_proposal_fsm_rpc_timeout: 0.2
+    velocity_proposal_stop_confirm_timeout: 0.5
+    velocity_proposal_stop_linear_epsilon: 0.03
+    velocity_proposal_stop_yaw_epsilon: 0.05
+    velocity_proposal_allowed_fsm_ids: [500, 801]
   arm:
     enabled: true
   state:

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -29,10 +29,14 @@ plugins:
     velocity_proposal_fsm_timeout: 0.5
     velocity_proposal_nav_status_timeout: 0.25
     velocity_proposal_watchdog_hz: 40
-    velocity_proposal_rpc_timeout: 0.1
+    # Parent continuous-velocity RPC is asynchronous to ROS proposal intake;
+    # this bound is for collecting the hardware acknowledgement, not the TTL.
+    velocity_proposal_rpc_timeout: 0.5
     velocity_proposal_stop_rpc_timeout: 0.1
     velocity_proposal_fsm_rpc_timeout: 0.2
-    velocity_proposal_stop_confirm_timeout: 0.5
+    # G1 StopMove is a one-second zero-velocity SetVelocity command; allow
+    # bounded gait settling while keeping the zero-odom thresholds unchanged.
+    velocity_proposal_stop_confirm_timeout: 2.0
     velocity_proposal_stop_linear_epsilon: 0.03
     velocity_proposal_stop_yaw_epsilon: 0.05
     velocity_proposal_allowed_fsm_ids: [500, 801]

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -30,7 +30,7 @@ plugins:
     velocity_proposal_nav_status_timeout: 0.25
     velocity_proposal_watchdog_hz: 40
     velocity_proposal_rpc_timeout: 0.1
-    velocity_proposal_stop_rpc_timeout: 0.1
+    velocity_proposal_stop_rpc_timeout: 0.2
     velocity_proposal_fsm_rpc_timeout: 0.2
     velocity_proposal_stop_confirm_timeout: 0.5
     velocity_proposal_stop_linear_epsilon: 0.03

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -30,7 +30,7 @@ plugins:
     velocity_proposal_nav_status_timeout: 0.25
     velocity_proposal_watchdog_hz: 40
     velocity_proposal_rpc_timeout: 0.1
-    velocity_proposal_stop_rpc_timeout: 0.2
+    velocity_proposal_stop_rpc_timeout: 0.1
     velocity_proposal_fsm_rpc_timeout: 0.2
     velocity_proposal_stop_confirm_timeout: 0.5
     velocity_proposal_stop_linear_epsilon: 0.03

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -1447,7 +1447,15 @@ class LocoPlugin:
         if result.get("error") or not (
             result.get("connected") and result.get("armed")
         ):
-            self._client.StopMove()
+            result = dict(result)
+            fallback_stop_ret = None
+            fallback_stop_error = None
+            try:
+                fallback_stop_ret = self._client.StopMove()
+            except Exception as exc:
+                fallback_stop_error = str(exc)
+            result["fallback_stop_ret"] = fallback_stop_ret
+            result["fallback_stop_error"] = fallback_stop_error
         return {
             **result,
             "state": "ready" if (

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -18,6 +18,8 @@ drivers/unitree/g1/device.py — Unitree G1 设备插件（重构版）。
   StatePlugin        (sensor)    — DDS LowState → IMU/battery ROS2 topic
 """
 
+from __future__ import annotations
+
 import json
 import queue
 import socket
@@ -34,6 +36,11 @@ from audio_msgs.msg import AudioChunk
 
 from unitree_sdk2py.g1.audio.g1_audio_client import AudioClient
 from pointcloud_utils import gravity_align_inplace
+from velocity_proposal import (
+    DEFAULT_VELOCITY_PROPOSAL_TOPIC,
+    resolve_input_topic,
+    velocity_proposal_port,
+)
 
 # ── 常量 ──────────────────────────────────────────────────────────────────────
 
@@ -1263,13 +1270,18 @@ def _loco_acp_notify(action_id: str, status: str, result: dict, tool: str = "loc
 
 class LocoPlugin:
     PREFIX = "loco"
+    # Stop locomotion before tearing down any other plugin during bundle
+    # shutdown.  This is an explicit lifecycle contract consumed by main.py.
+    STOP_PRIORITY = 0
 
     def __init__(self, plugin_config: dict, namespace: str, executor, loco_client, slam_client=None, smart_motion=None):
         self._client = loco_client
         self._slam_client = slam_client
         self._smart_motion = smart_motion
         self._namespace = namespace
+        self._control_lock = threading.RLock()
         self._move_timer: threading.Timer | None = None
+        self._velocity_proposal_topic = DEFAULT_VELOCITY_PROPOSAL_TOPIC
 
     def get_tools(self) -> list:
         tools = [self._loco_tool(), self._switch_mode_tool(), self._switch_mode_expert_tool()]
@@ -1328,7 +1340,11 @@ class LocoPlugin:
                     "shake_hand":       {"params": [],                                 "description": "Perform a handshake gesture"},
                 },
             },
+            "topic_in": [self._velocity_proposal_port()],
         }
+
+    def _velocity_proposal_port(self) -> dict:
+        return velocity_proposal_port(self._velocity_proposal_topic)
 
     # ── FSM state groups for safety checks ──────────────────────────────────────
     _GROUND_STATES = {0, 1}            # zero_torque, damp — lying on ground
@@ -1393,18 +1409,89 @@ class LocoPlugin:
         }
 
     def start(self) -> None:
+        # Driver startup remains disarmed.  Canvas action=start with the exact
+        # connected topic is the only path that arms proposal execution.
         pass
 
     def stop(self) -> None:
-        if self._move_timer:
-            self._move_timer.cancel()
-            self._move_timer = None
-        self._client.StopMove()
+        with self._control_lock:
+            if self._move_timer:
+                self._move_timer.cancel()
+                self._move_timer = None
+            self._disconnect_velocity_proposal("driver_stop")
+
+    def _connect_velocity_proposal(self, args: dict) -> dict:
+        try:
+            topic = resolve_input_topic(args, self._velocity_proposal_topic)
+        except ValueError as exc:
+            self._client.StopMove()
+            if self._smart_motion:
+                self._smart_motion.unbind_velocity_proposal("proposal_bind_rejected")
+            return {
+                "state": "error",
+                "connected": False,
+                "error": str(exc),
+                "topic_in": [self._velocity_proposal_port()],
+            }
+        if not self._smart_motion:
+            self._client.StopMove()
+            return {
+                "state": "error",
+                "connected": False,
+                "error": "SmartMotion safety harness is required for velocity_proposal",
+                "topic_in": [self._velocity_proposal_port()],
+            }
+        result = self._smart_motion.bind_velocity_proposal(topic)
+        if result.get("error") or not (
+            result.get("connected") and result.get("armed")
+        ):
+            self._client.StopMove()
+        return {
+            "state": "ready" if result.get("connected") else "error",
+            "topic_in": [self._velocity_proposal_port()],
+            **result,
+        }
+
+    def _disconnect_velocity_proposal(self, reason: str) -> dict:
+        # Main-process RPC is an independent first stop path.  It guarantees
+        # StopMove precedes subscriber teardown even if SmartMotion IPC hangs
+        # and the child has to be terminated fail-closed.
+        fallback_stop_ret = self._client.StopMove()
+        if self._smart_motion:
+            try:
+                result = self._smart_motion.unbind_velocity_proposal(reason)
+            except Exception as exc:
+                return {
+                    "state": "error",
+                    "connected": False,
+                    "stop_confirmed": False,
+                    "error": f"SmartMotion unbind failed: {exc}",
+                    "fallback_stop_ret": fallback_stop_ret,
+                    "topic_in": [self._velocity_proposal_port()],
+                }
+            stop_failed = (
+                result.get("error")
+                or result.get("stop_confirmed") is not True
+            )
+            if stop_failed:
+                result.setdefault("state", "error")
+                result.setdefault("error", "StopMove was not confirmed")
+                result["fallback_stop_ret"] = fallback_stop_ret
+            return {"topic_in": [self._velocity_proposal_port()], **result}
+        return {
+            "state": "idle" if fallback_stop_ret == 0 else "error",
+            "connected": False,
+            "stop_confirmed": fallback_stop_ret == 0,
+            "reason": reason,
+            "topic_in": [self._velocity_proposal_port()],
+            **({"error": f"StopMove failed: code={fallback_stop_ret}"} if fallback_stop_ret != 0 else {}),
+        }
 
     def _auto_stop(self):
         """Timer 回调：自动停止运动"""
-        self._move_timer = None
-        self._client.StopMove()
+        with self._control_lock:
+            self._move_timer = None
+            self._client.StopMove()
 
     def _auto_stop_acp(self, action_id: str):
         """Timer 回调：自动停止运动 + fire ACP callback."""
@@ -1418,16 +1505,50 @@ class LocoPlugin:
         _loco_acp_notify(action_id, "completed", {"reason": "duration_expired"}, tool="loco")
 
     def dispatch(self, action: str, args: dict) -> dict | None:
+        with self._control_lock:
+            try:
+                return self._dispatch_serialized(action, args)
+            except Exception as exc:
+                self._client.StopMove()
+                return {
+                    "state": "error",
+                    "connected": False,
+                    "error": f"loco safety fallback: {exc}",
+                    "topic_in": [self._velocity_proposal_port()],
+                }
+
+    def _dispatch_serialized(self, action: str, args: dict) -> dict | None:
+        tool_name = args.get("_tool_name", "loco")
         if action == "start":
-            return {"state": "ready"}
+            if tool_name == "loco":
+                return self._connect_velocity_proposal(args)
+            return {"state": "running" if tool_name == "motion_events" else "ready"}
         if action == "stop":
+            if tool_name == "loco":
+                return self._disconnect_velocity_proposal("canvas_stop")
             return {"state": "idle"}
         if action == "info":
-            tool_name = args.get("_tool_name", "motion_events")
             if tool_name == "motion_events" and self._smart_motion:
                 topic = f"/{self._namespace}/safety/motion_events"
                 return {"state": "running", "topic_out": [{"topic": topic, "format": "data/json"}]}
-            return None
+            if tool_name != "loco":
+                return {"state": "ready"}
+            if self._smart_motion:
+                result = self._smart_motion.get_velocity_proposal_status()
+                if result.get("error"):
+                    self._client.StopMove()
+            else:
+                result = {
+                    "enabled": False,
+                    "connected": False,
+                    "armed": False,
+                    "last_reason": "SmartMotion safety harness unavailable",
+                }
+            return {
+                "state": "running" if result.get("connected") else "ready",
+                "topic_in": [self._velocity_proposal_port()],
+                **result,
+            }
         if action == "move":
             vx   = float(args.get("vx",   0))
             vy   = float(args.get("vy",   0))
@@ -1437,7 +1558,9 @@ class LocoPlugin:
             # Route through SmartMotion safety harness
             if self._smart_motion:
                 result = self._smart_motion.move(vx, vy, vyaw, duration)
-                if duration > 0:
+                if result.get("error"):
+                    self._client.StopMove()
+                elif duration > 0:
                     from uuid import uuid4
                     action_id = f"g1_move_{uuid4().hex[:8]}"
                     result["action_id"] = action_id
@@ -1474,7 +1597,10 @@ class LocoPlugin:
         elif action == "stop_move":
             # Route through SmartMotion safety harness
             if self._smart_motion:
-                return self._smart_motion.stop()
+                result = self._smart_motion.stop()
+                if result.get("error"):
+                    self._client.StopMove()
+                return result
 
             # Fallback: direct control
             if self._move_timer:
@@ -1492,6 +1618,13 @@ class LocoPlugin:
             # x-action-params split: action is the mode directly
             # Legacy: action == "switch_mode" with mode in args
             mode = action if action != "switch_mode" else args.get("mode", "")
+            if mode != "get_current_mode":
+                stopped = self._disconnect_velocity_proposal("mode_switch")
+                if mode != "emergency_stop" and (
+                    stopped.get("error")
+                    or stopped.get("stop_confirmed") is not True
+                ):
+                    return stopped
             code, current_fsm = self._client.GetFsmId()
 
             if code != 0:
@@ -1585,6 +1718,9 @@ class LocoPlugin:
                                  f"standup2squat, squat2standup, damp, zero_torque, "
                                  f"emergency_stop, get_current_mode"}
         elif action == "switch_mode_expert":
+            stopped = self._disconnect_velocity_proposal("expert_mode_switch")
+            if stopped.get("error") or stopped.get("stop_confirmed") is not True:
+                return stopped
             fid = int(args.get("fsm_id", 0))
             ret = self._client.SetFsmId(fid)
             return {"ret": ret, "fsm_id": fid}

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -38,6 +38,7 @@ from unitree_sdk2py.g1.audio.g1_audio_client import AudioClient
 from pointcloud_utils import gravity_align_inplace
 from velocity_proposal import (
     DEFAULT_VELOCITY_PROPOSAL_TOPIC,
+    resolve_expected_nav_id,
     resolve_input_topic,
     velocity_proposal_port,
 )
@@ -1423,6 +1424,7 @@ class LocoPlugin:
     def _connect_velocity_proposal(self, args: dict) -> dict:
         try:
             topic = resolve_input_topic(args, self._velocity_proposal_topic)
+            expected_nav_id = resolve_expected_nav_id(args)
         except ValueError as exc:
             self._client.StopMove()
             if self._smart_motion:
@@ -1441,15 +1443,17 @@ class LocoPlugin:
                 "error": "SmartMotion safety harness is required for velocity_proposal",
                 "topic_in": [self._velocity_proposal_port()],
             }
-        result = self._smart_motion.bind_velocity_proposal(topic)
+        result = self._smart_motion.bind_velocity_proposal(topic, expected_nav_id)
         if result.get("error") or not (
             result.get("connected") and result.get("armed")
         ):
             self._client.StopMove()
         return {
-            "state": "ready" if result.get("connected") else "error",
-            "topic_in": [self._velocity_proposal_port()],
             **result,
+            "state": "ready" if (
+                result.get("connected") and result.get("armed")
+            ) else "error",
+            "topic_in": [self._velocity_proposal_port()],
         }
 
     def _disconnect_velocity_proposal(self, reason: str) -> dict:

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -422,6 +422,7 @@ def main():
             proposal_config=proposal_cfg,
             fallback_stop=loco_client.StopMove,
             parent_set_velocity=loco_client.SetVelocity,
+            parent_get_fsm_id=loco_client.GetFsmId,
         )
         print("[bundle] SmartMotion safety harness active (subprocess)")
 

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -421,6 +421,7 @@ def main():
             network_iface,
             proposal_config=proposal_cfg,
             fallback_stop=loco_client.StopMove,
+            parent_set_velocity=loco_client.SetVelocity,
         )
         print("[bundle] SmartMotion safety harness active (subprocess)")
 

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -193,8 +193,18 @@ class G1DeviceBundle:
         print(f"[bundle] All {len(self._plugins)} plugins started", flush=True)
 
     def stop_all(self) -> None:
-        for p in self._plugins:
-            p.stop()
+        ordered_plugins = sorted(
+            enumerate(self._plugins),
+            key=lambda item: getattr(item[1], "STOP_PRIORITY", 100),
+        )
+        for i, p in ordered_plugins:
+            try:
+                p.stop()
+            except Exception as exc:
+                print(
+                    f"[bundle] Plugin {i} ({type(p).__name__}) stop() FAILED: {exc}",
+                    flush=True,
+                )
         print("[bundle] All plugins stopped")
 
     def get_all_tools(self) -> list:
@@ -404,7 +414,14 @@ def main():
     harness_cfg = cfg.get("safety_harness", {})
     if harness_cfg.get("enabled", True):
         from safety_harness import SmartMotionProxy
-        smart_motion = SmartMotionProxy(namespace, harness_cfg, network_iface)
+        proposal_cfg = cfg.get("plugins", {}).get("loco", {})
+        smart_motion = SmartMotionProxy(
+            namespace,
+            harness_cfg,
+            network_iface,
+            proposal_config=proposal_cfg,
+            fallback_stop=loco_client.StopMove,
+        )
         print("[bundle] SmartMotion safety harness active (subprocess)")
 
     _bundle = G1DeviceBundle(cfg, namespace, executor, audio_client, loco_client, arm_client, slam_client, msc_client, smart_motion=smart_motion, network_iface=network_iface)
@@ -422,12 +439,29 @@ def main():
     server = ThreadingHTTPServer(("", mcp_port), make_handler())
     print(f"[bundle] MCP server → http://localhost:{mcp_port}")
 
+    shutdown_lock = threading.RLock()
+    shutdown_started = False
+
+    def _stop_runtime():
+        nonlocal shutdown_started
+        with shutdown_lock:
+            if shutdown_started:
+                return
+            shutdown_started = True
+            # LocoPlugin must StopMove/unbind while both motion subprocesses
+            # are still available; only then terminate those subprocesses.
+            try:
+                _bundle.stop_all()
+            finally:
+                try:
+                    if smart_motion:
+                        smart_motion.shutdown()
+                finally:
+                    loco_client.stop()
+
     def _shutdown(signum, frame):
         print(f"[bundle] signal {signum}, shutting down")
-        if smart_motion:
-            smart_motion.shutdown()
-        _bundle.stop_all()
-        loco_client.stop()
+        _stop_runtime()
         threading.Thread(target=server.shutdown, daemon=True).start()
 
     signal.signal(signal.SIGTERM, _shutdown)
@@ -436,7 +470,7 @@ def main():
     try:
         server.serve_forever()
     finally:
-        _bundle.stop_all()
+        _stop_runtime()
         executor.shutdown()
         rclpy.shutdown()
 

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -421,7 +421,7 @@ def main():
             network_iface,
             proposal_config=proposal_cfg,
             fallback_stop=loco_client.StopMove,
-            parent_set_velocity=loco_client.SetVelocity,
+            parent_apply_velocity_proposal=loco_client.ApplyVelocityProposal,
             parent_get_fsm_id=loco_client.GetFsmId,
         )
         print("[bundle] SmartMotion safety harness active (subprocess)")

--- a/unitree/g1/rpc_proxy.py
+++ b/unitree/g1/rpc_proxy.py
@@ -8,9 +8,166 @@ responses arrive late or timeout. Running LocoClient in a subprocess avoids this
 Modeled after R1's rpc_proxy.py with G1-specific adaptations.
 """
 
+import math
 import multiprocessing
+import queue
 import threading
 import time
+
+
+PROPOSAL_CONTINUOUS_DURATION_SECONDS = 864000.0
+
+
+class ProposalRpcExecutor:
+    """Own one fail-closed velocity-proposal lease inside the RPC worker.
+
+    G1 firmware does not reliably execute sub-second ``duration`` values.  A
+    proposal therefore uses the same continuous velocity command as the known
+    working ``Move(..., True)`` path, while this worker owns the short deadline
+    and sends ``StopMove`` when it expires.
+    """
+
+    def __init__(self, loco, monotonic=time.monotonic, wall_time=time.time):
+        self._loco = loco
+        self._monotonic = monotonic
+        self._wall_time = wall_time
+        self.active = False
+        self.deadline_monotonic = 0.0
+        self.nav_id = None
+        self.sequence = None
+
+    def _clear(self) -> None:
+        self.active = False
+        self.deadline_monotonic = 0.0
+        self.nav_id = None
+        self.sequence = None
+
+    def seconds_until_deadline(self):
+        if not self.active:
+            return None
+        return max(0.0, self.deadline_monotonic - self._monotonic())
+
+    def stop(self, reason: str, force: bool = False) -> dict:
+        """Stop and retire the current lease; ``force`` also stops when idle."""
+        if not self.active and not force:
+            return {
+                "ret": 0,
+                "error": None,
+                "reason": reason,
+                "stop_issued": False,
+            }
+        started = self._monotonic()
+        ret = None
+        error = None
+        try:
+            ret = self._loco.StopMove()
+        except Exception as exc:
+            error = str(exc)
+        completed = self._monotonic()
+        self._clear()
+        return {
+            "ret": ret,
+            "error": error,
+            "reason": reason,
+            "stop_issued": True,
+            "started_monotonic": started,
+            "completed_monotonic": completed,
+            "completed_unix_ms": round(self._wall_time() * 1000),
+            "duration_ms": max(0, round((completed - started) * 1000)),
+        }
+
+    def expire_if_due(self) -> dict | None:
+        if not self.active or self._monotonic() < self.deadline_monotonic:
+            return None
+        return self.stop("proposal_ttl_expired")
+
+    def apply(
+        self,
+        vx: float,
+        vy: float,
+        vyaw: float,
+        deadline_monotonic: float,
+        nav_id: str,
+        sequence: int,
+        request_id: int | None = None,
+    ) -> dict:
+        """Apply a continuous velocity only while the Driver deadline is live."""
+        started = self._monotonic()
+        deadline = float(deadline_monotonic)
+        request = {
+            "vx": float(vx),
+            "vy": float(vy),
+            "vyaw": float(vyaw),
+            "deadline_monotonic": deadline,
+            "nav_id": nav_id,
+            "sequence": int(sequence),
+        }
+        base = {
+            "request_id": request_id,
+            "rpc_method": "SetVelocity(continuous)",
+            "request": request,
+            "ret": None,
+            "error": None,
+            "applied": False,
+            "started_monotonic": started,
+        }
+        if not math.isfinite(deadline) or deadline <= started:
+            stopped = self.stop("proposal_ttl_expired_before_rpc", force=True)
+            return {
+                **base,
+                "error": "proposal_ttl_expired_before_rpc",
+                "stop_ret": stopped.get("ret"),
+                "stop_error": stopped.get("error"),
+                "completed_monotonic": self._monotonic(),
+                "completed_unix_ms": round(self._wall_time() * 1000),
+            }
+
+        ret = None
+        error = None
+        try:
+            # LocoClient.Move(..., True) maps to this exact long-duration RPC,
+            # but its Python wrapper does not return the SetVelocity code.
+            ret = self._loco.SetVelocity(
+                float(vx),
+                float(vy),
+                float(vyaw),
+                PROPOSAL_CONTINUOUS_DURATION_SECONDS,
+            )
+        except Exception as exc:
+            error = str(exc)
+        completed = self._monotonic()
+        result = {
+            **base,
+            "ret": ret,
+            "error": error,
+            "completed_monotonic": completed,
+            "completed_unix_ms": round(self._wall_time() * 1000),
+            "duration_ms": max(0, round((completed - started) * 1000)),
+        }
+
+        if error is not None or ret != 0:
+            stopped = self.stop("proposal_velocity_rpc_failed", force=True)
+            result.update({
+                "stop_ret": stopped.get("ret"),
+                "stop_error": stopped.get("error"),
+            })
+            return result
+
+        if completed >= deadline:
+            stopped = self.stop("proposal_ttl_expired_after_rpc", force=True)
+            result.update({
+                "error": "proposal_ttl_expired_after_rpc",
+                "stop_ret": stopped.get("ret"),
+                "stop_error": stopped.get("error"),
+            })
+            return result
+
+        self.active = True
+        self.deadline_monotonic = deadline
+        self.nav_id = nav_id
+        self.sequence = int(sequence)
+        result["applied"] = True
+        return result
 
 
 def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.Queue,
@@ -25,22 +182,63 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
     loco.SetTimeout(10.0)
     loco.Init()
 
+    proposal_executor = ProposalRpcExecutor(loco)
+
     time.sleep(0.5)
     print("[G1 RpcWorker] ready", flush=True)
 
+    read_only_methods = {
+        "GetFsmId",
+        "GetFsmMode",
+        "GetBalanceMode",
+        "GetSwingHeight",
+        "GetStandHeight",
+        "GetPhase",
+    }
+
     while True:
+        proposal_executor.expire_if_due()
         try:
-            cmd = cmd_queue.get()
+            wait_timeout = proposal_executor.seconds_until_deadline()
+            if wait_timeout is None:
+                cmd = cmd_queue.get()
+            else:
+                cmd = cmd_queue.get(timeout=wait_timeout)
+        except queue.Empty:
+            proposal_executor.expire_if_due()
+            continue
         except Exception:
             break
         if cmd is None:
+            proposal_executor.stop("rpc_worker_shutdown")
             break
 
         method = cmd.get("method")
         args = cmd.get("args", [])
         kwargs = cmd.get("kwargs", {})
+        rpc_request_id = cmd.get("request_id")
 
         try:
+            if method == "__apply_velocity_proposal":
+                result_queue.put({
+                    "request_id": rpc_request_id,
+                    "result": proposal_executor.apply(*args, **kwargs),
+                })
+                continue
+
+            if method == "StopMove":
+                stopped = proposal_executor.stop("explicit_stop_move", force=True)
+                result_queue.put({
+                    "request_id": rpc_request_id,
+                    "result": stopped.get("ret"),
+                })
+                continue
+
+            # Read-only state queries may run while a proposal is active.  Any
+            # other Loco operation first retires the proposal authority.
+            if proposal_executor.active and method not in read_only_methods:
+                proposal_executor.stop("parent_rpc_override", force=True)
+
             # Special: FSM sequence execution (runs entirely in subprocess, no GIL)
             if method == "__run_fsm_sequence":
                 steps_spec, interval, step_timeout, settle_delay = args
@@ -49,7 +247,7 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                     fn = getattr(loco, method_name)
                     ret = fn()
                     if ret != 0:
-                        result_queue.put({"result": {
+                        result_queue.put({"request_id": rpc_request_id, "result": {
                             "error": f"Step '{step_name}' failed: code={ret}",
                             "step": step_name, "completed": completed}})
                         break  # abort sequence on failure
@@ -65,7 +263,7 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                             break
                     if not ok:
                         _, current = loco.GetFsmId()
-                        result_queue.put({"result": {
+                        result_queue.put({"request_id": rpc_request_id, "result": {
                             "error": f"Timeout '{step_name}' (expected={target_fsm}, got={current})",
                             "step": step_name, "fsm_id": current, "completed": completed}})
                         break  # abort sequence on timeout
@@ -74,15 +272,23 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                     time.sleep(settle_delay)
                 else:
                     # Only reached if loop completed without break (all steps succeeded)
-                    result_queue.put({"result": {"ret": 0, "steps": completed,
-                                                 "fsm_id": steps_spec[-1][1]}})
+                    result_queue.put({
+                        "request_id": rpc_request_id,
+                        "result": {
+                            "ret": 0,
+                            "steps": completed,
+                            "fsm_id": steps_spec[-1][1],
+                        },
+                    })
                 continue  # next cmd
 
             fn = getattr(loco, method)
             result = fn(*args, **kwargs)
-            result_queue.put({"result": result})
+            result_queue.put({"request_id": rpc_request_id, "result": result})
         except Exception as e:
-            result_queue.put({"error": str(e)})
+            result_queue.put({"request_id": rpc_request_id, "error": str(e)})
+        finally:
+            proposal_executor.expire_if_due()
 
 
 class RpcProxy:
@@ -99,18 +305,36 @@ class RpcProxy:
         )
         self._proc.start()
         self._lock = threading.Lock()
+        self._request_id = 0
 
     def _call(self, method: str, *args, timeout: float = 15.0, **kwargs):
         with self._lock:
-            self._cmd_q.put({"method": method, "args": args, "kwargs": kwargs})
-            try:
-                r = self._result_q.get(timeout=timeout)
-            except Exception:
-                return None
-            if "error" in r:
-                print(f"[G1 RpcProxy] {method} error: {r['error']}", flush=True)
-                return None
-            return r["result"]
+            self._request_id += 1
+            request_id = self._request_id
+            self._cmd_q.put({
+                "request_id": request_id,
+                "method": method,
+                "args": args,
+                "kwargs": kwargs,
+            })
+            deadline = time.monotonic() + timeout
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0.0:
+                    return None
+                try:
+                    response = self._result_q.get(timeout=remaining)
+                except Exception:
+                    return None
+                if response.get("request_id") != request_id:
+                    continue
+                if "error" in response:
+                    print(
+                        f"[G1 RpcProxy] {method} error: {response['error']}",
+                        flush=True,
+                    )
+                    return None
+                return response["result"]
 
     def _call_code(self, method: str, *args, **kwargs) -> int:
         """For methods that return a single int code."""
@@ -174,6 +398,47 @@ class RpcProxy:
 
     def SetVelocity(self, vx: float, vy: float, omega: float, duration: float = 1.0):
         return self._call_code("SetVelocity", vx, vy, omega, duration)
+
+    def ApplyVelocityProposal(
+        self,
+        vx: float,
+        vy: float,
+        vyaw: float,
+        deadline_monotonic: float,
+        nav_id: str,
+        sequence: int,
+        request_id: int | None = None,
+    ) -> dict:
+        result = self._call(
+            "__apply_velocity_proposal",
+            vx,
+            vy,
+            vyaw,
+            deadline_monotonic,
+            nav_id,
+            sequence,
+            request_id,
+            timeout=1.0,
+        )
+        if isinstance(result, dict):
+            return result
+        return {
+            "request_id": request_id,
+            "rpc_method": "SetVelocity(continuous)",
+            "request": {
+                "vx": vx,
+                "vy": vy,
+                "vyaw": vyaw,
+                "deadline_monotonic": deadline_monotonic,
+                "nav_id": nav_id,
+                "sequence": sequence,
+            },
+            "ret": None,
+            "error": "parent_proposal_rpc_unavailable",
+            "applied": False,
+            "completed_monotonic": time.monotonic(),
+            "completed_unix_ms": round(time.time() * 1000),
+        }
 
     def SetTaskId(self, task_id: float):
         return self._call_code("SetTaskId", task_id)

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -474,6 +474,35 @@ def velocity_commands_differ(current, target, abs_tol: float = 1e-9) -> bool:
     )
 
 
+def put_latest(command_queue, command) -> bool:
+    """Insert one command and replace, rather than backlog, an older one.
+
+    Returns true when a queued command was coalesced away.  The consumer may
+    race with replacement, but a capacity-one queue can never retain more than
+    the newest command available at the replacement boundary.
+    """
+    coalesced = False
+    while True:
+        try:
+            command_queue.put_nowait(command)
+            return coalesced
+        except queue.Full:
+            try:
+                command_queue.get_nowait()
+                coalesced = True
+            except queue.Empty:
+                pass
+
+
+def percentile_ms(samples, percentile):
+    """Return a nearest-rank latency percentile for diagnostics."""
+    if not samples:
+        return None
+    ordered = sorted(int(value) for value in samples)
+    rank = max(1, math.ceil(float(percentile) * len(ordered)))
+    return ordered[min(len(ordered) - 1, rank - 1)]
+
+
 @dataclass
 class ProposalApplyDiagnostics:
     """Current or most recent nav-lease execution evidence for ``loco info``."""
@@ -483,6 +512,7 @@ class ProposalApplyDiagnostics:
     accepted: int = 0
     rejected: int = 0
     applied: int = 0
+    coalesced: int = 0
     first_received_monotonic: Optional[float] = None
     last_received_monotonic: Optional[float] = None
     last_receive_gap_ms: Optional[int] = None
@@ -501,6 +531,8 @@ class ProposalApplyDiagnostics:
     last_set_velocity_applied: Optional[bool] = None
     last_set_velocity_request_id: Optional[int] = None
     last_set_velocity_duration_ms: Optional[int] = None
+    last_set_velocity_queue_delay_ms: Optional[int] = None
+    last_set_velocity_end_to_end_ms: Optional[int] = None
     last_set_velocity_completed_monotonic: Optional[float] = None
     last_set_velocity_completed_unix_ms: Optional[int] = None
     last_set_velocity_stop_ret: Optional[int] = None
@@ -515,6 +547,11 @@ class ProposalApplyDiagnostics:
         init=False,
         repr=False,
     )
+    _set_velocity_rpc_durations_ms: deque = field(
+        default_factory=lambda: deque(maxlen=512),
+        init=False,
+        repr=False,
+    )
 
     def begin_session(self, nav_id: str) -> None:
         """Reset per-lease counters while retaining them after later cleanup."""
@@ -524,6 +561,7 @@ class ProposalApplyDiagnostics:
             self.accepted = 0
             self.rejected = 0
             self.applied = 0
+            self.coalesced = 0
             self.first_received_monotonic = None
             self.last_received_monotonic = None
             self.last_receive_gap_ms = None
@@ -542,11 +580,14 @@ class ProposalApplyDiagnostics:
             self.last_set_velocity_applied = None
             self.last_set_velocity_request_id = None
             self.last_set_velocity_duration_ms = None
+            self.last_set_velocity_queue_delay_ms = None
+            self.last_set_velocity_end_to_end_ms = None
             self.last_set_velocity_completed_monotonic = None
             self.last_set_velocity_completed_unix_ms = None
             self.last_set_velocity_stop_ret = None
             self.last_set_velocity_stop_error = None
             self._applied_identities = set()
+            self._set_velocity_rpc_durations_ms = deque(maxlen=512)
 
     def record_received(self, received_monotonic: Optional[float] = None) -> None:
         received = (
@@ -613,6 +654,10 @@ class ProposalApplyDiagnostics:
         with self._lock:
             self.accepted += 1
 
+    def record_coalesced(self) -> None:
+        with self._lock:
+            self.coalesced += 1
+
     def record_rejected(self, reason: str) -> None:
         with self._lock:
             self.rejected += 1
@@ -623,9 +668,46 @@ class ProposalApplyDiagnostics:
                 self.rejections_by_reason.get(reason, 0) + 1
             )
 
-    def record_set_velocity(self, result: dict, duration: float) -> None:
+    def record_set_velocity(
+        self,
+        result: dict,
+        queued_monotonic: Optional[float] = None,
+    ) -> None:
+        """Record measured RPC timing, never the proposal TTL budget."""
+        started_monotonic = result.get("started_monotonic")
         completed_monotonic = result.get("completed_monotonic")
         completed_unix_ms = result.get("completed_unix_ms")
+        duration_ms = result.get("duration_ms")
+        if (
+            duration_ms is None
+            and started_monotonic is not None
+            and completed_monotonic is not None
+        ):
+            duration_ms = max(
+                0,
+                round(
+                    (float(completed_monotonic) - float(started_monotonic))
+                    * 1000
+                ),
+            )
+        queue_delay_ms = None
+        end_to_end_ms = None
+        if queued_monotonic is not None and started_monotonic is not None:
+            queue_delay_ms = max(
+                0,
+                round(
+                    (float(started_monotonic) - float(queued_monotonic))
+                    * 1000
+                ),
+            )
+        if queued_monotonic is not None and completed_monotonic is not None:
+            end_to_end_ms = max(
+                0,
+                round(
+                    (float(completed_monotonic) - float(queued_monotonic))
+                    * 1000
+                ),
+            )
         with self._lock:
             self.last_set_velocity_rpc_method = result.get("rpc_method")
             request = result.get("request")
@@ -636,10 +718,17 @@ class ProposalApplyDiagnostics:
             self.last_set_velocity_error = result.get("error")
             self.last_set_velocity_applied = bool(result.get("applied"))
             self.last_set_velocity_request_id = result.get("request_id")
-            self.last_set_velocity_duration_ms = max(
-                0,
-                round(float(duration) * 1000),
+            self.last_set_velocity_duration_ms = (
+                max(0, int(duration_ms))
+                if duration_ms is not None
+                else None
             )
+            self.last_set_velocity_queue_delay_ms = queue_delay_ms
+            self.last_set_velocity_end_to_end_ms = end_to_end_ms
+            if duration_ms is not None:
+                self._set_velocity_rpc_durations_ms.append(
+                    max(0, int(duration_ms))
+                )
             self.last_set_velocity_completed_monotonic = (
                 float(completed_monotonic)
                 if completed_monotonic is not None
@@ -674,6 +763,7 @@ class ProposalApplyDiagnostics:
                 "accepted": self.accepted,
                 "rejected": self.rejected,
                 "applied": self.applied,
+                "coalesced": self.coalesced,
                 "first_received_monotonic": self.first_received_monotonic,
                 "last_received_monotonic": self.last_received_monotonic,
                 "last_receive_gap_ms": self.last_receive_gap_ms,
@@ -703,6 +793,32 @@ class ProposalApplyDiagnostics:
                 ),
                 "last_set_velocity_duration_ms": (
                     self.last_set_velocity_duration_ms
+                ),
+                "last_set_velocity_queue_delay_ms": (
+                    self.last_set_velocity_queue_delay_ms
+                ),
+                "last_set_velocity_end_to_end_ms": (
+                    self.last_set_velocity_end_to_end_ms
+                ),
+                "set_velocity_rpc_samples": len(
+                    self._set_velocity_rpc_durations_ms
+                ),
+                "set_velocity_rpc_p50_ms": percentile_ms(
+                    self._set_velocity_rpc_durations_ms,
+                    0.50,
+                ),
+                "set_velocity_rpc_p95_ms": percentile_ms(
+                    self._set_velocity_rpc_durations_ms,
+                    0.95,
+                ),
+                "set_velocity_rpc_p99_ms": percentile_ms(
+                    self._set_velocity_rpc_durations_ms,
+                    0.99,
+                ),
+                "set_velocity_rpc_max_ms": (
+                    max(self._set_velocity_rpc_durations_ms)
+                    if self._set_velocity_rpc_durations_ms
+                    else None
                 ),
                 "last_set_velocity_completed_monotonic": (
                     self.last_set_velocity_completed_monotonic
@@ -1421,7 +1537,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             )
         proposal_apply_diagnostics.record_set_velocity(
             result,
-            max(0.0, command["deadline_monotonic"] - command["queued_monotonic"]),
+            queued_monotonic=command["queued_monotonic"],
         )
         return result
 
@@ -1446,15 +1562,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
 
     def enqueue_proposal_apply(command):
         """Keep only the newest validated command while the parent RPC is busy."""
-        while True:
-            try:
-                proposal_apply_queue.put_nowait(command)
-                return
-            except queue.Full:
-                try:
-                    proposal_apply_queue.get_nowait()
-                except queue.Empty:
-                    pass
+        if put_latest(proposal_apply_queue, command):
+            proposal_apply_diagnostics.record_coalesced()
 
     def query_parent_fsm_id():
         nonlocal parent_loco_request_id
@@ -1521,9 +1630,19 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             reason_str,
             watchdog_fault,
         )
-        if watchdog_fault:
+        if watchdog_fault and reason_str != "proposal_ttl_expired":
             proposal_gate.disarm(reason_str)
-        retry_proposal_stop = was_proposal_motion and not confirm_physical_stop
+        recoverable_stop_requested = bool(
+            proposal_gate.armed
+            and reason_str in {"obstacle", "proposal_ttl_expired"}
+            and (was_proposal_motion or reason_str == "proposal_ttl_expired")
+        )
+        proposal_stop_context = bool(
+            was_proposal_motion or recoverable_stop_requested
+        )
+        retry_proposal_stop = (
+            proposal_stop_context and not confirm_physical_stop
+        )
         if move_timer:
             move_timer.cancel()
             move_timer = None
@@ -1531,7 +1650,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         clear_proposal_execution()
         was_moving = state == MotionState.MOVING
 
-        if was_proposal_motion and not confirm_physical_stop:
+        if proposal_stop_context and not confirm_physical_stop:
             # The independent client brakes immediately.  The ordered parent
             # StopMove then runs after any in-flight continuous SetVelocity,
             # preventing a late successful apply from restarting motion.
@@ -1646,11 +1765,16 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             }
             if stop_error:
                 result["error"] = f"StopMove failed: {stop_error}"
-        if was_proposal_motion and reason_str == "obstacle":
+        if recoverable_stop_requested:
             if result.get("stop_confirmed"):
-                proposal_gate.hold_for_obstacle()
+                proposal_gate.hold_after_confirmed_stop(reason_str)
             else:
-                proposal_gate.disarm("obstacle_stop_unconfirmed")
+                unconfirmed_reason = (
+                    "obstacle_stop_unconfirmed"
+                    if reason_str == "obstacle"
+                    else "proposal_ttl_stop_unconfirmed"
+                )
+                proposal_gate.disarm(unconfirmed_reason)
         if was_moving:
             event_data = {"reason": reason_str}
             if reason_str == "obstacle":
@@ -1661,7 +1785,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         result.update({"state": "idle", "reason": reason_str})
         if confirm_physical_stop:
             last_stop_result = dict(result)
-            if retry_proposal_stop:
+            if proposal_stop_context:
                 last_proposal_stop_result = dict(result)
         return result
 
@@ -2962,7 +3086,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     else:
                         reason = "set_velocity_failed"
                     proposal_apply_diagnostics.record_rejected(reason)
-                    proposal_gate.disarm(reason)
+                    if reason == "proposal_ttl_expired":
+                        proposal_gate.request_ttl_stop(time.monotonic())
+                    else:
+                        proposal_gate.disarm(reason)
                     do_stop(reason)
                     continue
                 proposal_apply_diagnostics.record_applied(

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -41,6 +41,7 @@ from velocity_proposal import (
 UNITREE_STOP_MOVE_DURATION_SECONDS = 1.0
 DEFAULT_STOP_CONFIRM_TIMEOUT_SECONDS = 2.0
 MAX_STOP_CONFIRM_TIMEOUT_SECONDS = 3.0
+TRANSLATION_OBSTACLE_EPSILON = 0.01
 
 
 def resolve_stop_confirmation_timeout(configured_timeout):
@@ -84,6 +85,59 @@ class SpeedZone(enum.Enum):
     NORMAL = "normal"
     DECELERATED = "decelerated"
     STOPPED = "stopped"
+
+
+def translation_obstacle_heading(command, epsilon=TRANSLATION_OBSTACLE_EPSILON):
+    """Return the translation heading, or ``None`` for an in-place command."""
+    if not command:
+        return None
+    vx = float(command.get("vx", 0.0))
+    vy = float(command.get("vy", 0.0))
+    if math.hypot(vx, vy) <= float(epsilon):
+        return None
+    return math.atan2(vy, vx)
+
+
+def obstacle_observation_applies(
+    command,
+    observation_heading,
+    heading_tolerance,
+):
+    """Reject stale cones and never treat pure rotation as translation."""
+    command_heading = translation_obstacle_heading(command)
+    if command_heading is None or observation_heading is None:
+        return False
+    delta = abs(
+        (command_heading - float(observation_heading) + math.pi)
+        % (2 * math.pi)
+        - math.pi
+    )
+    return delta <= max(0.0, float(heading_tolerance))
+
+
+def authoritative_proposal_stop_reason(requested_reason, watchdog_fault):
+    """Preserve an execution fault that won before a concurrent local stop."""
+    if watchdog_fault:
+        return str(watchdog_fault[1])
+    return str(requested_reason)
+
+
+def proposal_decision_requires_physical_stop(
+    reason,
+    has_proposal,
+    proposal_motion_active,
+    newly_disarmed,
+    recoverable_stop_active,
+):
+    """Let confirmed obstacle holds drain stale ROS samples without RPCs."""
+    if (
+        recoverable_stop_active
+        and reason == "proposal_ttl_expired"
+        and not proposal_motion_active
+        and not newly_disarmed
+    ):
+        return False
+    return bool(has_proposal or proposal_motion_active or newly_disarmed)
 
 
 @dataclass
@@ -1418,6 +1472,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     obstacle_dist = float("inf")
     obstacle_angle = 0.0
     lateral_obstacle = False
+    obstacle_scan_heading = None
 
     # Nav arrival state (updated by rt/slam_info DDS callback in this subprocess)
     slam_info_lock = threading.Lock()
@@ -1457,6 +1512,17 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         was_proposal_motion = bool(
             current_cmd and current_cmd.get("source") == "velocity_proposal"
         )
+        watchdog_fault = (
+            current_proposal_watchdog_fault()
+            if was_proposal_motion
+            else None
+        )
+        reason_str = authoritative_proposal_stop_reason(
+            reason_str,
+            watchdog_fault,
+        )
+        if watchdog_fault:
+            proposal_gate.disarm(reason_str)
         retry_proposal_stop = was_proposal_motion and not confirm_physical_stop
         if move_timer:
             move_timer.cancel()
@@ -1581,7 +1647,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             if stop_error:
                 result["error"] = f"StopMove failed: {stop_error}"
         if was_proposal_motion and reason_str == "obstacle":
-            proposal_gate.disarm("obstacle_stop_latched")
+            if result.get("stop_confirmed"):
+                proposal_gate.hold_for_obstacle()
+            else:
+                proposal_gate.disarm("obstacle_stop_unconfirmed")
         if was_moving:
             event_data = {"reason": reason_str}
             if reason_str == "obstacle":
@@ -1620,13 +1689,12 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
 
     # ── LiDAR DDS Subscription ──
     def on_cloud(msg):
-        nonlocal obstacle_dist, obstacle_angle, lateral_obstacle, last_cloud_time
+        nonlocal obstacle_dist, obstacle_angle, lateral_obstacle
+        nonlocal obstacle_scan_heading, last_cloud_time
 
         # Get heading
         if state == MotionState.MOVING and current_cmd:
-            vx_cmd = current_cmd.get("vx", 0)
-            vy_cmd = current_cmd.get("vy", 0)
-            heading = math.atan2(vy_cmd, vx_cmd) if (abs(vx_cmd) > 0.01 or abs(vy_cmd) > 0.01) else 0.0
+            heading = translation_obstacle_heading(current_cmd)
         else:
             # NAVIGATING/IDLE: LiDAR is in body frame, heading=0 = robot forward
             heading = 0.0
@@ -1644,6 +1712,15 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             return
         with safety_lock:
             last_cloud_time = time.monotonic()
+        if heading is None:
+            # In-place rotation has no translation corridor.  Keep scan
+            # freshness, but do not apply a synthetic forward obstacle cone.
+            with obstacle_lock:
+                obstacle_dist = float("inf")
+                obstacle_angle = 0.0
+                lateral_obstacle = False
+                obstacle_scan_heading = None
+            return
 
         # Numpy batch extraction (xyz at offsets 0, 4, 8 — already gravity-aligned)
         buf = np.frombuffer(data, dtype=np.uint8, count=n_valid * point_step).reshape(n_valid, point_step)
@@ -1662,6 +1739,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 obstacle_dist = float("inf")
                 obstacle_angle = 0.0
                 lateral_obstacle = False
+                obstacle_scan_heading = heading
             return
 
         vx_pts = px[valid]
@@ -1702,6 +1780,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             obstacle_dist = min_fwd_dist
             obstacle_angle = min_fwd_angle
             lateral_obstacle = lat_detected
+            obstacle_scan_heading = heading
 
     try:
         event_node.create_subscription(
@@ -2604,7 +2683,13 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 current_cmd and current_cmd.get("source") == "velocity_proposal"
             )
             newly_disarmed = was_armed and not proposal_gate.armed
-            if decision.proposal is not None or is_proposal_motion or newly_disarmed:
+            if proposal_decision_requires_physical_stop(
+                decision.reason,
+                decision.proposal is not None,
+                is_proposal_motion,
+                newly_disarmed,
+                proposal_gate.recoverable_stop_active,
+            ):
                 do_stop(decision.reason)
             return
         if not decision.execute or decision.proposal is None:
@@ -2735,18 +2820,26 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         with obstacle_lock:
             dist = obstacle_dist
             lateral = lateral_obstacle
+            angle = obstacle_angle
+            scan_heading = obstacle_scan_heading
 
         if state == MotionState.MOVING:
             cmd = current_cmd  # snapshot to avoid race condition
+            if not obstacle_observation_applies(
+                cmd,
+                scan_heading,
+                cone_half_angle,
+            ):
+                return
             if dist <= stop_threshold:
                 if speed_zone != SpeedZone.STOPPED:
                     speed_zone = SpeedZone.STOPPED
-                    print(f"[SmartMotion:obstacle] STOP — dist={dist:.2f}m angle={math.degrees(obstacle_angle):.1f}° lateral={lateral}", flush=True)
+                    print(f"[SmartMotion:obstacle] STOP — dist={dist:.2f}m angle={math.degrees(angle):.1f}° lateral={lateral}", flush=True)
                     do_stop("obstacle")
             elif dist <= decel_threshold or lateral:
                 if speed_zone != SpeedZone.DECELERATED:
                     speed_zone = SpeedZone.DECELERATED
-                    print(f"[SmartMotion:obstacle] DECEL — dist={dist:.2f}m angle={math.degrees(obstacle_angle):.1f}° lateral={lateral}", flush=True)
+                    print(f"[SmartMotion:obstacle] DECEL — dist={dist:.2f}m angle={math.degrees(angle):.1f}° lateral={lateral}", flush=True)
                     if cmd:
                         dvx, dvy, dvyaw = clamp(cmd["vx"], cmd["vy"], cmd["vyaw"], SpeedZone.DECELERATED)
                         apply_safety_velocity(cmd, dvx, dvy, dvyaw)

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -75,6 +75,193 @@ class SpeedLimits:
     vyaw_decel: float = 0.2
 
 
+@dataclass(frozen=True)
+class StopConfirmationStart:
+    monotonic: float
+    unix_ms: int
+    odometry_callback_count: int
+
+
+class OdomStopMonitor:
+    """Wait for measured zero velocity without blocking the odom callback."""
+
+    def __init__(self):
+        self._condition = threading.Condition()
+        self._last_time = 0.0
+        self._last_velocity = (float("inf"), float("inf"), float("inf"))
+        self._callback_count = 0
+
+    def record(self, velocity, received_monotonic=None):
+        received = (
+            time.monotonic()
+            if received_monotonic is None
+            else float(received_monotonic)
+        )
+        motion = tuple(float(value) for value in velocity)
+        if len(motion) != 3:
+            raise ValueError("odometry velocity must contain x, y, and yaw")
+        with self._condition:
+            self._last_time = received
+            self._last_velocity = motion
+            self._callback_count += 1
+            self._condition.notify_all()
+
+    def begin_confirmation(self):
+        with self._condition:
+            return StopConfirmationStart(
+                monotonic=time.monotonic(),
+                unix_ms=round(time.time() * 1000),
+                odometry_callback_count=self._callback_count,
+            )
+
+    def latest(self, now=None):
+        observed_at = time.monotonic() if now is None else float(now)
+        with self._condition:
+            age = (
+                observed_at - self._last_time
+                if self._last_time
+                else float("inf")
+            )
+            return {
+                "time": self._last_time,
+                "age": age,
+                "velocity": self._last_velocity,
+                "callback_count": self._callback_count,
+            }
+
+    def wait_for_stopped(
+        self,
+        start,
+        timeout,
+        max_age,
+        linear_epsilon,
+        yaw_epsilon,
+        stop_move_ret,
+        stop_move_error=None,
+        stop_move_completed_monotonic=None,
+        callbacks_at_stop_move_completion=None,
+    ):
+        deadline = start.monotonic + timeout
+        confirmed = False
+        timed_out = False
+        with self._condition:
+            while stop_move_ret == 0:
+                now = time.monotonic()
+                vx, vy, yaw = self._last_velocity
+                is_new = (
+                    self._callback_count > start.odometry_callback_count
+                    and self._last_time >= start.monotonic
+                    and self._last_time <= deadline
+                )
+                is_fresh = self._last_time and now - self._last_time <= max_age
+                is_zero = (
+                    abs(vx) <= linear_epsilon
+                    and abs(vy) <= linear_epsilon
+                    and abs(yaw) <= yaw_epsilon
+                )
+                if is_new and is_fresh and is_zero:
+                    confirmed = True
+                    break
+                remaining = deadline - now
+                if remaining <= 0.0:
+                    timed_out = True
+                    break
+                # Condition.wait releases the monitor lock, so the dedicated
+                # Unitree ch_reader thread can record and signal the next odom.
+                self._condition.wait(timeout=remaining)
+
+            now = time.monotonic()
+            age = now - self._last_time if self._last_time else float("inf")
+            vx, vy, yaw = self._last_velocity
+            diagnostics = {
+                "stop_move_ret": stop_move_ret,
+                "stop_move_error": stop_move_error,
+                "confirmation_started_monotonic": start.monotonic,
+                "confirmation_started_unix_ms": start.unix_ms,
+                "stop_move_completed_monotonic": stop_move_completed_monotonic,
+                "stop_move_duration_ms": (
+                    round(
+                        (stop_move_completed_monotonic - start.monotonic) * 1000
+                    )
+                    if stop_move_completed_monotonic is not None
+                    else None
+                ),
+                "last_odometry_monotonic": self._last_time or None,
+                "last_odometry_age_ms": (
+                    round(age * 1000) if math.isfinite(age) else None
+                ),
+                "last_odometry_velocity": {
+                    "x": vx if math.isfinite(vx) else None,
+                    "y": vy if math.isfinite(vy) else None,
+                    "yaw": yaw if math.isfinite(yaw) else None,
+                },
+                "odometry_callback_count": self._callback_count,
+                "odometry_callbacks_since_confirmation": max(
+                    0,
+                    self._callback_count - start.odometry_callback_count,
+                ),
+                "odometry_callbacks_during_stop_move": max(
+                    0,
+                    (
+                        callbacks_at_stop_move_completion
+                        if callbacks_at_stop_move_completion is not None
+                        else start.odometry_callback_count
+                    ) - start.odometry_callback_count,
+                ),
+                "confirmation_timed_out": timed_out,
+            }
+        return confirmed, diagnostics
+
+
+def issue_stop_and_confirm(
+    stop_move,
+    monitor,
+    timeout,
+    max_age,
+    linear_epsilon,
+    yaw_epsilon,
+    after_stop_attempt=None,
+):
+    """Issue a bounded StopMove and require a subsequent measured zero frame."""
+    start = monitor.begin_confirmation()
+    stop_move_ret = None
+    stop_move_error = None
+    try:
+        stop_move_ret = stop_move()
+    except Exception as exc:
+        stop_move_error = str(exc)
+    finally:
+        stop_move_completed_monotonic = time.monotonic()
+        callbacks_at_stop_move_completion = monitor.latest(
+            stop_move_completed_monotonic
+        )["callback_count"]
+        if after_stop_attempt is not None:
+            after_stop_attempt()
+
+    stop_confirmed, diagnostics = monitor.wait_for_stopped(
+        start=start,
+        timeout=timeout,
+        max_age=max_age,
+        linear_epsilon=linear_epsilon,
+        yaw_epsilon=yaw_epsilon,
+        stop_move_ret=stop_move_ret,
+        stop_move_error=stop_move_error,
+        stop_move_completed_monotonic=stop_move_completed_monotonic,
+        callbacks_at_stop_move_completion=callbacks_at_stop_move_completion,
+    )
+    result = {
+        "ret": stop_move_ret,
+        "stop_confirmed": stop_confirmed,
+        "stop_issued_monotonic": start.monotonic,
+        "stop_confirmation": diagnostics,
+    }
+    if stop_move_error:
+        result["error"] = f"StopMove failed: {stop_move_error}"
+    elif stop_move_ret != 0:
+        result["error"] = f"StopMove failed, ret={stop_move_ret}"
+    return result
+
+
 # ── SmartMotionProxy (main process) ─────────────────────────────────────────
 
 class SmartMotionProxy:
@@ -425,12 +612,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     speed_zone = SpeedZone.NORMAL
     move_timer = None   # threading.Timer
     last_cloud_time = 0.0
-    last_odom_time = 0.0
     last_fsm_check = 0.0
     last_fsm_id = None
     main_control_ready = False
     last_nav_status_time = 0.0
-    last_odom_motion = (float("inf"), float("inf"), float("inf"))
+    odom_stop_monitor = OdomStopMonitor()
     safety_lock = threading.Lock()
     motion_command_lock = threading.RLock()
     proposal_execution_lock = threading.Lock()
@@ -510,7 +696,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         return stop_loco_client.StopMove()
 
     @motion_synchronized
-    def do_stop(reason_str):
+    def do_stop(reason_str, confirm_physical_stop=False):
         nonlocal state, current_cmd, speed_zone, move_timer, stop_repeat_count
         was_proposal_motion = bool(
             current_cmd and current_cmd.get("source") == "velocity_proposal"
@@ -519,20 +705,40 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             move_timer.cancel()
             move_timer = None
         clear_proposal_execution()
-        stop_ret = None
-        stop_error = None
-        try:
-            stop_ret = issue_stop_move()
-        except Exception as exc:
-            stop_error = str(exc)
-        # A physical-stop confirmation must use odometry newer than the
-        # completed StopMove RPC attempt.
-        stop_issued_monotonic = time.monotonic()
         was_moving = state == MotionState.MOVING
-        state = MotionState.IDLE
-        current_cmd = None
-        speed_zone = SpeedZone.NORMAL
-        stop_repeat_count = 3  # repeat StopMove to ensure controller stops
+
+        def complete_logical_stop():
+            nonlocal state, current_cmd, speed_zone, stop_repeat_count
+            state = MotionState.IDLE
+            current_cmd = None
+            speed_zone = SpeedZone.NORMAL
+            stop_repeat_count = 3  # repeat StopMove to ensure controller stops
+
+        if confirm_physical_stop:
+            result = issue_stop_and_confirm(
+                issue_stop_move,
+                odom_stop_monitor,
+                proposal_stop_confirm_timeout,
+                proposal_odom_timeout,
+                proposal_stop_linear_epsilon,
+                proposal_stop_yaw_epsilon,
+                after_stop_attempt=complete_logical_stop,
+            )
+        else:
+            stop_ret = None
+            stop_error = None
+            try:
+                stop_ret = issue_stop_move()
+            except Exception as exc:
+                stop_error = str(exc)
+            complete_logical_stop()
+            result = {
+                "ret": stop_ret,
+                "stop_confirmed": stop_ret == 0,
+                "stop_issued_monotonic": time.monotonic(),
+            }
+            if stop_error:
+                result["error"] = f"StopMove failed: {stop_error}"
         if was_proposal_motion and reason_str == "obstacle":
             proposal_gate.disarm("obstacle_stop_latched")
         if was_moving:
@@ -542,15 +748,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     event_data["obstacle_distance"] = round(obstacle_dist, 2)
                     event_data["obstacle_angle_deg"] = round(math.degrees(obstacle_angle), 1)
             publish_event("motion_stop", event_data)
-        result = {
-            "ret": stop_ret,
-            "state": "idle",
-            "reason": reason_str,
-            "stop_confirmed": stop_ret == 0,
-            "stop_issued_monotonic": stop_issued_monotonic,
-        }
-        if stop_error:
-            result["error"] = f"StopMove failed: {stop_error}"
+        result.update({"state": "idle", "reason": reason_str})
         return result
 
     @motion_synchronized
@@ -771,7 +969,6 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     # ── OdomState DDS Subscription (foot force) ──
     def on_odom(msg):
         nonlocal foot_airborne_start, foot_force_seen_nonzero
-        nonlocal last_odom_time, last_odom_motion
 
         velocity = list(msg.velocity)
         motion = (
@@ -779,9 +976,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             float(velocity[1]) if len(velocity) > 1 else float("inf"),
             float(msg.yaw_speed),
         )
-        with safety_lock:
-            last_odom_time = time.monotonic()
-            last_odom_motion = motion
+        odom_stop_monitor.record(motion)
 
         if state != MotionState.MOVING:
             foot_airborne_start = 0.0
@@ -894,9 +1089,9 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         if force_fsm_check:
             refresh_fsm_state()
         now = time.monotonic()
+        odom = odom_stop_monitor.latest(now)
         with safety_lock:
             lowstate_age = now - last_lowstate_time if last_lowstate_time else float("inf")
-            odom_age = now - last_odom_time if last_odom_time else float("inf")
             scan_age = now - last_cloud_time if last_cloud_time else float("inf")
             nav_status_age = (
                 now - last_nav_status_time if last_nav_status_time else float("inf")
@@ -906,6 +1101,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             fsm_id = last_fsm_id
             control_ready = main_control_ready
             tilted = tilt_triggered
+        odom_age = odom["age"]
 
         reason = ""
         if not proposal_driver_authorized:
@@ -936,31 +1132,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             "emergency_stop_clear": control_ready and fsm_age <= proposal_fsm_timeout,
             "lowstate_age_ms": None if not math.isfinite(lowstate_age) else round(lowstate_age * 1000),
             "odometry_age_ms": None if not math.isfinite(odom_age) else round(odom_age * 1000),
+            "odometry_callback_count": odom["callback_count"],
             "scan_age_ms": None if not math.isfinite(scan_age) else round(scan_age * 1000),
             "nav2_status_age_ms": None if not math.isfinite(nav_status_age) else round(nav_status_age * 1000),
             "fsm_age_ms": None if not math.isfinite(fsm_age) else round(fsm_age * 1000),
         }
-
-    def confirm_robot_stopped(timeout, not_before):
-        """Confirm StopMove using a fresh near-zero measured odometry sample."""
-        deadline = time.monotonic() + timeout
-        while True:
-            now = time.monotonic()
-            with safety_lock:
-                odom_time = last_odom_time
-                vx, vy, yaw = last_odom_motion
-            if (
-                odom_time
-                and odom_time >= not_before
-                and now - odom_time <= proposal_odom_timeout
-                and abs(vx) <= proposal_stop_linear_epsilon
-                and abs(vy) <= proposal_stop_linear_epsilon
-                and abs(yaw) <= proposal_stop_yaw_epsilon
-            ):
-                return True
-            if now >= deadline:
-                return False
-            time.sleep(min(0.02, deadline - now))
 
     # ── Command handlers ──
     @motion_synchronized
@@ -1243,21 +1419,21 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     "error": "StopMove was not confirmed before proposal rebind",
                     "connected": False,
                     "stop_confirmed": False,
+                    "stop_move_ret": stopped.get("stop_move_ret"),
+                    "stop_move_error": stopped.get("stop_move_error"),
+                    "stop_confirmation": stopped.get("stop_confirmation"),
                 }
         else:
-            stopped = do_stop("proposal_bind")
-            physically_stopped = (
-                stopped.get("stop_confirmed")
-                and confirm_robot_stopped(
-                    proposal_stop_confirm_timeout,
-                    stopped["stop_issued_monotonic"],
-                )
-            )
-            if not physically_stopped:
+            stopped = do_stop("proposal_bind", confirm_physical_stop=True)
+            if not stopped.get("stop_confirmed"):
+                diagnostics = stopped.get("stop_confirmation") or {}
                 return {
                     "error": "StopMove/odometry stop was not confirmed before proposal bind",
                     "connected": False,
                     "stop_confirmed": False,
+                    "stop_move_ret": diagnostics.get("stop_move_ret"),
+                    "stop_move_error": diagnostics.get("stop_move_error"),
+                    "stop_confirmation": diagnostics,
                 }
         if not proposal_enabled:
             return {"error": "velocity_proposal_execution_disabled", "connected": False}
@@ -1285,6 +1461,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             return {"error": f"velocity_proposal_subscribe_failed: {exc}", "connected": False}
         result = handle_get_velocity_proposal_status()
         result["state"] = "connected"
+        result["stop_confirmed"] = True
+        result["stop_move_ret"] = stopped.get("stop_move_ret", stopped.get("ret"))
+        result["stop_move_error"] = stopped.get("stop_move_error")
+        result["stop_confirmation"] = stopped.get("stop_confirmation")
         return result
 
     @motion_synchronized
@@ -1293,29 +1473,25 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         # only proposal subscription.
         if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
             do_stop_nav()
-        stopped = do_stop(reason)
+        stopped = do_stop(reason, confirm_physical_stop=True)
         for _ in range(2):
-            if stopped.get("stop_confirmed"):
+            # Preserve the original retry contract: retry rejected/failed RPC
+            # attempts, but do not mask a measured nonzero or odom timeout by
+            # issuing more StopMove calls.
+            if stopped.get("ret") == 0:
                 break
-            try:
-                stop_ret = issue_stop_move()
-            except Exception as exc:
-                stopped["error"] = f"StopMove failed: {exc}"
-            else:
-                stopped["ret"] = stop_ret
-                stopped["stop_confirmed"] = stop_ret == 0
-            finally:
-                stopped["stop_issued_monotonic"] = time.monotonic()
-        stopped["stop_confirmed"] = bool(
-            stopped.get("stop_confirmed")
-            and confirm_robot_stopped(
+            stopped = issue_stop_and_confirm(
+                issue_stop_move,
+                odom_stop_monitor,
                 proposal_stop_confirm_timeout,
-                stopped["stop_issued_monotonic"],
+                proposal_odom_timeout,
+                proposal_stop_linear_epsilon,
+                proposal_stop_yaw_epsilon,
             )
-        )
         if not stopped["stop_confirmed"]:
             proposal_gate.disarm("stop_unconfirmed")
             proposal_connected.clear()
+            diagnostics = stopped.get("stop_confirmation") or {}
             return {
                 "state": "error",
                 "connected": bool(proposal_node.topic),
@@ -1324,6 +1500,9 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 "subscriber_retained": bool(proposal_node.topic),
                 "reason": reason,
                 "error": stopped.get("error") or "fresh zero-odometry stop was not confirmed",
+                "stop_move_ret": diagnostics.get("stop_move_ret"),
+                "stop_move_error": diagnostics.get("stop_move_error"),
+                "stop_confirmation": diagnostics,
             }
         proposal_gate.unbind(reason)
         proposal_connected.clear()
@@ -1333,6 +1512,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             "connected": False,
             "stop_confirmed": True,
             "reason": reason,
+            "stop_move_ret": stopped.get("ret"),
+            "stop_move_error": (
+                (stopped.get("stop_confirmation") or {}).get("stop_move_error")
+            ),
+            "stop_confirmation": stopped.get("stop_confirmation"),
             **({"error": stopped["error"]} if stopped.get("error") else {}),
         }
 
@@ -1767,12 +1951,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     if move_timer:
         move_timer.cancel()
     with motion_command_lock:
-        stopped = do_stop("process_exit")
-        if stopped.get("stop_confirmed"):
-            stopped["stop_confirmed"] = confirm_robot_stopped(
-                proposal_stop_confirm_timeout,
-                stopped["stop_issued_monotonic"],
-            )
+        do_stop("process_exit", confirm_physical_stop=True)
         proposal_gate.unbind("process_exit")
         proposal_node.unbind()
     executor.shutdown()

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -14,6 +14,8 @@ drivers/unitree/g1/safety_harness.py — SmartMotion 独立进程安全层。
 此模块不是 MCP plugin，由驱动生命周期管理，默认自动启动。
 """
 
+from __future__ import annotations
+
 import enum
 import json
 import math
@@ -25,6 +27,12 @@ import threading
 import time
 from dataclasses import dataclass, field
 from typing import Optional
+
+from velocity_proposal import (
+    DEFAULT_VELOCITY_PROPOSAL_TOPIC,
+    ProposalLimits,
+    VelocityProposalGate,
+)
 
 
 # ── Enums & Data Classes (shared between processes) ──────────────────────────
@@ -71,16 +79,28 @@ class SpeedLimits:
 class SmartMotionProxy:
     """Main-process proxy that communicates with the SmartMotion subprocess."""
 
-    def __init__(self, namespace: str, config: dict, network_iface: str):
+    def __init__(self, namespace: str, config: dict, network_iface: str,
+                 proposal_config: Optional[dict] = None,
+                 fallback_stop=None):
         ctx = mp.get_context("spawn")
         self._cmd_queue = ctx.Queue()
         self._result_queue = ctx.Queue()
+        self._call_lock = threading.Lock()
+        self._request_id = 0
         self._proc = ctx.Process(
             target=_run_smart_motion_process,
-            args=(namespace, config, network_iface, self._cmd_queue, self._result_queue),
+            args=(namespace, config, proposal_config or {}, network_iface,
+                  self._cmd_queue, self._result_queue),
             name="smart_motion", daemon=True,
         )
         self._proc.start()
+        self._fallback_stop = fallback_stop
+        self._exit_monitor = threading.Thread(
+            target=self._monitor_process_exit,
+            daemon=True,
+            name="smart_motion_exit_monitor",
+        )
+        self._exit_monitor.start()
         print(f"[SmartMotionProxy] subprocess started → pid={self._proc.pid}")
         # Per-request result routing: avoid race when multiple threads call _call
         self._pending: dict[str, queue.Queue] = {}  # req_id → per-request queue
@@ -115,21 +135,48 @@ class SmartMotionProxy:
             except Exception:
                 continue
 
+    def _monitor_process_exit(self) -> None:
+        """Issue an independent parent-side stop on every child exit.
+
+        The child normally stops itself in its cleanup path.  This second path
+        covers unhandled exceptions, SIGKILL/SIGTERM, and forced termination
+        after an IPC timeout, where Python cleanup cannot be relied upon.
+        """
+        self._proc.join()
+        if self._fallback_stop is None:
+            return
+        try:
+            self._fallback_stop()
+        except Exception as exc:
+            print(
+                f"[SmartMotionProxy] child-exit StopMove failed: {exc}",
+                flush=True,
+            )
+
     def _call(self, method: str, timeout: float = 15.0, **kwargs) -> dict:
-        """Send command to subprocess and wait for result (thread-safe)."""
+        """Send a correlated command without serializing independent callers."""
+        if not self._proc.is_alive():
+            return {"error": "SmartMotion subprocess is not running"}
         req_id = self._next_req_id()
         result_q = queue.Queue(maxsize=1)
         with self._dispatch_lock:
             self._pending[req_id] = result_q
         try:
             self._cmd_queue.put({"method": method, "_req_id": req_id, **kwargs})
-            result = result_q.get(timeout=timeout)
-            return result
-        except queue.Empty:
-            return {"error": f"SmartMotion subprocess timeout ({method})"}
+            try:
+                return result_q.get(timeout=timeout)
+            except queue.Empty:
+                self._terminate_unresponsive_process()
+                return {"error": f"SmartMotion subprocess timeout ({method})"}
         finally:
             with self._dispatch_lock:
                 self._pending.pop(req_id, None)
+
+    def _terminate_unresponsive_process(self) -> None:
+        """Fail closed: an IPC-hung motion owner may not keep executing."""
+        if self._proc.is_alive():
+            self._proc.terminate()
+            self._proc.join(timeout=1.0)
 
     def move(self, vx: float, vy: float, vyaw: float, duration: float = -1.0) -> dict:
         return self._call("move", vx=vx, vy=vy, vyaw=vyaw, duration=duration)
@@ -158,6 +205,15 @@ class SmartMotionProxy:
     def get_state(self) -> dict:
         return self._call("get_state")
 
+    def bind_velocity_proposal(self, topic: str) -> dict:
+        return self._call("bind_velocity_proposal", topic=topic)
+
+    def unbind_velocity_proposal(self, reason: str = "canvas_stop") -> dict:
+        return self._call("unbind_velocity_proposal", reason=reason)
+
+    def get_velocity_proposal_status(self) -> dict:
+        return self._call("get_velocity_proposal_status")
+
     # ── SLAM RPC passthrough (single SlamClient owns all SLAM operations) ──
 
     def start_mapping(self) -> dict:
@@ -173,20 +229,24 @@ class SmartMotionProxy:
 
     def shutdown(self) -> None:
         try:
-            self._cmd_queue.put({"method": "shutdown"})
+            self._call("shutdown", timeout=3.0)
             self._proc.join(timeout=3.0)
         except Exception:
             pass
         if self._proc.is_alive():
             self._proc.terminate()
             self._proc.join(timeout=2.0)
+        # Ensure the parent-side child-exit StopMove completes before the
+        # caller tears down the independent RpcProxy used by that callback.
+        self._exit_monitor.join(timeout=2.0)
         print("[SmartMotionProxy] subprocess stopped")
 
 
 # ── SmartMotion subprocess entry ─────────────────────────────────────────────
 
-def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
-                              cmd_queue: mp.Queue, result_queue: mp.Queue):
+def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dict,
+                              network_iface: str, cmd_queue: mp.Queue,
+                              result_queue: mp.Queue):
     """Entry point for the SmartMotion subprocess.
 
     Initializes its own DDS channel, RPC clients, ROS2 node, and LiDAR subscription.
@@ -209,6 +269,12 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         depth=200,
         durability=DurabilityPolicy.VOLATILE,
     )
+    _PROPOSAL_QOS = QoSProfile(
+        reliability=ReliabilityPolicy.RELIABLE,
+        history=HistoryPolicy.KEEP_LAST,
+        depth=10,
+        durability=DurabilityPolicy.VOLATILE,
+    )
 
     # ── Initialize DDS ──
     ChannelFactoryInitialize(0, network_iface)
@@ -218,6 +284,30 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     loco_client = LocoClient()
     loco_client.Init()
     loco_client.SetTimeout(10.0)
+
+    # Proposal execution, stopping, watchdog stopping and FSM polling use
+    # independent RPC clients so a delayed call cannot block physical stop.
+    proposal_rpc_timeout = min(
+        0.2, max(0.02, float(proposal_config.get("velocity_proposal_rpc_timeout", 0.1)))
+    )
+    stop_rpc_timeout = min(
+        0.2, max(0.02, float(proposal_config.get("velocity_proposal_stop_rpc_timeout", 0.1)))
+    )
+    fsm_rpc_timeout = min(
+        0.5, max(0.05, float(proposal_config.get("velocity_proposal_fsm_rpc_timeout", 0.2)))
+    )
+    proposal_loco_client = LocoClient()
+    proposal_loco_client.Init()
+    proposal_loco_client.SetTimeout(proposal_rpc_timeout)
+    stop_loco_client = LocoClient()
+    stop_loco_client.Init()
+    stop_loco_client.SetTimeout(stop_rpc_timeout)
+    watchdog_loco_client = LocoClient()
+    watchdog_loco_client.Init()
+    watchdog_loco_client.SetTimeout(stop_rpc_timeout)
+    fsm_loco_client = LocoClient()
+    fsm_loco_client.Init()
+    fsm_loco_client.SetTimeout(fsm_rpc_timeout)
 
     slam_client = SlamClient()
     slam_client.Init()
@@ -245,6 +335,30 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     executor.add_node(event_node)
     print(f"[SmartMotion:pid={os.getpid()}] ROS2 event node ready → /{namespace}/safety/motion_events")
 
+    class _VelocityProposalNode(Node):
+        """Own the one dynamically connected N5 proposal subscription."""
+
+        def __init__(self):
+            super().__init__("g1_loco_velocity_proposal")
+            self._subscription = None
+            self.topic = ""
+
+        def bind(self, topic: str, callback) -> None:
+            self.unbind()
+            self._subscription = self.create_subscription(
+                String, topic, callback, _PROPOSAL_QOS
+            )
+            self.topic = topic
+
+        def unbind(self) -> None:
+            if self._subscription is not None:
+                self.destroy_subscription(self._subscription)
+                self._subscription = None
+            self.topic = ""
+
+    proposal_node = _VelocityProposalNode()
+    executor.add_node(proposal_node)
+
     # ── Config ──
     decel_threshold = config.get("decel_threshold", 2.0)
     stop_threshold = config.get("stop_threshold", 0.8)
@@ -252,6 +366,52 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     z_min = config.get("z_min", 0.1)
     z_max = config.get("z_max", 1.8)
     limits = SpeedLimits()
+    proposal_enabled = bool(proposal_config.get("velocity_proposal_enabled", True))
+    proposal_driver_authorized = bool(
+        proposal_config.get("velocity_proposal_driver_authorized", False)
+    )
+    expected_proposal_topic = DEFAULT_VELOCITY_PROPOSAL_TOPIC
+    # Deployment configuration may tighten, but never loosen, N5 limits.
+    proposal_limits = ProposalLimits(
+        frame="base_link",
+        max_ttl_ms=min(250, int(proposal_config.get("velocity_proposal_max_ttl_ms", 250))),
+        min_x=max(-0.05, float(proposal_config.get("velocity_proposal_min_x", -0.05))),
+        max_x=min(0.15, float(proposal_config.get("velocity_proposal_max_x", 0.15))),
+        max_abs_y=min(0.12, float(proposal_config.get("velocity_proposal_max_abs_y", 0.12))),
+        max_abs_yaw=min(0.35, float(proposal_config.get("velocity_proposal_max_abs_yaw", 0.35))),
+        max_planar_speed=min(0.18, float(proposal_config.get("velocity_proposal_max_planar_speed", 0.18))),
+    )
+    proposal_gate = VelocityProposalGate(proposal_limits)
+    proposal_odom_timeout = float(proposal_config.get("velocity_proposal_odom_timeout", 0.5))
+    proposal_scan_timeout = float(proposal_config.get("velocity_proposal_scan_timeout", 0.5))
+    proposal_fsm_check_interval = float(
+        proposal_config.get("velocity_proposal_fsm_check_interval", 0.2)
+    )
+    proposal_fsm_timeout = max(
+        proposal_fsm_check_interval,
+        float(proposal_config.get("velocity_proposal_fsm_timeout", 0.5)),
+    )
+    proposal_nav_status_timeout = min(
+        proposal_limits.max_ttl_ms / 1000.0,
+        float(proposal_config.get("velocity_proposal_nav_status_timeout", 0.25)),
+    )
+    proposal_watchdog_hz = max(
+        20.0, float(proposal_config.get("velocity_proposal_watchdog_hz", 40.0))
+    )
+    proposal_stop_confirm_timeout = min(
+        1.0,
+        max(0.1, float(proposal_config.get("velocity_proposal_stop_confirm_timeout", 0.5))),
+    )
+    proposal_stop_linear_epsilon = max(
+        0.0, float(proposal_config.get("velocity_proposal_stop_linear_epsilon", 0.03))
+    )
+    proposal_stop_yaw_epsilon = max(
+        0.0, float(proposal_config.get("velocity_proposal_stop_yaw_epsilon", 0.05))
+    )
+    proposal_allowed_fsm_ids = {
+        int(value)
+        for value in proposal_config.get("velocity_proposal_allowed_fsm_ids", [500, 801])
+    }
 
     # ── State ──
     state = MotionState.IDLE
@@ -259,6 +419,57 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     nav_cmd = None      # dict: {target_name, target_pose, start_time}
     speed_zone = SpeedZone.NORMAL
     move_timer = None   # threading.Timer
+    last_cloud_time = 0.0
+    last_odom_time = 0.0
+    last_fsm_check = 0.0
+    last_fsm_id = None
+    main_control_ready = False
+    last_nav_status_time = 0.0
+    last_odom_motion = (float("inf"), float("inf"), float("inf"))
+    safety_lock = threading.Lock()
+    motion_command_lock = threading.RLock()
+    proposal_execution_lock = threading.Lock()
+    proposal_connected = threading.Event()
+    safety_threads_shutdown = threading.Event()
+    proposal_execution_generation = 0
+    proposal_execution_active = False
+    proposal_execution_deadline = 0.0
+    proposal_watchdog_fault = None
+
+    def motion_synchronized(func):
+        def locked(*args, **kwargs):
+            with motion_command_lock:
+                return func(*args, **kwargs)
+        return locked
+
+    def arm_proposal_execution(deadline):
+        nonlocal proposal_execution_generation, proposal_execution_active
+        nonlocal proposal_execution_deadline, proposal_watchdog_fault
+        with proposal_execution_lock:
+            proposal_execution_generation += 1
+            proposal_execution_active = True
+            proposal_execution_deadline = deadline
+            proposal_watchdog_fault = None
+            return proposal_execution_generation
+
+    def clear_proposal_execution():
+        nonlocal proposal_execution_generation, proposal_execution_active
+        nonlocal proposal_execution_deadline, proposal_watchdog_fault
+        with proposal_execution_lock:
+            proposal_execution_generation += 1
+            proposal_execution_active = False
+            proposal_execution_deadline = 0.0
+            proposal_watchdog_fault = None
+
+    def proposal_fault_for_generation(generation):
+        with proposal_execution_lock:
+            if proposal_watchdog_fault and proposal_watchdog_fault[0] == generation:
+                return proposal_watchdog_fault[1]
+            return ""
+
+    def current_proposal_watchdog_fault():
+        with proposal_execution_lock:
+            return proposal_watchdog_fault
 
     # Obstacle state (written by LiDAR callback, read by main loop)
     obstacle_lock = threading.Lock()
@@ -289,17 +500,36 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         event_node.publish(event)
         print(f"[SmartMotion] event: {event_type} | {json.dumps(data)}", flush=True)
 
+    def issue_stop_move():
+        """Call StopMove and return the Unitree RPC acknowledgement code."""
+        return stop_loco_client.StopMove()
+
+    @motion_synchronized
     def do_stop(reason_str):
         nonlocal state, current_cmd, speed_zone, move_timer, stop_repeat_count
+        was_proposal_motion = bool(
+            current_cmd and current_cmd.get("source") == "velocity_proposal"
+        )
         if move_timer:
             move_timer.cancel()
             move_timer = None
-        loco_client.StopMove()
+        clear_proposal_execution()
+        stop_ret = None
+        stop_error = None
+        try:
+            stop_ret = issue_stop_move()
+        except Exception as exc:
+            stop_error = str(exc)
+        # A physical-stop confirmation must use odometry newer than the
+        # completed StopMove RPC attempt.
+        stop_issued_monotonic = time.monotonic()
         was_moving = state == MotionState.MOVING
         state = MotionState.IDLE
         current_cmd = None
         speed_zone = SpeedZone.NORMAL
         stop_repeat_count = 3  # repeat StopMove to ensure controller stops
+        if was_proposal_motion and reason_str == "obstacle":
+            proposal_gate.disarm("obstacle_stop_latched")
         if was_moving:
             event_data = {"reason": reason_str}
             if reason_str == "obstacle":
@@ -307,8 +537,18 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     event_data["obstacle_distance"] = round(obstacle_dist, 2)
                     event_data["obstacle_angle_deg"] = round(math.degrees(obstacle_angle), 1)
             publish_event("motion_stop", event_data)
-        return {"ret": 0, "state": "idle", "reason": reason_str}
+        result = {
+            "ret": stop_ret,
+            "state": "idle",
+            "reason": reason_str,
+            "stop_confirmed": stop_ret == 0,
+            "stop_issued_monotonic": stop_issued_monotonic,
+        }
+        if stop_error:
+            result["error"] = f"StopMove failed: {stop_error}"
+        return result
 
+    @motion_synchronized
     def do_stop_nav():
         nonlocal state, nav_cmd, speed_zone
         try:
@@ -323,6 +563,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             publish_event("nav_stopped", {"reason": "command"})
         return {"status": "stopped"}
 
+    @motion_synchronized
     def duration_expired():
         nonlocal state, current_cmd, speed_zone, move_timer
         move_timer = None
@@ -331,7 +572,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
 
     # ── LiDAR DDS Subscription ──
     def on_cloud(msg):
-        nonlocal obstacle_dist, obstacle_angle, lateral_obstacle
+        nonlocal obstacle_dist, obstacle_angle, lateral_obstacle, last_cloud_time
 
         # Get heading
         if state == MotionState.MOVING and current_cmd:
@@ -353,6 +594,8 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         n_valid = min(total_points, len(data) // point_step)
         if n_valid == 0:
             return
+        with safety_lock:
+            last_cloud_time = time.monotonic()
 
         # Numpy batch extraction (xyz at offsets 0, 4, 8 — already gravity-aligned)
         buf = np.frombuffer(data, dtype=np.uint8, count=n_valid * point_step).reshape(n_valid, point_step)
@@ -428,8 +671,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     motor_temp_stop = config.get("motor_temp_stop", 85)
 
     # Safety state
-    safety_lock = threading.Lock()
-    last_lowstate_time = time.monotonic()
+    last_lowstate_time = 0.0
     tilt_triggered = False
     foot_airborne_start = 0.0
     foot_force_seen_nonzero = False  # only enable airborne detection after seeing real force
@@ -437,13 +679,20 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     last_temp_check = 0.0
     stop_repeat_count = 0  # counter for repeated StopMove after emergency
 
+    @motion_synchronized
     def emergency_stop(reason_str, extra=None):
         """Emergency stop with optional damp mode for tilt."""
         nonlocal state, current_cmd, speed_zone, move_timer, stop_repeat_count
+        if current_cmd and current_cmd.get("source") == "velocity_proposal":
+            proposal_gate.disarm(f"{reason_str}_latched")
         if move_timer:
             move_timer.cancel()
             move_timer = None
-        loco_client.StopMove()
+        clear_proposal_execution()
+        try:
+            stop_loco_client.StopMove()
+        except Exception:
+            pass
         if reason_str == "tilt":
             try:
                 loco_client.SetFsmId(1)  # damp mode
@@ -471,23 +720,29 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         nonlocal last_lowstate_time, tilt_triggered, max_motor_temp, last_temp_check
 
         now = time.monotonic()
-        with safety_lock:
-            last_lowstate_time = now
-
         # Tilt detection (20Hz, every callback)
         imu = msg.imu_state
         roll = abs(float(imu.rpy[0]))
         pitch = abs(float(imu.rpy[1]))
+        is_tilted = roll > tilt_threshold or pitch > tilt_threshold
+        with safety_lock:
+            last_lowstate_time = now
+            was_tilted = tilt_triggered
+            tilt_triggered = is_tilted
 
-        if (roll > tilt_threshold or pitch > tilt_threshold):
-            if not tilt_triggered and state in (MotionState.MOVING, MotionState.NAVIGATING, MotionState.NAV_PAUSED):
-                tilt_triggered = True
-                emergency_stop("tilt", {
-                    "roll_deg": round(math.degrees(roll), 1),
-                    "pitch_deg": round(math.degrees(pitch), 1),
-                })
-        else:
-            tilt_triggered = False
+        if (
+            is_tilted
+            and not was_tilted
+            and state in (
+                MotionState.MOVING,
+                MotionState.NAVIGATING,
+                MotionState.NAV_PAUSED,
+            )
+        ):
+            emergency_stop("tilt", {
+                "roll_deg": round(math.degrees(roll), 1),
+                "pitch_deg": round(math.degrees(pitch), 1),
+            })
 
         # Joint temperature (1Hz check)
         if now - last_temp_check >= 1.0:
@@ -511,6 +766,17 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     # ── OdomState DDS Subscription (foot force) ──
     def on_odom(msg):
         nonlocal foot_airborne_start, foot_force_seen_nonzero
+        nonlocal last_odom_time, last_odom_motion
+
+        velocity = list(msg.velocity)
+        motion = (
+            float(velocity[0]) if len(velocity) > 0 else float("inf"),
+            float(velocity[1]) if len(velocity) > 1 else float("inf"),
+            float(msg.yaw_speed),
+        )
+        with safety_lock:
+            last_odom_time = time.monotonic()
+            last_odom_motion = motion
 
         if state != MotionState.MOVING:
             foot_airborne_start = 0.0
@@ -605,8 +871,95 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     except Exception as e:
         print(f"[SmartMotion:pid={os.getpid()}] WARNING: rt/slam_info subscribe failed: {e}")
 
+    def refresh_fsm_state():
+        nonlocal last_fsm_check, last_fsm_id, main_control_ready
+        try:
+            code, fsm_id = fsm_loco_client.GetFsmId()
+            ready = code == 0 and int(fsm_id) in proposal_allowed_fsm_ids
+        except Exception:
+            fsm_id = None
+            ready = False
+        with safety_lock:
+            last_fsm_check = time.monotonic()
+            last_fsm_id = fsm_id
+            main_control_ready = ready
+
+    def proposal_runtime_status(force_fsm_check=False):
+        """Return current Driver-owned readiness for proposal execution."""
+        if force_fsm_check:
+            refresh_fsm_state()
+        now = time.monotonic()
+        with safety_lock:
+            lowstate_age = now - last_lowstate_time if last_lowstate_time else float("inf")
+            odom_age = now - last_odom_time if last_odom_time else float("inf")
+            scan_age = now - last_cloud_time if last_cloud_time else float("inf")
+            nav_status_age = (
+                now - last_nav_status_time if last_nav_status_time else float("inf")
+            )
+            fsm_age = now - last_fsm_check if last_fsm_check else float("inf")
+            temperature = max_motor_temp
+            fsm_id = last_fsm_id
+            control_ready = main_control_ready
+            tilted = tilt_triggered
+
+        reason = ""
+        if not proposal_driver_authorized:
+            reason = "driver_execution_not_authorized"
+        elif lowstate_age > comm_timeout:
+            reason = "main_control_state_stale"
+        elif odom_age > proposal_odom_timeout:
+            reason = "odometry_stale"
+        elif scan_age > proposal_scan_timeout:
+            reason = "scan_stale"
+        elif tilted:
+            reason = "tilt_latched"
+        elif temperature > motor_temp_stop:
+            reason = "joint_overheat_latched"
+        elif nav_status_age > proposal_nav_status_timeout:
+            reason = "nav2_status_stale"
+        elif fsm_age > proposal_fsm_timeout:
+            reason = "main_control_status_stale"
+        elif not control_ready:
+            reason = "main_control_not_ready"
+
+        return {
+            "ready": not reason,
+            "reason": reason or None,
+            "fsm_id": fsm_id,
+            # In this G1 API, a fresh allowed locomotion FSM is the native
+            # fail-closed proxy for main-control/e-stop execution permission.
+            "emergency_stop_clear": control_ready and fsm_age <= proposal_fsm_timeout,
+            "lowstate_age_ms": None if not math.isfinite(lowstate_age) else round(lowstate_age * 1000),
+            "odometry_age_ms": None if not math.isfinite(odom_age) else round(odom_age * 1000),
+            "scan_age_ms": None if not math.isfinite(scan_age) else round(scan_age * 1000),
+            "nav2_status_age_ms": None if not math.isfinite(nav_status_age) else round(nav_status_age * 1000),
+            "fsm_age_ms": None if not math.isfinite(fsm_age) else round(fsm_age * 1000),
+        }
+
+    def confirm_robot_stopped(timeout, not_before):
+        """Confirm StopMove using a fresh near-zero measured odometry sample."""
+        deadline = time.monotonic() + timeout
+        while True:
+            now = time.monotonic()
+            with safety_lock:
+                odom_time = last_odom_time
+                vx, vy, yaw = last_odom_motion
+            if (
+                odom_time
+                and odom_time >= not_before
+                and now - odom_time <= proposal_odom_timeout
+                and abs(vx) <= proposal_stop_linear_epsilon
+                and abs(vy) <= proposal_stop_linear_epsilon
+                and abs(yaw) <= proposal_stop_yaw_epsilon
+            ):
+                return True
+            if now >= deadline:
+                return False
+            time.sleep(min(0.02, deadline - now))
+
     # ── Command handlers ──
-    def handle_move(vx, vy, vyaw, duration):
+    @motion_synchronized
+    def handle_move(vx, vy, vyaw, duration, finite_rpc=False, source="mcp"):
         nonlocal state, current_cmd, speed_zone, move_timer
 
         if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
@@ -617,7 +970,12 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
 
         previous = None
         if state == MotionState.MOVING and current_cmd:
-            previous = {"vx": current_cmd["vx"], "vy": current_cmd["vy"], "vyaw": current_cmd["vyaw"]}
+            previous = {
+                "vx": current_cmd["vx"],
+                "vy": current_cmd["vy"],
+                "vyaw": current_cmd["vyaw"],
+                "source": current_cmd.get("source", "mcp"),
+            }
 
         clamped_vx, clamped_vy, clamped_vyaw = clamp(vx, vy, vyaw, SpeedZone.NORMAL)
 
@@ -626,29 +984,68 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             "vx": vx, "vy": vy, "vyaw": vyaw,
             "duration": duration, "start_time": now,
             "end_time": (now + duration) if duration > 0 else None,
+            "source": source,
         }
         state = MotionState.MOVING
         speed_zone = SpeedZone.NORMAL
 
-        ret = loco_client.Move(clamped_vx, clamped_vy, clamped_vyaw, True)
+        proposal_generation = None
+        if finite_rpc:
+            proposal_generation = arm_proposal_execution(
+                time.monotonic() + duration
+            )
+            ret = proposal_loco_client.SetVelocity(
+                clamped_vx, clamped_vy, clamped_vyaw, duration
+            )
+        else:
+            clear_proposal_execution()
+            ret = loco_client.Move(clamped_vx, clamped_vy, clamped_vyaw, True)
 
-        if duration > 0:
+        watchdog_reason = (
+            proposal_fault_for_generation(proposal_generation)
+            if proposal_generation is not None
+            else ""
+        )
+        if watchdog_reason:
+            return {
+                "ret": ret,
+                "duration": duration,
+                "state": state.value,
+                "watchdog_reason": watchdog_reason,
+            }
+
+        if duration > 0 and not finite_rpc:
             move_timer = threading.Timer(duration, duration_expired)
             move_timer.start()
 
-        if previous:
+        if previous and not (
+            source == "velocity_proposal"
+            and previous.get("source") == "velocity_proposal"
+        ):
             publish_event("new_command", {
                 "previous": previous,
-                "new": {"vx": clamped_vx, "vy": clamped_vy, "vyaw": clamped_vyaw},
+                "new": {
+                    "vx": clamped_vx,
+                    "vy": clamped_vy,
+                    "vyaw": clamped_vyaw,
+                    "source": source,
+                },
             })
-        else:
+        elif not previous:
             publish_event("motion_start", {
-                "params": {"vx": clamped_vx, "vy": clamped_vy, "vyaw": clamped_vyaw, "duration": duration},
+                "params": {
+                    "vx": clamped_vx,
+                    "vy": clamped_vy,
+                    "vyaw": clamped_vyaw,
+                    "duration": duration,
+                    "source": source,
+                },
             })
 
         return {"ret": ret, "vx": clamped_vx, "vy": clamped_vy, "vyaw": clamped_vyaw,
                 "duration": duration, "state": state.value}
 
+    @motion_synchronized
     def handle_navigate_to(x, y, yaw, target_name, speed=0.5, mode=1, stall_timeout=60):
         nonlocal state, nav_cmd, speed_zone, nav_arrived_flag, nav_arrived_error
 
@@ -776,6 +1173,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         print(f"[SmartMotion] wait_nav_done: state changed to {state.value}", flush=True)
         return {"status": "stopped", "state": state.value}
 
+    @motion_synchronized
     def handle_pause_nav(reason_str):
         nonlocal state
         if state != MotionState.NAVIGATING:
@@ -789,6 +1187,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         publish_event("nav_paused", event_data)
         return {"status": "paused"} if code == 0 else {"error": f"PauseNav failed, code={code}"}
 
+    @motion_synchronized
     def handle_resume_nav():
         nonlocal state
         if state != MotionState.NAV_PAUSED:
@@ -798,6 +1197,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         publish_event("nav_resumed", {})
         return {"status": "resumed"} if code == 0 else {"error": f"ResumeNav failed, code={code}"}
 
+    @motion_synchronized
     def handle_get_state():
         result = {"state": state.value, "speed_zone": speed_zone.value}
         if current_cmd and state == MotionState.MOVING:
@@ -809,7 +1209,221 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             result["lateral_obstacle"] = lateral_obstacle
         return result
 
+    @motion_synchronized
+    def handle_bind_velocity_proposal(topic):
+        # A proposal stream and Unitree native navigation may never own motion
+        # at the same time.
+        if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
+            do_stop_nav()
+        if proposal_gate.connected_topic or proposal_node.topic:
+            stopped = handle_unbind_velocity_proposal("proposal_rebind")
+            if not stopped.get("stop_confirmed"):
+                return {
+                    "error": "StopMove was not confirmed before proposal rebind",
+                    "connected": False,
+                    "stop_confirmed": False,
+                }
+        else:
+            stopped = do_stop("proposal_bind")
+            physically_stopped = (
+                stopped.get("stop_confirmed")
+                and confirm_robot_stopped(
+                    proposal_stop_confirm_timeout,
+                    stopped["stop_issued_monotonic"],
+                )
+            )
+            if not physically_stopped:
+                return {
+                    "error": "StopMove/odometry stop was not confirmed before proposal bind",
+                    "connected": False,
+                    "stop_confirmed": False,
+                }
+        if not proposal_enabled:
+            return {"error": "velocity_proposal_execution_disabled", "connected": False}
+        if not proposal_driver_authorized:
+            return {"error": "driver_execution_not_authorized", "connected": False}
+        if topic != expected_proposal_topic:
+            return {
+                "error": "unexpected_velocity_proposal_topic",
+                "expected_topic": expected_proposal_topic,
+                "connected": False,
+            }
+        try:
+            proposal_node.bind(topic, on_velocity_proposal)
+            proposal_gate.bind(topic)
+            proposal_connected.set()
+            refresh_fsm_state()
+        except Exception as exc:
+            proposal_gate.unbind("subscription_create_failed")
+            proposal_connected.clear()
+            proposal_node.unbind()
+            try:
+                stop_loco_client.StopMove()
+            except Exception:
+                pass
+            return {"error": f"velocity_proposal_subscribe_failed: {exc}", "connected": False}
+        result = handle_get_velocity_proposal_status()
+        result["state"] = "connected"
+        return result
+
+    @motion_synchronized
+    def handle_unbind_velocity_proposal(reason="canvas_stop"):
+        # N5 ordering: command and observe physical stop before destroying the
+        # only proposal subscription.
+        if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
+            do_stop_nav()
+        stopped = do_stop(reason)
+        for _ in range(2):
+            if stopped.get("stop_confirmed"):
+                break
+            try:
+                stop_ret = issue_stop_move()
+            except Exception as exc:
+                stopped["error"] = f"StopMove failed: {exc}"
+            else:
+                stopped["ret"] = stop_ret
+                stopped["stop_confirmed"] = stop_ret == 0
+            finally:
+                stopped["stop_issued_monotonic"] = time.monotonic()
+        stopped["stop_confirmed"] = bool(
+            stopped.get("stop_confirmed")
+            and confirm_robot_stopped(
+                proposal_stop_confirm_timeout,
+                stopped["stop_issued_monotonic"],
+            )
+        )
+        if not stopped["stop_confirmed"]:
+            proposal_gate.disarm("stop_unconfirmed")
+            proposal_connected.clear()
+            return {
+                "state": "error",
+                "connected": bool(proposal_node.topic),
+                "armed": False,
+                "stop_confirmed": False,
+                "subscriber_retained": bool(proposal_node.topic),
+                "reason": reason,
+                "error": stopped.get("error") or "fresh zero-odometry stop was not confirmed",
+            }
+        proposal_gate.unbind(reason)
+        proposal_connected.clear()
+        proposal_node.unbind()
+        return {
+            "state": "idle",
+            "connected": False,
+            "stop_confirmed": True,
+            "reason": reason,
+            **({"error": stopped["error"]} if stopped.get("error") else {}),
+        }
+
+    @motion_synchronized
+    def handle_get_velocity_proposal_status():
+        result = proposal_gate.snapshot(time.monotonic())
+        result.update({
+            "enabled": proposal_enabled,
+            "canvas_running": proposal_connected.is_set(),
+            "driver_authorized": bool(
+                proposal_driver_authorized
+                and proposal_gate.connected_topic
+                and proposal_gate.armed
+            ),
+            "expected_topic": expected_proposal_topic,
+            "schema": proposal_limits.schema,
+            "safety": proposal_runtime_status(force_fsm_check=False),
+        })
+        return result
+
+    @motion_synchronized
+    def on_velocity_proposal(msg):
+        nonlocal last_nav_status_time
+        now = time.monotonic()
+        pending_fault = current_proposal_watchdog_fault()
+        if pending_fault:
+            _, reason = pending_fault
+            if reason == "proposal_ttl_expired":
+                proposal_gate.watchdog(now)
+                do_stop(reason)
+            else:
+                proposal_gate.disarm(reason)
+                do_stop(reason)
+                return
+        try:
+            payload = json.loads(msg.data)
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            if proposal_gate.armed:
+                proposal_gate.disarm("invalid_json")
+                do_stop("invalid_json")
+            return
+
+        was_armed = proposal_gate.armed
+        decision = proposal_gate.accept(payload, now)
+        if decision.stop:
+            is_proposal_motion = bool(
+                current_cmd and current_cmd.get("source") == "velocity_proposal"
+            )
+            newly_disarmed = was_armed and not proposal_gate.armed
+            if decision.proposal is not None or is_proposal_motion or newly_disarmed:
+                do_stop(decision.reason)
+            return
+        if not decision.execute or decision.proposal is None:
+            return
+
+        with safety_lock:
+            last_nav_status_time = now
+
+        # Refresh the Unitree controller state immediately before every
+        # physical command; do not authorize from a cached FSM sample.
+        runtime = proposal_runtime_status(force_fsm_check=True)
+        if not runtime["ready"]:
+            reason = runtime["reason"] or "driver_safety_not_ready"
+            proposal_gate.disarm(reason)
+            do_stop(reason)
+            return
+
+        proposal = decision.proposal
+        remaining = proposal_gate.deadline_monotonic - time.monotonic()
+        if remaining <= 0.0:
+            proposal_gate.watchdog(time.monotonic())
+            do_stop("proposal_ttl_expired")
+            return
+        result = handle_move(
+            proposal.x,
+            proposal.y,
+            proposal.yaw,
+            remaining,
+            finite_rpc=True,
+            source="velocity_proposal",
+        )
+        watchdog_reason = result.get("watchdog_reason")
+        if watchdog_reason:
+            if watchdog_reason != "proposal_ttl_expired":
+                proposal_gate.disarm(watchdog_reason)
+            else:
+                proposal_gate.watchdog(time.monotonic())
+            do_stop(watchdog_reason)
+            return
+        ret = result.get("ret")
+        if ret not in (None, 0):
+            proposal_gate.disarm("set_velocity_failed")
+            do_stop("set_velocity_failed")
+
+    @motion_synchronized
+    def apply_safety_velocity(cmd, vx, vy, vyaw):
+        """Preserve a proposal's finite firmware lease during deceleration."""
+        if cmd and cmd.get("source") == "velocity_proposal":
+            remaining = proposal_gate.deadline_monotonic - time.monotonic()
+            if remaining <= 0.0:
+                proposal_gate.watchdog(time.monotonic())
+                do_stop("proposal_ttl_expired")
+                return
+            ret = proposal_loco_client.SetVelocity(vx, vy, vyaw, remaining)
+            if ret != 0:
+                proposal_gate.disarm("set_velocity_failed")
+                do_stop("set_velocity_failed")
+            return
+        loco_client.Move(vx, vy, vyaw, True)
+
     # ── Safety checks (inline in main loop) ──
+    @motion_synchronized
     def process_safety_checks():
         nonlocal state, speed_zone
 
@@ -832,7 +1446,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     speed_zone = SpeedZone.DECELERATED
                     if current_cmd:
                         dvx, dvy, dvyaw = clamp(current_cmd["vx"], current_cmd["vy"], current_cmd["vyaw"], SpeedZone.DECELERATED)
-                        loco_client.Move(dvx, dvy, dvyaw, True)
+                        apply_safety_velocity(current_cmd, dvx, dvy, dvyaw)
                         publish_event("joint_overheat", {
                             "max_temp": round(temp, 1),
                             "action": "decelerate",
@@ -858,7 +1472,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     print(f"[SmartMotion:obstacle] DECEL — dist={dist:.2f}m angle={math.degrees(obstacle_angle):.1f}° lateral={lateral}", flush=True)
                     if cmd:
                         dvx, dvy, dvyaw = clamp(cmd["vx"], cmd["vy"], cmd["vyaw"], SpeedZone.DECELERATED)
-                        loco_client.Move(dvx, dvy, dvyaw, True)
+                        apply_safety_velocity(cmd, dvx, dvy, dvyaw)
                         with obstacle_lock:
                             od = obstacle_dist
                             oa = obstacle_angle
@@ -873,7 +1487,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     speed_zone = SpeedZone.NORMAL
                     if cmd:
                         cvx, cvy, cvyaw = clamp(cmd["vx"], cmd["vy"], cmd["vyaw"], SpeedZone.NORMAL)
-                        loco_client.Move(cvx, cvy, cvyaw, True)
+                        apply_safety_velocity(cmd, cvx, cvy, cvyaw)
                         publish_event("motion_resume", {"speed": {"vx": cvx, "vy": cvy, "vyaw": cvyaw}})
 
         elif state == MotionState.NAVIGATING:
@@ -895,39 +1509,147 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                 print(f"[SmartMotion:nav_obstacle] RESUME NAV — "
                       f"dist={dist:.2f}m, obstacle cleared", flush=True)
 
+    def fsm_monitor_loop():
+        """Poll main-control authorization independently of proposal callbacks."""
+        while not safety_threads_shutdown.is_set():
+            if not proposal_connected.wait(timeout=0.05):
+                continue
+            refresh_fsm_state()
+            if safety_threads_shutdown.wait(proposal_fsm_check_interval):
+                break
+
+    def proposal_watchdog_loop():
+        """At >=20 Hz, physically stop an active proposal on TTL or fault."""
+        nonlocal proposal_execution_active, proposal_watchdog_fault
+        period = 1.0 / proposal_watchdog_hz
+        while not safety_threads_shutdown.wait(period):
+            now = time.monotonic()
+            with proposal_execution_lock:
+                if not proposal_execution_active:
+                    continue
+                generation = proposal_execution_generation
+                deadline = proposal_execution_deadline
+            reason = "proposal_ttl_expired" if now >= deadline else ""
+            if not reason:
+                runtime = proposal_runtime_status(force_fsm_check=False)
+                if not runtime["ready"]:
+                    reason = runtime["reason"] or "driver_safety_not_ready"
+            if not reason:
+                continue
+            with proposal_execution_lock:
+                if (
+                    not proposal_execution_active
+                    or generation != proposal_execution_generation
+                ):
+                    continue
+                proposal_execution_active = False
+                proposal_watchdog_fault = (generation, reason)
+            try:
+                watchdog_loco_client.StopMove()
+            except Exception:
+                pass
+
+    def consume_proposal_watchdog_fault():
+        with proposal_execution_lock:
+            fault = proposal_watchdog_fault
+        if not fault:
+            return
+        generation, reason = fault
+        with proposal_execution_lock:
+            if generation != proposal_execution_generation:
+                return
+        with motion_command_lock:
+            if reason == "proposal_ttl_expired":
+                proposal_gate.watchdog(time.monotonic())
+            else:
+                proposal_gate.disarm(reason)
+            do_stop(reason)
+
     # ── Main loop ──
+    fsm_monitor_thread = threading.Thread(
+        target=fsm_monitor_loop,
+        daemon=True,
+        name="g1_loco_fsm_monitor",
+    )
+    proposal_watchdog_thread = threading.Thread(
+        target=proposal_watchdog_loop,
+        daemon=True,
+        name="g1_loco_velocity_watchdog",
+    )
+    fsm_monitor_thread.start()
+    proposal_watchdog_thread.start()
     print(f"[SmartMotion:pid={os.getpid()}] entering main loop")
     running = True
     last_obstacle_check = 0.0
     last_slam_info_log = 0.0
 
     while running:
+        try:
+            consume_proposal_watchdog_fault()
+        except Exception as exc:
+            with motion_command_lock:
+                proposal_gate.disarm("watchdog_fault_handler_error")
+                try:
+                    stop_loco_client.StopMove()
+                except Exception:
+                    pass
+            print(
+                f"[SmartMotion] watchdog fault handling failed closed: {exc}",
+                flush=True,
+            )
         # Process commands (non-blocking)
+        cmd = None
         try:
             cmd = cmd_queue.get(timeout=0.05)
             method = cmd.get("method")
             result = None
 
             if method == "move":
-                result = handle_move(cmd["vx"], cmd["vy"], cmd["vyaw"], cmd["duration"])
+                with motion_command_lock:
+                    proposal_gate.disarm("manual_override")
+                    result = handle_move(
+                        cmd["vx"], cmd["vy"], cmd["vyaw"], cmd["duration"],
+                        source="mcp",
+                    )
             elif method == "stop":
-                result = do_stop(cmd.get("reason", "command"))
+                with motion_command_lock:
+                    proposal_gate.disarm("manual_stop")
+                    if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
+                        do_stop_nav()
+                    result = do_stop(cmd.get("reason", "command"))
             elif method == "navigate_to":
-                result = handle_navigate_to(cmd["x"], cmd["y"], cmd["yaw"],
-                                            cmd.get("target_name", ""),
-                                            speed=cmd.get("speed", 0.5),
-                                            mode=cmd.get("mode", 1),
-                                            stall_timeout=cmd.get("stall_timeout", 60))
+                with motion_command_lock:
+                    proposal_gate.disarm("native_navigation_override")
+                    result = handle_navigate_to(
+                        cmd["x"], cmd["y"], cmd["yaw"],
+                        cmd.get("target_name", ""),
+                        speed=cmd.get("speed", 0.5),
+                        mode=cmd.get("mode", 1),
+                        stall_timeout=cmd.get("stall_timeout", 60),
+                    )
             elif method == "pause_nav":
                 result = handle_pause_nav(cmd.get("reason", "command"))
             elif method == "resume_nav":
                 result = handle_resume_nav()
             elif method == "stop_nav":
-                result = do_stop_nav()
+                with motion_command_lock:
+                    proposal_gate.disarm("native_stop_nav")
+                    if state == MotionState.MOVING:
+                        result = do_stop("native_stop_nav")
+                    else:
+                        result = do_stop_nav()
             elif method == "wait_nav_done":
                 result = handle_wait_nav_done(cmd.get("stall_timeout", 60))
             elif method == "get_state":
                 result = handle_get_state()
+            elif method == "bind_velocity_proposal":
+                result = handle_bind_velocity_proposal(cmd.get("topic", ""))
+            elif method == "unbind_velocity_proposal":
+                result = handle_unbind_velocity_proposal(
+                    cmd.get("reason", "canvas_stop")
+                )
+            elif method == "get_velocity_proposal_status":
+                result = handle_get_velocity_proposal_status()
             elif method == "start_mapping":
                 code, resp = slam_client.StartMapping()
                 result = {"code": code, "response": resp}
@@ -948,31 +1670,54 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                 )
                 result = {"code": code, "response": resp}
             elif method == "shutdown":
-                if state == MotionState.MOVING:
-                    loco_client.StopMove()
-                elif state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
-                    try:
-                        slam_client.PauseNav()
-                    except Exception:
-                        pass
+                handle_unbind_velocity_proposal("process_shutdown")
                 running = False
                 result = {"status": "shutdown"}
+            else:
+                result = {"error": f"unknown SmartMotion method: {method}"}
 
             if result is not None:
                 result["_req_id"] = cmd.get("_req_id")
                 result_queue.put(result)
         except queue.Empty:
             pass
+        except Exception as exc:
+            with motion_command_lock:
+                proposal_gate.disarm("smart_motion_command_error")
+                try:
+                    stop_loco_client.StopMove()
+                except Exception:
+                    pass
+            if cmd is not None:
+                result_queue.put({
+                    "_req_id": cmd.get("_req_id"),
+                    "error": f"SmartMotion command failed: {exc}",
+                })
 
         # Safety checks at 10Hz
         now = time.monotonic()
         if now - last_obstacle_check >= 0.1:
             last_obstacle_check = now
-            process_safety_checks()
+            try:
+                process_safety_checks()
+            except Exception as exc:
+                with motion_command_lock:
+                    proposal_gate.disarm("safety_check_error")
+                    try:
+                        stop_loco_client.StopMove()
+                    except Exception:
+                        pass
+                print(
+                    f"[SmartMotion] safety check failed closed: {exc}",
+                    flush=True,
+                )
 
             # Repeat StopMove after emergency_stop to ensure controller receives it
             if stop_repeat_count > 0 and state == MotionState.IDLE:
-                loco_client.StopMove()
+                try:
+                    stop_loco_client.StopMove()
+                except Exception:
+                    pass
                 stop_repeat_count -= 1
 
         # Periodic health log: verify slam_info subscription is working
@@ -982,11 +1727,30 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                   f"pos_info={slam_info_pos_count} state={state.value}", flush=True)
 
         # Spin ROS2 (non-blocking)
-        executor.spin_once(timeout_sec=0)
+        try:
+            executor.spin_once(timeout_sec=0)
+        except Exception as exc:
+            with motion_command_lock:
+                proposal_gate.disarm("proposal_callback_error")
+                do_stop("proposal_callback_error")
+            print(f"[SmartMotion] ROS callback failed: {exc}", flush=True)
 
     # Cleanup
+    safety_threads_shutdown.set()
+    proposal_connected.clear()
+    proposal_watchdog_thread.join(timeout=0.5)
+    fsm_monitor_thread.join(timeout=0.75)
     if move_timer:
         move_timer.cancel()
+    with motion_command_lock:
+        stopped = do_stop("process_exit")
+        if stopped.get("stop_confirmed"):
+            stopped["stop_confirmed"] = confirm_robot_stopped(
+                proposal_stop_confirm_timeout,
+                stopped["stop_issued_monotonic"],
+            )
+        proposal_gate.unbind("process_exit")
+        proposal_node.unbind()
     executor.shutdown()
     rclpy.shutdown()
     print(f"[SmartMotion:pid={os.getpid()}] shutdown complete")

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -25,6 +25,7 @@ import queue
 import struct
 import threading
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -90,6 +91,7 @@ class OdomStopMonitor:
         self._last_time = 0.0
         self._last_velocity = (float("inf"), float("inf"), float("inf"))
         self._callback_count = 0
+        self._callback_history = deque(maxlen=4096)
 
     def record(self, velocity, received_monotonic=None):
         received = (
@@ -104,6 +106,7 @@ class OdomStopMonitor:
             self._last_time = received
             self._last_velocity = motion
             self._callback_count += 1
+            self._callback_history.append((received, self._callback_count))
             self._condition.notify_all()
 
     def begin_confirmation(self):
@@ -128,6 +131,15 @@ class OdomStopMonitor:
                 "velocity": self._last_velocity,
                 "callback_count": self._callback_count,
             }
+
+    def callback_count_at(self, observed_monotonic):
+        """Return the last callback count observed at or before a timestamp."""
+        boundary = float(observed_monotonic)
+        with self._condition:
+            for received, callback_count in reversed(self._callback_history):
+                if received <= boundary:
+                    return callback_count
+            return 0
 
     def wait_for_stopped(
         self,
@@ -213,30 +225,24 @@ class OdomStopMonitor:
         return confirmed, diagnostics
 
 
-def issue_stop_and_confirm(
-    stop_move,
+def finish_stop_confirmation(
     monitor,
+    start,
+    stop_move_ret,
+    stop_move_error,
+    stop_move_completed_monotonic,
     timeout,
     max_age,
     linear_epsilon,
     yaw_epsilon,
     after_stop_attempt=None,
 ):
-    """Issue a bounded StopMove and require a subsequent measured zero frame."""
-    start = monitor.begin_confirmation()
-    stop_move_ret = None
-    stop_move_error = None
-    try:
-        stop_move_ret = stop_move()
-    except Exception as exc:
-        stop_move_error = str(exc)
-    finally:
-        stop_move_completed_monotonic = time.monotonic()
-        callbacks_at_stop_move_completion = monitor.latest(
-            stop_move_completed_monotonic
-        )["callback_count"]
-        if after_stop_attempt is not None:
-            after_stop_attempt()
+    """Confirm an acknowledged StopMove against post-boundary odometry."""
+    callbacks_at_stop_move_completion = monitor.callback_count_at(
+        stop_move_completed_monotonic
+    )
+    if after_stop_attempt is not None:
+        after_stop_attempt()
 
     stop_confirmed, diagnostics = monitor.wait_for_stopped(
         start=start,
@@ -262,29 +268,36 @@ def issue_stop_and_confirm(
     return result
 
 
-def resolve_proposal_stop_timeouts(proposal_config):
-    """Keep StopMove acknowledgement bounded within the odometry budget."""
-    confirmation_timeout = min(
-        1.0,
-        max(
-            0.1,
-            float(
-                proposal_config.get(
-                    "velocity_proposal_stop_confirm_timeout",
-                    0.5,
-                )
-            ),
-        ),
+def issue_stop_and_confirm(
+    stop_move,
+    monitor,
+    timeout,
+    max_age,
+    linear_epsilon,
+    yaw_epsilon,
+    after_stop_attempt=None,
+):
+    """Issue a bounded StopMove and require a subsequent measured zero frame."""
+    start = monitor.begin_confirmation()
+    stop_move_ret = None
+    stop_move_error = None
+    try:
+        stop_move_ret = stop_move()
+    except Exception as exc:
+        stop_move_error = str(exc)
+    stop_move_completed_monotonic = time.monotonic()
+    return finish_stop_confirmation(
+        monitor=monitor,
+        start=start,
+        stop_move_ret=stop_move_ret,
+        stop_move_error=stop_move_error,
+        stop_move_completed_monotonic=stop_move_completed_monotonic,
+        timeout=timeout,
+        max_age=max_age,
+        linear_epsilon=linear_epsilon,
+        yaw_epsilon=yaw_epsilon,
+        after_stop_attempt=after_stop_attempt,
     )
-    requested_rpc_timeout = float(
-        proposal_config.get("velocity_proposal_stop_rpc_timeout", 0.2)
-    )
-    # G1 cfb8efe hardware returned StopMove in about 111 ms.  A 100 ms
-    # client timeout therefore produced SDK code 3104 even while fresh zero
-    # odometry continued to arrive.  Preserve a bounded margin without ever
-    # extending beyond the physical-stop confirmation budget.
-    rpc_timeout = min(confirmation_timeout, max(0.2, requested_rpc_timeout))
-    return rpc_timeout, confirmation_timeout
 
 
 # ── SmartMotionProxy (main process) ─────────────────────────────────────────
@@ -298,7 +311,7 @@ class SmartMotionProxy:
         ctx = mp.get_context("spawn")
         self._cmd_queue = ctx.Queue()
         self._result_queue = ctx.Queue()
-        self._call_lock = threading.Lock()
+        self._call_lock = threading.RLock()
         self._request_id = 0
         self._proc = ctx.Process(
             target=_run_smart_motion_process,
@@ -391,6 +404,42 @@ class SmartMotionProxy:
             self._proc.terminate()
             self._proc.join(timeout=1.0)
 
+    def _call_with_parent_stop(self, method: str, **kwargs) -> dict:
+        """Bracket a parent-side StopMove with child odometry confirmation."""
+        with self._call_lock:
+            prepared = self._call("begin_velocity_proposal_stop_confirmation")
+            confirmation_start = prepared.get("confirmation_start")
+            stop_move_ret = None
+            stop_move_error = None
+            try:
+                if self._fallback_stop is None:
+                    raise RuntimeError("parent StopMove RPC is unavailable")
+                stop_move_ret = self._fallback_stop()
+            except Exception as exc:
+                stop_move_error = str(exc)
+            stop_move_completed_monotonic = time.monotonic()
+
+            if not confirmation_start:
+                return {
+                    "error": prepared.get("error")
+                    or "SmartMotion stop confirmation did not start",
+                    "stop_confirmed": False,
+                    "stop_move_ret": stop_move_ret,
+                    "stop_move_error": stop_move_error,
+                }
+            return self._call(
+                method,
+                external_stop_attempt={
+                    "confirmation_start": confirmation_start,
+                    "stop_move_ret": stop_move_ret,
+                    "stop_move_error": stop_move_error,
+                    "stop_move_completed_monotonic": (
+                        stop_move_completed_monotonic
+                    ),
+                },
+                **kwargs,
+            )
+
     def move(self, vx: float, vy: float, vyaw: float, duration: float = -1.0) -> dict:
         return self._call("move", vx=vx, vy=vy, vyaw=vyaw, duration=duration)
 
@@ -419,14 +468,17 @@ class SmartMotionProxy:
         return self._call("get_state")
 
     def bind_velocity_proposal(self, topic: str, expected_nav_id: str) -> dict:
-        return self._call(
+        return self._call_with_parent_stop(
             "bind_velocity_proposal",
             topic=topic,
             expected_nav_id=expected_nav_id,
         )
 
     def unbind_velocity_proposal(self, reason: str = "canvas_stop") -> dict:
-        return self._call("unbind_velocity_proposal", reason=reason)
+        return self._call_with_parent_stop(
+            "unbind_velocity_proposal",
+            reason=reason,
+        )
 
     def get_velocity_proposal_status(self) -> dict:
         return self._call("get_velocity_proposal_status")
@@ -507,8 +559,17 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     proposal_rpc_timeout = min(
         0.2, max(0.02, float(proposal_config.get("velocity_proposal_rpc_timeout", 0.1)))
     )
-    stop_rpc_timeout, proposal_stop_confirm_timeout = (
-        resolve_proposal_stop_timeouts(proposal_config)
+    stop_rpc_timeout = min(
+        0.2,
+        max(
+            0.02,
+            float(
+                proposal_config.get(
+                    "velocity_proposal_stop_rpc_timeout",
+                    0.1,
+                )
+            ),
+        ),
     )
     fsm_rpc_timeout = min(
         0.5, max(0.05, float(proposal_config.get("velocity_proposal_fsm_rpc_timeout", 0.2)))
@@ -615,6 +676,18 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     proposal_watchdog_hz = max(
         20.0, float(proposal_config.get("velocity_proposal_watchdog_hz", 40.0))
     )
+    proposal_stop_confirm_timeout = min(
+        1.0,
+        max(
+            0.1,
+            float(
+                proposal_config.get(
+                    "velocity_proposal_stop_confirm_timeout",
+                    0.5,
+                )
+            ),
+        ),
+    )
     proposal_stop_linear_epsilon = max(
         0.0, float(proposal_config.get("velocity_proposal_stop_linear_epsilon", 0.03))
     )
@@ -642,6 +715,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     motion_command_lock = threading.RLock()
     proposal_execution_lock = threading.Lock()
     proposal_connected = threading.Event()
+    proposal_stop_transition = threading.Event()
     safety_threads_shutdown = threading.Event()
     proposal_execution_generation = 0
     proposal_execution_active = False
@@ -717,7 +791,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         return stop_loco_client.StopMove()
 
     @motion_synchronized
-    def do_stop(reason_str, confirm_physical_stop=False):
+    def do_stop(
+        reason_str,
+        confirm_physical_stop=False,
+        external_stop_attempt=None,
+    ):
         nonlocal state, current_cmd, speed_zone, move_timer, stop_repeat_count
         was_proposal_motion = bool(
             current_cmd and current_cmd.get("source") == "velocity_proposal"
@@ -736,15 +814,42 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             stop_repeat_count = 3  # repeat StopMove to ensure controller stops
 
         if confirm_physical_stop:
-            result = issue_stop_and_confirm(
-                issue_stop_move,
-                odom_stop_monitor,
-                proposal_stop_confirm_timeout,
-                proposal_odom_timeout,
-                proposal_stop_linear_epsilon,
-                proposal_stop_yaw_epsilon,
-                after_stop_attempt=complete_logical_stop,
-            )
+            if external_stop_attempt is not None:
+                start_data = external_stop_attempt["confirmation_start"]
+                result = finish_stop_confirmation(
+                    monitor=odom_stop_monitor,
+                    start=StopConfirmationStart(
+                        monotonic=float(start_data["monotonic"]),
+                        unix_ms=int(start_data["unix_ms"]),
+                        odometry_callback_count=int(
+                            start_data["odometry_callback_count"]
+                        ),
+                    ),
+                    stop_move_ret=external_stop_attempt.get("stop_move_ret"),
+                    stop_move_error=external_stop_attempt.get(
+                        "stop_move_error"
+                    ),
+                    stop_move_completed_monotonic=float(
+                        external_stop_attempt[
+                            "stop_move_completed_monotonic"
+                        ]
+                    ),
+                    timeout=proposal_stop_confirm_timeout,
+                    max_age=proposal_odom_timeout,
+                    linear_epsilon=proposal_stop_linear_epsilon,
+                    yaw_epsilon=proposal_stop_yaw_epsilon,
+                    after_stop_attempt=complete_logical_stop,
+                )
+            else:
+                result = issue_stop_and_confirm(
+                    issue_stop_move,
+                    odom_stop_monitor,
+                    proposal_stop_confirm_timeout,
+                    proposal_odom_timeout,
+                    proposal_stop_linear_epsilon,
+                    proposal_stop_yaw_epsilon,
+                    after_stop_attempt=complete_logical_stop,
+                )
         else:
             stop_ret = None
             stop_error = None
@@ -1412,29 +1517,87 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         return result
 
     @motion_synchronized
-    def handle_bind_velocity_proposal(topic, expected_nav_id):
+    def handle_begin_velocity_proposal_stop_confirmation():
+        # Freeze proposal execution before the responsive parent RpcProxy
+        # issues StopMove.  Keep the subscription until zero odometry is
+        # confirmed so teardown remains fail-closed.
+        if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
+            do_stop_nav()
+        proposal_stop_transition.set()
+        proposal_connected.clear()
+        clear_proposal_execution()
+        start = odom_stop_monitor.begin_confirmation()
+        return {
+            "confirmation_start": {
+                "monotonic": start.monotonic,
+                "unix_ms": start.unix_ms,
+                "odometry_callback_count": start.odometry_callback_count,
+            }
+        }
+
+    @motion_synchronized
+    def handle_bind_velocity_proposal(
+        topic,
+        expected_nav_id,
+        external_stop_attempt=None,
+    ):
         try:
             expected_nav_id = resolve_expected_nav_id(
                 {"expected_nav_id": expected_nav_id}
             )
         except ValueError as exc:
+            stopped = do_stop(
+                str(exc),
+                confirm_physical_stop=True,
+                external_stop_attempt=external_stop_attempt,
+            )
             proposal_gate.disarm(str(exc))
-            do_stop(str(exc))
+            diagnostics = stopped.get("stop_confirmation") or {}
             return {
                 "error": str(exc),
                 "connected": bool(proposal_node.topic),
                 "armed": False,
+                "stop_confirmed": stopped.get("stop_confirmed", False),
+                "stop_move_ret": diagnostics.get("stop_move_ret"),
+                "stop_move_error": diagnostics.get("stop_move_error"),
+                "stop_confirmation": diagnostics,
             }
         if proposal_gate.is_bound_to(topic, expected_nav_id):
+            stopped = do_stop(
+                "proposal_bind_existing",
+                confirm_physical_stop=True,
+                external_stop_attempt=external_stop_attempt,
+            )
+            if not stopped.get("stop_confirmed"):
+                proposal_gate.disarm("stop_unconfirmed")
+                diagnostics = stopped.get("stop_confirmation") or {}
+                return {
+                    "error": "StopMove/odometry stop was not confirmed before proposal bind",
+                    "connected": bool(proposal_node.topic),
+                    "armed": False,
+                    "stop_confirmed": False,
+                    "stop_move_ret": diagnostics.get("stop_move_ret"),
+                    "stop_move_error": diagnostics.get("stop_move_error"),
+                    "stop_confirmation": diagnostics,
+                }
+            proposal_connected.set()
+            proposal_stop_transition.clear()
             result = handle_get_velocity_proposal_status()
             result["state"] = "connected"
+            result["stop_confirmed"] = True
+            result["stop_move_ret"] = stopped.get("ret")
+            result["stop_move_error"] = (
+                (stopped.get("stop_confirmation") or {}).get(
+                    "stop_move_error"
+                )
+            )
+            result["stop_confirmation"] = stopped.get("stop_confirmation")
             return result
-        # A proposal stream and Unitree native navigation may never own motion
-        # at the same time.
-        if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
-            do_stop_nav()
         if proposal_gate.connected_topic or proposal_node.topic:
-            stopped = handle_unbind_velocity_proposal("proposal_rebind")
+            stopped = handle_unbind_velocity_proposal(
+                "proposal_rebind",
+                external_stop_attempt=external_stop_attempt,
+            )
             if not stopped.get("stop_confirmed"):
                 return {
                     "error": "StopMove was not confirmed before proposal rebind",
@@ -1445,7 +1608,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     "stop_confirmation": stopped.get("stop_confirmation"),
                 }
         else:
-            stopped = do_stop("proposal_bind", confirm_physical_stop=True)
+            stopped = do_stop(
+                "proposal_bind",
+                confirm_physical_stop=True,
+                external_stop_attempt=external_stop_attempt,
+            )
             if not stopped.get("stop_confirmed"):
                 diagnostics = stopped.get("stop_confirmation") or {}
                 return {
@@ -1480,6 +1647,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             except Exception:
                 pass
             return {"error": f"velocity_proposal_subscribe_failed: {exc}", "connected": False}
+        proposal_stop_transition.clear()
         result = handle_get_velocity_proposal_status()
         result["state"] = "connected"
         result["stop_confirmed"] = True
@@ -1489,13 +1657,23 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         return result
 
     @motion_synchronized
-    def handle_unbind_velocity_proposal(reason="canvas_stop"):
+    def handle_unbind_velocity_proposal(
+        reason="canvas_stop",
+        external_stop_attempt=None,
+    ):
         # N5 ordering: command and observe physical stop before destroying the
         # only proposal subscription.
-        if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
+        if (
+            external_stop_attempt is None
+            and state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED)
+        ):
             do_stop_nav()
-        stopped = do_stop(reason, confirm_physical_stop=True)
-        for _ in range(2):
+        stopped = do_stop(
+            reason,
+            confirm_physical_stop=True,
+            external_stop_attempt=external_stop_attempt,
+        )
+        for _ in range(2 if external_stop_attempt is None else 0):
             # Preserve the original retry contract: retry rejected/failed RPC
             # attempts, but do not mask a measured nonzero or odom timeout by
             # issuing more StopMove calls.
@@ -1549,6 +1727,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             "canvas_running": proposal_connected.is_set(),
             "driver_authorized": bool(
                 proposal_driver_authorized
+                and not proposal_stop_transition.is_set()
                 and proposal_gate.connected_topic
                 and proposal_gate.armed
             ),
@@ -1561,6 +1740,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     @motion_synchronized
     def on_velocity_proposal(msg):
         nonlocal last_nav_status_time
+        if proposal_stop_transition.is_set():
+            return
         now = time.monotonic()
         pending_fault = current_proposal_watchdog_fault()
         if pending_fault:
@@ -1868,15 +2049,29 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 result = handle_wait_nav_done(cmd.get("stall_timeout", 60))
             elif method == "get_state":
                 result = handle_get_state()
+            elif method == "begin_velocity_proposal_stop_confirmation":
+                result = handle_begin_velocity_proposal_stop_confirmation()
             elif method == "bind_velocity_proposal":
-                result = handle_bind_velocity_proposal(
-                    cmd.get("topic", ""),
-                    cmd.get("expected_nav_id", ""),
-                )
+                try:
+                    result = handle_bind_velocity_proposal(
+                        cmd.get("topic", ""),
+                        cmd.get("expected_nav_id", ""),
+                        external_stop_attempt=cmd.get(
+                            "external_stop_attempt"
+                        ),
+                    )
+                finally:
+                    proposal_stop_transition.clear()
             elif method == "unbind_velocity_proposal":
-                result = handle_unbind_velocity_proposal(
-                    cmd.get("reason", "canvas_stop")
-                )
+                try:
+                    result = handle_unbind_velocity_proposal(
+                        cmd.get("reason", "canvas_stop"),
+                        external_stop_attempt=cmd.get(
+                            "external_stop_attempt"
+                        ),
+                    )
+                finally:
+                    proposal_stop_transition.clear()
             elif method == "get_velocity_proposal_status":
                 result = handle_get_velocity_proposal_status()
             elif method == "start_mapping":
@@ -1913,6 +2108,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         except Exception as exc:
             with motion_command_lock:
                 proposal_gate.disarm("smart_motion_command_error")
+                proposal_stop_transition.clear()
                 try:
                     stop_loco_client.StopMove()
                 except Exception:

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -262,6 +262,31 @@ def issue_stop_and_confirm(
     return result
 
 
+def resolve_proposal_stop_timeouts(proposal_config):
+    """Keep StopMove acknowledgement bounded within the odometry budget."""
+    confirmation_timeout = min(
+        1.0,
+        max(
+            0.1,
+            float(
+                proposal_config.get(
+                    "velocity_proposal_stop_confirm_timeout",
+                    0.5,
+                )
+            ),
+        ),
+    )
+    requested_rpc_timeout = float(
+        proposal_config.get("velocity_proposal_stop_rpc_timeout", 0.2)
+    )
+    # G1 cfb8efe hardware returned StopMove in about 111 ms.  A 100 ms
+    # client timeout therefore produced SDK code 3104 even while fresh zero
+    # odometry continued to arrive.  Preserve a bounded margin without ever
+    # extending beyond the physical-stop confirmation budget.
+    rpc_timeout = min(confirmation_timeout, max(0.2, requested_rpc_timeout))
+    return rpc_timeout, confirmation_timeout
+
+
 # ── SmartMotionProxy (main process) ─────────────────────────────────────────
 
 class SmartMotionProxy:
@@ -482,8 +507,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     proposal_rpc_timeout = min(
         0.2, max(0.02, float(proposal_config.get("velocity_proposal_rpc_timeout", 0.1)))
     )
-    stop_rpc_timeout = min(
-        0.2, max(0.02, float(proposal_config.get("velocity_proposal_stop_rpc_timeout", 0.1)))
+    stop_rpc_timeout, proposal_stop_confirm_timeout = (
+        resolve_proposal_stop_timeouts(proposal_config)
     )
     fsm_rpc_timeout = min(
         0.5, max(0.05, float(proposal_config.get("velocity_proposal_fsm_rpc_timeout", 0.2)))
@@ -589,10 +614,6 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     )
     proposal_watchdog_hz = max(
         20.0, float(proposal_config.get("velocity_proposal_watchdog_hz", 40.0))
-    )
-    proposal_stop_confirm_timeout = min(
-        1.0,
-        max(0.1, float(proposal_config.get("velocity_proposal_stop_confirm_timeout", 0.5))),
     )
     proposal_stop_linear_epsilon = max(
         0.0, float(proposal_config.get("velocity_proposal_stop_linear_epsilon", 0.03))

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -5,7 +5,8 @@ drivers/unitree/g1/safety_harness.py — SmartMotion 独立进程安全层。
 架构：
   - SmartMotionProcess: 独立子进程，拥有自己的 DDS 通道和 ROS2 节点
     - 订阅 LiDAR 点云，10Hz 全量 numpy 处理
-    - 执行 LocoClient / SlamClient RPC 调用
+    - 在本地执行停止、FSM 和 SlamClient RPC
+    - 将安全判定通过的 proposal SetVelocity 有界交给主进程 Driver RPC
     - 发布运动事件到 ROS2 topic
   - SmartMotionProxy: 主进程中的轻量代理，通过 multiprocessing Queue 通信
     - 对外暴露与原 SmartMotion 相同的 API
@@ -300,6 +301,145 @@ def issue_stop_and_confirm(
     )
 
 
+@dataclass
+class ProposalApplyDiagnostics:
+    """Process-lifetime proposal receive/apply evidence for ``loco info``."""
+
+    received: int = 0
+    accepted: int = 0
+    rejected: int = 0
+    applied: int = 0
+    last_rejection_reason: Optional[str] = None
+    last_set_velocity_ret: Optional[int] = None
+    last_set_velocity_error: Optional[str] = None
+    last_set_velocity_request_id: Optional[int] = None
+    last_set_velocity_duration_ms: Optional[int] = None
+    last_set_velocity_completed_monotonic: Optional[float] = None
+    last_set_velocity_completed_unix_ms: Optional[int] = None
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock,
+        init=False,
+        repr=False,
+    )
+
+    def record_received(self) -> None:
+        with self._lock:
+            self.received += 1
+
+    def record_accepted(self) -> None:
+        with self._lock:
+            self.accepted += 1
+
+    def record_rejected(self, reason: str) -> None:
+        with self._lock:
+            self.rejected += 1
+            self.last_rejection_reason = reason
+
+    def record_set_velocity(self, result: dict, duration: float) -> None:
+        completed_monotonic = result.get("completed_monotonic")
+        completed_unix_ms = result.get("completed_unix_ms")
+        with self._lock:
+            self.last_set_velocity_ret = result.get("ret")
+            self.last_set_velocity_error = result.get("error")
+            self.last_set_velocity_request_id = result.get("request_id")
+            self.last_set_velocity_duration_ms = max(
+                0,
+                round(float(duration) * 1000),
+            )
+            self.last_set_velocity_completed_monotonic = (
+                float(completed_monotonic)
+                if completed_monotonic is not None
+                else None
+            )
+            self.last_set_velocity_completed_unix_ms = (
+                int(completed_unix_ms)
+                if completed_unix_ms is not None
+                else None
+            )
+
+    def record_applied(self) -> None:
+        with self._lock:
+            self.applied += 1
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            return {
+                "received": self.received,
+                "accepted": self.accepted,
+                "rejected": self.rejected,
+                "applied": self.applied,
+                "last_rejection_reason": self.last_rejection_reason,
+                "last_set_velocity_ret": self.last_set_velocity_ret,
+                "last_set_velocity_error": self.last_set_velocity_error,
+                "last_set_velocity_request_id": (
+                    self.last_set_velocity_request_id
+                ),
+                "last_set_velocity_duration_ms": (
+                    self.last_set_velocity_duration_ms
+                ),
+                "last_set_velocity_completed_monotonic": (
+                    self.last_set_velocity_completed_monotonic
+                ),
+                "last_set_velocity_completed_unix_ms": (
+                    self.last_set_velocity_completed_unix_ms
+                ),
+            }
+
+
+def request_parent_set_velocity(
+    request_queue,
+    result_queue,
+    request_id: int,
+    vx: float,
+    vy: float,
+    vyaw: float,
+    duration: float,
+    timeout: float,
+) -> dict:
+    """Request one finite SetVelocity from the parent and wait boundedly."""
+    started = time.monotonic()
+    try:
+        request_queue.put({
+            "request_id": request_id,
+            "vx": vx,
+            "vy": vy,
+            "vyaw": vyaw,
+            "duration": duration,
+        })
+    except Exception as exc:
+        return {
+            "request_id": request_id,
+            "ret": None,
+            "error": f"parent_set_velocity_ipc_error: {exc}",
+            "completed_monotonic": time.monotonic(),
+            "completed_unix_ms": round(time.time() * 1000),
+        }
+
+    deadline = started + max(0.0, float(timeout))
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0.0:
+            return {
+                "request_id": request_id,
+                "ret": None,
+                "error": "parent_set_velocity_timeout",
+                "completed_monotonic": time.monotonic(),
+                "completed_unix_ms": round(time.time() * 1000),
+            }
+        try:
+            result = result_queue.get(timeout=remaining)
+        except queue.Empty:
+            return {
+                "request_id": request_id,
+                "ret": None,
+                "error": "parent_set_velocity_timeout",
+                "completed_monotonic": time.monotonic(),
+                "completed_unix_ms": round(time.time() * 1000),
+            }
+        if result.get("request_id") == request_id:
+            return result
+
+
 # ── SmartMotionProxy (main process) ─────────────────────────────────────────
 
 class SmartMotionProxy:
@@ -307,20 +447,32 @@ class SmartMotionProxy:
 
     def __init__(self, namespace: str, config: dict, network_iface: str,
                  proposal_config: Optional[dict] = None,
-                 fallback_stop=None):
+                 fallback_stop=None, parent_set_velocity=None):
         ctx = mp.get_context("spawn")
         self._cmd_queue = ctx.Queue()
         self._result_queue = ctx.Queue()
+        self._parent_velocity_queue = ctx.Queue()
+        self._parent_velocity_result_queue = ctx.Queue()
         self._call_lock = threading.RLock()
         self._request_id = 0
+        self._fallback_stop = fallback_stop
+        self._parent_set_velocity = parent_set_velocity
+        self._parent_velocity_shutdown = threading.Event()
         self._proc = ctx.Process(
             target=_run_smart_motion_process,
             args=(namespace, config, proposal_config or {}, network_iface,
-                  self._cmd_queue, self._result_queue),
+                  self._cmd_queue, self._result_queue,
+                  self._parent_velocity_queue,
+                  self._parent_velocity_result_queue),
             name="smart_motion", daemon=True,
         )
         self._proc.start()
-        self._fallback_stop = fallback_stop
+        self._parent_velocity_thread = threading.Thread(
+            target=self._serve_parent_velocity_requests,
+            daemon=True,
+            name="smart_motion_parent_velocity",
+        )
+        self._parent_velocity_thread.start()
         self._exit_monitor = threading.Thread(
             target=self._monitor_process_exit,
             daemon=True,
@@ -361,6 +513,42 @@ class SmartMotionProxy:
             except Exception:
                 continue
 
+    def _serve_parent_velocity_requests(self) -> None:
+        """Execute child-approved SetVelocity calls on the parent RpcProxy."""
+        while True:
+            request = self._parent_velocity_queue.get()
+            if request is None:
+                return
+            request_id = request.get("request_id")
+            ret = None
+            error = None
+            try:
+                if self._parent_set_velocity is None:
+                    raise RuntimeError("parent SetVelocity RPC is unavailable")
+                ret = self._parent_set_velocity(
+                    request["vx"],
+                    request["vy"],
+                    request["vyaw"],
+                    request["duration"],
+                )
+            except Exception as exc:
+                error = str(exc)
+            self._parent_velocity_result_queue.put({
+                "request_id": request_id,
+                "ret": ret,
+                "error": error,
+                "completed_monotonic": time.monotonic(),
+                "completed_unix_ms": round(time.time() * 1000),
+            })
+
+    def _signal_parent_velocity_shutdown(self) -> None:
+        shutdown = getattr(self, "_parent_velocity_shutdown", None)
+        request_queue = getattr(self, "_parent_velocity_queue", None)
+        if shutdown is None or request_queue is None or shutdown.is_set():
+            return
+        shutdown.set()
+        request_queue.put(None)
+
     def _monitor_process_exit(self) -> None:
         """Issue an independent parent-side stop on every child exit.
 
@@ -369,15 +557,16 @@ class SmartMotionProxy:
         after an IPC timeout, where Python cleanup cannot be relied upon.
         """
         self._proc.join()
-        if self._fallback_stop is None:
-            return
         try:
-            self._fallback_stop()
+            if self._fallback_stop is not None:
+                self._fallback_stop()
         except Exception as exc:
             print(
                 f"[SmartMotionProxy] child-exit StopMove failed: {exc}",
                 flush=True,
             )
+        finally:
+            self._signal_parent_velocity_shutdown()
 
     def _call(self, method: str, timeout: float = 15.0, **kwargs) -> dict:
         """Send a correlated command without serializing independent callers."""
@@ -508,6 +697,8 @@ class SmartMotionProxy:
         # Ensure the parent-side child-exit StopMove completes before the
         # caller tears down the independent RpcProxy used by that callback.
         self._exit_monitor.join(timeout=2.0)
+        self._signal_parent_velocity_shutdown()
+        self._parent_velocity_thread.join(timeout=2.0)
         print("[SmartMotionProxy] subprocess stopped")
 
 
@@ -515,7 +706,9 @@ class SmartMotionProxy:
 
 def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dict,
                               network_iface: str, cmd_queue: mp.Queue,
-                              result_queue: mp.Queue):
+                              result_queue: mp.Queue,
+                              parent_velocity_queue: mp.Queue,
+                              parent_velocity_result_queue: mp.Queue):
     """Entry point for the SmartMotion subprocess.
 
     Initializes its own DDS channel, RPC clients, ROS2 node, and LiDAR subscription.
@@ -554,8 +747,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     loco_client.Init()
     loco_client.SetTimeout(10.0)
 
-    # Proposal execution, stopping, watchdog stopping and FSM polling use
-    # independent RPC clients so a delayed call cannot block physical stop.
+    # Proposal execution is deliberately routed back through the parent
+    # Driver RpcProxy.  Stopping, watchdog stopping and FSM polling retain
+    # independent child clients so a delayed apply cannot block fail-closed
+    # stop paths.
     proposal_rpc_timeout = min(
         0.2, max(0.02, float(proposal_config.get("velocity_proposal_rpc_timeout", 0.1)))
     )
@@ -574,9 +769,6 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     fsm_rpc_timeout = min(
         0.5, max(0.05, float(proposal_config.get("velocity_proposal_fsm_rpc_timeout", 0.2)))
     )
-    proposal_loco_client = LocoClient()
-    proposal_loco_client.Init()
-    proposal_loco_client.SetTimeout(proposal_rpc_timeout)
     stop_loco_client = LocoClient()
     stop_loco_client.Init()
     stop_loco_client.SetTimeout(stop_rpc_timeout)
@@ -591,7 +783,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     slam_client.Init()
     slam_client.SetTimeout(10.0)  # must be AFTER Init() — Init() resets timeout to 5.0
 
-    print(f"[SmartMotion:pid={os.getpid()}] LocoClient + SlamClient ready")
+    print(
+        f"[SmartMotion:pid={os.getpid()}] stop/FSM LocoClient + "
+        "parent proposal RPC + SlamClient ready"
+    )
 
     # ── Initialize ROS2 ──
     rclpy.init()
@@ -721,6 +916,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     proposal_execution_active = False
     proposal_execution_deadline = 0.0
     proposal_watchdog_fault = None
+    proposal_apply_request_id = 0
+    proposal_apply_diagnostics = ProposalApplyDiagnostics()
 
     def motion_synchronized(func):
         def locked(*args, **kwargs):
@@ -756,6 +953,22 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     def current_proposal_watchdog_fault():
         with proposal_execution_lock:
             return proposal_watchdog_fault
+
+    def apply_parent_set_velocity(vx, vy, vyaw, duration):
+        nonlocal proposal_apply_request_id
+        proposal_apply_request_id += 1
+        result = request_parent_set_velocity(
+            request_queue=parent_velocity_queue,
+            result_queue=parent_velocity_result_queue,
+            request_id=proposal_apply_request_id,
+            vx=vx,
+            vy=vy,
+            vyaw=vyaw,
+            duration=duration,
+            timeout=proposal_rpc_timeout,
+        )
+        proposal_apply_diagnostics.record_set_velocity(result, duration)
+        return result
 
     # Obstacle state (written by LiDAR callback, read by main loop)
     obstacle_lock = threading.Lock()
@@ -1297,13 +1510,16 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         speed_zone = SpeedZone.NORMAL
 
         proposal_generation = None
+        set_velocity_error = None
         if finite_rpc:
             proposal_generation = arm_proposal_execution(
                 time.monotonic() + duration
             )
-            ret = proposal_loco_client.SetVelocity(
+            apply_result = apply_parent_set_velocity(
                 clamped_vx, clamped_vy, clamped_vyaw, duration
             )
+            ret = apply_result.get("ret")
+            set_velocity_error = apply_result.get("error")
         else:
             clear_proposal_execution()
             ret = loco_client.Move(clamped_vx, clamped_vy, clamped_vyaw, True)
@@ -1319,6 +1535,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 "duration": duration,
                 "state": state.value,
                 "watchdog_reason": watchdog_reason,
+                "set_velocity_error": set_velocity_error,
             }
 
         if duration > 0 and not finite_rpc:
@@ -1349,8 +1566,15 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 },
             })
 
-        return {"ret": ret, "vx": clamped_vx, "vy": clamped_vy, "vyaw": clamped_vyaw,
-                "duration": duration, "state": state.value}
+        return {
+            "ret": ret,
+            "vx": clamped_vx,
+            "vy": clamped_vy,
+            "vyaw": clamped_vyaw,
+            "duration": duration,
+            "state": state.value,
+            "set_velocity_error": set_velocity_error,
+        }
 
     @motion_synchronized
     def handle_navigate_to(x, y, yaw, target_name, speed=0.5, mode=1, stall_timeout=60):
@@ -1734,28 +1958,33 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             "expected_topic": expected_proposal_topic,
             "schema": proposal_limits.schema,
             "safety": proposal_runtime_status(force_fsm_check=False),
+            "proposal_execution": proposal_apply_diagnostics.snapshot(),
         })
         return result
 
     @motion_synchronized
     def on_velocity_proposal(msg):
         nonlocal last_nav_status_time
+        proposal_apply_diagnostics.record_received()
         if proposal_stop_transition.is_set():
+            proposal_apply_diagnostics.record_rejected("stop_transition")
             return
         now = time.monotonic()
         pending_fault = current_proposal_watchdog_fault()
         if pending_fault:
             _, reason = pending_fault
+            proposal_apply_diagnostics.record_rejected(reason)
             if reason == "proposal_ttl_expired":
                 proposal_gate.watchdog(now)
                 do_stop(reason)
             else:
                 proposal_gate.disarm(reason)
                 do_stop(reason)
-                return
+            return
         try:
             payload = json.loads(msg.data)
         except (json.JSONDecodeError, TypeError, AttributeError):
+            proposal_apply_diagnostics.record_rejected("invalid_json")
             if proposal_gate.armed:
                 proposal_gate.disarm("invalid_json")
                 do_stop("invalid_json")
@@ -1764,6 +1993,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         was_armed = proposal_gate.armed
         decision = proposal_gate.accept(payload, now)
         if decision.stop:
+            if decision.reason != "proposal_zero":
+                proposal_apply_diagnostics.record_rejected(decision.reason)
             is_proposal_motion = bool(
                 current_cmd and current_cmd.get("source") == "velocity_proposal"
             )
@@ -1772,6 +2003,9 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 do_stop(decision.reason)
             return
         if not decision.execute or decision.proposal is None:
+            proposal_apply_diagnostics.record_rejected(
+                decision.reason or "proposal_not_executable"
+            )
             return
 
         with safety_lock:
@@ -1782,6 +2016,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         runtime = proposal_runtime_status(force_fsm_check=True)
         if not runtime["ready"]:
             reason = runtime["reason"] or "driver_safety_not_ready"
+            proposal_apply_diagnostics.record_rejected(reason)
             proposal_gate.disarm(reason)
             do_stop(reason)
             return
@@ -1789,9 +2024,13 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         proposal = decision.proposal
         remaining = proposal_gate.deadline_monotonic - time.monotonic()
         if remaining <= 0.0:
+            proposal_apply_diagnostics.record_rejected(
+                "proposal_ttl_expired"
+            )
             proposal_gate.watchdog(time.monotonic())
             do_stop("proposal_ttl_expired")
             return
+        proposal_apply_diagnostics.record_accepted()
         result = handle_move(
             proposal.x,
             proposal.y,
@@ -1802,6 +2041,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         )
         watchdog_reason = result.get("watchdog_reason")
         if watchdog_reason:
+            proposal_apply_diagnostics.record_rejected(watchdog_reason)
             if watchdog_reason != "proposal_ttl_expired":
                 proposal_gate.disarm(watchdog_reason)
             else:
@@ -1809,9 +2049,18 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             do_stop(watchdog_reason)
             return
         ret = result.get("ret")
-        if ret not in (None, 0):
-            proposal_gate.disarm("set_velocity_failed")
-            do_stop("set_velocity_failed")
+        set_velocity_error = result.get("set_velocity_error")
+        if set_velocity_error or ret != 0:
+            reason = (
+                "parent_set_velocity_timeout"
+                if set_velocity_error == "parent_set_velocity_timeout"
+                else "set_velocity_failed"
+            )
+            proposal_apply_diagnostics.record_rejected(reason)
+            proposal_gate.disarm(reason)
+            do_stop(reason)
+            return
+        proposal_apply_diagnostics.record_applied()
 
     @motion_synchronized
     def apply_safety_velocity(cmd, vx, vy, vyaw):
@@ -1822,10 +2071,16 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 proposal_gate.watchdog(time.monotonic())
                 do_stop("proposal_ttl_expired")
                 return
-            ret = proposal_loco_client.SetVelocity(vx, vy, vyaw, remaining)
-            if ret != 0:
-                proposal_gate.disarm("set_velocity_failed")
-                do_stop("set_velocity_failed")
+            result = apply_parent_set_velocity(vx, vy, vyaw, remaining)
+            if result.get("error") or result.get("ret") != 0:
+                reason = (
+                    "parent_set_velocity_timeout"
+                    if result.get("error") == "parent_set_velocity_timeout"
+                    else "set_velocity_failed"
+                )
+                proposal_apply_diagnostics.record_rejected(reason)
+                proposal_gate.disarm(reason)
+                do_stop(reason)
             return
         loco_client.Move(vx, vy, vyaw, True)
 

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -5,8 +5,8 @@ drivers/unitree/g1/safety_harness.py — SmartMotion 独立进程安全层。
 架构：
   - SmartMotionProcess: 独立子进程，拥有自己的 DDS 通道和 ROS2 节点
     - 订阅 LiDAR 点云，10Hz 全量 numpy 处理
-    - 在本地执行停止、FSM 和 SlamClient RPC
-    - 将安全判定通过的 proposal SetVelocity 有界交给主进程 Driver RPC
+    - 在本地执行停止和 SlamClient RPC
+    - 将 proposal SetVelocity 和 FSM GetFsmId 有界交给主进程 Driver RPC
     - 发布运动事件到 ROS2 topic
   - SmartMotionProxy: 主进程中的轻量代理，通过 multiprocessing Queue 通信
     - 对外暴露与原 SmartMotion 相同的 API
@@ -386,31 +386,24 @@ class ProposalApplyDiagnostics:
             }
 
 
-def request_parent_set_velocity(
+def _request_parent_loco_rpc(
     request_queue,
     result_queue,
-    request_id: int,
-    vx: float,
-    vy: float,
-    vyaw: float,
-    duration: float,
+    request: dict,
     timeout: float,
+    timeout_error: str,
+    ipc_error_prefix: str,
 ) -> dict:
-    """Request one finite SetVelocity from the parent and wait boundedly."""
+    """Send one correlated parent Loco RPC request and wait boundedly."""
     started = time.monotonic()
+    request_id = request["request_id"]
     try:
-        request_queue.put({
-            "request_id": request_id,
-            "vx": vx,
-            "vy": vy,
-            "vyaw": vyaw,
-            "duration": duration,
-        })
+        request_queue.put(request)
     except Exception as exc:
         return {
             "request_id": request_id,
             "ret": None,
-            "error": f"parent_set_velocity_ipc_error: {exc}",
+            "error": f"{ipc_error_prefix}: {exc}",
             "completed_monotonic": time.monotonic(),
             "completed_unix_ms": round(time.time() * 1000),
         }
@@ -422,7 +415,7 @@ def request_parent_set_velocity(
             return {
                 "request_id": request_id,
                 "ret": None,
-                "error": "parent_set_velocity_timeout",
+                "error": timeout_error,
                 "completed_monotonic": time.monotonic(),
                 "completed_unix_ms": round(time.time() * 1000),
             }
@@ -432,12 +425,60 @@ def request_parent_set_velocity(
             return {
                 "request_id": request_id,
                 "ret": None,
-                "error": "parent_set_velocity_timeout",
+                "error": timeout_error,
                 "completed_monotonic": time.monotonic(),
                 "completed_unix_ms": round(time.time() * 1000),
             }
         if result.get("request_id") == request_id:
             return result
+
+
+def request_parent_set_velocity(
+    request_queue,
+    result_queue,
+    request_id: int,
+    vx: float,
+    vy: float,
+    vyaw: float,
+    duration: float,
+    timeout: float,
+) -> dict:
+    """Request one finite SetVelocity from the parent and wait boundedly."""
+    return _request_parent_loco_rpc(
+        request_queue,
+        result_queue,
+        request={
+            "method": "set_velocity",
+            "request_id": request_id,
+            "vx": vx,
+            "vy": vy,
+            "vyaw": vyaw,
+            "duration": duration,
+        },
+        timeout=timeout,
+        timeout_error="parent_set_velocity_timeout",
+        ipc_error_prefix="parent_set_velocity_ipc_error",
+    )
+
+
+def request_parent_get_fsm_id(
+    request_queue,
+    result_queue,
+    request_id: int,
+    timeout: float,
+) -> dict:
+    """Request one fail-closed GetFsmId sample from the parent RpcProxy."""
+    return _request_parent_loco_rpc(
+        request_queue,
+        result_queue,
+        request={
+            "method": "get_fsm_id",
+            "request_id": request_id,
+        },
+        timeout=timeout,
+        timeout_error="parent_get_fsm_id_timeout",
+        ipc_error_prefix="parent_get_fsm_id_ipc_error",
+    )
 
 
 # ── SmartMotionProxy (main process) ─────────────────────────────────────────
@@ -447,7 +488,8 @@ class SmartMotionProxy:
 
     def __init__(self, namespace: str, config: dict, network_iface: str,
                  proposal_config: Optional[dict] = None,
-                 fallback_stop=None, parent_set_velocity=None):
+                 fallback_stop=None, parent_set_velocity=None,
+                 parent_get_fsm_id=None):
         ctx = mp.get_context("spawn")
         self._cmd_queue = ctx.Queue()
         self._result_queue = ctx.Queue()
@@ -457,6 +499,7 @@ class SmartMotionProxy:
         self._request_id = 0
         self._fallback_stop = fallback_stop
         self._parent_set_velocity = parent_set_velocity
+        self._parent_get_fsm_id = parent_get_fsm_id
         self._parent_velocity_shutdown = threading.Event()
         self._proc = ctx.Process(
             target=_run_smart_motion_process,
@@ -514,28 +557,50 @@ class SmartMotionProxy:
                 continue
 
     def _serve_parent_velocity_requests(self) -> None:
-        """Execute child-approved SetVelocity calls on the parent RpcProxy."""
+        """Execute child-approved Loco calls on the parent RpcProxy."""
         while True:
             request = self._parent_velocity_queue.get()
             if request is None:
                 return
             request_id = request.get("request_id")
+            method = request.get("method", "set_velocity")
             ret = None
+            fsm_id = None
             error = None
             try:
-                if self._parent_set_velocity is None:
-                    raise RuntimeError("parent SetVelocity RPC is unavailable")
-                ret = self._parent_set_velocity(
-                    request["vx"],
-                    request["vy"],
-                    request["vyaw"],
-                    request["duration"],
-                )
+                if method == "set_velocity":
+                    if self._parent_set_velocity is None:
+                        raise RuntimeError(
+                            "parent SetVelocity RPC is unavailable"
+                        )
+                    ret = self._parent_set_velocity(
+                        request["vx"],
+                        request["vy"],
+                        request["vyaw"],
+                        request["duration"],
+                    )
+                elif method == "get_fsm_id":
+                    if self._parent_get_fsm_id is None:
+                        raise RuntimeError(
+                            "parent GetFsmId RPC is unavailable"
+                        )
+                    result = self._parent_get_fsm_id()
+                    if not isinstance(result, (list, tuple)) or len(result) != 2:
+                        raise RuntimeError(
+                            "parent GetFsmId returned an invalid result"
+                        )
+                    ret, fsm_id = result
+                else:
+                    raise RuntimeError(
+                        f"unsupported parent Loco RPC method: {method}"
+                    )
             except Exception as exc:
                 error = str(exc)
             self._parent_velocity_result_queue.put({
+                "method": method,
                 "request_id": request_id,
                 "ret": ret,
+                "fsm_id": fsm_id,
                 "error": error,
                 "completed_monotonic": time.monotonic(),
                 "completed_unix_ms": round(time.time() * 1000),
@@ -747,10 +812,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     loco_client.Init()
     loco_client.SetTimeout(10.0)
 
-    # Proposal execution is deliberately routed back through the parent
-    # Driver RpcProxy.  Stopping, watchdog stopping and FSM polling retain
-    # independent child clients so a delayed apply cannot block fail-closed
-    # stop paths.
+    # Proposal execution and its FSM authorization are deliberately routed
+    # through the parent Driver RpcProxy. Stopping and watchdog stopping keep
+    # independent child clients so a delayed parent RPC cannot block the
+    # fail-closed stop paths.
     proposal_rpc_timeout = min(
         0.2, max(0.02, float(proposal_config.get("velocity_proposal_rpc_timeout", 0.1)))
     )
@@ -775,17 +840,13 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     watchdog_loco_client = LocoClient()
     watchdog_loco_client.Init()
     watchdog_loco_client.SetTimeout(stop_rpc_timeout)
-    fsm_loco_client = LocoClient()
-    fsm_loco_client.Init()
-    fsm_loco_client.SetTimeout(fsm_rpc_timeout)
-
     slam_client = SlamClient()
     slam_client.Init()
     slam_client.SetTimeout(10.0)  # must be AFTER Init() — Init() resets timeout to 5.0
 
     print(
-        f"[SmartMotion:pid={os.getpid()}] stop/FSM LocoClient + "
-        "parent proposal RPC + SlamClient ready"
+        f"[SmartMotion:pid={os.getpid()}] stop LocoClient + "
+        "parent proposal/FSM RPC + SlamClient ready"
     )
 
     # ── Initialize ROS2 ──
@@ -903,6 +964,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     last_cloud_time = 0.0
     last_fsm_check = 0.0
     last_fsm_id = None
+    last_fsm_ret = None
+    last_fsm_error = None
     main_control_ready = False
     last_nav_status_time = 0.0
     odom_stop_monitor = OdomStopMonitor()
@@ -916,7 +979,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     proposal_execution_active = False
     proposal_execution_deadline = 0.0
     proposal_watchdog_fault = None
-    proposal_apply_request_id = 0
+    parent_loco_request_id = 0
+    parent_loco_rpc_lock = threading.Lock()
     proposal_apply_diagnostics = ProposalApplyDiagnostics()
 
     def motion_synchronized(func):
@@ -955,20 +1019,34 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             return proposal_watchdog_fault
 
     def apply_parent_set_velocity(vx, vy, vyaw, duration):
-        nonlocal proposal_apply_request_id
-        proposal_apply_request_id += 1
-        result = request_parent_set_velocity(
-            request_queue=parent_velocity_queue,
-            result_queue=parent_velocity_result_queue,
-            request_id=proposal_apply_request_id,
-            vx=vx,
-            vy=vy,
-            vyaw=vyaw,
-            duration=duration,
-            timeout=proposal_rpc_timeout,
-        )
+        nonlocal parent_loco_request_id
+        # The FSM monitor and proposal callback share one request/result pair.
+        # Serialize them so one waiter cannot consume the other's reply.
+        with parent_loco_rpc_lock:
+            parent_loco_request_id += 1
+            result = request_parent_set_velocity(
+                request_queue=parent_velocity_queue,
+                result_queue=parent_velocity_result_queue,
+                request_id=parent_loco_request_id,
+                vx=vx,
+                vy=vy,
+                vyaw=vyaw,
+                duration=duration,
+                timeout=proposal_rpc_timeout,
+            )
         proposal_apply_diagnostics.record_set_velocity(result, duration)
         return result
+
+    def query_parent_fsm_id():
+        nonlocal parent_loco_request_id
+        with parent_loco_rpc_lock:
+            parent_loco_request_id += 1
+            return request_parent_get_fsm_id(
+                request_queue=parent_velocity_queue,
+                result_queue=parent_velocity_result_queue,
+                request_id=parent_loco_request_id,
+                timeout=fsm_rpc_timeout,
+            )
 
     # Obstacle state (written by LiDAR callback, read by main loop)
     obstacle_lock = threading.Lock()
@@ -1411,16 +1489,29 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         print(f"[SmartMotion:pid={os.getpid()}] WARNING: rt/slam_info subscribe failed: {e}")
 
     def refresh_fsm_state():
-        nonlocal last_fsm_check, last_fsm_id, main_control_ready
+        nonlocal last_fsm_check, last_fsm_id, last_fsm_ret
+        nonlocal last_fsm_error, main_control_ready
+        fsm_id = None
+        ret = None
+        error = None
         try:
-            code, fsm_id = fsm_loco_client.GetFsmId()
-            ready = code == 0 and int(fsm_id) in proposal_allowed_fsm_ids
-        except Exception:
-            fsm_id = None
+            result = query_parent_fsm_id()
+            ret = result.get("ret")
+            fsm_id = result.get("fsm_id")
+            error = result.get("error")
+            ready = (
+                error is None
+                and ret == 0
+                and int(fsm_id) in proposal_allowed_fsm_ids
+            )
+        except Exception as exc:
+            error = str(exc)
             ready = False
         with safety_lock:
             last_fsm_check = time.monotonic()
             last_fsm_id = fsm_id
+            last_fsm_ret = ret
+            last_fsm_error = error
             main_control_ready = ready
 
     def proposal_runtime_status(force_fsm_check=False):
@@ -1438,6 +1529,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             fsm_age = now - last_fsm_check if last_fsm_check else float("inf")
             temperature = max_motor_temp
             fsm_id = last_fsm_id
+            fsm_ret = last_fsm_ret
+            fsm_error = last_fsm_error
             control_ready = main_control_ready
             tilted = tilt_triggered
         odom_age = odom["age"]
@@ -1457,6 +1550,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             reason = "joint_overheat_latched"
         elif nav_status_age > proposal_nav_status_timeout:
             reason = "nav2_status_stale"
+        elif fsm_error is not None or (fsm_ret is not None and fsm_ret != 0):
+            reason = "main_control_rpc_failed"
         elif fsm_age > proposal_fsm_timeout:
             reason = "main_control_status_stale"
         elif not control_ready:
@@ -1466,6 +1561,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             "ready": not reason,
             "reason": reason or None,
             "fsm_id": fsm_id,
+            "fsm_ret": fsm_ret,
+            "fsm_error": fsm_error,
             # In this G1 API, a fresh allowed locomotion FSM is the native
             # fail-closed proxy for main-control/e-stop execution permission.
             "emergency_stop_clear": control_ready and fsm_age <= proposal_fsm_timeout,

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -38,6 +38,28 @@ from velocity_proposal import (
 )
 
 
+UNITREE_STOP_MOVE_DURATION_SECONDS = 1.0
+DEFAULT_STOP_CONFIRM_TIMEOUT_SECONDS = 2.0
+MAX_STOP_CONFIRM_TIMEOUT_SECONDS = 3.0
+
+
+def resolve_stop_confirmation_timeout(configured_timeout):
+    """Bound zero-odom confirmation around the G1 StopMove command.
+
+    unitree_sdk2py implements StopMove as SetVelocity(0, 0, 0) with the
+    default one-second duration.  The physical confirmation window must not
+    expire before that command can finish, while remaining fail-closed and
+    bounded against missing odometry.
+    """
+    return min(
+        MAX_STOP_CONFIRM_TIMEOUT_SECONDS,
+        max(
+            UNITREE_STOP_MOVE_DURATION_SECONDS,
+            float(configured_timeout),
+        ),
+    )
+
+
 # ── Enums & Data Classes (shared between processes) ──────────────────────────
 
 class MotionState(enum.Enum):
@@ -301,30 +323,237 @@ def issue_stop_and_confirm(
     )
 
 
+def aggregate_stop_attempts(attempts):
+    """Return the final stop result without discarding earlier evidence."""
+    if not attempts:
+        raise ValueError("at least one stop attempt is required")
+    result = dict(attempts[-1])
+    result["stop_attempt_count"] = len(attempts)
+    result["stop_attempts"] = [dict(attempt) for attempt in attempts]
+    return result
+
+
+class ProposalExecutionLease:
+    """Thread-safe deadline ownership for an applied velocity proposal.
+
+    A newly validated proposal may renew an already applied velocity while the
+    serialized parent RPC is still in flight.  It must not, however, activate
+    execution before the first SetVelocity call starts or revive a lease after
+    the watchdog has tripped.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._generation = 0
+        self._active = False
+        self._deadline = 0.0
+        self._fault = None
+
+    def arm(self, deadline: float) -> Optional[int]:
+        candidate = float(deadline)
+        with self._lock:
+            if self._fault is not None:
+                return None
+            self._generation += 1
+            if self._active:
+                self._deadline = max(self._deadline, candidate)
+            else:
+                self._deadline = candidate
+            self._active = True
+            return self._generation
+
+    def renew_if_active(self, deadline: float) -> bool:
+        """Renew an active lease; return false if a fault already won."""
+        candidate = float(deadline)
+        with self._lock:
+            if self._fault is not None:
+                return False
+            if self._active:
+                self._deadline = max(self._deadline, candidate)
+            return True
+
+    def clear(self) -> None:
+        with self._lock:
+            self._generation += 1
+            self._active = False
+            self._deadline = 0.0
+            self._fault = None
+
+    def fault_for_generation(self, generation: int) -> str:
+        with self._lock:
+            if self._fault and self._fault[0] == generation:
+                return self._fault[1]
+            return ""
+
+    def current_fault(self):
+        with self._lock:
+            return self._fault
+
+    def watchdog_snapshot(self):
+        with self._lock:
+            if not self._active:
+                return None
+            return self._generation, self._deadline
+
+    def trip(self, generation: int, reason: str, now: float) -> bool:
+        """Atomically trip only if the observed lease is still due/faulted."""
+        with self._lock:
+            if not self._active or generation != self._generation:
+                return False
+            if reason == "proposal_ttl_expired" and now < self._deadline:
+                return False
+            self._active = False
+            self._fault = (generation, reason)
+            return True
+
+
+def velocity_commands_differ(current, target, abs_tol: float = 1e-9) -> bool:
+    """Return whether a safety update changes the effective velocity."""
+    return any(
+        not math.isclose(
+            float(before),
+            float(after),
+            rel_tol=0.0,
+            abs_tol=abs_tol,
+        )
+        for before, after in zip(current, target)
+    )
+
+
 @dataclass
 class ProposalApplyDiagnostics:
-    """Process-lifetime proposal receive/apply evidence for ``loco info``."""
+    """Current or most recent nav-lease execution evidence for ``loco info``."""
 
+    session_nav_id: Optional[str] = None
     received: int = 0
     accepted: int = 0
     rejected: int = 0
     applied: int = 0
+    first_received_monotonic: Optional[float] = None
+    last_received_monotonic: Optional[float] = None
+    last_receive_gap_ms: Optional[int] = None
+    max_receive_gap_ms: Optional[int] = None
+    last_proposal_age_ms: Optional[int] = None
+    max_proposal_age_ms: Optional[int] = None
+    expired_on_arrival: int = 0
+    watchdog_faults_by_reason: dict = field(default_factory=dict)
+    first_rejection_reason: Optional[str] = None
     last_rejection_reason: Optional[str] = None
+    rejections_by_reason: dict = field(default_factory=dict)
+    last_set_velocity_rpc_method: Optional[str] = None
+    last_set_velocity_request: Optional[dict] = None
     last_set_velocity_ret: Optional[int] = None
     last_set_velocity_error: Optional[str] = None
+    last_set_velocity_applied: Optional[bool] = None
     last_set_velocity_request_id: Optional[int] = None
     last_set_velocity_duration_ms: Optional[int] = None
     last_set_velocity_completed_monotonic: Optional[float] = None
     last_set_velocity_completed_unix_ms: Optional[int] = None
+    last_set_velocity_stop_ret: Optional[int] = None
+    last_set_velocity_stop_error: Optional[str] = None
     _lock: threading.Lock = field(
         default_factory=threading.Lock,
         init=False,
         repr=False,
     )
+    _applied_identities: set = field(
+        default_factory=set,
+        init=False,
+        repr=False,
+    )
 
-    def record_received(self) -> None:
+    def begin_session(self, nav_id: str) -> None:
+        """Reset per-lease counters while retaining them after later cleanup."""
+        with self._lock:
+            self.session_nav_id = nav_id
+            self.received = 0
+            self.accepted = 0
+            self.rejected = 0
+            self.applied = 0
+            self.first_received_monotonic = None
+            self.last_received_monotonic = None
+            self.last_receive_gap_ms = None
+            self.max_receive_gap_ms = None
+            self.last_proposal_age_ms = None
+            self.max_proposal_age_ms = None
+            self.expired_on_arrival = 0
+            self.watchdog_faults_by_reason = {}
+            self.first_rejection_reason = None
+            self.last_rejection_reason = None
+            self.rejections_by_reason = {}
+            self.last_set_velocity_rpc_method = None
+            self.last_set_velocity_request = None
+            self.last_set_velocity_ret = None
+            self.last_set_velocity_error = None
+            self.last_set_velocity_applied = None
+            self.last_set_velocity_request_id = None
+            self.last_set_velocity_duration_ms = None
+            self.last_set_velocity_completed_monotonic = None
+            self.last_set_velocity_completed_unix_ms = None
+            self.last_set_velocity_stop_ret = None
+            self.last_set_velocity_stop_error = None
+            self._applied_identities = set()
+
+    def record_received(self, received_monotonic: Optional[float] = None) -> None:
+        received = (
+            time.monotonic()
+            if received_monotonic is None
+            else float(received_monotonic)
+        )
         with self._lock:
             self.received += 1
+            if self.first_received_monotonic is None:
+                self.first_received_monotonic = received
+            if self.last_received_monotonic is not None:
+                gap_ms = max(
+                    0,
+                    round((received - self.last_received_monotonic) * 1000),
+                )
+                self.last_receive_gap_ms = gap_ms
+                if (
+                    self.max_receive_gap_ms is None
+                    or gap_ms > self.max_receive_gap_ms
+                ):
+                    self.max_receive_gap_ms = gap_ms
+            self.last_received_monotonic = received
+
+    def record_proposal_arrival(
+        self,
+        payload,
+        received_unix_ms: float,
+    ) -> None:
+        """Record source-to-callback age without participating in validation."""
+        if not isinstance(payload, dict):
+            return
+        issued_at = payload.get("issued_at_unix_ms")
+        ttl_ms = payload.get("ttl_ms")
+        if (
+            isinstance(issued_at, bool)
+            or not isinstance(issued_at, (int, float))
+            or not math.isfinite(float(issued_at))
+        ):
+            return
+        age_ms = round(float(received_unix_ms) - float(issued_at))
+        with self._lock:
+            self.last_proposal_age_ms = age_ms
+            if (
+                self.max_proposal_age_ms is None
+                or age_ms > self.max_proposal_age_ms
+            ):
+                self.max_proposal_age_ms = age_ms
+            if (
+                not isinstance(ttl_ms, bool)
+                and isinstance(ttl_ms, int)
+                and ttl_ms > 0
+                and age_ms >= ttl_ms
+            ):
+                self.expired_on_arrival += 1
+
+    def record_watchdog_fault(self, reason: str) -> None:
+        with self._lock:
+            self.watchdog_faults_by_reason[reason] = (
+                self.watchdog_faults_by_reason.get(reason, 0) + 1
+            )
 
     def record_accepted(self) -> None:
         with self._lock:
@@ -333,14 +562,25 @@ class ProposalApplyDiagnostics:
     def record_rejected(self, reason: str) -> None:
         with self._lock:
             self.rejected += 1
+            if self.first_rejection_reason is None:
+                self.first_rejection_reason = reason
             self.last_rejection_reason = reason
+            self.rejections_by_reason[reason] = (
+                self.rejections_by_reason.get(reason, 0) + 1
+            )
 
     def record_set_velocity(self, result: dict, duration: float) -> None:
         completed_monotonic = result.get("completed_monotonic")
         completed_unix_ms = result.get("completed_unix_ms")
         with self._lock:
+            self.last_set_velocity_rpc_method = result.get("rpc_method")
+            request = result.get("request")
+            self.last_set_velocity_request = (
+                dict(request) if isinstance(request, dict) else None
+            )
             self.last_set_velocity_ret = result.get("ret")
             self.last_set_velocity_error = result.get("error")
+            self.last_set_velocity_applied = bool(result.get("applied"))
             self.last_set_velocity_request_id = result.get("request_id")
             self.last_set_velocity_duration_ms = max(
                 0,
@@ -356,21 +596,54 @@ class ProposalApplyDiagnostics:
                 if completed_unix_ms is not None
                 else None
             )
+            self.last_set_velocity_stop_ret = result.get("stop_ret")
+            self.last_set_velocity_stop_error = result.get("stop_error")
 
-    def record_applied(self) -> None:
+    def record_applied(
+        self,
+        nav_id: Optional[str] = None,
+        sequence: Optional[int] = None,
+    ) -> None:
         with self._lock:
+            if nav_id is not None and sequence is not None:
+                identity = (str(nav_id), int(sequence))
+                if identity in self._applied_identities:
+                    return
+                self._applied_identities.add(identity)
             self.applied += 1
 
     def snapshot(self) -> dict:
         with self._lock:
             return {
+                "session_nav_id": self.session_nav_id,
                 "received": self.received,
                 "accepted": self.accepted,
                 "rejected": self.rejected,
                 "applied": self.applied,
+                "first_received_monotonic": self.first_received_monotonic,
+                "last_received_monotonic": self.last_received_monotonic,
+                "last_receive_gap_ms": self.last_receive_gap_ms,
+                "max_receive_gap_ms": self.max_receive_gap_ms,
+                "last_proposal_age_ms": self.last_proposal_age_ms,
+                "max_proposal_age_ms": self.max_proposal_age_ms,
+                "expired_on_arrival": self.expired_on_arrival,
+                "watchdog_faults_by_reason": dict(
+                    self.watchdog_faults_by_reason
+                ),
+                "first_rejection_reason": self.first_rejection_reason,
                 "last_rejection_reason": self.last_rejection_reason,
+                "rejections_by_reason": dict(self.rejections_by_reason),
+                "last_set_velocity_rpc_method": (
+                    self.last_set_velocity_rpc_method
+                ),
+                "last_set_velocity_request": (
+                    dict(self.last_set_velocity_request)
+                    if self.last_set_velocity_request is not None
+                    else None
+                ),
                 "last_set_velocity_ret": self.last_set_velocity_ret,
                 "last_set_velocity_error": self.last_set_velocity_error,
+                "last_set_velocity_applied": self.last_set_velocity_applied,
                 "last_set_velocity_request_id": (
                     self.last_set_velocity_request_id
                 ),
@@ -382,6 +655,10 @@ class ProposalApplyDiagnostics:
                 ),
                 "last_set_velocity_completed_unix_ms": (
                     self.last_set_velocity_completed_unix_ms
+                ),
+                "last_set_velocity_stop_ret": self.last_set_velocity_stop_ret,
+                "last_set_velocity_stop_error": (
+                    self.last_set_velocity_stop_error
                 ),
             }
 
@@ -433,31 +710,62 @@ def _request_parent_loco_rpc(
             return result
 
 
-def request_parent_set_velocity(
+def request_parent_apply_velocity_proposal(
     request_queue,
     result_queue,
     request_id: int,
     vx: float,
     vy: float,
     vyaw: float,
-    duration: float,
+    deadline_monotonic: float,
+    nav_id: str,
+    sequence: int,
     timeout: float,
 ) -> dict:
-    """Request one finite SetVelocity from the parent and wait boundedly."""
+    """Request one Driver-deadline-controlled velocity from the parent."""
+    request = {
+        "vx": vx,
+        "vy": vy,
+        "vyaw": vyaw,
+        "deadline_monotonic": deadline_monotonic,
+        "nav_id": nav_id,
+        "sequence": sequence,
+    }
+    result = _request_parent_loco_rpc(
+        request_queue,
+        result_queue,
+        request={
+            "method": "apply_velocity_proposal",
+            "request_id": request_id,
+            **request,
+        },
+        timeout=timeout,
+        timeout_error="parent_velocity_proposal_timeout",
+        ipc_error_prefix="parent_velocity_proposal_ipc_error",
+    )
+    result.setdefault("rpc_method", "SetVelocity(continuous)")
+    result.setdefault("request", request)
+    result.setdefault("applied", False)
+    return result
+
+
+def request_parent_stop_velocity_proposal(
+    request_queue,
+    result_queue,
+    request_id: int,
+    timeout: float,
+) -> dict:
+    """Order StopMove after every earlier parent proposal RPC."""
     return _request_parent_loco_rpc(
         request_queue,
         result_queue,
         request={
-            "method": "set_velocity",
+            "method": "stop_velocity_proposal",
             "request_id": request_id,
-            "vx": vx,
-            "vy": vy,
-            "vyaw": vyaw,
-            "duration": duration,
         },
         timeout=timeout,
-        timeout_error="parent_set_velocity_timeout",
-        ipc_error_prefix="parent_set_velocity_ipc_error",
+        timeout_error="parent_velocity_stop_timeout",
+        ipc_error_prefix="parent_velocity_stop_ipc_error",
     )
 
 
@@ -488,7 +796,7 @@ class SmartMotionProxy:
 
     def __init__(self, namespace: str, config: dict, network_iface: str,
                  proposal_config: Optional[dict] = None,
-                 fallback_stop=None, parent_set_velocity=None,
+                 fallback_stop=None, parent_apply_velocity_proposal=None,
                  parent_get_fsm_id=None):
         ctx = mp.get_context("spawn")
         self._cmd_queue = ctx.Queue()
@@ -498,7 +806,7 @@ class SmartMotionProxy:
         self._call_lock = threading.RLock()
         self._request_id = 0
         self._fallback_stop = fallback_stop
-        self._parent_set_velocity = parent_set_velocity
+        self._parent_apply_velocity_proposal = parent_apply_velocity_proposal
         self._parent_get_fsm_id = parent_get_fsm_id
         self._parent_velocity_shutdown = threading.Event()
         self._proc = ctx.Process(
@@ -563,22 +871,33 @@ class SmartMotionProxy:
             if request is None:
                 return
             request_id = request.get("request_id")
-            method = request.get("method", "set_velocity")
+            method = request.get("method", "apply_velocity_proposal")
             ret = None
             fsm_id = None
             error = None
+            response = {}
             try:
-                if method == "set_velocity":
-                    if self._parent_set_velocity is None:
+                if method == "apply_velocity_proposal":
+                    if self._parent_apply_velocity_proposal is None:
                         raise RuntimeError(
-                            "parent SetVelocity RPC is unavailable"
+                            "parent proposal RPC is unavailable"
                         )
-                    ret = self._parent_set_velocity(
+                    result = self._parent_apply_velocity_proposal(
                         request["vx"],
                         request["vy"],
                         request["vyaw"],
-                        request["duration"],
+                        request["deadline_monotonic"],
+                        request["nav_id"],
+                        request["sequence"],
+                        request_id,
                     )
+                    if not isinstance(result, dict):
+                        raise RuntimeError(
+                            "parent proposal RPC returned an invalid result"
+                        )
+                    response.update(result)
+                    ret = result.get("ret")
+                    error = result.get("error")
                 elif method == "get_fsm_id":
                     if self._parent_get_fsm_id is None:
                         raise RuntimeError(
@@ -590,21 +909,28 @@ class SmartMotionProxy:
                             "parent GetFsmId returned an invalid result"
                         )
                     ret, fsm_id = result
+                elif method == "stop_velocity_proposal":
+                    if self._fallback_stop is None:
+                        raise RuntimeError(
+                            "parent StopMove RPC is unavailable"
+                        )
+                    ret = self._fallback_stop()
                 else:
                     raise RuntimeError(
                         f"unsupported parent Loco RPC method: {method}"
                     )
             except Exception as exc:
                 error = str(exc)
-            self._parent_velocity_result_queue.put({
+            response.update({
                 "method": method,
                 "request_id": request_id,
                 "ret": ret,
                 "fsm_id": fsm_id,
                 "error": error,
-                "completed_monotonic": time.monotonic(),
-                "completed_unix_ms": round(time.time() * 1000),
             })
+            response.setdefault("completed_monotonic", time.monotonic())
+            response.setdefault("completed_unix_ms", round(time.time() * 1000))
+            self._parent_velocity_result_queue.put(response)
 
     def _signal_parent_velocity_shutdown(self) -> None:
         shutdown = getattr(self, "_parent_velocity_shutdown", None)
@@ -817,7 +1143,13 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     # independent child clients so a delayed parent RPC cannot block the
     # fail-closed stop paths.
     proposal_rpc_timeout = min(
-        0.2, max(0.02, float(proposal_config.get("velocity_proposal_rpc_timeout", 0.1)))
+        1.0,
+        max(
+            0.1,
+            float(
+                proposal_config.get("velocity_proposal_rpc_timeout", 0.5)
+            ),
+        ),
     )
     stop_rpc_timeout = min(
         0.2,
@@ -932,17 +1264,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     proposal_watchdog_hz = max(
         20.0, float(proposal_config.get("velocity_proposal_watchdog_hz", 40.0))
     )
-    proposal_stop_confirm_timeout = min(
-        1.0,
-        max(
-            0.1,
-            float(
-                proposal_config.get(
-                    "velocity_proposal_stop_confirm_timeout",
-                    0.5,
-                )
-            ),
-        ),
+    proposal_stop_confirm_timeout = resolve_stop_confirmation_timeout(
+        proposal_config.get(
+            "velocity_proposal_stop_confirm_timeout",
+            DEFAULT_STOP_CONFIRM_TIMEOUT_SECONDS,
+        )
     )
     proposal_stop_linear_epsilon = max(
         0.0, float(proposal_config.get("velocity_proposal_stop_linear_epsilon", 0.03))
@@ -971,17 +1297,21 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     odom_stop_monitor = OdomStopMonitor()
     safety_lock = threading.Lock()
     motion_command_lock = threading.RLock()
-    proposal_execution_lock = threading.Lock()
+    proposal_execution_lease = ProposalExecutionLease()
     proposal_connected = threading.Event()
     proposal_stop_transition = threading.Event()
     safety_threads_shutdown = threading.Event()
-    proposal_execution_generation = 0
-    proposal_execution_active = False
-    proposal_execution_deadline = 0.0
-    proposal_watchdog_fault = None
+    proposal_callback_ready = threading.Event()
+    proposal_callback_failed = threading.Event()
+    proposal_callback_error_lock = threading.Lock()
+    proposal_callback_error = None
+    proposal_ros_thread = None
     parent_loco_request_id = 0
     parent_loco_rpc_lock = threading.Lock()
     proposal_apply_diagnostics = ProposalApplyDiagnostics()
+    proposal_apply_queue = queue.Queue(maxsize=1)
+    last_stop_result = None
+    last_proposal_stop_result = None
 
     def motion_synchronized(func):
         def locked(*args, **kwargs):
@@ -989,53 +1319,88 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 return func(*args, **kwargs)
         return locked
 
+    def proposal_callback_status():
+        with proposal_callback_error_lock:
+            error = proposal_callback_error
+        return {
+            "ready": proposal_callback_ready.is_set(),
+            "alive": bool(
+                proposal_ros_thread is not None
+                and proposal_ros_thread.is_alive()
+            ),
+            "failed": proposal_callback_failed.is_set(),
+            "error": error,
+        }
+
     def arm_proposal_execution(deadline):
-        nonlocal proposal_execution_generation, proposal_execution_active
-        nonlocal proposal_execution_deadline, proposal_watchdog_fault
-        with proposal_execution_lock:
-            proposal_execution_generation += 1
-            proposal_execution_active = True
-            proposal_execution_deadline = deadline
-            proposal_watchdog_fault = None
-            return proposal_execution_generation
+        return proposal_execution_lease.arm(deadline)
+
+    def refresh_proposal_execution_deadline(deadline):
+        return proposal_execution_lease.renew_if_active(deadline)
 
     def clear_proposal_execution():
-        nonlocal proposal_execution_generation, proposal_execution_active
-        nonlocal proposal_execution_deadline, proposal_watchdog_fault
-        with proposal_execution_lock:
-            proposal_execution_generation += 1
-            proposal_execution_active = False
-            proposal_execution_deadline = 0.0
-            proposal_watchdog_fault = None
+        proposal_execution_lease.clear()
 
     def proposal_fault_for_generation(generation):
-        with proposal_execution_lock:
-            if proposal_watchdog_fault and proposal_watchdog_fault[0] == generation:
-                return proposal_watchdog_fault[1]
-            return ""
+        return proposal_execution_lease.fault_for_generation(generation)
 
     def current_proposal_watchdog_fault():
-        with proposal_execution_lock:
-            return proposal_watchdog_fault
+        return proposal_execution_lease.current_fault()
 
-    def apply_parent_set_velocity(vx, vy, vyaw, duration):
+    def apply_parent_velocity_proposal(command):
         nonlocal parent_loco_request_id
         # The FSM monitor and proposal callback share one request/result pair.
         # Serialize them so one waiter cannot consume the other's reply.
         with parent_loco_rpc_lock:
             parent_loco_request_id += 1
-            result = request_parent_set_velocity(
+            result = request_parent_apply_velocity_proposal(
                 request_queue=parent_velocity_queue,
                 result_queue=parent_velocity_result_queue,
                 request_id=parent_loco_request_id,
-                vx=vx,
-                vy=vy,
-                vyaw=vyaw,
-                duration=duration,
+                vx=command["vx"],
+                vy=command["vy"],
+                vyaw=command["vyaw"],
+                deadline_monotonic=command["deadline_monotonic"],
+                nav_id=command["nav_id"],
+                sequence=command["sequence"],
                 timeout=proposal_rpc_timeout,
             )
-        proposal_apply_diagnostics.record_set_velocity(result, duration)
+        proposal_apply_diagnostics.record_set_velocity(
+            result,
+            max(0.0, command["deadline_monotonic"] - command["queued_monotonic"]),
+        )
         return result
+
+    def stop_parent_velocity_proposal():
+        """Serialize StopMove behind any in-flight parent proposal apply."""
+        nonlocal parent_loco_request_id
+        with parent_loco_rpc_lock:
+            parent_loco_request_id += 1
+            return request_parent_stop_velocity_proposal(
+                request_queue=parent_velocity_queue,
+                result_queue=parent_velocity_result_queue,
+                request_id=parent_loco_request_id,
+                timeout=proposal_rpc_timeout,
+            )
+
+    def clear_proposal_apply_queue():
+        while True:
+            try:
+                proposal_apply_queue.get_nowait()
+            except queue.Empty:
+                return
+
+    def enqueue_proposal_apply(command):
+        """Keep only the newest validated command while the parent RPC is busy."""
+        while True:
+            try:
+                proposal_apply_queue.put_nowait(command)
+                return
+            except queue.Full:
+                try:
+                    proposal_apply_queue.get_nowait()
+                except queue.Empty:
+                    pass
 
     def query_parent_fsm_id():
         nonlocal parent_loco_request_id
@@ -1088,14 +1453,42 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         external_stop_attempt=None,
     ):
         nonlocal state, current_cmd, speed_zone, move_timer, stop_repeat_count
+        nonlocal last_stop_result, last_proposal_stop_result
         was_proposal_motion = bool(
             current_cmd and current_cmd.get("source") == "velocity_proposal"
         )
+        retry_proposal_stop = was_proposal_motion and not confirm_physical_stop
         if move_timer:
             move_timer.cancel()
             move_timer = None
+        clear_proposal_apply_queue()
         clear_proposal_execution()
         was_moving = state == MotionState.MOVING
+
+        if was_proposal_motion and not confirm_physical_stop:
+            # The independent client brakes immediately.  The ordered parent
+            # StopMove then runs after any in-flight continuous SetVelocity,
+            # preventing a late successful apply from restarting motion.
+            start = odom_stop_monitor.begin_confirmation()
+            try:
+                watchdog_loco_client.StopMove()
+            except Exception:
+                pass
+            parent_stop = stop_parent_velocity_proposal()
+            external_stop_attempt = {
+                "confirmation_start": {
+                    "monotonic": start.monotonic,
+                    "unix_ms": start.unix_ms,
+                    "odometry_callback_count": start.odometry_callback_count,
+                },
+                "stop_move_ret": parent_stop.get("ret"),
+                "stop_move_error": parent_stop.get("error"),
+                "stop_move_completed_monotonic": parent_stop.get(
+                    "completed_monotonic",
+                    time.monotonic(),
+                ),
+            }
+            confirm_physical_stop = True
 
         def complete_logical_stop():
             nonlocal state, current_cmd, speed_zone, stop_repeat_count
@@ -1125,7 +1518,11 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                             "stop_move_completed_monotonic"
                         ]
                     ),
-                    timeout=proposal_stop_confirm_timeout,
+                    timeout=(
+                        min(0.15, proposal_stop_confirm_timeout)
+                        if retry_proposal_stop
+                        else proposal_stop_confirm_timeout
+                    ),
                     max_age=proposal_odom_timeout,
                     linear_epsilon=proposal_stop_linear_epsilon,
                     yaw_epsilon=proposal_stop_yaw_epsilon,
@@ -1141,6 +1538,33 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     proposal_stop_yaw_epsilon,
                     after_stop_attempt=complete_logical_stop,
                 )
+            stop_attempts = [result]
+            if retry_proposal_stop and not result.get("stop_confirmed"):
+                # A continuous G1 velocity command can acknowledge one
+                # StopMove while measured gait velocity remains nonzero.  Use
+                # one bounded, ordered retry and retain both confirmations.
+                retry_start = odom_stop_monitor.begin_confirmation()
+                try:
+                    watchdog_loco_client.StopMove()
+                except Exception:
+                    pass
+                retry_parent_stop = stop_parent_velocity_proposal()
+                result = finish_stop_confirmation(
+                    monitor=odom_stop_monitor,
+                    start=retry_start,
+                    stop_move_ret=retry_parent_stop.get("ret"),
+                    stop_move_error=retry_parent_stop.get("error"),
+                    stop_move_completed_monotonic=retry_parent_stop.get(
+                        "completed_monotonic",
+                        time.monotonic(),
+                    ),
+                    timeout=proposal_stop_confirm_timeout,
+                    max_age=proposal_odom_timeout,
+                    linear_epsilon=proposal_stop_linear_epsilon,
+                    yaw_epsilon=proposal_stop_yaw_epsilon,
+                )
+                stop_attempts.append(result)
+            result = aggregate_stop_attempts(stop_attempts)
         else:
             stop_ret = None
             stop_error = None
@@ -1166,6 +1590,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     event_data["obstacle_angle_deg"] = round(math.degrees(obstacle_angle), 1)
             publish_event("motion_stop", event_data)
         result.update({"state": "idle", "reason": reason_str})
+        if confirm_physical_stop:
+            last_stop_result = dict(result)
+            if retry_proposal_stop:
+                last_proposal_stop_result = dict(result)
         return result
 
     @motion_synchronized
@@ -1303,12 +1731,17 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     def emergency_stop(reason_str, extra=None):
         """Emergency stop with optional damp mode for tilt."""
         nonlocal state, current_cmd, speed_zone, move_timer, stop_repeat_count
-        if current_cmd and current_cmd.get("source") == "velocity_proposal":
-            proposal_gate.disarm(f"{reason_str}_latched")
-        if move_timer:
-            move_timer.cancel()
-            move_timer = None
-        clear_proposal_execution()
+        was_proposal_motion = bool(
+            current_cmd and current_cmd.get("source") == "velocity_proposal"
+        )
+        was_active = state in (
+            MotionState.MOVING,
+            MotionState.NAVIGATING,
+            MotionState.NAV_PAUSED,
+        )
+        # Preserve the emergency path's immediate physical brake.  Proposal
+        # motion additionally performs an ordered parent stop below so a late
+        # continuous-velocity reply cannot restart the robot.
         try:
             stop_loco_client.StopMove()
         except Exception:
@@ -1318,7 +1751,14 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 loco_client.SetFsmId(1)  # damp mode
             except Exception:
                 pass
-        was_active = state in (MotionState.MOVING, MotionState.NAVIGATING, MotionState.NAV_PAUSED)
+        if was_proposal_motion:
+            proposal_gate.disarm(f"{reason_str}_latched")
+            do_stop(reason_str)
+        else:
+            if move_timer:
+                move_timer.cancel()
+                move_timer = None
+            clear_proposal_execution()
         if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
             try:
                 slam_client.PauseNav()
@@ -1576,7 +2016,16 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
 
     # ── Command handlers ──
     @motion_synchronized
-    def handle_move(vx, vy, vyaw, duration, finite_rpc=False, source="mcp"):
+    def handle_move(
+        vx,
+        vy,
+        vyaw,
+        duration,
+        finite_rpc=False,
+        source="mcp",
+        proposal=None,
+        deadline_monotonic=None,
+    ):
         nonlocal state, current_cmd, speed_zone, move_timer
 
         if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
@@ -1602,38 +2051,37 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             "duration": duration, "start_time": now,
             "end_time": (now + duration) if duration > 0 else None,
             "source": source,
+            "effective_velocity": (
+                clamped_vx,
+                clamped_vy,
+                clamped_vyaw,
+            ),
         }
+        if proposal is not None:
+            current_cmd.update({
+                "nav_id": proposal.nav_id,
+                "sequence": proposal.sequence,
+                "deadline_monotonic": deadline_monotonic,
+            })
         state = MotionState.MOVING
         speed_zone = SpeedZone.NORMAL
 
-        proposal_generation = None
-        set_velocity_error = None
         if finite_rpc:
-            proposal_generation = arm_proposal_execution(
-                time.monotonic() + duration
-            )
-            apply_result = apply_parent_set_velocity(
-                clamped_vx, clamped_vy, clamped_vyaw, duration
-            )
-            ret = apply_result.get("ret")
-            set_velocity_error = apply_result.get("error")
+            if proposal is None or deadline_monotonic is None:
+                raise ValueError("proposal identity and deadline are required")
+            enqueue_proposal_apply({
+                "vx": clamped_vx,
+                "vy": clamped_vy,
+                "vyaw": clamped_vyaw,
+                "deadline_monotonic": float(deadline_monotonic),
+                "queued_monotonic": time.monotonic(),
+                "nav_id": proposal.nav_id,
+                "sequence": proposal.sequence,
+            })
+            ret = None
         else:
             clear_proposal_execution()
             ret = loco_client.Move(clamped_vx, clamped_vy, clamped_vyaw, True)
-
-        watchdog_reason = (
-            proposal_fault_for_generation(proposal_generation)
-            if proposal_generation is not None
-            else ""
-        )
-        if watchdog_reason:
-            return {
-                "ret": ret,
-                "duration": duration,
-                "state": state.value,
-                "watchdog_reason": watchdog_reason,
-                "set_velocity_error": set_velocity_error,
-            }
 
         if duration > 0 and not finite_rpc:
             move_timer = threading.Timer(duration, duration_expired)
@@ -1670,7 +2118,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             "vyaw": clamped_vyaw,
             "duration": duration,
             "state": state.value,
-            "set_velocity_error": set_velocity_error,
+            "queued": finite_rpc,
         }
 
     @motion_synchronized
@@ -1788,12 +2236,12 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                         "error": f"No movement for {stall_timeout}s, navigation cancelled",
                         "pose": pose}
 
-            # Run safety checks and ROS2 spin during wait
+            # Run safety checks during wait.  ROS callbacks are serviced by
+            # the dedicated proposal/event executor thread.
             process_safety_checks()
             if stop_repeat_count > 0 and state == MotionState.IDLE:
                 loco_client.StopMove()
                 stop_repeat_count -= 1
-            executor.spin_once(timeout_sec=0)
 
             time.sleep(poll_interval)
 
@@ -1846,14 +2294,23 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             do_stop_nav()
         proposal_stop_transition.set()
         proposal_connected.clear()
+        clear_proposal_apply_queue()
         clear_proposal_execution()
         start = odom_stop_monitor.begin_confirmation()
+        fail_safe_stop_ret = None
+        fail_safe_stop_error = None
+        try:
+            fail_safe_stop_ret = watchdog_loco_client.StopMove()
+        except Exception as exc:
+            fail_safe_stop_error = str(exc)
         return {
             "confirmation_start": {
                 "monotonic": start.monotonic,
                 "unix_ms": start.unix_ms,
                 "odometry_callback_count": start.odometry_callback_count,
-            }
+            },
+            "fail_safe_stop_ret": fail_safe_stop_ret,
+            "fail_safe_stop_error": fail_safe_stop_error,
         }
 
     @motion_synchronized
@@ -1862,6 +2319,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         expected_nav_id,
         external_stop_attempt=None,
     ):
+        nonlocal last_proposal_stop_result
         try:
             expected_nav_id = resolve_expected_nav_id(
                 {"expected_nav_id": expected_nav_id}
@@ -1954,8 +2412,22 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 "expected_topic": expected_proposal_topic,
                 "connected": False,
             }
+        callback_status = proposal_callback_status()
+        if (
+            callback_status["failed"]
+            or not callback_status["ready"]
+            or not callback_status["alive"]
+        ):
+            proposal_gate.disarm("proposal_callback_unavailable")
+            return {
+                "error": "velocity_proposal_callback_unavailable",
+                "connected": False,
+                "proposal_callback": callback_status,
+            }
         try:
+            last_proposal_stop_result = None
             proposal_gate.bind(topic, expected_nav_id)
+            proposal_apply_diagnostics.begin_session(expected_nav_id)
             proposal_node.bind(topic, on_velocity_proposal)
             proposal_connected.set()
             refresh_fsm_state()
@@ -1982,6 +2454,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         reason="canvas_stop",
         external_stop_attempt=None,
     ):
+        nonlocal last_stop_result
         # N5 ordering: command and observe physical stop before destroying the
         # only proposal subscription.
         if (
@@ -2008,6 +2481,7 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 proposal_stop_linear_epsilon,
                 proposal_stop_yaw_epsilon,
             )
+        last_stop_result = dict(stopped)
         if not stopped["stop_confirmed"]:
             proposal_gate.disarm("stop_unconfirmed")
             proposal_connected.clear()
@@ -2043,9 +2517,12 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
     @motion_synchronized
     def handle_get_velocity_proposal_status():
         result = proposal_gate.snapshot(time.monotonic())
+        latest_stop = last_stop_result or {}
+        latest_proposal_stop = last_proposal_stop_result or {}
         result.update({
             "enabled": proposal_enabled,
             "canvas_running": proposal_connected.is_set(),
+            "stop_transition_active": proposal_stop_transition.is_set(),
             "driver_authorized": bool(
                 proposal_driver_authorized
                 and not proposal_stop_transition.is_set()
@@ -2054,41 +2531,72 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             ),
             "expected_topic": expected_proposal_topic,
             "schema": proposal_limits.schema,
+            "proposal_callback": proposal_callback_status(),
             "safety": proposal_runtime_status(force_fsm_check=False),
             "proposal_execution": proposal_apply_diagnostics.snapshot(),
+            "last_stop_confirmed": latest_stop.get("stop_confirmed"),
+            "last_stop_move_ret": latest_stop.get("ret"),
+            "last_stop_move_error": (
+                (latest_stop.get("stop_confirmation") or {}).get(
+                    "stop_move_error"
+                )
+            ),
+            "last_stop_confirmation": latest_stop.get("stop_confirmation"),
+            "last_proposal_stop": (
+                dict(latest_proposal_stop)
+                if latest_proposal_stop
+                else None
+            ),
         })
         return result
 
     @motion_synchronized
     def on_velocity_proposal(msg):
         nonlocal last_nav_status_time
-        proposal_apply_diagnostics.record_received()
+        now = time.monotonic()
+        received_unix_ms = time.time() * 1000
+        proposal_apply_diagnostics.record_received(now)
         if proposal_stop_transition.is_set():
             proposal_apply_diagnostics.record_rejected("stop_transition")
             return
-        now = time.monotonic()
         pending_fault = current_proposal_watchdog_fault()
-        if pending_fault:
-            _, reason = pending_fault
-            proposal_apply_diagnostics.record_rejected(reason)
-            if reason == "proposal_ttl_expired":
-                proposal_gate.watchdog(now)
-                do_stop(reason)
-            else:
-                proposal_gate.disarm(reason)
-                do_stop(reason)
-            return
         try:
             payload = json.loads(msg.data)
         except (json.JSONDecodeError, TypeError, AttributeError):
+            if pending_fault:
+                _, reason = pending_fault
+                proposal_apply_diagnostics.record_rejected(reason)
+                if reason == "proposal_ttl_expired":
+                    proposal_gate.watchdog(now)
+                else:
+                    proposal_gate.disarm(reason)
+                do_stop(reason)
+                return
             proposal_apply_diagnostics.record_rejected("invalid_json")
             if proposal_gate.armed:
                 proposal_gate.disarm("invalid_json")
                 do_stop("invalid_json")
             return
+        proposal_apply_diagnostics.record_proposal_arrival(
+            payload,
+            received_unix_ms,
+        )
+        if pending_fault:
+            _, reason = pending_fault
+            proposal_apply_diagnostics.record_rejected(reason)
+            if reason == "proposal_ttl_expired":
+                proposal_gate.watchdog(now)
+            else:
+                proposal_gate.disarm(reason)
+            do_stop(reason)
+            return
 
         was_armed = proposal_gate.armed
-        decision = proposal_gate.accept(payload, now)
+        decision = proposal_gate.accept(
+            payload,
+            now,
+            now_unix_ms=received_unix_ms,
+        )
         if decision.stop:
             if decision.reason != "proposal_zero":
                 proposal_apply_diagnostics.record_rejected(decision.reason)
@@ -2108,9 +2616,9 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         with safety_lock:
             last_nav_status_time = now
 
-        # Refresh the Unitree controller state immediately before every
-        # physical command; do not authorize from a cached FSM sample.
-        runtime = proposal_runtime_status(force_fsm_check=True)
+        # The independent FSM monitor keeps this sample fresh.  Avoid a
+        # synchronous per-frame query that would block ROS proposal callbacks.
+        runtime = proposal_runtime_status(force_fsm_check=False)
         if not runtime["ready"]:
             reason = runtime["reason"] or "driver_safety_not_ready"
             proposal_apply_diagnostics.record_rejected(reason)
@@ -2127,59 +2635,69 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             proposal_gate.watchdog(time.monotonic())
             do_stop("proposal_ttl_expired")
             return
+        if not refresh_proposal_execution_deadline(
+            proposal_gate.deadline_monotonic
+        ):
+            fault = current_proposal_watchdog_fault()
+            reason = fault[1] if fault else "proposal_execution_fault"
+            proposal_apply_diagnostics.record_rejected(reason)
+            if reason == "proposal_ttl_expired":
+                proposal_gate.watchdog(time.monotonic())
+            else:
+                proposal_gate.disarm(reason)
+            do_stop(reason)
+            return
         proposal_apply_diagnostics.record_accepted()
-        result = handle_move(
+        handle_move(
             proposal.x,
             proposal.y,
             proposal.yaw,
             remaining,
             finite_rpc=True,
             source="velocity_proposal",
+            proposal=proposal,
+            deadline_monotonic=proposal_gate.deadline_monotonic,
         )
-        watchdog_reason = result.get("watchdog_reason")
-        if watchdog_reason:
-            proposal_apply_diagnostics.record_rejected(watchdog_reason)
-            if watchdog_reason != "proposal_ttl_expired":
-                proposal_gate.disarm(watchdog_reason)
-            else:
-                proposal_gate.watchdog(time.monotonic())
-            do_stop(watchdog_reason)
-            return
-        ret = result.get("ret")
-        set_velocity_error = result.get("set_velocity_error")
-        if set_velocity_error or ret != 0:
-            reason = (
-                "parent_set_velocity_timeout"
-                if set_velocity_error == "parent_set_velocity_timeout"
-                else "set_velocity_failed"
-            )
-            proposal_apply_diagnostics.record_rejected(reason)
-            proposal_gate.disarm(reason)
-            do_stop(reason)
-            return
-        proposal_apply_diagnostics.record_applied()
 
     @motion_synchronized
     def apply_safety_velocity(cmd, vx, vy, vyaw):
-        """Preserve a proposal's finite firmware lease during deceleration."""
+        """Queue a bounded parent-side proposal update during deceleration."""
         if cmd and cmd.get("source") == "velocity_proposal":
             remaining = proposal_gate.deadline_monotonic - time.monotonic()
             if remaining <= 0.0:
                 proposal_gate.watchdog(time.monotonic())
                 do_stop("proposal_ttl_expired")
                 return
-            result = apply_parent_set_velocity(vx, vy, vyaw, remaining)
-            if result.get("error") or result.get("ret") != 0:
-                reason = (
-                    "parent_set_velocity_timeout"
-                    if result.get("error") == "parent_set_velocity_timeout"
-                    else "set_velocity_failed"
+            if not cmd.get("nav_id") or cmd.get("sequence") is None:
+                proposal_apply_diagnostics.record_rejected(
+                    "proposal_identity_missing"
                 )
-                proposal_apply_diagnostics.record_rejected(reason)
-                proposal_gate.disarm(reason)
-                do_stop(reason)
-            return
+                proposal_gate.disarm("proposal_identity_missing")
+                do_stop("proposal_identity_missing")
+                return
+            target_velocity = (float(vx), float(vy), float(vyaw))
+            effective_velocity = cmd.get("effective_velocity")
+            if (
+                effective_velocity is not None
+                and not velocity_commands_differ(
+                    effective_velocity,
+                    target_velocity,
+                )
+            ):
+                return False
+            cmd["effective_velocity"] = target_velocity
+            enqueue_proposal_apply({
+                "vx": vx,
+                "vy": vy,
+                "vyaw": vyaw,
+                "deadline_monotonic": proposal_gate.deadline_monotonic,
+                "queued_monotonic": time.monotonic(),
+                "nav_id": cmd["nav_id"],
+                "sequence": cmd["sequence"],
+            })
+            return True
         loco_client.Move(vx, vy, vyaw, True)
+        return True
 
     # ── Safety checks (inline in main loop) ──
     @motion_synchronized
@@ -2277,17 +2795,97 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             if safety_threads_shutdown.wait(proposal_fsm_check_interval):
                 break
 
+    def proposal_apply_loop():
+        """Apply only the newest validated proposal without blocking ROS spin."""
+        while not safety_threads_shutdown.is_set():
+            try:
+                command = proposal_apply_queue.get(timeout=0.05)
+            except queue.Empty:
+                continue
+
+            with motion_command_lock:
+                if (
+                    proposal_stop_transition.is_set()
+                    or not proposal_connected.is_set()
+                    or not proposal_gate.armed
+                    or command["nav_id"] != proposal_gate.expected_nav_id
+                    or command["sequence"] != proposal_gate.last_sequence
+                ):
+                    continue
+                now = time.monotonic()
+                if now >= command["deadline_monotonic"]:
+                    proposal_apply_diagnostics.record_rejected(
+                        "proposal_ttl_expired"
+                    )
+                    proposal_gate.watchdog(now)
+                    do_stop("proposal_ttl_expired")
+                    continue
+                runtime = proposal_runtime_status(force_fsm_check=False)
+                if not runtime["ready"]:
+                    reason = runtime["reason"] or "driver_safety_not_ready"
+                    proposal_apply_diagnostics.record_rejected(reason)
+                    proposal_gate.disarm(reason)
+                    do_stop(reason)
+                    continue
+                generation = arm_proposal_execution(
+                    command["deadline_monotonic"]
+                )
+                if generation is None:
+                    fault = current_proposal_watchdog_fault()
+                    reason = fault[1] if fault else "proposal_execution_fault"
+                    proposal_apply_diagnostics.record_rejected(reason)
+                    if reason == "proposal_ttl_expired":
+                        proposal_gate.watchdog(time.monotonic())
+                    else:
+                        proposal_gate.disarm(reason)
+                    do_stop(reason)
+                    continue
+
+            result = apply_parent_velocity_proposal(command)
+
+            with motion_command_lock:
+                watchdog_reason = proposal_fault_for_generation(generation)
+                if watchdog_reason:
+                    proposal_apply_diagnostics.record_rejected(
+                        watchdog_reason
+                    )
+                    if watchdog_reason == "proposal_ttl_expired":
+                        proposal_gate.watchdog(time.monotonic())
+                    else:
+                        proposal_gate.disarm(watchdog_reason)
+                    do_stop(watchdog_reason)
+                    continue
+
+                error = result.get("error")
+                ret = result.get("ret")
+                if error or ret != 0 or not result.get("applied"):
+                    if error in {
+                        "proposal_ttl_expired_before_rpc",
+                        "proposal_ttl_expired_after_rpc",
+                    }:
+                        reason = "proposal_ttl_expired"
+                    elif error == "parent_velocity_proposal_timeout":
+                        reason = "parent_velocity_proposal_timeout"
+                    else:
+                        reason = "set_velocity_failed"
+                    proposal_apply_diagnostics.record_rejected(reason)
+                    proposal_gate.disarm(reason)
+                    do_stop(reason)
+                    continue
+                proposal_apply_diagnostics.record_applied(
+                    command["nav_id"],
+                    command["sequence"],
+                )
+
     def proposal_watchdog_loop():
         """At >=20 Hz, physically stop an active proposal on TTL or fault."""
-        nonlocal proposal_execution_active, proposal_watchdog_fault
         period = 1.0 / proposal_watchdog_hz
         while not safety_threads_shutdown.wait(period):
             now = time.monotonic()
-            with proposal_execution_lock:
-                if not proposal_execution_active:
-                    continue
-                generation = proposal_execution_generation
-                deadline = proposal_execution_deadline
+            lease = proposal_execution_lease.watchdog_snapshot()
+            if lease is None:
+                continue
+            generation, deadline = lease
             reason = "proposal_ttl_expired" if now >= deadline else ""
             if not reason:
                 runtime = proposal_runtime_status(force_fsm_check=False)
@@ -2295,34 +2893,56 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                     reason = runtime["reason"] or "driver_safety_not_ready"
             if not reason:
                 continue
-            with proposal_execution_lock:
-                if (
-                    not proposal_execution_active
-                    or generation != proposal_execution_generation
-                ):
-                    continue
-                proposal_execution_active = False
-                proposal_watchdog_fault = (generation, reason)
+            if not proposal_execution_lease.trip(generation, reason, now):
+                continue
+            proposal_apply_diagnostics.record_watchdog_fault(reason)
             try:
                 watchdog_loco_client.StopMove()
             except Exception:
                 pass
 
     def consume_proposal_watchdog_fault():
-        with proposal_execution_lock:
-            fault = proposal_watchdog_fault
+        fault = current_proposal_watchdog_fault()
         if not fault:
             return
-        generation, reason = fault
-        with proposal_execution_lock:
-            if generation != proposal_execution_generation:
-                return
+        _, reason = fault
         with motion_command_lock:
+            if current_proposal_watchdog_fault() != fault:
+                return
             if reason == "proposal_ttl_expired":
                 proposal_gate.watchdog(time.monotonic())
             else:
                 proposal_gate.disarm(reason)
             do_stop(reason)
+
+    def proposal_ros_spin_loop():
+        """Service proposal/event callbacks independently of the busy loop."""
+        nonlocal proposal_callback_error
+        try:
+            # Complete one non-blocking executor cycle before advertising that
+            # binds can safely create the proposal subscription.
+            executor.spin_once(timeout_sec=0)
+            proposal_callback_ready.set()
+            while not safety_threads_shutdown.is_set():
+                executor.spin_once(timeout_sec=0.02)
+        except Exception as exc:
+            with proposal_callback_error_lock:
+                proposal_callback_error = str(exc)
+            proposal_callback_failed.set()
+            proposal_callback_ready.clear()
+            with motion_command_lock:
+                if proposal_gate.connected_topic or proposal_gate.armed:
+                    proposal_apply_diagnostics.record_rejected(
+                        "proposal_callback_error"
+                    )
+                proposal_gate.disarm("proposal_callback_error")
+                do_stop("proposal_callback_error")
+            print(
+                f"[SmartMotion] proposal ROS callback failed closed: {exc}",
+                flush=True,
+            )
+        finally:
+            proposal_callback_ready.clear()
 
     # ── Main loop ──
     fsm_monitor_thread = threading.Thread(
@@ -2335,8 +2955,25 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         daemon=True,
         name="g1_loco_velocity_watchdog",
     )
+    proposal_apply_thread = threading.Thread(
+        target=proposal_apply_loop,
+        daemon=True,
+        name="g1_loco_velocity_apply",
+    )
+    proposal_ros_thread = threading.Thread(
+        target=proposal_ros_spin_loop,
+        daemon=True,
+        name="g1_loco_proposal_ros",
+    )
+    proposal_ros_thread.start()
+    if not proposal_callback_ready.wait(timeout=1.0):
+        with proposal_callback_error_lock:
+            if proposal_callback_error is None:
+                proposal_callback_error = "proposal_callback_start_timeout"
+        proposal_callback_failed.set()
     fsm_monitor_thread.start()
     proposal_watchdog_thread.start()
+    proposal_apply_thread.start()
     print(f"[SmartMotion:pid={os.getpid()}] entering main loop")
     running = True
     last_obstacle_check = 0.0
@@ -2503,20 +3140,17 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             print(f"[SmartMotion] health: slam_info msgs={slam_info_msg_count} "
                   f"pos_info={slam_info_pos_count} state={state.value}", flush=True)
 
-        # Spin ROS2 (non-blocking)
-        try:
-            executor.spin_once(timeout_sec=0)
-        except Exception as exc:
-            with motion_command_lock:
-                proposal_gate.disarm("proposal_callback_error")
-                do_stop("proposal_callback_error")
-            print(f"[SmartMotion] ROS callback failed: {exc}", flush=True)
-
     # Cleanup
     safety_threads_shutdown.set()
     proposal_connected.clear()
+    try:
+        executor.wake()
+    except Exception:
+        pass
+    proposal_ros_thread.join(timeout=0.5)
     proposal_watchdog_thread.join(timeout=0.5)
     fsm_monitor_thread.join(timeout=0.75)
+    proposal_apply_thread.join(timeout=proposal_rpc_timeout + 0.25)
     if move_timer:
         move_timer.cancel()
     with motion_command_lock:

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -32,6 +32,7 @@ from velocity_proposal import (
     DEFAULT_VELOCITY_PROPOSAL_TOPIC,
     ProposalLimits,
     VelocityProposalGate,
+    resolve_expected_nav_id,
 )
 
 
@@ -205,8 +206,12 @@ class SmartMotionProxy:
     def get_state(self) -> dict:
         return self._call("get_state")
 
-    def bind_velocity_proposal(self, topic: str) -> dict:
-        return self._call("bind_velocity_proposal", topic=topic)
+    def bind_velocity_proposal(self, topic: str, expected_nav_id: str) -> dict:
+        return self._call(
+            "bind_velocity_proposal",
+            topic=topic,
+            expected_nav_id=expected_nav_id,
+        )
 
     def unbind_velocity_proposal(self, reason: str = "canvas_stop") -> dict:
         return self._call("unbind_velocity_proposal", reason=reason)
@@ -1210,7 +1215,23 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
         return result
 
     @motion_synchronized
-    def handle_bind_velocity_proposal(topic):
+    def handle_bind_velocity_proposal(topic, expected_nav_id):
+        try:
+            expected_nav_id = resolve_expected_nav_id(
+                {"expected_nav_id": expected_nav_id}
+            )
+        except ValueError as exc:
+            proposal_gate.disarm(str(exc))
+            do_stop(str(exc))
+            return {
+                "error": str(exc),
+                "connected": bool(proposal_node.topic),
+                "armed": False,
+            }
+        if proposal_gate.is_bound_to(topic, expected_nav_id):
+            result = handle_get_velocity_proposal_status()
+            result["state"] = "connected"
+            return result
         # A proposal stream and Unitree native navigation may never own motion
         # at the same time.
         if state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
@@ -1249,8 +1270,8 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
                 "connected": False,
             }
         try:
+            proposal_gate.bind(topic, expected_nav_id)
             proposal_node.bind(topic, on_velocity_proposal)
-            proposal_gate.bind(topic)
             proposal_connected.set()
             refresh_fsm_state()
         except Exception as exc:
@@ -1643,7 +1664,10 @@ def _run_smart_motion_process(namespace: str, config: dict, proposal_config: dic
             elif method == "get_state":
                 result = handle_get_state()
             elif method == "bind_velocity_proposal":
-                result = handle_bind_velocity_proposal(cmd.get("topic", ""))
+                result = handle_bind_velocity_proposal(
+                    cmd.get("topic", ""),
+                    cmd.get("expected_nav_id", ""),
+                )
             elif method == "unbind_velocity_proposal":
                 result = handle_unbind_velocity_proposal(
                     cmd.get("reason", "canvas_stop")

--- a/unitree/g1/tests/test_loco_topic_lifecycle.py
+++ b/unitree/g1/tests/test_loco_topic_lifecycle.py
@@ -90,6 +90,7 @@ class FakeSmartMotion:
     def __init__(self):
         self.bound_topic = ""
         self.expected_nav_id = ""
+        self.bind_result = None
         self.unbind_reasons = []
         self.unbind_result = {
             "state": "idle",
@@ -98,6 +99,8 @@ class FakeSmartMotion:
         }
 
     def bind_velocity_proposal(self, topic, expected_nav_id):
+        if self.bind_result is not None:
+            return dict(self.bind_result)
         self.bound_topic = topic
         self.expected_nav_id = expected_nav_id
         return {
@@ -188,6 +191,39 @@ class LocoTopicLifecycleTest(unittest.TestCase):
         self.assertFalse(result["connected"])
         self.assertEqual(result["error"], "expected_nav_id_required")
         self.assertEqual(self.smart_motion.bound_topic, "")
+        self.assertEqual(self.client.stop_count, 1)
+
+    def test_start_preserves_stop_confirmation_diagnostics_on_failure(self):
+        diagnostics = {
+            "stop_move_ret": 0,
+            "stop_move_error": None,
+            "confirmation_started_monotonic": 123.0,
+            "last_odometry_monotonic": 123.4,
+            "last_odometry_age_ms": 100,
+            "last_odometry_velocity": {"x": 0.04, "y": 0.0, "yaw": 0.0},
+            "odometry_callback_count": 42,
+            "odometry_callbacks_since_confirmation": 1,
+            "confirmation_timed_out": True,
+        }
+        self.smart_motion.bind_result = {
+            "error": "StopMove/odometry stop was not confirmed before proposal bind",
+            "connected": False,
+            "armed": False,
+            "stop_confirmed": False,
+            "stop_move_ret": 0,
+            "stop_move_error": None,
+            "stop_confirmation": diagnostics,
+        }
+
+        result = self.plugin.dispatch(
+            "start",
+            {"input_topic": self.topic, "expected_nav_id": self.nav_id},
+        )
+
+        self.assertEqual(result["state"], "error")
+        self.assertFalse(result["connected"])
+        self.assertEqual(result["stop_move_ret"], 0)
+        self.assertEqual(result["stop_confirmation"], diagnostics)
         self.assertEqual(self.client.stop_count, 1)
 
     def test_other_tools_do_not_bind_or_unbind_loco_topic(self):

--- a/unitree/g1/tests/test_loco_topic_lifecycle.py
+++ b/unitree/g1/tests/test_loco_topic_lifecycle.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+
+
+def _install_driver_import_stubs():
+    rclpy = types.ModuleType("rclpy")
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_qos = types.ModuleType("rclpy.qos")
+
+    class Node:
+        pass
+
+    class QoSProfile:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class EnumValue:
+        BEST_EFFORT = "best_effort"
+        RELIABLE = "reliable"
+        KEEP_LAST = "keep_last"
+        VOLATILE = "volatile"
+
+    rclpy_node.Node = Node
+    rclpy_qos.QoSProfile = QoSProfile
+    rclpy_qos.ReliabilityPolicy = EnumValue
+    rclpy_qos.HistoryPolicy = EnumValue
+    rclpy_qos.DurabilityPolicy = EnumValue
+
+    std_msgs = types.ModuleType("std_msgs")
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    std_msgs_msg.Header = type("Header", (), {})
+    std_msgs_msg.String = type("String", (), {})
+
+    audio_msgs = types.ModuleType("audio_msgs")
+    audio_msgs_msg = types.ModuleType("audio_msgs.msg")
+    audio_msgs_msg.AudioChunk = type("AudioChunk", (), {})
+
+    unitree_sdk = types.ModuleType("unitree_sdk2py")
+    unitree_g1 = types.ModuleType("unitree_sdk2py.g1")
+    unitree_audio = types.ModuleType("unitree_sdk2py.g1.audio")
+    unitree_audio_client = types.ModuleType("unitree_sdk2py.g1.audio.g1_audio_client")
+    unitree_audio_client.AudioClient = type("AudioClient", (), {})
+
+    pointcloud_utils = types.ModuleType("pointcloud_utils")
+    pointcloud_utils.gravity_align_inplace = lambda *args, **kwargs: None
+    numpy = types.ModuleType("numpy")
+
+    modules = {
+        "rclpy": rclpy,
+        "rclpy.node": rclpy_node,
+        "rclpy.qos": rclpy_qos,
+        "std_msgs": std_msgs,
+        "std_msgs.msg": std_msgs_msg,
+        "audio_msgs": audio_msgs,
+        "audio_msgs.msg": audio_msgs_msg,
+        "unitree_sdk2py": unitree_sdk,
+        "unitree_sdk2py.g1": unitree_g1,
+        "unitree_sdk2py.g1.audio": unitree_audio,
+        "unitree_sdk2py.g1.audio.g1_audio_client": unitree_audio_client,
+        "pointcloud_utils": pointcloud_utils,
+        "numpy": numpy,
+    }
+    for name, module in modules.items():
+        sys.modules.setdefault(name, module)
+
+
+_install_driver_import_stubs()
+
+from device import LocoPlugin  # noqa: E402
+
+
+class FakeClient:
+    def __init__(self):
+        self.stop_count = 0
+        self.fsm_ids = []
+
+    def StopMove(self):
+        self.stop_count += 1
+        return 0
+
+    def SetFsmId(self, fsm_id):
+        self.fsm_ids.append(fsm_id)
+        return 0
+
+
+class FakeSmartMotion:
+    def __init__(self):
+        self.bound_topic = ""
+        self.unbind_reasons = []
+        self.unbind_result = {
+            "state": "idle",
+            "connected": False,
+            "stop_confirmed": True,
+        }
+
+    def bind_velocity_proposal(self, topic):
+        self.bound_topic = topic
+        return {"connected": True, "armed": True, "topic": topic}
+
+    def unbind_velocity_proposal(self, reason):
+        self.unbind_reasons.append(reason)
+        result = dict(self.unbind_result)
+        if not result.get("connected"):
+            self.bound_topic = ""
+        return result
+
+    def get_velocity_proposal_status(self):
+        return {
+            "connected": bool(self.bound_topic),
+            "armed": bool(self.bound_topic),
+            "topic": self.bound_topic or None,
+        }
+
+
+class LocoTopicLifecycleTest(unittest.TestCase):
+    def setUp(self):
+        self.client = FakeClient()
+        self.smart_motion = FakeSmartMotion()
+        self.plugin = LocoPlugin(
+            {}, "ubuntu", executor=None, loco_client=self.client,
+            smart_motion=self.smart_motion,
+        )
+        self.topic = "/ubuntu/navigation/nav2/velocity_proposal"
+
+    def test_tool_exposes_velocity_proposal_input(self):
+        self.assertEqual(self.plugin.STOP_PRIORITY, 0)
+        tool = self.plugin.get_tools()[0]
+        port = tool["topic_in"]
+        self.assertEqual(len(port), 1)
+        self.assertEqual(port[0]["port"], "velocity_proposal")
+        self.assertEqual(port[0]["topic"], self.topic)
+        self.assertEqual(
+            tool["inputSchema"]["properties"]["action"]["enum"],
+            [
+                "move", "stop_move", "set_stand_height", "get_fsm_id",
+                "get_fsm_mode", "get_balance_mode", "get_swing_height",
+                "get_stand_height", "get_phase", "wave_hand", "shake_hand",
+            ],
+        )
+
+    def test_start_info_stop_owns_real_subscription_lifecycle(self):
+        started = self.plugin.dispatch("start", {"input_topic": self.topic})
+        self.assertTrue(started["connected"])
+        self.assertEqual(self.smart_motion.bound_topic, self.topic)
+
+        info = self.plugin.dispatch("info", {"_tool_name": "loco"})
+        self.assertTrue(info["connected"])
+        self.assertTrue(info["armed"])
+
+        stopped = self.plugin.dispatch("stop", {})
+        self.assertFalse(stopped["connected"])
+        self.assertTrue(stopped["stop_confirmed"])
+        self.assertEqual(self.smart_motion.unbind_reasons, ["canvas_stop"])
+
+    def test_start_accepts_exactly_one_input_topics_entry(self):
+        started = self.plugin.dispatch("start", {"input_topics": [self.topic]})
+        self.assertTrue(started["connected"])
+        self.assertEqual(self.smart_motion.bound_topic, self.topic)
+
+    def test_other_tools_do_not_bind_or_unbind_loco_topic(self):
+        self.smart_motion.bound_topic = self.topic
+
+        started = self.plugin.dispatch(
+            "start", {"_tool_name": "motion_events"}
+        )
+        stopped = self.plugin.dispatch(
+            "stop", {"_tool_name": "switch_mode"}
+        )
+
+        self.assertEqual(started, {"state": "running"})
+        self.assertEqual(stopped, {"state": "idle"})
+        self.assertEqual(self.smart_motion.bound_topic, self.topic)
+        self.assertEqual(self.smart_motion.unbind_reasons, [])
+        self.assertEqual(self.client.stop_count, 0)
+
+    def test_wrong_topic_fails_closed_without_binding(self):
+        self.smart_motion.bound_topic = self.topic
+        result = self.plugin.dispatch(
+            "start", {"input_topic": "/ubuntu/navigation/nav2/cmd_vel_shadow"}
+        )
+        self.assertEqual(result["state"], "error")
+        self.assertFalse(result["connected"])
+        self.assertEqual(self.client.stop_count, 1)
+        self.assertEqual(self.smart_motion.bound_topic, "")
+        self.assertEqual(self.smart_motion.unbind_reasons, ["proposal_bind_rejected"])
+
+    def test_missing_safety_harness_cannot_execute_topic(self):
+        plugin = LocoPlugin({}, "ubuntu", None, self.client, smart_motion=None)
+        result = plugin.dispatch("start", {"input_topic": self.topic})
+        self.assertEqual(result["state"], "error")
+        self.assertFalse(result["connected"])
+        self.assertEqual(self.client.stop_count, 1)
+
+    def test_unconfirmed_stop_falls_back_and_blocks_mode_switch(self):
+        self.smart_motion.bound_topic = self.topic
+        self.smart_motion.unbind_result = {
+            "state": "error",
+            "connected": True,
+            "stop_confirmed": False,
+            "error": "fresh zero-odometry stop was not confirmed",
+        }
+
+        result = self.plugin.dispatch("switch_mode_expert", {"fsm_id": 1})
+
+        self.assertEqual(result["state"], "error")
+        self.assertEqual(self.client.stop_count, 1)
+        self.assertEqual(self.client.fsm_ids, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_loco_topic_lifecycle.py
+++ b/unitree/g1/tests/test_loco_topic_lifecycle.py
@@ -94,6 +94,15 @@ class FakeSmartMotion:
     def __init__(self):
         self.bound_topic = ""
         self.expected_nav_id = ""
+        self.last_reason = None
+        self.proposal_execution = {
+            "received": 0,
+            "accepted": 0,
+            "rejected": 0,
+            "applied": 0,
+            "last_rejection_reason": None,
+            "last_set_velocity_ret": None,
+        }
         self.bind_result = None
         self.unbind_reasons = []
         self.unbind_result = {
@@ -118,6 +127,7 @@ class FakeSmartMotion:
 
     def unbind_velocity_proposal(self, reason):
         self.unbind_reasons.append(reason)
+        self.last_reason = reason
         result = dict(self.unbind_result)
         if not result.get("connected"):
             self.bound_topic = ""
@@ -131,6 +141,8 @@ class FakeSmartMotion:
             "topic": self.bound_topic or None,
             "expected_nav_id": self.expected_nav_id or None,
             "active_nav_id": self.expected_nav_id or None,
+            "last_reason": self.last_reason,
+            "proposal_execution": dict(self.proposal_execution),
         }
 
 
@@ -179,6 +191,29 @@ class LocoTopicLifecycleTest(unittest.TestCase):
         self.assertFalse(stopped["connected"])
         self.assertTrue(stopped["stop_confirmed"])
         self.assertEqual(self.smart_motion.unbind_reasons, ["canvas_stop"])
+
+    def test_info_retains_proposal_execution_diagnostics_after_unbind(self):
+        self.smart_motion.proposal_execution.update({
+            "received": 3,
+            "accepted": 2,
+            "rejected": 1,
+            "applied": 1,
+            "last_rejection_reason": "set_velocity_failed",
+            "last_set_velocity_ret": 3104,
+        })
+        self.plugin.dispatch(
+            "start",
+            {"input_topic": self.topic, "expected_nav_id": self.nav_id},
+        )
+
+        self.plugin.dispatch("stop", {})
+        info = self.plugin.dispatch("info", {"_tool_name": "loco"})
+
+        self.assertEqual(info["last_reason"], "canvas_stop")
+        self.assertEqual(
+            info["proposal_execution"],
+            self.smart_motion.proposal_execution,
+        )
 
     def test_start_accepts_exactly_one_input_topics_entry(self):
         started = self.plugin.dispatch(

--- a/unitree/g1/tests/test_loco_topic_lifecycle.py
+++ b/unitree/g1/tests/test_loco_topic_lifecycle.py
@@ -89,6 +89,7 @@ class FakeClient:
 class FakeSmartMotion:
     def __init__(self):
         self.bound_topic = ""
+        self.expected_nav_id = ""
         self.unbind_reasons = []
         self.unbind_result = {
             "state": "idle",
@@ -96,15 +97,24 @@ class FakeSmartMotion:
             "stop_confirmed": True,
         }
 
-    def bind_velocity_proposal(self, topic):
+    def bind_velocity_proposal(self, topic, expected_nav_id):
         self.bound_topic = topic
-        return {"connected": True, "armed": True, "topic": topic}
+        self.expected_nav_id = expected_nav_id
+        return {
+            "state": "connected",
+            "connected": True,
+            "armed": True,
+            "topic": topic,
+            "expected_nav_id": expected_nav_id,
+            "active_nav_id": expected_nav_id,
+        }
 
     def unbind_velocity_proposal(self, reason):
         self.unbind_reasons.append(reason)
         result = dict(self.unbind_result)
         if not result.get("connected"):
             self.bound_topic = ""
+            self.expected_nav_id = ""
         return result
 
     def get_velocity_proposal_status(self):
@@ -112,6 +122,8 @@ class FakeSmartMotion:
             "connected": bool(self.bound_topic),
             "armed": bool(self.bound_topic),
             "topic": self.bound_topic or None,
+            "expected_nav_id": self.expected_nav_id or None,
+            "active_nav_id": self.expected_nav_id or None,
         }
 
 
@@ -124,6 +136,7 @@ class LocoTopicLifecycleTest(unittest.TestCase):
             smart_motion=self.smart_motion,
         )
         self.topic = "/ubuntu/navigation/nav2/velocity_proposal"
+        self.nav_id = "nav-001"
 
     def test_tool_exposes_velocity_proposal_input(self):
         self.assertEqual(self.plugin.STOP_PRIORITY, 0)
@@ -142,9 +155,14 @@ class LocoTopicLifecycleTest(unittest.TestCase):
         )
 
     def test_start_info_stop_owns_real_subscription_lifecycle(self):
-        started = self.plugin.dispatch("start", {"input_topic": self.topic})
+        started = self.plugin.dispatch(
+            "start",
+            {"input_topic": self.topic, "expected_nav_id": self.nav_id},
+        )
         self.assertTrue(started["connected"])
+        self.assertEqual(started["state"], "ready")
         self.assertEqual(self.smart_motion.bound_topic, self.topic)
+        self.assertEqual(self.smart_motion.expected_nav_id, self.nav_id)
 
         info = self.plugin.dispatch("info", {"_tool_name": "loco"})
         self.assertTrue(info["connected"])
@@ -156,9 +174,21 @@ class LocoTopicLifecycleTest(unittest.TestCase):
         self.assertEqual(self.smart_motion.unbind_reasons, ["canvas_stop"])
 
     def test_start_accepts_exactly_one_input_topics_entry(self):
-        started = self.plugin.dispatch("start", {"input_topics": [self.topic]})
+        started = self.plugin.dispatch(
+            "start",
+            {"input_topics": [self.topic], "expected_nav_id": self.nav_id},
+        )
         self.assertTrue(started["connected"])
         self.assertEqual(self.smart_motion.bound_topic, self.topic)
+
+    def test_start_without_trusted_nav_id_fails_closed(self):
+        result = self.plugin.dispatch("start", {"input_topic": self.topic})
+
+        self.assertEqual(result["state"], "error")
+        self.assertFalse(result["connected"])
+        self.assertEqual(result["error"], "expected_nav_id_required")
+        self.assertEqual(self.smart_motion.bound_topic, "")
+        self.assertEqual(self.client.stop_count, 1)
 
     def test_other_tools_do_not_bind_or_unbind_loco_topic(self):
         self.smart_motion.bound_topic = self.topic
@@ -179,7 +209,11 @@ class LocoTopicLifecycleTest(unittest.TestCase):
     def test_wrong_topic_fails_closed_without_binding(self):
         self.smart_motion.bound_topic = self.topic
         result = self.plugin.dispatch(
-            "start", {"input_topic": "/ubuntu/navigation/nav2/cmd_vel_shadow"}
+            "start",
+            {
+                "input_topic": "/ubuntu/navigation/nav2/cmd_vel_shadow",
+                "expected_nav_id": self.nav_id,
+            },
         )
         self.assertEqual(result["state"], "error")
         self.assertFalse(result["connected"])
@@ -189,7 +223,10 @@ class LocoTopicLifecycleTest(unittest.TestCase):
 
     def test_missing_safety_harness_cannot_execute_topic(self):
         plugin = LocoPlugin({}, "ubuntu", None, self.client, smart_motion=None)
-        result = plugin.dispatch("start", {"input_topic": self.topic})
+        result = plugin.dispatch(
+            "start",
+            {"input_topic": self.topic, "expected_nav_id": self.nav_id},
+        )
         self.assertEqual(result["state"], "error")
         self.assertFalse(result["connected"])
         self.assertEqual(self.client.stop_count, 1)

--- a/unitree/g1/tests/test_loco_topic_lifecycle.py
+++ b/unitree/g1/tests/test_loco_topic_lifecycle.py
@@ -75,11 +75,15 @@ from device import LocoPlugin  # noqa: E402
 class FakeClient:
     def __init__(self):
         self.stop_count = 0
+        self.stop_ret = 0
+        self.stop_error = None
         self.fsm_ids = []
 
     def StopMove(self):
         self.stop_count += 1
-        return 0
+        if self.stop_error is not None:
+            raise self.stop_error
+        return self.stop_ret
 
     def SetFsmId(self, fsm_id):
         self.fsm_ids.append(fsm_id)
@@ -224,6 +228,35 @@ class LocoTopicLifecycleTest(unittest.TestCase):
         self.assertFalse(result["connected"])
         self.assertEqual(result["stop_move_ret"], 0)
         self.assertEqual(result["stop_confirmation"], diagnostics)
+        self.assertEqual(result["fallback_stop_ret"], 0)
+        self.assertIsNone(result["fallback_stop_error"])
+        self.assertEqual(self.client.stop_count, 1)
+
+    def test_start_preserves_child_diagnostics_when_fallback_stop_raises(self):
+        diagnostics = {
+            "stop_move_ret": 3104,
+            "stop_move_error": None,
+            "confirmation_timed_out": False,
+        }
+        self.smart_motion.bind_result = {
+            "error": "StopMove/odometry stop was not confirmed before proposal bind",
+            "connected": False,
+            "armed": False,
+            "stop_confirmed": False,
+            "stop_move_ret": 3104,
+            "stop_move_error": None,
+            "stop_confirmation": diagnostics,
+        }
+        self.client.stop_error = RuntimeError("fallback unavailable")
+
+        result = self.plugin.dispatch(
+            "start",
+            {"input_topic": self.topic, "expected_nav_id": self.nav_id},
+        )
+
+        self.assertEqual(result["stop_confirmation"], diagnostics)
+        self.assertIsNone(result["fallback_stop_ret"])
+        self.assertEqual(result["fallback_stop_error"], "fallback unavailable")
         self.assertEqual(self.client.stop_count, 1)
 
     def test_other_tools_do_not_bind_or_unbind_loco_topic(self):

--- a/unitree/g1/tests/test_proposal_apply_diagnostics.py
+++ b/unitree/g1/tests/test_proposal_apply_diagnostics.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import unittest
+
+from safety_harness import ProposalApplyDiagnostics
+from velocity_proposal import VelocityProposalGate, ProposalLimits
+
+
+class ProposalApplyDiagnosticsTest(unittest.TestCase):
+    def test_counts_and_last_set_velocity_result_are_reported(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.record_received()
+        diagnostics.record_accepted()
+        diagnostics.record_set_velocity(
+            {
+                "request_id": 12,
+                "ret": 0,
+                "error": None,
+                "completed_monotonic": 34.5,
+                "completed_unix_ms": 56,
+            },
+            duration=0.2,
+        )
+        diagnostics.record_applied()
+
+        self.assertEqual(
+            diagnostics.snapshot(),
+            {
+                "received": 1,
+                "accepted": 1,
+                "rejected": 0,
+                "applied": 1,
+                "last_rejection_reason": None,
+                "last_set_velocity_ret": 0,
+                "last_set_velocity_error": None,
+                "last_set_velocity_request_id": 12,
+                "last_set_velocity_duration_ms": 200,
+                "last_set_velocity_completed_monotonic": 34.5,
+                "last_set_velocity_completed_unix_ms": 56,
+            },
+        )
+
+    def test_rejection_and_apply_failure_remain_after_canvas_stop(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.record_received()
+        diagnostics.record_accepted()
+        diagnostics.record_set_velocity(
+            {
+                "request_id": 13,
+                "ret": 3104,
+                "error": None,
+                "completed_monotonic": 70.0,
+                "completed_unix_ms": 80,
+            },
+            duration=0.15,
+        )
+        diagnostics.record_rejected("set_velocity_failed")
+
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind("/proposal", "nav-1")
+        gate.unbind("canvas_stop")
+        status = gate.snapshot(100.0)
+        status["proposal_execution"] = diagnostics.snapshot()
+
+        self.assertEqual(status["last_reason"], "canvas_stop")
+        self.assertEqual(
+            status["proposal_execution"]["last_rejection_reason"],
+            "set_velocity_failed",
+        )
+        self.assertEqual(
+            status["proposal_execution"]["last_set_velocity_ret"],
+            3104,
+        )
+        self.assertEqual(status["proposal_execution"]["received"], 1)
+        self.assertEqual(status["proposal_execution"]["accepted"], 1)
+        self.assertEqual(status["proposal_execution"]["rejected"], 1)
+        self.assertEqual(status["proposal_execution"]["applied"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_proposal_apply_diagnostics.py
+++ b/unitree/g1/tests/test_proposal_apply_diagnostics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import queue
 import unittest
 
 from safety_harness import (
@@ -8,6 +9,8 @@ from safety_harness import (
     ProposalExecutionLease,
     authoritative_proposal_stop_reason,
     obstacle_observation_applies,
+    percentile_ms,
+    put_latest,
     proposal_decision_requires_physical_stop,
     translation_obstacle_heading,
     velocity_commands_differ,
@@ -35,10 +38,12 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
                 "ret": 0,
                 "error": None,
                 "applied": True,
+                "started_monotonic": 34.3,
                 "completed_monotonic": 34.5,
                 "completed_unix_ms": 56,
+                "duration_ms": 200,
             },
-            duration=0.2,
+            queued_monotonic=34.25,
         )
         diagnostics.record_applied()
 
@@ -50,6 +55,7 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
                 "accepted": 1,
                 "rejected": 0,
                 "applied": 1,
+                "coalesced": 0,
                 "first_received_monotonic": 10.0,
                 "last_received_monotonic": 10.0,
                 "last_receive_gap_ms": None,
@@ -74,6 +80,13 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
                 "last_set_velocity_applied": True,
                 "last_set_velocity_request_id": 12,
                 "last_set_velocity_duration_ms": 200,
+                "last_set_velocity_queue_delay_ms": 50,
+                "last_set_velocity_end_to_end_ms": 250,
+                "set_velocity_rpc_samples": 1,
+                "set_velocity_rpc_p50_ms": 200,
+                "set_velocity_rpc_p95_ms": 200,
+                "set_velocity_rpc_p99_ms": 200,
+                "set_velocity_rpc_max_ms": 200,
                 "last_set_velocity_completed_monotonic": 34.5,
                 "last_set_velocity_completed_unix_ms": 56,
                 "last_set_velocity_stop_ret": None,
@@ -90,10 +103,11 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
                 "request_id": 13,
                 "ret": 3104,
                 "error": None,
+                "started_monotonic": 69.85,
                 "completed_monotonic": 70.0,
                 "completed_unix_ms": 80,
+                "duration_ms": 150,
             },
-            duration=0.15,
         )
         diagnostics.record_rejected("set_velocity_failed")
 
@@ -116,6 +130,31 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
         self.assertEqual(status["proposal_execution"]["accepted"], 1)
         self.assertEqual(status["proposal_execution"]["rejected"], 1)
         self.assertEqual(status["proposal_execution"]["applied"], 0)
+
+    def test_rpc_percentiles_use_measured_result_duration(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.begin_session("nav-latency")
+        for duration_ms in (10, 20, 30, 40, 500):
+            diagnostics.record_set_velocity({"duration_ms": duration_ms})
+
+        status = diagnostics.snapshot()
+
+        self.assertEqual(status["set_velocity_rpc_samples"], 5)
+        self.assertEqual(status["set_velocity_rpc_p50_ms"], 30)
+        self.assertEqual(status["set_velocity_rpc_p95_ms"], 500)
+        self.assertEqual(status["set_velocity_rpc_p99_ms"], 500)
+        self.assertEqual(status["set_velocity_rpc_max_ms"], 500)
+        self.assertEqual(percentile_ms([], 0.99), None)
+
+    def test_latest_only_queue_coalesces_without_backlog(self):
+        commands = queue.Queue(maxsize=1)
+
+        self.assertFalse(put_latest(commands, {"sequence": 1}))
+        self.assertTrue(put_latest(commands, {"sequence": 2}))
+        self.assertTrue(put_latest(commands, {"sequence": 3}))
+
+        self.assertEqual(commands.qsize(), 1)
+        self.assertEqual(commands.get_nowait(), {"sequence": 3})
 
     def test_arrival_timing_and_watchdog_faults_are_reported(self):
         diagnostics = ProposalApplyDiagnostics()

--- a/unitree/g1/tests/test_proposal_apply_diagnostics.py
+++ b/unitree/g1/tests/test_proposal_apply_diagnostics.py
@@ -2,20 +2,34 @@ from __future__ import annotations
 
 import unittest
 
-from safety_harness import ProposalApplyDiagnostics
+from safety_harness import (
+    ProposalApplyDiagnostics,
+    ProposalExecutionLease,
+    velocity_commands_differ,
+)
 from velocity_proposal import VelocityProposalGate, ProposalLimits
 
 
 class ProposalApplyDiagnosticsTest(unittest.TestCase):
     def test_counts_and_last_set_velocity_result_are_reported(self):
         diagnostics = ProposalApplyDiagnostics()
-        diagnostics.record_received()
+        diagnostics.begin_session("nav-1")
+        diagnostics.record_received(10.0)
         diagnostics.record_accepted()
         diagnostics.record_set_velocity(
             {
                 "request_id": 12,
+                "rpc_method": "SetVelocity(continuous)",
+                "request": {
+                    "vx": 0.1,
+                    "vy": 0.0,
+                    "vyaw": 0.0,
+                    "nav_id": "nav-1",
+                    "sequence": 1,
+                },
                 "ret": 0,
                 "error": None,
+                "applied": True,
                 "completed_monotonic": 34.5,
                 "completed_unix_ms": 56,
             },
@@ -26,17 +40,39 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
         self.assertEqual(
             diagnostics.snapshot(),
             {
+                "session_nav_id": "nav-1",
                 "received": 1,
                 "accepted": 1,
                 "rejected": 0,
                 "applied": 1,
+                "first_received_monotonic": 10.0,
+                "last_received_monotonic": 10.0,
+                "last_receive_gap_ms": None,
+                "max_receive_gap_ms": None,
+                "last_proposal_age_ms": None,
+                "max_proposal_age_ms": None,
+                "expired_on_arrival": 0,
+                "watchdog_faults_by_reason": {},
+                "first_rejection_reason": None,
                 "last_rejection_reason": None,
+                "rejections_by_reason": {},
+                "last_set_velocity_rpc_method": "SetVelocity(continuous)",
+                "last_set_velocity_request": {
+                    "vx": 0.1,
+                    "vy": 0.0,
+                    "vyaw": 0.0,
+                    "nav_id": "nav-1",
+                    "sequence": 1,
+                },
                 "last_set_velocity_ret": 0,
                 "last_set_velocity_error": None,
+                "last_set_velocity_applied": True,
                 "last_set_velocity_request_id": 12,
                 "last_set_velocity_duration_ms": 200,
                 "last_set_velocity_completed_monotonic": 34.5,
                 "last_set_velocity_completed_unix_ms": 56,
+                "last_set_velocity_stop_ret": None,
+                "last_set_velocity_stop_error": None,
             },
         )
 
@@ -75,6 +111,159 @@ class ProposalApplyDiagnosticsTest(unittest.TestCase):
         self.assertEqual(status["proposal_execution"]["accepted"], 1)
         self.assertEqual(status["proposal_execution"]["rejected"], 1)
         self.assertEqual(status["proposal_execution"]["applied"], 0)
+
+    def test_arrival_timing_and_watchdog_faults_are_reported(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.begin_session("nav-timing")
+        diagnostics.record_received(10.0)
+        diagnostics.record_received(10.12)
+        diagnostics.record_proposal_arrival(
+            {"issued_at_unix_ms": 1_000, "ttl_ms": 200},
+            received_unix_ms=1_120,
+        )
+        diagnostics.record_proposal_arrival(
+            {"issued_at_unix_ms": 2_000, "ttl_ms": 200},
+            received_unix_ms=2_250,
+        )
+        diagnostics.record_watchdog_fault("proposal_ttl_expired")
+        diagnostics.record_watchdog_fault("proposal_ttl_expired")
+
+        status = diagnostics.snapshot()
+
+        self.assertEqual(status["first_received_monotonic"], 10.0)
+        self.assertEqual(status["last_received_monotonic"], 10.12)
+        self.assertEqual(status["last_receive_gap_ms"], 120)
+        self.assertEqual(status["max_receive_gap_ms"], 120)
+        self.assertEqual(status["last_proposal_age_ms"], 250)
+        self.assertEqual(status["max_proposal_age_ms"], 250)
+        self.assertEqual(status["expired_on_arrival"], 1)
+        self.assertEqual(
+            status["watchdog_faults_by_reason"],
+            {"proposal_ttl_expired": 2},
+        )
+
+    def test_first_rejection_and_breakdown_survive_cleanup_rejection(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.begin_session("nav-9")
+        diagnostics.record_rejected("set_velocity_failed")
+        diagnostics.record_rejected("stop_transition")
+        diagnostics.record_rejected("stop_transition")
+
+        status = diagnostics.snapshot()
+
+        self.assertEqual(status["first_rejection_reason"], "set_velocity_failed")
+        self.assertEqual(status["last_rejection_reason"], "stop_transition")
+        self.assertEqual(
+            status["rejections_by_reason"],
+            {"set_velocity_failed": 1, "stop_transition": 2},
+        )
+
+    def test_new_lease_resets_counts_but_unbind_does_not(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.begin_session("nav-1")
+        diagnostics.record_received()
+        diagnostics.record_rejected("invalid_json")
+
+        retained = diagnostics.snapshot()
+        diagnostics.begin_session("nav-2")
+        reset = diagnostics.snapshot()
+
+        self.assertEqual(retained["session_nav_id"], "nav-1")
+        self.assertEqual(retained["received"], 1)
+        self.assertEqual(reset["session_nav_id"], "nav-2")
+        self.assertEqual(reset["received"], 0)
+        self.assertIsNone(reset["first_received_monotonic"])
+        self.assertEqual(reset["watchdog_faults_by_reason"], {})
+        self.assertIsNone(reset["first_rejection_reason"])
+
+    def test_applied_count_deduplicates_safety_reapply_by_proposal_identity(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.begin_session("nav-1")
+
+        diagnostics.record_applied("nav-1", 4)
+        diagnostics.record_applied("nav-1", 4)
+        diagnostics.record_applied("nav-1", 5)
+
+        self.assertEqual(diagnostics.snapshot()["applied"], 2)
+
+    def test_new_session_can_apply_the_same_sequence_again(self):
+        diagnostics = ProposalApplyDiagnostics()
+        diagnostics.begin_session("nav-1")
+        diagnostics.record_applied("nav-1", 1)
+
+        diagnostics.begin_session("nav-2")
+        diagnostics.record_applied("nav-2", 1)
+
+        self.assertEqual(diagnostics.snapshot()["applied"], 1)
+
+
+class ProposalExecutionLeaseTest(unittest.TestCase):
+    def test_first_proposal_does_not_activate_before_rpc_arm(self):
+        lease = ProposalExecutionLease()
+
+        self.assertTrue(lease.renew_if_active(10.25))
+        self.assertIsNone(lease.watchdog_snapshot())
+
+    def test_valid_new_proposal_renews_active_deadline_without_shortening(self):
+        lease = ProposalExecutionLease()
+        generation = lease.arm(10.25)
+
+        self.assertTrue(lease.renew_if_active(10.40))
+        self.assertEqual(lease.watchdog_snapshot(), (generation, 10.40))
+        self.assertTrue(lease.renew_if_active(10.30))
+        self.assertEqual(lease.watchdog_snapshot(), (generation, 10.40))
+
+    def test_watchdog_rechecks_deadline_after_concurrent_renewal(self):
+        lease = ProposalExecutionLease()
+        generation = lease.arm(10.25)
+        observed = lease.watchdog_snapshot()
+        lease.renew_if_active(10.50)
+
+        tripped = lease.trip(
+            observed[0],
+            "proposal_ttl_expired",
+            now=10.30,
+        )
+
+        self.assertFalse(tripped)
+        self.assertEqual(lease.watchdog_snapshot(), (generation, 10.50))
+        self.assertIsNone(lease.current_fault())
+
+    def test_fault_cannot_be_renewed_or_cleared_by_later_apply(self):
+        lease = ProposalExecutionLease()
+        generation = lease.arm(10.25)
+
+        self.assertTrue(
+            lease.trip(generation, "proposal_ttl_expired", now=10.26)
+        )
+        self.assertFalse(lease.renew_if_active(10.50))
+        self.assertIsNone(lease.arm(10.50))
+        self.assertEqual(
+            lease.current_fault(),
+            (generation, "proposal_ttl_expired"),
+        )
+
+        lease.clear()
+        self.assertTrue(lease.renew_if_active(10.75))
+        self.assertIsNotNone(lease.arm(10.75))
+
+
+class VelocityCommandDifferenceTest(unittest.TestCase):
+    def test_identical_safety_velocity_is_a_noop(self):
+        self.assertFalse(
+            velocity_commands_differ(
+                (0.15, 0.0, 0.0),
+                (0.15, 0.0, 0.0),
+            )
+        )
+
+    def test_deceleration_and_resume_are_changes(self):
+        self.assertTrue(
+            velocity_commands_differ(
+                (0.15, 0.12, 0.35),
+                (0.15, 0.10, 0.20),
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_proposal_apply_diagnostics.py
+++ b/unitree/g1/tests/test_proposal_apply_diagnostics.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import math
 import unittest
 
 from safety_harness import (
     ProposalApplyDiagnostics,
     ProposalExecutionLease,
+    authoritative_proposal_stop_reason,
+    obstacle_observation_applies,
+    proposal_decision_requires_physical_stop,
+    translation_obstacle_heading,
     velocity_commands_differ,
 )
 from velocity_proposal import VelocityProposalGate, ProposalLimits
@@ -262,6 +267,67 @@ class VelocityCommandDifferenceTest(unittest.TestCase):
             velocity_commands_differ(
                 (0.15, 0.12, 0.35),
                 (0.15, 0.10, 0.20),
+            )
+        )
+
+
+class ObstacleRecoveryPolicyTest(unittest.TestCase):
+    def test_pure_rotation_has_no_translation_obstacle_cone(self):
+        command = {"vx": 0.0, "vy": 0.0, "vyaw": 0.2}
+
+        self.assertIsNone(translation_obstacle_heading(command))
+        self.assertFalse(
+            obstacle_observation_applies(command, 0.0, math.radians(30))
+        )
+
+    def test_matching_translation_cone_remains_fail_closed(self):
+        command = {"vx": 0.1, "vy": 0.0, "vyaw": 0.0}
+
+        self.assertTrue(
+            obstacle_observation_applies(command, 0.0, math.radians(30))
+        )
+
+    def test_stale_forward_cone_does_not_block_escape_direction(self):
+        reverse = {"vx": -0.05, "vy": 0.0, "vyaw": 0.0}
+        lateral = {"vx": 0.0, "vy": 0.1, "vyaw": 0.0}
+
+        self.assertFalse(
+            obstacle_observation_applies(reverse, 0.0, math.radians(30))
+        )
+        self.assertFalse(
+            obstacle_observation_applies(lateral, 0.0, math.radians(30))
+        )
+
+    def test_watchdog_fault_wins_over_concurrent_obstacle_stop(self):
+        self.assertEqual(
+            authoritative_proposal_stop_reason(
+                "obstacle",
+                (4, "proposal_ttl_expired"),
+            ),
+            "proposal_ttl_expired",
+        )
+        self.assertEqual(
+            authoritative_proposal_stop_reason("obstacle", None),
+            "obstacle",
+        )
+
+    def test_recoverable_hold_drains_stale_samples_without_repeated_stop(self):
+        self.assertFalse(
+            proposal_decision_requires_physical_stop(
+                "proposal_ttl_expired",
+                has_proposal=True,
+                proposal_motion_active=False,
+                newly_disarmed=False,
+                recoverable_stop_active=True,
+            )
+        )
+        self.assertTrue(
+            proposal_decision_requires_physical_stop(
+                "proposal_ttl_expired",
+                has_proposal=True,
+                proposal_motion_active=True,
+                newly_disarmed=True,
+                recoverable_stop_active=False,
             )
         )
 

--- a/unitree/g1/tests/test_proposal_rpc_executor.py
+++ b/unitree/g1/tests/test_proposal_rpc_executor.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import queue
+import threading
+import unittest
+
+from rpc_proxy import (
+    PROPOSAL_CONTINUOUS_DURATION_SECONDS,
+    ProposalRpcExecutor,
+    RpcProxy,
+)
+
+
+class FakeClock:
+    def __init__(self, monotonic=10.0, wall=1_800_000_000.0):
+        self.monotonic_value = monotonic
+        self.wall_value = wall
+
+    def monotonic(self):
+        return self.monotonic_value
+
+    def wall(self):
+        return self.wall_value
+
+    def advance(self, seconds):
+        self.monotonic_value += seconds
+        self.wall_value += seconds
+
+
+class FakeLoco:
+    def __init__(self, clock, set_velocity_ret=0, set_velocity_delay=0.0):
+        self.clock = clock
+        self.set_velocity_ret = set_velocity_ret
+        self.set_velocity_delay = set_velocity_delay
+        self.velocity_calls = []
+        self.stop_calls = 0
+
+    def SetVelocity(self, vx, vy, vyaw, duration):
+        self.velocity_calls.append((vx, vy, vyaw, duration))
+        self.clock.advance(self.set_velocity_delay)
+        return self.set_velocity_ret
+
+    def StopMove(self):
+        self.stop_calls += 1
+        return 0
+
+
+class ProposalRpcExecutorTest(unittest.TestCase):
+    def make_executor(self, **loco_kwargs):
+        clock = FakeClock()
+        loco = FakeLoco(clock, **loco_kwargs)
+        executor = ProposalRpcExecutor(
+            loco,
+            monotonic=clock.monotonic,
+            wall_time=clock.wall,
+        )
+        return clock, loco, executor
+
+    def apply(self, executor, deadline=10.25, sequence=1):
+        return executor.apply(
+            0.1,
+            0.02,
+            0.03,
+            deadline_monotonic=deadline,
+            nav_id="nav-1",
+            sequence=sequence,
+            request_id=7,
+        )
+
+    def test_live_proposal_uses_known_working_continuous_velocity_semantics(self):
+        _, loco, executor = self.make_executor()
+
+        result = self.apply(executor)
+
+        self.assertTrue(result["applied"])
+        self.assertEqual(result["ret"], 0)
+        self.assertEqual(result["rpc_method"], "SetVelocity(continuous)")
+        self.assertEqual(
+            loco.velocity_calls,
+            [(0.1, 0.02, 0.03, PROPOSAL_CONTINUOUS_DURATION_SECONDS)],
+        )
+        self.assertTrue(executor.active)
+        self.assertEqual(executor.nav_id, "nav-1")
+        self.assertEqual(executor.sequence, 1)
+
+    def test_deadline_expiry_stops_and_retires_parent_lease(self):
+        clock, loco, executor = self.make_executor()
+        self.apply(executor)
+
+        clock.advance(0.251)
+        stopped = executor.expire_if_due()
+
+        self.assertEqual(stopped["reason"], "proposal_ttl_expired")
+        self.assertEqual(stopped["ret"], 0)
+        self.assertEqual(loco.stop_calls, 1)
+        self.assertFalse(executor.active)
+
+    def test_command_expired_in_queue_is_never_applied(self):
+        _, loco, executor = self.make_executor()
+
+        result = self.apply(executor, deadline=9.99)
+
+        self.assertFalse(result["applied"])
+        self.assertEqual(result["error"], "proposal_ttl_expired_before_rpc")
+        self.assertEqual(loco.velocity_calls, [])
+        self.assertEqual(loco.stop_calls, 1)
+        self.assertFalse(executor.active)
+
+    def test_rpc_completion_after_deadline_is_stopped_fail_closed(self):
+        _, loco, executor = self.make_executor(set_velocity_delay=0.3)
+
+        result = self.apply(executor)
+
+        self.assertEqual(result["ret"], 0)
+        self.assertFalse(result["applied"])
+        self.assertEqual(result["error"], "proposal_ttl_expired_after_rpc")
+        self.assertEqual(loco.stop_calls, 1)
+        self.assertFalse(executor.active)
+
+    def test_nonzero_velocity_rpc_return_triggers_stop(self):
+        _, loco, executor = self.make_executor(set_velocity_ret=3104)
+
+        result = self.apply(executor)
+
+        self.assertEqual(result["ret"], 3104)
+        self.assertFalse(result["applied"])
+        self.assertEqual(loco.stop_calls, 1)
+        self.assertFalse(executor.active)
+
+    def test_newer_proposal_refreshes_parent_deadline_and_identity(self):
+        clock, loco, executor = self.make_executor()
+        self.apply(executor, deadline=10.20, sequence=1)
+        clock.advance(0.1)
+
+        result = self.apply(executor, deadline=10.35, sequence=2)
+
+        self.assertTrue(result["applied"])
+        self.assertEqual(executor.deadline_monotonic, 10.35)
+        self.assertEqual(executor.sequence, 2)
+        self.assertEqual(len(loco.velocity_calls), 2)
+        clock.advance(0.11)
+        self.assertIsNone(executor.expire_if_due())
+
+
+class RpcProxyCorrelationTest(unittest.TestCase):
+    def make_proxy(self):
+        proxy = RpcProxy.__new__(RpcProxy)
+        proxy._lock = threading.Lock()
+        proxy._request_id = 0
+        proxy._cmd_q = queue.Queue()
+        proxy._result_q = queue.Queue()
+        return proxy
+
+    def test_late_timed_out_reply_cannot_satisfy_next_stop(self):
+        proxy = self.make_proxy()
+        first = proxy._call("SetVelocity", timeout=0.01)
+        first_command = proxy._cmd_q.get_nowait()
+        proxy._result_q.put({
+            "request_id": first_command["request_id"],
+            "result": {"stale": True},
+        })
+
+        def respond_to_stop():
+            command = proxy._cmd_q.get(timeout=0.2)
+            proxy._result_q.put({
+                "request_id": command["request_id"],
+                "result": 0,
+            })
+
+        responder = threading.Thread(target=respond_to_stop, daemon=True)
+        responder.start()
+        second = proxy._call("StopMove", timeout=0.2)
+        responder.join(timeout=0.5)
+
+        self.assertIsNone(first)
+        self.assertEqual(second, 0)
+        self.assertFalse(responder.is_alive())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 import unittest
 
 from safety_harness import SmartMotionProxy
@@ -35,6 +36,80 @@ class SmartMotionExitMonitorTest(unittest.TestCase):
 
         proxy._fallback_stop = fail_stop
         proxy._monitor_process_exit()
+
+
+class SmartMotionParentStopSequenceTest(unittest.TestCase):
+    def make_proxy(self, fallback_stop):
+        proxy = SmartMotionProxy.__new__(SmartMotionProxy)
+        proxy._call_lock = threading.RLock()
+        proxy._fallback_stop = fallback_stop
+        return proxy
+
+    def test_bind_brackets_parent_stop_with_child_confirmation(self):
+        calls = []
+        proxy = self.make_proxy(lambda: calls.append(("stop", {})) or 0)
+
+        def fake_call(method, **kwargs):
+            calls.append((method, kwargs))
+            if method == "begin_velocity_proposal_stop_confirmation":
+                return {
+                    "confirmation_start": {
+                        "monotonic": 12.0,
+                        "unix_ms": 34,
+                        "odometry_callback_count": 56,
+                    }
+                }
+            return {"connected": True, "external": kwargs["external_stop_attempt"]}
+
+        proxy._call = fake_call
+        result = proxy.bind_velocity_proposal("/proposal", "nav-1")
+
+        self.assertEqual(
+            [name for name, _ in calls],
+            ["begin_velocity_proposal_stop_confirmation", "stop", "bind_velocity_proposal"],
+        )
+        self.assertTrue(result["connected"])
+        self.assertEqual(result["external"]["stop_move_ret"], 0)
+        self.assertIsNone(result["external"]["stop_move_error"])
+        self.assertEqual(
+            result["external"]["confirmation_start"]["odometry_callback_count"],
+            56,
+        )
+
+    def test_parent_stop_exception_is_forwarded_for_fail_closed_confirmation(self):
+        def fail_stop():
+            raise RuntimeError("parent rpc unavailable")
+
+        proxy = self.make_proxy(fail_stop)
+
+        def fake_call(method, **kwargs):
+            if method == "begin_velocity_proposal_stop_confirmation":
+                return {
+                    "confirmation_start": {
+                        "monotonic": 1.0,
+                        "unix_ms": 2,
+                        "odometry_callback_count": 3,
+                    }
+                }
+            return kwargs["external_stop_attempt"]
+
+        proxy._call = fake_call
+        result = proxy.unbind_velocity_proposal("canvas_stop")
+
+        self.assertIsNone(result["stop_move_ret"])
+        self.assertEqual(result["stop_move_error"], "parent rpc unavailable")
+
+    def test_missing_child_boundary_still_issues_parent_stop_and_fails_closed(self):
+        stop_calls = []
+        proxy = self.make_proxy(lambda: stop_calls.append("stop") or 0)
+        proxy._call = lambda method, **kwargs: {"error": "child unavailable"}
+
+        result = proxy.bind_velocity_proposal("/proposal", "nav-1")
+
+        self.assertEqual(stop_calls, ["stop"])
+        self.assertFalse(result["stop_confirmed"])
+        self.assertEqual(result["stop_move_ret"], 0)
+        self.assertEqual(result["error"], "child unavailable")
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import unittest
+
+from safety_harness import SmartMotionProxy
+
+
+class FakeProcess:
+    def __init__(self):
+        self.join_count = 0
+
+    def join(self):
+        self.join_count += 1
+
+
+class SmartMotionExitMonitorTest(unittest.TestCase):
+    def test_child_exit_always_issues_parent_side_stop(self):
+        process = FakeProcess()
+        stop_calls = []
+        proxy = SmartMotionProxy.__new__(SmartMotionProxy)
+        proxy._proc = process
+        proxy._fallback_stop = lambda: stop_calls.append("StopMove")
+
+        proxy._monitor_process_exit()
+
+        self.assertEqual(process.join_count, 1)
+        self.assertEqual(stop_calls, ["StopMove"])
+
+    def test_stop_failure_does_not_crash_exit_monitor(self):
+        proxy = SmartMotionProxy.__new__(SmartMotionProxy)
+        proxy._proc = FakeProcess()
+
+        def fail_stop():
+            raise RuntimeError("rpc unavailable")
+
+        proxy._fallback_stop = fail_stop
+        proxy._monitor_process_exit()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -10,8 +10,9 @@ import unittest
 from safety_harness import (
     SmartMotionProxy,
     _run_smart_motion_process,
+    request_parent_apply_velocity_proposal,
     request_parent_get_fsm_id,
-    request_parent_set_velocity,
+    request_parent_stop_velocity_proposal,
 )
 
 
@@ -122,13 +123,19 @@ class SmartMotionParentStopSequenceTest(unittest.TestCase):
 
 
 class SmartMotionParentLocoSequenceTest(unittest.TestCase):
-    def start_proxy(self, parent_set_velocity, parent_get_fsm_id=lambda: (0, 500)):
+    def start_proxy(
+        self,
+        parent_apply_velocity,
+        parent_get_fsm_id=lambda: (0, 500),
+        fallback_stop=lambda: 0,
+    ):
         proxy = SmartMotionProxy.__new__(SmartMotionProxy)
         proxy._parent_velocity_queue = queue.Queue()
         proxy._parent_velocity_result_queue = queue.Queue()
         proxy._parent_velocity_shutdown = threading.Event()
-        proxy._parent_set_velocity = parent_set_velocity
+        proxy._parent_apply_velocity_proposal = parent_apply_velocity
         proxy._parent_get_fsm_id = parent_get_fsm_id
+        proxy._fallback_stop = fallback_stop
         proxy._parent_velocity_thread = threading.Thread(
             target=proxy._serve_parent_velocity_requests,
             daemon=True,
@@ -141,44 +148,122 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
         proxy._parent_velocity_thread.join(timeout=0.5)
         self.assertFalse(proxy._parent_velocity_thread.is_alive())
 
-    def test_child_request_executes_set_velocity_on_parent(self):
+    def test_child_request_executes_controlled_velocity_on_parent(self):
         calls = []
-        proxy = self.start_proxy(
-            lambda vx, vy, vyaw, duration: calls.append(
-                (vx, vy, vyaw, duration)
-            ) or 0
-        )
+        def apply(vx, vy, vyaw, deadline, nav_id, sequence, request_id):
+            calls.append(
+                (vx, vy, vyaw, deadline, nav_id, sequence, request_id)
+            )
+            return {"ret": 0, "error": None, "applied": True}
+
+        proxy = self.start_proxy(apply)
+        deadline = time.monotonic() + 0.2
         try:
-            result = request_parent_set_velocity(
+            result = request_parent_apply_velocity_proposal(
                 proxy._parent_velocity_queue,
                 proxy._parent_velocity_result_queue,
                 request_id=7,
                 vx=0.1,
                 vy=0.02,
                 vyaw=0.03,
-                duration=0.2,
+                deadline_monotonic=deadline,
+                nav_id="nav-1",
+                sequence=3,
                 timeout=0.2,
             )
         finally:
             self.stop_proxy(proxy)
 
-        self.assertEqual(calls, [(0.1, 0.02, 0.03, 0.2)])
+        self.assertEqual(
+            calls,
+            [(0.1, 0.02, 0.03, deadline, "nav-1", 3, 7)],
+        )
         self.assertEqual(result["request_id"], 7)
         self.assertEqual(result["ret"], 0)
         self.assertIsNone(result["error"])
         self.assertIsNotNone(result["completed_monotonic"])
 
     def test_parent_nonzero_return_is_correlated(self):
-        proxy = self.start_proxy(lambda *_: 3104)
+        proxy = self.start_proxy(
+            lambda *_: {"ret": 3104, "error": None, "applied": False}
+        )
         try:
-            result = request_parent_set_velocity(
+            result = request_parent_apply_velocity_proposal(
                 proxy._parent_velocity_queue,
                 proxy._parent_velocity_result_queue,
                 request_id=8,
                 vx=0.1,
                 vy=0.0,
                 vyaw=0.0,
-                duration=0.2,
+                deadline_monotonic=time.monotonic() + 0.2,
+                nav_id="nav-1",
+                sequence=4,
+                timeout=0.2,
+            )
+        finally:
+            self.stop_proxy(proxy)
+
+        self.assertEqual(result["ret"], 3104)
+        self.assertIsNone(result["error"])
+
+    def test_runtime_stop_is_ordered_after_inflight_parent_apply(self):
+        calls = []
+        apply_started = threading.Event()
+        release_apply = threading.Event()
+
+        def apply(*_):
+            calls.append("apply_started")
+            apply_started.set()
+            release_apply.wait(timeout=0.5)
+            calls.append("apply_completed")
+            return {"ret": 0, "error": None, "applied": True}
+
+        def stop():
+            calls.append("stop")
+            return 0
+
+        proxy = self.start_proxy(apply, fallback_stop=stop)
+        try:
+            proxy._parent_velocity_queue.put({
+                "method": "apply_velocity_proposal",
+                "request_id": 20,
+                "vx": 0.1,
+                "vy": 0.0,
+                "vyaw": 0.0,
+                "deadline_monotonic": time.monotonic() + 1.0,
+                "nav_id": "nav-1",
+                "sequence": 1,
+            })
+            self.assertTrue(apply_started.wait(timeout=0.2))
+            proxy._parent_velocity_queue.put({
+                "method": "stop_velocity_proposal",
+                "request_id": 21,
+            })
+            time.sleep(0.01)
+            self.assertEqual(calls, ["apply_started"])
+            release_apply.set()
+            first = proxy._parent_velocity_result_queue.get(timeout=0.5)
+            second = proxy._parent_velocity_result_queue.get(timeout=0.5)
+        finally:
+            release_apply.set()
+            self.stop_proxy(proxy)
+
+        self.assertEqual(calls, ["apply_started", "apply_completed", "stop"])
+        self.assertEqual(first["request_id"], 20)
+        self.assertEqual(first["ret"], 0)
+        self.assertEqual(second["request_id"], 21)
+        self.assertEqual(second["ret"], 0)
+
+    def test_runtime_parent_stop_failure_is_reported(self):
+        proxy = self.start_proxy(
+            lambda *_: {"ret": 0, "error": None, "applied": True},
+            fallback_stop=lambda: 3104,
+        )
+        try:
+            result = request_parent_stop_velocity_proposal(
+                proxy._parent_velocity_queue,
+                proxy._parent_velocity_result_queue,
+                request_id=22,
                 timeout=0.2,
             )
         finally:
@@ -193,14 +278,16 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
 
         proxy = self.start_proxy(fail)
         try:
-            result = request_parent_set_velocity(
+            result = request_parent_apply_velocity_proposal(
                 proxy._parent_velocity_queue,
                 proxy._parent_velocity_result_queue,
                 request_id=9,
                 vx=0.1,
                 vy=0.0,
                 vyaw=0.0,
-                duration=0.2,
+                deadline_monotonic=time.monotonic() + 0.2,
+                nav_id="nav-1",
+                sequence=5,
                 timeout=0.2,
             )
         finally:
@@ -214,20 +301,22 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
         result_queue = queue.Queue()
         started = time.monotonic()
 
-        result = request_parent_set_velocity(
+        result = request_parent_apply_velocity_proposal(
             request_queue,
             result_queue,
             request_id=10,
             vx=0.1,
             vy=0.0,
             vyaw=0.0,
-            duration=0.2,
+            deadline_monotonic=time.monotonic() + 0.2,
+            nav_id="nav-1",
+            sequence=6,
             timeout=0.03,
         )
 
         self.assertLess(time.monotonic() - started, 0.15)
         self.assertIsNone(result["ret"])
-        self.assertEqual(result["error"], "parent_set_velocity_timeout")
+        self.assertEqual(result["error"], "parent_velocity_proposal_timeout")
 
     def test_stale_parent_reply_cannot_satisfy_new_request(self):
         request_queue = queue.Queue()
@@ -244,14 +333,16 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
 
         responder = threading.Thread(target=reply_current, daemon=True)
         responder.start()
-        result = request_parent_set_velocity(
+        result = request_parent_apply_velocity_proposal(
             request_queue,
             result_queue,
             request_id=11,
             vx=0.1,
             vy=0.0,
             vyaw=0.0,
-            duration=0.2,
+            deadline_monotonic=time.monotonic() + 0.2,
+            nav_id="nav-1",
+            sequence=7,
             timeout=0.2,
         )
         responder.join(timeout=0.5)
@@ -260,7 +351,10 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
         self.assertEqual(result["ret"], 3104)
 
     def test_child_request_gets_fsm_id_from_parent(self):
-        proxy = self.start_proxy(lambda *_: 0, lambda: (0, 500))
+        proxy = self.start_proxy(
+            lambda *_: {"ret": 0, "error": None, "applied": True},
+            lambda: (0, 500),
+        )
         try:
             result = request_parent_get_fsm_id(
                 proxy._parent_velocity_queue,
@@ -280,7 +374,10 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
         def fail():
             raise RuntimeError("parent FSM RPC unavailable")
 
-        proxy = self.start_proxy(lambda *_: 0, fail)
+        proxy = self.start_proxy(
+            lambda *_: {"ret": 0, "error": None, "applied": True},
+            fail,
+        )
         try:
             result = request_parent_get_fsm_id(
                 proxy._parent_velocity_queue,
@@ -346,9 +443,29 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
 
         self.assertNotIn("proposal_loco_client", source)
         self.assertNotIn("fsm_loco_client", source)
-        self.assertIn("apply_parent_set_velocity", source)
+        self.assertIn("apply_parent_velocity_proposal", source)
+        self.assertIn("proposal_apply_loop", source)
         self.assertIn("query_parent_fsm_id", source)
+        self.assertIn("stop_parent_velocity_proposal", source)
+        self.assertEqual(
+            source.count("= stop_parent_velocity_proposal()"),
+            2,
+        )
+        self.assertIn("last_proposal_stop_result = dict(result)", source)
+        self.assertIn('"last_proposal_stop": (', source)
+        self.assertIn("last_proposal_stop_result = None", source)
         self.assertIn("parent_loco_rpc_lock", source)
+        self.assertIn("proposal_ros_spin_loop", source)
+        callback_source = source[
+            source.index("def on_velocity_proposal"):
+            source.index("def apply_safety_velocity")
+        ]
+        self.assertLess(
+            callback_source.index("refresh_proposal_execution_deadline("),
+            callback_source.index("proposal_apply_diagnostics.record_accepted()"),
+        )
+        self.assertIn('name="g1_loco_proposal_ros"', source)
+        self.assertEqual(source.count("executor.spin_once"), 2)
 
     def test_main_wires_parent_rpc_proxy_loco_calls(self):
         main_source = Path(__file__).resolve().parents[1].joinpath(
@@ -356,7 +473,7 @@ class SmartMotionParentLocoSequenceTest(unittest.TestCase):
         ).read_text(encoding="utf-8")
 
         self.assertIn(
-            "parent_set_velocity=loco_client.SetVelocity",
+            "parent_apply_velocity_proposal=loco_client.ApplyVelocityProposal",
             main_source,
         )
         self.assertIn(

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -10,6 +10,7 @@ import unittest
 from safety_harness import (
     SmartMotionProxy,
     _run_smart_motion_process,
+    request_parent_get_fsm_id,
     request_parent_set_velocity,
 )
 
@@ -120,13 +121,14 @@ class SmartMotionParentStopSequenceTest(unittest.TestCase):
         self.assertEqual(result["error"], "child unavailable")
 
 
-class SmartMotionParentVelocitySequenceTest(unittest.TestCase):
-    def start_proxy(self, parent_set_velocity):
+class SmartMotionParentLocoSequenceTest(unittest.TestCase):
+    def start_proxy(self, parent_set_velocity, parent_get_fsm_id=lambda: (0, 500)):
         proxy = SmartMotionProxy.__new__(SmartMotionProxy)
         proxy._parent_velocity_queue = queue.Queue()
         proxy._parent_velocity_result_queue = queue.Queue()
         proxy._parent_velocity_shutdown = threading.Event()
         proxy._parent_set_velocity = parent_set_velocity
+        proxy._parent_get_fsm_id = parent_get_fsm_id
         proxy._parent_velocity_thread = threading.Thread(
             target=proxy._serve_parent_velocity_requests,
             daemon=True,
@@ -257,19 +259,108 @@ class SmartMotionParentVelocitySequenceTest(unittest.TestCase):
         self.assertEqual(result["request_id"], 11)
         self.assertEqual(result["ret"], 3104)
 
+    def test_child_request_gets_fsm_id_from_parent(self):
+        proxy = self.start_proxy(lambda *_: 0, lambda: (0, 500))
+        try:
+            result = request_parent_get_fsm_id(
+                proxy._parent_velocity_queue,
+                proxy._parent_velocity_result_queue,
+                request_id=12,
+                timeout=0.2,
+            )
+        finally:
+            self.stop_proxy(proxy)
+
+        self.assertEqual(result["request_id"], 12)
+        self.assertEqual(result["ret"], 0)
+        self.assertEqual(result["fsm_id"], 500)
+        self.assertIsNone(result["error"])
+
+    def test_parent_fsm_exception_is_returned_to_child(self):
+        def fail():
+            raise RuntimeError("parent FSM RPC unavailable")
+
+        proxy = self.start_proxy(lambda *_: 0, fail)
+        try:
+            result = request_parent_get_fsm_id(
+                proxy._parent_velocity_queue,
+                proxy._parent_velocity_result_queue,
+                request_id=13,
+                timeout=0.2,
+            )
+        finally:
+            self.stop_proxy(proxy)
+
+        self.assertIsNone(result["ret"])
+        self.assertIsNone(result["fsm_id"])
+        self.assertEqual(result["error"], "parent FSM RPC unavailable")
+
+    def test_parent_fsm_wait_is_bounded(self):
+        started = time.monotonic()
+        result = request_parent_get_fsm_id(
+            queue.Queue(),
+            queue.Queue(),
+            request_id=14,
+            timeout=0.03,
+        )
+
+        self.assertLess(time.monotonic() - started, 0.15)
+        self.assertIsNone(result["ret"])
+        self.assertEqual(result["error"], "parent_get_fsm_id_timeout")
+
+    def test_stale_set_velocity_reply_cannot_satisfy_fsm_request(self):
+        request_queue = queue.Queue()
+        result_queue = queue.Queue()
+        result_queue.put({
+            "method": "set_velocity",
+            "request_id": 14,
+            "ret": 0,
+            "error": None,
+        })
+
+        def reply_current():
+            time.sleep(0.01)
+            result_queue.put({
+                "method": "get_fsm_id",
+                "request_id": 15,
+                "ret": 0,
+                "fsm_id": 801,
+                "error": None,
+            })
+
+        responder = threading.Thread(target=reply_current, daemon=True)
+        responder.start()
+        result = request_parent_get_fsm_id(
+            request_queue,
+            result_queue,
+            request_id=15,
+            timeout=0.2,
+        )
+        responder.join(timeout=0.5)
+
+        self.assertEqual(result["request_id"], 15)
+        self.assertEqual(result["fsm_id"], 801)
+
     def test_proposal_execution_has_no_child_loco_setvelocity(self):
         source = inspect.getsource(_run_smart_motion_process)
 
         self.assertNotIn("proposal_loco_client", source)
+        self.assertNotIn("fsm_loco_client", source)
         self.assertIn("apply_parent_set_velocity", source)
+        self.assertIn("query_parent_fsm_id", source)
+        self.assertIn("parent_loco_rpc_lock", source)
 
-    def test_main_wires_parent_rpc_proxy_set_velocity(self):
+    def test_main_wires_parent_rpc_proxy_loco_calls(self):
         main_source = Path(__file__).resolve().parents[1].joinpath(
             "main.py"
         ).read_text(encoding="utf-8")
 
         self.assertIn(
             "parent_set_velocity=loco_client.SetVelocity",
+            main_source,
+        )
+        self.assertIn(
+            "parent_get_fsm_id=loco_client.GetFsmId",
             main_source,
         )
 

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import inspect
+from pathlib import Path
+import queue
 import threading
+import time
 import unittest
 
-from safety_harness import SmartMotionProxy
+from safety_harness import (
+    SmartMotionProxy,
+    _run_smart_motion_process,
+    request_parent_set_velocity,
+)
 
 
 class FakeProcess:
@@ -110,6 +118,160 @@ class SmartMotionParentStopSequenceTest(unittest.TestCase):
         self.assertFalse(result["stop_confirmed"])
         self.assertEqual(result["stop_move_ret"], 0)
         self.assertEqual(result["error"], "child unavailable")
+
+
+class SmartMotionParentVelocitySequenceTest(unittest.TestCase):
+    def start_proxy(self, parent_set_velocity):
+        proxy = SmartMotionProxy.__new__(SmartMotionProxy)
+        proxy._parent_velocity_queue = queue.Queue()
+        proxy._parent_velocity_result_queue = queue.Queue()
+        proxy._parent_velocity_shutdown = threading.Event()
+        proxy._parent_set_velocity = parent_set_velocity
+        proxy._parent_velocity_thread = threading.Thread(
+            target=proxy._serve_parent_velocity_requests,
+            daemon=True,
+        )
+        proxy._parent_velocity_thread.start()
+        return proxy
+
+    def stop_proxy(self, proxy):
+        proxy._signal_parent_velocity_shutdown()
+        proxy._parent_velocity_thread.join(timeout=0.5)
+        self.assertFalse(proxy._parent_velocity_thread.is_alive())
+
+    def test_child_request_executes_set_velocity_on_parent(self):
+        calls = []
+        proxy = self.start_proxy(
+            lambda vx, vy, vyaw, duration: calls.append(
+                (vx, vy, vyaw, duration)
+            ) or 0
+        )
+        try:
+            result = request_parent_set_velocity(
+                proxy._parent_velocity_queue,
+                proxy._parent_velocity_result_queue,
+                request_id=7,
+                vx=0.1,
+                vy=0.02,
+                vyaw=0.03,
+                duration=0.2,
+                timeout=0.2,
+            )
+        finally:
+            self.stop_proxy(proxy)
+
+        self.assertEqual(calls, [(0.1, 0.02, 0.03, 0.2)])
+        self.assertEqual(result["request_id"], 7)
+        self.assertEqual(result["ret"], 0)
+        self.assertIsNone(result["error"])
+        self.assertIsNotNone(result["completed_monotonic"])
+
+    def test_parent_nonzero_return_is_correlated(self):
+        proxy = self.start_proxy(lambda *_: 3104)
+        try:
+            result = request_parent_set_velocity(
+                proxy._parent_velocity_queue,
+                proxy._parent_velocity_result_queue,
+                request_id=8,
+                vx=0.1,
+                vy=0.0,
+                vyaw=0.0,
+                duration=0.2,
+                timeout=0.2,
+            )
+        finally:
+            self.stop_proxy(proxy)
+
+        self.assertEqual(result["ret"], 3104)
+        self.assertIsNone(result["error"])
+
+    def test_parent_exception_is_returned_to_child(self):
+        def fail(*_):
+            raise RuntimeError("parent rpc unavailable")
+
+        proxy = self.start_proxy(fail)
+        try:
+            result = request_parent_set_velocity(
+                proxy._parent_velocity_queue,
+                proxy._parent_velocity_result_queue,
+                request_id=9,
+                vx=0.1,
+                vy=0.0,
+                vyaw=0.0,
+                duration=0.2,
+                timeout=0.2,
+            )
+        finally:
+            self.stop_proxy(proxy)
+
+        self.assertIsNone(result["ret"])
+        self.assertEqual(result["error"], "parent rpc unavailable")
+
+    def test_child_wait_is_bounded_when_parent_does_not_reply(self):
+        request_queue = queue.Queue()
+        result_queue = queue.Queue()
+        started = time.monotonic()
+
+        result = request_parent_set_velocity(
+            request_queue,
+            result_queue,
+            request_id=10,
+            vx=0.1,
+            vy=0.0,
+            vyaw=0.0,
+            duration=0.2,
+            timeout=0.03,
+        )
+
+        self.assertLess(time.monotonic() - started, 0.15)
+        self.assertIsNone(result["ret"])
+        self.assertEqual(result["error"], "parent_set_velocity_timeout")
+
+    def test_stale_parent_reply_cannot_satisfy_new_request(self):
+        request_queue = queue.Queue()
+        result_queue = queue.Queue()
+        result_queue.put({"request_id": 10, "ret": 0, "error": None})
+
+        def reply_current():
+            time.sleep(0.01)
+            result_queue.put({
+                "request_id": 11,
+                "ret": 3104,
+                "error": None,
+            })
+
+        responder = threading.Thread(target=reply_current, daemon=True)
+        responder.start()
+        result = request_parent_set_velocity(
+            request_queue,
+            result_queue,
+            request_id=11,
+            vx=0.1,
+            vy=0.0,
+            vyaw=0.0,
+            duration=0.2,
+            timeout=0.2,
+        )
+        responder.join(timeout=0.5)
+
+        self.assertEqual(result["request_id"], 11)
+        self.assertEqual(result["ret"], 3104)
+
+    def test_proposal_execution_has_no_child_loco_setvelocity(self):
+        source = inspect.getsource(_run_smart_motion_process)
+
+        self.assertNotIn("proposal_loco_client", source)
+        self.assertIn("apply_parent_set_velocity", source)
+
+    def test_main_wires_parent_rpc_proxy_set_velocity(self):
+        main_source = Path(__file__).resolve().parents[1].joinpath(
+            "main.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "parent_set_velocity=loco_client.SetVelocity",
+            main_source,
+        )
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_smart_motion_proxy.py
+++ b/unitree/g1/tests/test_smart_motion_proxy.py
@@ -48,6 +48,92 @@ class SmartMotionExitMonitorTest(unittest.TestCase):
         proxy._monitor_process_exit()
 
 
+class SmartMotionCallRoutingTest(unittest.TestCase):
+    class AliveProcess:
+        def __init__(self):
+            self.alive = True
+            self.terminate_count = 0
+            self.join_count = 0
+
+        def is_alive(self):
+            return self.alive
+
+        def terminate(self):
+            self.terminate_count += 1
+            self.alive = False
+
+        def join(self, timeout=None):
+            self.join_count += 1
+
+    def make_proxy(self, *, dispatch_results: bool):
+        proxy = SmartMotionProxy.__new__(SmartMotionProxy)
+        proxy._proc = self.AliveProcess()
+        proxy._cmd_queue = queue.Queue()
+        proxy._result_queue = queue.Queue()
+        proxy._pending = {}
+        proxy._dispatch_lock = threading.Lock()
+        proxy._req_counter = 0
+        proxy._req_lock = threading.Lock()
+        if dispatch_results:
+            proxy._dispatch_thread = threading.Thread(
+                target=proxy._dispatch_results,
+                daemon=True,
+            )
+            proxy._dispatch_thread.start()
+        return proxy
+
+    def test_concurrent_calls_receive_only_their_correlated_reply(self):
+        proxy = self.make_proxy(dispatch_results=True)
+        results = {}
+
+        first_thread = threading.Thread(
+            target=lambda: results.setdefault(
+                "first", proxy._call("first", timeout=0.5)
+            ),
+            daemon=True,
+        )
+        second_thread = threading.Thread(
+            target=lambda: results.setdefault(
+                "second", proxy._call("second", timeout=0.5)
+            ),
+            daemon=True,
+        )
+        first_thread.start()
+        second_thread.start()
+        commands = {
+            command["method"]: command
+            for command in (
+                proxy._cmd_queue.get(timeout=0.2),
+                proxy._cmd_queue.get(timeout=0.2),
+            )
+        }
+
+        proxy._result_queue.put({
+            "_req_id": commands["second"]["_req_id"],
+            "reply": "second-result",
+        })
+        proxy._result_queue.put({
+            "_req_id": commands["first"]["_req_id"],
+            "reply": "first-result",
+        })
+        first_thread.join(timeout=0.5)
+        second_thread.join(timeout=0.5)
+
+        self.assertFalse(first_thread.is_alive())
+        self.assertFalse(second_thread.is_alive())
+        self.assertEqual(results["first"], {"reply": "first-result"})
+        self.assertEqual(results["second"], {"reply": "second-result"})
+
+    def test_timeout_terminates_unresponsive_motion_owner(self):
+        proxy = self.make_proxy(dispatch_results=False)
+
+        result = proxy._call("hung", timeout=0.01)
+
+        self.assertEqual(result, {"error": "SmartMotion subprocess timeout (hung)"})
+        self.assertEqual(proxy._proc.terminate_count, 1)
+        self.assertEqual(proxy._proc.join_count, 1)
+
+
 class SmartMotionParentStopSequenceTest(unittest.TestCase):
     def make_proxy(self, fallback_stop):
         proxy = SmartMotionProxy.__new__(SmartMotionProxy)

--- a/unitree/g1/tests/test_stop_confirmation.py
+++ b/unitree/g1/tests/test_stop_confirmation.py
@@ -6,8 +6,9 @@ import unittest
 
 from safety_harness import (
     OdomStopMonitor,
+    StopConfirmationStart,
+    finish_stop_confirmation,
     issue_stop_and_confirm,
-    resolve_proposal_stop_timeouts,
 )
 
 
@@ -116,23 +117,77 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
             "rpc unavailable",
         )
 
-    def test_stop_rpc_timeout_has_margin_within_confirmation_budget(self):
-        rpc_timeout, confirmation_timeout = resolve_proposal_stop_timeouts({
-            "velocity_proposal_stop_rpc_timeout": 0.1,
-            "velocity_proposal_stop_confirm_timeout": 0.5,
-        })
+    def test_parent_stop_ack_is_confirmed_by_child_odometry(self):
+        start = self.monitor.begin_confirmation()
+        self.monitor.record((0.0, 0.0, 0.0))
+        completed = time.monotonic()
 
-        self.assertEqual(rpc_timeout, 0.2)
-        self.assertEqual(confirmation_timeout, 0.5)
+        result = finish_stop_confirmation(
+            monitor=self.monitor,
+            start=start,
+            stop_move_ret=0,
+            stop_move_error=None,
+            stop_move_completed_monotonic=completed,
+            timeout=0.2,
+            max_age=0.5,
+            linear_epsilon=0.03,
+            yaw_epsilon=0.05,
+        )
 
-    def test_stop_rpc_timeout_never_exceeds_confirmation_budget(self):
-        rpc_timeout, confirmation_timeout = resolve_proposal_stop_timeouts({
-            "velocity_proposal_stop_rpc_timeout": 10.0,
-            "velocity_proposal_stop_confirm_timeout": 0.4,
-        })
+        self.assertTrue(result["stop_confirmed"])
+        diagnostics = result["stop_confirmation"]
+        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 1)
+        self.assertEqual(diagnostics["odometry_callbacks_during_stop_move"], 1)
 
-        self.assertEqual(rpc_timeout, 0.4)
-        self.assertEqual(confirmation_timeout, 0.4)
+    def test_parent_stop_failure_stays_fail_closed_with_zero_odometry(self):
+        start = StopConfirmationStart(
+            monotonic=time.monotonic(),
+            unix_ms=round(time.time() * 1000),
+            odometry_callback_count=0,
+        )
+        self.monitor.record((0.0, 0.0, 0.0))
+
+        result = finish_stop_confirmation(
+            monitor=self.monitor,
+            start=start,
+            stop_move_ret=3104,
+            stop_move_error=None,
+            stop_move_completed_monotonic=time.monotonic(),
+            timeout=0.2,
+            max_age=0.5,
+            linear_epsilon=0.03,
+            yaw_epsilon=0.05,
+        )
+
+        self.assertFalse(result["stop_confirmed"])
+        self.assertEqual(result["ret"], 3104)
+        self.assertEqual(
+            result["stop_confirmation"]["odometry_callbacks_since_confirmation"],
+            1,
+        )
+
+    def test_parent_completion_count_excludes_later_ipc_callbacks(self):
+        start = self.monitor.begin_confirmation()
+        self.monitor.record((0.0, 0.0, 0.0))
+        completed = time.monotonic()
+        self.monitor.record((0.0, 0.0, 0.0))
+
+        result = finish_stop_confirmation(
+            monitor=self.monitor,
+            start=start,
+            stop_move_ret=0,
+            stop_move_error=None,
+            stop_move_completed_monotonic=completed,
+            timeout=0.2,
+            max_age=0.5,
+            linear_epsilon=0.03,
+            yaw_epsilon=0.05,
+        )
+
+        diagnostics = result["stop_confirmation"]
+        self.assertTrue(result["stop_confirmed"])
+        self.assertEqual(diagnostics["odometry_callbacks_during_stop_move"], 1)
+        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 2)
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_stop_confirmation.py
+++ b/unitree/g1/tests/test_stop_confirmation.py
@@ -7,8 +7,10 @@ import unittest
 from safety_harness import (
     OdomStopMonitor,
     StopConfirmationStart,
+    aggregate_stop_attempts,
     finish_stop_confirmation,
     issue_stop_and_confirm,
+    resolve_stop_confirmation_timeout,
 )
 
 
@@ -67,6 +69,37 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
             result["stop_confirmation"]["odometry_callbacks_during_stop_move"],
             0,
         )
+
+    def test_zero_frame_after_old_half_second_window_is_confirmed(self):
+        callback_finished = threading.Event()
+
+        def publish_gait_settled_zero():
+            try:
+                time.sleep(0.55)
+                self.monitor.record((0.0, 0.0, 0.0))
+            finally:
+                callback_finished.set()
+
+        publisher = threading.Thread(
+            target=publish_gait_settled_zero,
+            daemon=True,
+        )
+        publisher.start()
+
+        result = self.confirm(
+            lambda: 0,
+            timeout=resolve_stop_confirmation_timeout(0.5),
+        )
+
+        self.assertTrue(callback_finished.wait(0.5))
+        publisher.join(timeout=0.5)
+        self.assertTrue(result["stop_confirmed"])
+        self.assertFalse(result["stop_confirmation"]["confirmation_timed_out"])
+
+    def test_stop_confirmation_timeout_is_sdk_aware_and_bounded(self):
+        self.assertEqual(resolve_stop_confirmation_timeout(0.1), 1.0)
+        self.assertEqual(resolve_stop_confirmation_timeout(2.0), 2.0)
+        self.assertEqual(resolve_stop_confirmation_timeout(10.0), 3.0)
 
     def test_nonzero_frame_fails_closed_and_reports_last_velocity(self):
         def publish_nonzero():
@@ -188,6 +221,47 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
         self.assertTrue(result["stop_confirmed"])
         self.assertEqual(diagnostics["odometry_callbacks_during_stop_move"], 1)
         self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 2)
+
+    def test_bounded_retry_keeps_first_failed_confirmation(self):
+        first = {
+            "ret": 0,
+            "stop_confirmed": False,
+            "stop_confirmation": {
+                "confirmation_timed_out": True,
+                "last_odometry_velocity": {
+                    "x": 0.1,
+                    "y": 0.0,
+                    "yaw": 0.0,
+                },
+            },
+        }
+        second = {
+            "ret": 0,
+            "stop_confirmed": True,
+            "stop_confirmation": {
+                "confirmation_timed_out": False,
+                "last_odometry_velocity": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "yaw": 0.0,
+                },
+            },
+        }
+
+        result = aggregate_stop_attempts([first, second])
+
+        self.assertTrue(result["stop_confirmed"])
+        self.assertEqual(result["stop_attempt_count"], 2)
+        self.assertTrue(
+            result["stop_attempts"][0]["stop_confirmation"][
+                "confirmation_timed_out"
+            ]
+        )
+        self.assertFalse(
+            result["stop_attempts"][1]["stop_confirmation"][
+                "confirmation_timed_out"
+            ]
+        )
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_stop_confirmation.py
+++ b/unitree/g1/tests/test_stop_confirmation.py
@@ -4,7 +4,11 @@ import threading
 import time
 import unittest
 
-from safety_harness import OdomStopMonitor, issue_stop_and_confirm
+from safety_harness import (
+    OdomStopMonitor,
+    issue_stop_and_confirm,
+    resolve_proposal_stop_timeouts,
+)
 
 
 class StopMoveConfirmationIntegrationTest(unittest.TestCase):
@@ -111,6 +115,24 @@ class StopMoveConfirmationIntegrationTest(unittest.TestCase):
             result["stop_confirmation"]["stop_move_error"],
             "rpc unavailable",
         )
+
+    def test_stop_rpc_timeout_has_margin_within_confirmation_budget(self):
+        rpc_timeout, confirmation_timeout = resolve_proposal_stop_timeouts({
+            "velocity_proposal_stop_rpc_timeout": 0.1,
+            "velocity_proposal_stop_confirm_timeout": 0.5,
+        })
+
+        self.assertEqual(rpc_timeout, 0.2)
+        self.assertEqual(confirmation_timeout, 0.5)
+
+    def test_stop_rpc_timeout_never_exceeds_confirmation_budget(self):
+        rpc_timeout, confirmation_timeout = resolve_proposal_stop_timeouts({
+            "velocity_proposal_stop_rpc_timeout": 10.0,
+            "velocity_proposal_stop_confirm_timeout": 0.4,
+        })
+
+        self.assertEqual(rpc_timeout, 0.4)
+        self.assertEqual(confirmation_timeout, 0.4)
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_stop_confirmation.py
+++ b/unitree/g1/tests/test_stop_confirmation.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+
+from safety_harness import OdomStopMonitor, issue_stop_and_confirm
+
+
+class StopMoveConfirmationIntegrationTest(unittest.TestCase):
+    def setUp(self):
+        self.monitor = OdomStopMonitor()
+
+    def confirm(self, stop_move, timeout=0.2):
+        return issue_stop_and_confirm(
+            stop_move=stop_move,
+            monitor=self.monitor,
+            timeout=timeout,
+            max_age=0.5,
+            linear_epsilon=0.03,
+            yaw_epsilon=0.05,
+        )
+
+    def test_zero_frame_arriving_during_synchronous_stopmove_is_confirmed(self):
+        def stop_move():
+            self.monitor.record((0.0, 0.0, 0.0))
+            return 0
+
+        result = self.confirm(stop_move)
+
+        self.assertTrue(result["stop_confirmed"])
+        diagnostics = result["stop_confirmation"]
+        self.assertEqual(diagnostics["stop_move_ret"], 0)
+        self.assertIsNone(diagnostics["stop_move_error"])
+        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 1)
+        self.assertEqual(diagnostics["odometry_callbacks_during_stop_move"], 1)
+        self.assertEqual(
+            diagnostics["last_odometry_velocity"],
+            {"x": 0.0, "y": 0.0, "yaw": 0.0},
+        )
+
+    def test_zero_frame_arriving_after_stopmove_waits_on_condition(self):
+        callback_finished = threading.Event()
+
+        def publish_delayed_zero():
+            try:
+                time.sleep(0.03)
+                self.monitor.record((0.0, 0.0, 0.0))
+            finally:
+                callback_finished.set()
+
+        publisher = threading.Thread(target=publish_delayed_zero, daemon=True)
+        publisher.start()
+
+        result = self.confirm(lambda: 0)
+
+        self.assertTrue(callback_finished.wait(0.5))
+        publisher.join(timeout=0.5)
+        self.assertTrue(result["stop_confirmed"])
+        self.assertFalse(result["stop_confirmation"]["confirmation_timed_out"])
+        self.assertEqual(
+            result["stop_confirmation"]["odometry_callbacks_during_stop_move"],
+            0,
+        )
+
+    def test_nonzero_frame_fails_closed_and_reports_last_velocity(self):
+        def publish_nonzero():
+            time.sleep(0.02)
+            self.monitor.record((0.04, 0.0, 0.0))
+
+        publisher = threading.Thread(target=publish_nonzero, daemon=True)
+        publisher.start()
+
+        result = self.confirm(lambda: 0, timeout=0.08)
+
+        publisher.join(timeout=0.5)
+        self.assertFalse(result["stop_confirmed"])
+        diagnostics = result["stop_confirmation"]
+        self.assertTrue(diagnostics["confirmation_timed_out"])
+        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 1)
+        self.assertEqual(
+            diagnostics["last_odometry_velocity"],
+            {"x": 0.04, "y": 0.0, "yaw": 0.0},
+        )
+
+    def test_no_new_frame_times_out_with_callback_counts(self):
+        self.monitor.record((0.0, 0.0, 0.0))
+
+        result = self.confirm(lambda: 0, timeout=0.05)
+
+        self.assertFalse(result["stop_confirmed"])
+        diagnostics = result["stop_confirmation"]
+        self.assertTrue(diagnostics["confirmation_timed_out"])
+        self.assertEqual(diagnostics["odometry_callback_count"], 1)
+        self.assertEqual(diagnostics["odometry_callbacks_since_confirmation"], 0)
+        self.assertIsNotNone(diagnostics["confirmation_started_monotonic"])
+        self.assertIsNotNone(diagnostics["confirmation_started_unix_ms"])
+        self.assertIsNotNone(diagnostics["last_odometry_age_ms"])
+
+    def test_stopmove_exception_is_reported_without_waiting(self):
+        def stop_move():
+            raise RuntimeError("rpc unavailable")
+
+        started = time.monotonic()
+        result = self.confirm(stop_move, timeout=0.2)
+
+        self.assertLess(time.monotonic() - started, 0.1)
+        self.assertFalse(result["stop_confirmed"])
+        self.assertIsNone(result["ret"])
+        self.assertEqual(
+            result["stop_confirmation"]["stop_move_error"],
+            "rpc unavailable",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -232,6 +232,39 @@ class ProposalGateTest(unittest.TestCase):
         self.assertFalse(self.gate.armed)
         self.assertFalse(self.gate.accept(proposal(sequence=2), now=50.202).execute)
 
+    def test_end_to_end_ttl_rejects_proposal_already_expired_at_driver(self):
+        rejected = self.gate.accept(
+            proposal(issued_at_unix_ms=1_000, ttl_ms=200),
+            now=50.0,
+            now_unix_ms=1_201,
+        )
+
+        self.assertTrue(rejected.stop)
+        self.assertEqual(rejected.reason, "proposal_ttl_expired")
+        self.assertFalse(self.gate.armed)
+        self.assertEqual(self.gate.last_reason, "proposal_ttl_expired")
+
+    def test_end_to_end_ttl_uses_only_remaining_producer_lease(self):
+        accepted = self.gate.accept(
+            proposal(issued_at_unix_ms=1_000, ttl_ms=200),
+            now=50.0,
+            now_unix_ms=1_150,
+        )
+
+        self.assertTrue(accepted.execute)
+        self.assertAlmostEqual(accepted.duration, 0.05)
+        self.assertAlmostEqual(self.gate.deadline_monotonic, 50.05)
+
+    def test_future_producer_timestamp_cannot_extend_max_ttl(self):
+        accepted = self.gate.accept(
+            proposal(issued_at_unix_ms=2_000, ttl_ms=200),
+            now=50.0,
+            now_unix_ms=1_000,
+        )
+
+        self.assertAlmostEqual(accepted.duration, 0.2)
+        self.assertAlmostEqual(self.gate.deadline_monotonic, 50.2)
+
     def test_invalid_payload_disarms_until_explicit_bind(self):
         rejected = self.gate.accept(proposal(frame="map"), now=10.0)
         self.assertTrue(rejected.stop)

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -222,15 +222,21 @@ class ProposalGateTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.gate.bind(EXPECTED_TOPIC, "nav-001")
 
-    def test_watchdog_uses_local_monotonic_deadline(self):
+    def test_watchdog_requests_stop_without_retiring_trusted_lease(self):
         accepted = self.gate.accept(proposal(ttl_ms=200), now=50.0)
         self.assertAlmostEqual(accepted.duration, 0.2)
         self.assertFalse(self.gate.watchdog(now=50.199).stop)
         expired = self.gate.watchdog(now=50.201)
         self.assertTrue(expired.stop)
         self.assertEqual(expired.reason, "proposal_ttl_expired")
-        self.assertFalse(self.gate.armed)
-        self.assertFalse(self.gate.accept(proposal(sequence=2), now=50.202).execute)
+        self.assertTrue(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
+
+        self.gate.hold_after_confirmed_stop("proposal_ttl_expired")
+        recovered = self.gate.accept(proposal(sequence=2), now=50.202)
+        self.assertTrue(recovered.execute)
+        self.assertTrue(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
 
     def test_end_to_end_ttl_rejects_proposal_already_expired_at_driver(self):
         rejected = self.gate.accept(
@@ -241,8 +247,18 @@ class ProposalGateTest(unittest.TestCase):
 
         self.assertTrue(rejected.stop)
         self.assertEqual(rejected.reason, "proposal_ttl_expired")
-        self.assertFalse(self.gate.armed)
+        self.assertTrue(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
         self.assertEqual(self.gate.last_reason, "proposal_ttl_expired")
+
+        self.gate.hold_after_confirmed_stop("proposal_ttl_expired")
+        self.assertEqual(
+            self.gate.last_reason,
+            "proposal_ttl_stop_recoverable",
+        )
+        self.assertTrue(
+            self.gate.accept(proposal(sequence=2), now=50.1).execute
+        )
 
     def test_confirmed_obstacle_stop_keeps_lease_for_fresh_escape_command(self):
         self.assertTrue(self.gate.accept(proposal(sequence=1), now=50.0).execute)
@@ -276,6 +292,29 @@ class ProposalGateTest(unittest.TestCase):
         self.assertTrue(escape.execute)
         self.assertTrue(self.gate.armed)
         self.assertFalse(self.gate.recoverable_stop_active)
+
+    def test_stale_samples_drain_during_confirmed_ttl_hold(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=1), now=50.0).execute)
+        self.gate.watchdog(now=50.3)
+        self.gate.hold_after_confirmed_stop("proposal_ttl_expired")
+
+        stale = self.gate.accept(
+            proposal(sequence=2, issued_at_unix_ms=1_000, ttl_ms=200),
+            now=50.4,
+            now_unix_ms=1_201,
+        )
+
+        self.assertTrue(stale.stop)
+        self.assertEqual(stale.reason, "proposal_ttl_expired")
+        self.assertTrue(self.gate.armed)
+        self.assertTrue(self.gate.recoverable_stop_active)
+        self.assertEqual(
+            self.gate.last_reason,
+            "proposal_ttl_stop_recoverable",
+        )
+        self.assertTrue(
+            self.gate.accept(proposal(sequence=3), now=50.5).execute
+        )
 
     def test_hard_fault_still_disarms_from_recoverable_obstacle_stop(self):
         self.assertTrue(self.gate.accept(proposal(sequence=1), now=10.0).execute)

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -8,6 +8,7 @@ from velocity_proposal import (
     ProposalLimits,
     VelocityProposalGate,
     VelocityProposalValidationError,
+    resolve_expected_nav_id,
     resolve_input_topic,
     validate_velocity_proposal,
     velocity_proposal_port,
@@ -78,6 +79,22 @@ class TopicResolutionTest(unittest.TestCase):
             with self.subTest(args=args), self.assertRaises(ValueError):
                 resolve_input_topic(args, EXPECTED_TOPIC)
 
+    def test_resolves_trusted_expected_nav_id_from_control_plane(self):
+        self.assertEqual(
+            resolve_expected_nav_id({"expected_nav_id": " nav-001 "}),
+            "nav-001",
+        )
+
+    def test_rejects_missing_or_invalid_expected_nav_id(self):
+        for args in (
+            {},
+            {"expected_nav_id": ""},
+            {"expected_nav_id": 123},
+            {"expected_nav_id": "x" * 129},
+        ):
+            with self.subTest(args=args), self.assertRaises(ValueError):
+                resolve_expected_nav_id(args)
+
 
 class ProposalValidationTest(unittest.TestCase):
     def setUp(self):
@@ -145,7 +162,15 @@ class ProposalValidationTest(unittest.TestCase):
 class ProposalGateTest(unittest.TestCase):
     def setUp(self):
         self.gate = VelocityProposalGate(ProposalLimits())
-        self.gate.bind(EXPECTED_TOPIC)
+        self.gate.bind(EXPECTED_TOPIC, "nav-001")
+
+    def test_first_packet_must_match_control_plane_nav_lease(self):
+        rejected = self.gate.accept(
+            proposal(nav_id="attacker-selected", sequence=1), now=10.0
+        )
+        self.assertTrue(rejected.stop)
+        self.assertEqual(rejected.reason, "nav_id_mismatch")
+        self.assertFalse(self.gate.armed)
 
     def test_sequence_must_strictly_increase_for_active_nav(self):
         first = self.gate.accept(proposal(sequence=10), now=100.0)
@@ -163,7 +188,7 @@ class ProposalGateTest(unittest.TestCase):
         self.assertTrue(rejected.stop)
         self.assertEqual(rejected.reason, "nav_id_mismatch")
 
-    def test_terminal_zero_releases_nav_lease(self):
+    def test_terminal_zero_retires_and_disarms_nav_lease(self):
         self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
         terminal = self.gate.accept(
             proposal(
@@ -174,8 +199,15 @@ class ProposalGateTest(unittest.TestCase):
             now=10.1,
         )
         self.assertTrue(terminal.stop)
+        self.assertFalse(self.gate.armed)
         next_task = self.gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.2)
-        self.assertTrue(next_task.execute)
+        self.assertFalse(next_task.execute)
+        self.assertTrue(next_task.stop)
+
+        self.gate.bind(EXPECTED_TOPIC, "nav-002")
+        self.assertTrue(
+            self.gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.3).execute
+        )
 
     def test_completed_nav_id_cannot_be_replayed(self):
         self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
@@ -187,9 +219,8 @@ class ProposalGateTest(unittest.TestCase):
             ),
             now=10.1,
         )
-        replay = self.gate.accept(proposal(sequence=3), now=10.2)
-        self.assertTrue(replay.stop)
-        self.assertEqual(replay.reason, "retired_nav_id_replay")
+        with self.assertRaises(ValueError):
+            self.gate.bind(EXPECTED_TOPIC, "nav-001")
 
     def test_watchdog_uses_local_monotonic_deadline(self):
         accepted = self.gate.accept(proposal(ttl_ms=200), now=50.0)
@@ -207,8 +238,33 @@ class ProposalGateTest(unittest.TestCase):
         self.assertFalse(self.gate.armed)
         still_rejected = self.gate.accept(proposal(sequence=2), now=10.1)
         self.assertFalse(still_rejected.execute)
-        self.gate.bind(EXPECTED_TOPIC)
-        self.assertTrue(self.gate.accept(proposal(), now=10.2).execute)
+        with self.assertRaises(ValueError):
+            self.gate.bind(EXPECTED_TOPIC, "nav-001")
+        self.gate.bind(EXPECTED_TOPIC, "nav-002")
+        self.assertTrue(
+            self.gate.accept(proposal(nav_id="nav-002"), now=10.2).execute
+        )
+
+    def test_canvas_unbind_retires_nav_id_against_delayed_replay(self):
+        self.gate.unbind("canvas_stop")
+        with self.assertRaises(ValueError):
+            self.gate.bind(EXPECTED_TOPIC, "nav-001")
+
+    def test_repeated_identical_bind_is_idempotent_without_sequence_reset(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=10), now=10.0).execute)
+        self.gate.bind(EXPECTED_TOPIC, "nav-001")
+        replay = self.gate.accept(proposal(sequence=10), now=10.1)
+        self.assertTrue(replay.stop)
+        self.assertEqual(replay.reason, "sequence_not_increasing")
+
+    def test_retired_nav_ids_are_not_dropped_after_a_fixed_window(self):
+        self.gate.unbind("canvas_stop")
+        for index in range(2, 41):
+            self.gate.bind(EXPECTED_TOPIC, f"nav-{index:03d}")
+            self.gate.unbind("canvas_stop")
+        for index in range(1, 41):
+            with self.subTest(index=index), self.assertRaises(ValueError):
+                self.gate.bind(EXPECTED_TOPIC, f"nav-{index:03d}")
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -244,6 +244,70 @@ class ProposalGateTest(unittest.TestCase):
         self.assertFalse(self.gate.armed)
         self.assertEqual(self.gate.last_reason, "proposal_ttl_expired")
 
+    def test_confirmed_obstacle_stop_keeps_lease_for_fresh_escape_command(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=1), now=50.0).execute)
+        self.gate.hold_for_obstacle()
+
+        held = self.gate.snapshot(50.1)
+        self.assertTrue(held["connected"])
+        self.assertTrue(held["armed"])
+        self.assertTrue(held["recoverable_stop_active"])
+        self.assertEqual(held["active_nav_id"], "nav-001")
+        self.assertEqual(held["last_reason"], "obstacle_stop_recoverable")
+
+        stale = self.gate.accept(
+            proposal(sequence=2, issued_at_unix_ms=1_000, ttl_ms=200),
+            now=50.2,
+            now_unix_ms=1_201,
+        )
+        self.assertTrue(stale.stop)
+        self.assertEqual(stale.reason, "proposal_ttl_expired")
+        self.assertTrue(self.gate.armed)
+        self.assertTrue(self.gate.recoverable_stop_active)
+        self.assertEqual(self.gate.last_sequence, 2)
+
+        escape = self.gate.accept(
+            proposal(
+                sequence=3,
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.2},
+            ),
+            now=50.3,
+        )
+        self.assertTrue(escape.execute)
+        self.assertTrue(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
+
+    def test_hard_fault_still_disarms_from_recoverable_obstacle_stop(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=1), now=10.0).execute)
+        self.gate.hold_for_obstacle()
+
+        rejected = self.gate.accept(
+            proposal(sequence=2, frame="map"),
+            now=10.1,
+        )
+
+        self.assertTrue(rejected.stop)
+        self.assertEqual(rejected.reason, "frame_mismatch")
+        self.assertFalse(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
+
+    def test_terminal_zero_retires_recoverable_obstacle_lease(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=1), now=10.0).execute)
+        self.gate.hold_for_obstacle()
+
+        terminal = self.gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+
+        self.assertTrue(terminal.stop)
+        self.assertFalse(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
+
     def test_end_to_end_ttl_uses_only_remaining_producer_lease(self):
         accepted = self.gate.accept(
             proposal(issued_at_unix_ms=1_000, ttl_ms=200),

--- a/unitree/g1/tests/test_velocity_proposal.py
+++ b/unitree/g1/tests/test_velocity_proposal.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import math
+import unittest
+
+from velocity_proposal import (
+    DEFAULT_VELOCITY_PROPOSAL_TOPIC,
+    ProposalLimits,
+    VelocityProposalGate,
+    VelocityProposalValidationError,
+    resolve_input_topic,
+    validate_velocity_proposal,
+    velocity_proposal_port,
+)
+
+
+EXPECTED_TOPIC = "/ubuntu/navigation/nav2/velocity_proposal"
+
+
+def proposal(**changes):
+    value = {
+        "schema": "phanthy.navigation.velocity_proposal.v1",
+        "nav_id": "nav-001",
+        "sequence": 1,
+        "issued_at_unix_ms": 1_800_000_000_000,
+        "ttl_ms": 200,
+        "frame": "base_link",
+        "shadow_only": True,
+        "physical_execution": False,
+        "nav_status": "navigating",
+        "velocity": {"x": 0.10, "y": 0.02, "yaw": 0.15},
+    }
+    value.update(changes)
+    return value
+
+
+class TopicResolutionTest(unittest.TestCase):
+    def test_n5_topic_is_not_namespace_dependent(self):
+        self.assertEqual(DEFAULT_VELOCITY_PROPOSAL_TOPIC, EXPECTED_TOPIC)
+
+    def test_port_matches_n5_contract(self):
+        self.assertEqual(
+            velocity_proposal_port(EXPECTED_TOPIC),
+            {
+                "port": "velocity_proposal",
+                "topic": EXPECTED_TOPIC,
+                "format": "data/json",
+                "ros_type": "std_msgs/msg/String",
+                "qos": "RELIABLE + KEEP_LAST(depth=10) + VOLATILE",
+                "schema": "phanthy.navigation.velocity_proposal.v1",
+            },
+        )
+
+    def test_accepts_single_input_topic(self):
+        self.assertEqual(
+            resolve_input_topic({"input_topic": EXPECTED_TOPIC}, EXPECTED_TOPIC),
+            EXPECTED_TOPIC,
+        )
+
+    def test_accepts_single_input_topics_entry(self):
+        self.assertEqual(
+            resolve_input_topic({"input_topics": [EXPECTED_TOPIC]}, EXPECTED_TOPIC),
+            EXPECTED_TOPIC,
+        )
+
+    def test_rejects_empty_multiple_or_unexpected_topics(self):
+        for args in (
+            {},
+            {"input_topics": []},
+            {"input_topics": [EXPECTED_TOPIC, ""]},
+            {"input_topics": [EXPECTED_TOPIC, "/other"]},
+            {
+                "input_topic": EXPECTED_TOPIC,
+                "input_topics": [EXPECTED_TOPIC],
+            },
+            {"input_topic": "/ubuntu/navigation/nav2/cmd_vel_shadow"},
+        ):
+            with self.subTest(args=args), self.assertRaises(ValueError):
+                resolve_input_topic(args, EXPECTED_TOPIC)
+
+
+class ProposalValidationTest(unittest.TestCase):
+    def setUp(self):
+        self.limits = ProposalLimits()
+
+    def test_valid_proposal(self):
+        result = validate_velocity_proposal(proposal(), self.limits)
+        self.assertEqual(result.nav_id, "nav-001")
+        self.assertEqual(result.ttl_ms, 200)
+        self.assertFalse(result.is_zero)
+
+    def test_rejects_wrong_schema_frame_or_flags(self):
+        cases = (
+            {"schema": "other"},
+            {"frame": "map"},
+            {"shadow_only": False},
+            {"physical_execution": True},
+        )
+        for changes in cases:
+            with self.subTest(changes=changes), self.assertRaises(VelocityProposalValidationError):
+                validate_velocity_proposal(proposal(**changes), self.limits)
+
+    def test_rejects_invalid_identity_timing_and_status_fields(self):
+        cases = (
+            {"nav_id": ""},
+            {"sequence": True},
+            {"issued_at_unix_ms": math.inf},
+            {"ttl_ms": True},
+            {"nav_status": "unknown"},
+            {"nav_status": None, "status": "navigating"},
+            {"nav_status": "navigating", "status": "navigating"},
+        )
+        for changes in cases:
+            with self.subTest(changes=changes), self.assertRaises(VelocityProposalValidationError):
+                validate_velocity_proposal(proposal(**changes), self.limits)
+
+    def test_rejects_nonfinite_and_each_speed_limit(self):
+        velocities = (
+            {"x": math.nan, "y": 0.0, "yaw": 0.0},
+            {"x": 0.151, "y": 0.0, "yaw": 0.0},
+            {"x": -0.051, "y": 0.0, "yaw": 0.0},
+            {"x": 0.0, "y": 0.121, "yaw": 0.0},
+            {"x": 0.0, "y": 0.0, "yaw": 0.351},
+            {"x": 0.15, "y": 0.11, "yaw": 0.0},
+        )
+        for velocity in velocities:
+            with self.subTest(velocity=velocity), self.assertRaises(VelocityProposalValidationError):
+                validate_velocity_proposal(proposal(velocity=velocity), self.limits)
+
+    def test_rejects_ttl_above_250_ms(self):
+        with self.assertRaises(VelocityProposalValidationError):
+            validate_velocity_proposal(proposal(ttl_ms=251), self.limits)
+
+    def test_terminal_status_requires_zero_velocity(self):
+        with self.assertRaises(VelocityProposalValidationError):
+            validate_velocity_proposal(proposal(nav_status="arrived"), self.limits)
+        result = validate_velocity_proposal(
+            proposal(nav_status="arrived", velocity={"x": 0.0, "y": 0.0, "yaw": 0.0}),
+            self.limits,
+        )
+        self.assertTrue(result.is_terminal)
+        self.assertTrue(result.is_zero)
+
+
+class ProposalGateTest(unittest.TestCase):
+    def setUp(self):
+        self.gate = VelocityProposalGate(ProposalLimits())
+        self.gate.bind(EXPECTED_TOPIC)
+
+    def test_sequence_must_strictly_increase_for_active_nav(self):
+        first = self.gate.accept(proposal(sequence=10), now=100.0)
+        second = self.gate.accept(proposal(sequence=11), now=100.05)
+        replay = self.gate.accept(proposal(sequence=11), now=100.10)
+        self.assertTrue(first.execute)
+        self.assertTrue(second.execute)
+        self.assertTrue(replay.stop)
+        self.assertFalse(self.gate.armed)
+        self.assertEqual(replay.reason, "sequence_not_increasing")
+
+    def test_nav_id_cannot_change_mid_task(self):
+        self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
+        rejected = self.gate.accept(proposal(nav_id="nav-002", sequence=2), now=10.1)
+        self.assertTrue(rejected.stop)
+        self.assertEqual(rejected.reason, "nav_id_mismatch")
+
+    def test_terminal_zero_releases_nav_lease(self):
+        self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
+        terminal = self.gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+        self.assertTrue(terminal.stop)
+        next_task = self.gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.2)
+        self.assertTrue(next_task.execute)
+
+    def test_completed_nav_id_cannot_be_replayed(self):
+        self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
+        self.gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+        replay = self.gate.accept(proposal(sequence=3), now=10.2)
+        self.assertTrue(replay.stop)
+        self.assertEqual(replay.reason, "retired_nav_id_replay")
+
+    def test_watchdog_uses_local_monotonic_deadline(self):
+        accepted = self.gate.accept(proposal(ttl_ms=200), now=50.0)
+        self.assertAlmostEqual(accepted.duration, 0.2)
+        self.assertFalse(self.gate.watchdog(now=50.199).stop)
+        expired = self.gate.watchdog(now=50.201)
+        self.assertTrue(expired.stop)
+        self.assertEqual(expired.reason, "proposal_ttl_expired")
+        self.assertFalse(self.gate.armed)
+        self.assertFalse(self.gate.accept(proposal(sequence=2), now=50.202).execute)
+
+    def test_invalid_payload_disarms_until_explicit_bind(self):
+        rejected = self.gate.accept(proposal(frame="map"), now=10.0)
+        self.assertTrue(rejected.stop)
+        self.assertFalse(self.gate.armed)
+        still_rejected = self.gate.accept(proposal(sequence=2), now=10.1)
+        self.assertFalse(still_rejected.execute)
+        self.gate.bind(EXPECTED_TOPIC)
+        self.assertTrue(self.gate.accept(proposal(), now=10.2).execute)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -1,0 +1,303 @@
+"""Pure validation and lease state for the N5 Nav2 velocity proposal gate.
+
+This module deliberately has no ROS 2 or Unitree dependency.  The SmartMotion
+subprocess owns physical execution; it may act only on a ProposalDecision
+returned here.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+
+VELOCITY_PROPOSAL_SCHEMA = "phanthy.navigation.velocity_proposal.v1"
+DEFAULT_VELOCITY_PROPOSAL_TOPIC = "/ubuntu/navigation/nav2/velocity_proposal"
+TERMINAL_STATUSES = {
+    "paused",
+    "arrived",
+    "cancelled",
+    "stopped",
+    "error",
+    "aborted",
+    "rejected",
+}
+ACTIVE_STATUSES = {"planning", "navigating", "replanning", "running", "active"}
+ALLOWED_STATUSES = TERMINAL_STATUSES | ACTIVE_STATUSES
+_STATUS_FIELD = "nav_status"
+_UNSUPPORTED_STATUS_ALIASES = {"status", "navigation_status", "navigation_state"}
+
+
+def velocity_proposal_port(topic: str) -> dict:
+    """Return the authoritative N5 canvas port declaration."""
+    return {
+        "port": "velocity_proposal",
+        "topic": topic,
+        "format": "data/json",
+        "ros_type": "std_msgs/msg/String",
+        "qos": "RELIABLE + KEEP_LAST(depth=10) + VOLATILE",
+        "schema": VELOCITY_PROPOSAL_SCHEMA,
+    }
+
+
+class VelocityProposalValidationError(ValueError):
+    """Validation error with a stable fail-closed reason code."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class ProposalLimits:
+    schema: str = VELOCITY_PROPOSAL_SCHEMA
+    frame: str = "base_link"
+    max_ttl_ms: int = 250
+    min_x: float = -0.05
+    max_x: float = 0.15
+    max_abs_y: float = 0.12
+    max_abs_yaw: float = 0.35
+    max_planar_speed: float = 0.18
+
+
+@dataclass(frozen=True)
+class ValidatedVelocityProposal:
+    nav_id: str
+    sequence: int
+    issued_at_unix_ms: float
+    ttl_ms: int
+    frame: str
+    status: str
+    x: float
+    y: float
+    yaw: float
+
+    @property
+    def is_zero(self) -> bool:
+        return self.x == 0.0 and self.y == 0.0 and self.yaw == 0.0
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in TERMINAL_STATUSES
+
+
+@dataclass(frozen=True)
+class ProposalDecision:
+    execute: bool = False
+    stop: bool = False
+    reason: str = ""
+    duration: float = 0.0
+    proposal: Optional[ValidatedVelocityProposal] = None
+
+
+def resolve_input_topic(args: Mapping[str, Any], expected_topic: str) -> str:
+    """Resolve the canvas connection and reject every topic except the N5 port."""
+    has_input_topic = bool(str(args.get("input_topic") or "").strip())
+    has_input_topics = args.get("input_topics") is not None
+    if has_input_topic and has_input_topics:
+        raise ValueError("input_topic_and_input_topics_are_mutually_exclusive")
+    topics = []
+    input_topics = args.get("input_topics")
+    if input_topics is not None:
+        if not isinstance(input_topics, (list, tuple)):
+            raise ValueError("input_topics_must_be_a_list")
+        if len(input_topics) != 1:
+            raise ValueError("exactly_one_velocity_proposal_topic_required")
+        topics.append(str(input_topics[0]).strip())
+    input_topic = str(args.get("input_topic") or "").strip()
+    if input_topic and input_topic not in topics:
+        topics.append(input_topic)
+    if len(topics) != 1:
+        raise ValueError("exactly_one_velocity_proposal_topic_required")
+    if topics[0] != expected_topic:
+        raise ValueError("unexpected_velocity_proposal_topic")
+    return topics[0]
+
+
+def _finite_number(value: Any, code: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise VelocityProposalValidationError(code)
+    result = float(value)
+    if not math.isfinite(result):
+        raise VelocityProposalValidationError(code)
+    return result
+
+
+def _status(payload: Mapping[str, Any]) -> str:
+    if any(field in payload for field in _UNSUPPORTED_STATUS_ALIASES):
+        raise VelocityProposalValidationError("unsupported_navigation_status_field")
+    status = payload.get(_STATUS_FIELD)
+    if not isinstance(status, str) or not status.strip():
+        raise VelocityProposalValidationError("invalid_navigation_status")
+    normalized = status.strip().lower()
+    if normalized not in ALLOWED_STATUSES:
+        raise VelocityProposalValidationError("unsupported_navigation_status")
+    return normalized
+
+
+def validate_velocity_proposal(
+    payload: Mapping[str, Any],
+    limits: ProposalLimits,
+) -> ValidatedVelocityProposal:
+    if not isinstance(payload, Mapping):
+        raise VelocityProposalValidationError("proposal_must_be_object")
+    if payload.get("schema") != limits.schema:
+        raise VelocityProposalValidationError("schema_mismatch")
+    if payload.get("frame") != limits.frame:
+        raise VelocityProposalValidationError("frame_mismatch")
+    if payload.get("shadow_only") is not True:
+        raise VelocityProposalValidationError("shadow_only_flag_required")
+    if payload.get("physical_execution") is not False:
+        raise VelocityProposalValidationError("physical_execution_flag_must_be_false")
+
+    nav_id = payload.get("nav_id")
+    if not isinstance(nav_id, str) or not nav_id.strip() or len(nav_id) > 128:
+        raise VelocityProposalValidationError("invalid_nav_id")
+    sequence = payload.get("sequence")
+    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 0:
+        raise VelocityProposalValidationError("invalid_sequence")
+    ttl_ms = payload.get("ttl_ms")
+    if (
+        isinstance(ttl_ms, bool)
+        or not isinstance(ttl_ms, int)
+        or ttl_ms <= 0
+        or ttl_ms > limits.max_ttl_ms
+    ):
+        raise VelocityProposalValidationError("invalid_ttl_ms")
+    issued_at = _finite_number(payload.get("issued_at_unix_ms"), "invalid_issued_at_unix_ms")
+
+    velocity = payload.get("velocity")
+    if not isinstance(velocity, Mapping):
+        raise VelocityProposalValidationError("velocity_must_be_object")
+    x = _finite_number(velocity.get("x"), "invalid_velocity_x")
+    y = _finite_number(velocity.get("y"), "invalid_velocity_y")
+    yaw = _finite_number(velocity.get("yaw"), "invalid_velocity_yaw")
+    if x < limits.min_x or x > limits.max_x:
+        raise VelocityProposalValidationError("velocity_x_limit")
+    if abs(y) > limits.max_abs_y:
+        raise VelocityProposalValidationError("velocity_y_limit")
+    if abs(yaw) > limits.max_abs_yaw:
+        raise VelocityProposalValidationError("velocity_yaw_limit")
+    if math.hypot(x, y) > limits.max_planar_speed:
+        raise VelocityProposalValidationError("planar_speed_limit")
+
+    result = ValidatedVelocityProposal(
+        nav_id=nav_id.strip(),
+        sequence=sequence,
+        issued_at_unix_ms=issued_at,
+        ttl_ms=ttl_ms,
+        frame=limits.frame,
+        status=_status(payload),
+        x=x,
+        y=y,
+        yaw=yaw,
+    )
+    if result.is_terminal and not result.is_zero:
+        raise VelocityProposalValidationError("terminal_status_requires_zero_velocity")
+    return result
+
+
+class VelocityProposalGate:
+    """Connection, task lease, replay protection, and monotonic TTL state."""
+
+    def __init__(self, limits: ProposalLimits):
+        self.limits = limits
+        self.connected_topic = ""
+        self.armed = False
+        self.active_nav_id = ""
+        self.retired_nav_ids: list[str] = []
+        self.last_sequence = -1
+        self.last_receive_monotonic = 0.0
+        self.deadline_monotonic = 0.0
+        self.last_reason = "not_connected"
+
+    def bind(self, topic: str) -> None:
+        self.connected_topic = topic
+        self.armed = True
+        self.active_nav_id = ""
+        self.retired_nav_ids = []
+        self.last_sequence = -1
+        self.last_receive_monotonic = 0.0
+        self.deadline_monotonic = 0.0
+        self.last_reason = ""
+
+    def unbind(self, reason: str = "canvas_stop") -> None:
+        self.connected_topic = ""
+        self.armed = False
+        self.active_nav_id = ""
+        self.retired_nav_ids = []
+        self.last_sequence = -1
+        self.last_receive_monotonic = 0.0
+        self.deadline_monotonic = 0.0
+        self.last_reason = reason
+
+    def disarm(self, reason: str) -> None:
+        self.armed = False
+        self.deadline_monotonic = 0.0
+        self.last_reason = reason
+
+    def accept(self, payload: Mapping[str, Any], now: float) -> ProposalDecision:
+        if not self.connected_topic:
+            return ProposalDecision(stop=True, reason="proposal_not_connected")
+        if not self.armed:
+            return ProposalDecision(stop=True, reason=self.last_reason or "proposal_not_armed")
+        try:
+            proposal = validate_velocity_proposal(payload, self.limits)
+        except VelocityProposalValidationError as exc:
+            self.disarm(exc.code)
+            return ProposalDecision(stop=True, reason=exc.code)
+
+        if not self.active_nav_id:
+            if proposal.nav_id in self.retired_nav_ids:
+                self.disarm("retired_nav_id_replay")
+                return ProposalDecision(
+                    stop=True,
+                    reason="retired_nav_id_replay",
+                    proposal=proposal,
+                )
+            self.active_nav_id = proposal.nav_id
+            self.last_sequence = -1
+        elif proposal.nav_id != self.active_nav_id:
+            self.disarm("nav_id_mismatch")
+            return ProposalDecision(stop=True, reason="nav_id_mismatch", proposal=proposal)
+        if proposal.sequence <= self.last_sequence:
+            self.disarm("sequence_not_increasing")
+            return ProposalDecision(stop=True, reason="sequence_not_increasing", proposal=proposal)
+
+        self.last_sequence = proposal.sequence
+        self.last_receive_monotonic = now
+        if proposal.is_zero:
+            self.deadline_monotonic = 0.0
+            if proposal.is_terminal:
+                self.retired_nav_ids.append(proposal.nav_id)
+                del self.retired_nav_ids[:-32]
+                self.active_nav_id = ""
+                self.last_sequence = -1
+            self.last_reason = proposal.status
+            return ProposalDecision(stop=True, reason="proposal_zero", proposal=proposal)
+
+        duration = proposal.ttl_ms / 1000.0
+        self.deadline_monotonic = now + duration
+        self.last_reason = ""
+        return ProposalDecision(execute=True, duration=duration, proposal=proposal)
+
+    def watchdog(self, now: float) -> ProposalDecision:
+        if self.deadline_monotonic <= 0.0 or now < self.deadline_monotonic:
+            return ProposalDecision()
+        self.disarm("proposal_ttl_expired")
+        return ProposalDecision(stop=True, reason=self.last_reason)
+
+    def snapshot(self, now: float) -> dict:
+        age_ms = None
+        if self.last_receive_monotonic > 0.0:
+            age_ms = max(0, round((now - self.last_receive_monotonic) * 1000))
+        return {
+            "connected": bool(self.connected_topic),
+            "armed": self.armed,
+            "topic": self.connected_topic or None,
+            "active_nav_id": self.active_nav_id or None,
+            "last_sequence": self.last_sequence if self.last_sequence >= 0 else None,
+            "last_message_age_ms": age_ms,
+            "last_reason": self.last_reason or None,
+        }

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -263,11 +263,50 @@ class VelocityProposalGate:
 
     def hold_for_obstacle(self) -> None:
         """Keep the nav lease armed after a confirmed local obstacle stop."""
+        self.hold_after_confirmed_stop("obstacle")
+
+    def hold_after_confirmed_stop(self, reason: str) -> None:
+        """Keep a trusted nav lease after a confirmed recoverable stop.
+
+        Ordinary obstacle stops and a single proposal TTL lapse are local
+        braking events, not proof that the Agent Core lease is invalid.  The
+        caller must only enter this state after StopMove has been acknowledged
+        and fresh odometry has confirmed zero velocity.
+        """
         if not self.armed:
             return
+        recoverable_reasons = {
+            "obstacle": "obstacle_stop_recoverable",
+            "proposal_ttl_expired": "proposal_ttl_stop_recoverable",
+        }
+        if reason not in recoverable_reasons:
+            raise ValueError("unsupported_recoverable_stop_reason")
         self.deadline_monotonic = 0.0
-        self.last_reason = "obstacle_stop_recoverable"
+        self.last_reason = recoverable_reasons[reason]
         self.recoverable_stop_active = True
+
+    def request_ttl_stop(
+        self,
+        now: float,
+        proposal: Optional[ValidatedVelocityProposal] = None,
+    ) -> ProposalDecision:
+        """Request fail-closed braking without retiring the trusted lease.
+
+        The lease remains armed only so the stop path can move it into a
+        recoverable hold after measured zero velocity.  No new command can be
+        executed while that serialized stop confirmation is in progress.
+        """
+        if proposal is not None:
+            self.last_sequence = proposal.sequence
+            self.last_receive_monotonic = now
+        self.deadline_monotonic = 0.0
+        self.last_reason = "proposal_ttl_expired"
+        self.recoverable_stop_active = False
+        return ProposalDecision(
+            stop=True,
+            reason="proposal_ttl_expired",
+            proposal=proposal,
+        )
 
     def _retire_expected_nav_id(self) -> None:
         if self.expected_nav_id:
@@ -320,18 +359,14 @@ class VelocityProposalGate:
                     self.last_sequence = proposal.sequence
                     self.last_receive_monotonic = now
                     self.deadline_monotonic = 0.0
-                    self.last_reason = "obstacle_stop_recoverable"
+                    # Preserve whether this hold came from an obstacle or a
+                    # prior TTL stop while stale retained samples drain.
                     return ProposalDecision(
                         stop=True,
                         reason="proposal_ttl_expired",
                         proposal=proposal,
                     )
-                self.disarm("proposal_ttl_expired")
-                return ProposalDecision(
-                    stop=True,
-                    reason="proposal_ttl_expired",
-                    proposal=proposal,
-                )
+                return self.request_ttl_stop(now, proposal)
             # A future producer timestamp may not extend the configured TTL.
             duration = min(duration, remaining)
 
@@ -353,8 +388,7 @@ class VelocityProposalGate:
     def watchdog(self, now: float) -> ProposalDecision:
         if self.deadline_monotonic <= 0.0 or now < self.deadline_monotonic:
             return ProposalDecision()
-        self.disarm("proposal_ttl_expired")
-        return ProposalDecision(stop=True, reason=self.last_reason)
+        return self.request_ttl_stop(now)
 
     def snapshot(self, now: float) -> dict:
         age_ms = None

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -226,6 +226,7 @@ class VelocityProposalGate:
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = "not_connected"
+        self.recoverable_stop_active = False
 
     def bind(self, topic: str, expected_nav_id: str) -> None:
         nav_id = resolve_expected_nav_id({"expected_nav_id": expected_nav_id})
@@ -240,6 +241,7 @@ class VelocityProposalGate:
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = ""
+        self.recoverable_stop_active = False
 
     def unbind(self, reason: str = "canvas_stop") -> None:
         self._retire_expected_nav_id()
@@ -250,12 +252,22 @@ class VelocityProposalGate:
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = reason
+        self.recoverable_stop_active = False
 
     def disarm(self, reason: str) -> None:
         self._retire_expected_nav_id()
         self.armed = False
         self.deadline_monotonic = 0.0
         self.last_reason = reason
+        self.recoverable_stop_active = False
+
+    def hold_for_obstacle(self) -> None:
+        """Keep the nav lease armed after a confirmed local obstacle stop."""
+        if not self.armed:
+            return
+        self.deadline_monotonic = 0.0
+        self.last_reason = "obstacle_stop_recoverable"
+        self.recoverable_stop_active = True
 
     def _retire_expected_nav_id(self) -> None:
         if self.expected_nav_id:
@@ -299,6 +311,21 @@ class VelocityProposalGate:
                 - float(now_unix_ms)
             ) / 1000.0
             if remaining <= 0.0:
+                if self.recoverable_stop_active:
+                    # Stop confirmation can outlive the proposal TTL while
+                    # ROS retains newer samples.  The robot is already at a
+                    # confirmed stop, so reject this stale sample without
+                    # retiring the task lease; only a fresh later sample may
+                    # resume execution.
+                    self.last_sequence = proposal.sequence
+                    self.last_receive_monotonic = now
+                    self.deadline_monotonic = 0.0
+                    self.last_reason = "obstacle_stop_recoverable"
+                    return ProposalDecision(
+                        stop=True,
+                        reason="proposal_ttl_expired",
+                        proposal=proposal,
+                    )
                 self.disarm("proposal_ttl_expired")
                 return ProposalDecision(
                     stop=True,
@@ -320,6 +347,7 @@ class VelocityProposalGate:
 
         self.deadline_monotonic = now + duration
         self.last_reason = ""
+        self.recoverable_stop_active = False
         return ProposalDecision(execute=True, duration=duration, proposal=proposal)
 
     def watchdog(self, now: float) -> ProposalDecision:
@@ -341,4 +369,5 @@ class VelocityProposalGate:
             "last_sequence": self.last_sequence if self.last_sequence >= 0 else None,
             "last_message_age_ms": age_ms,
             "last_reason": self.last_reason or None,
+            "recoverable_stop_active": self.recoverable_stop_active,
         }

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -115,6 +115,21 @@ def resolve_input_topic(args: Mapping[str, Any], expected_topic: str) -> str:
     return topics[0]
 
 
+def resolve_expected_nav_id(args: Mapping[str, Any]) -> str:
+    """Resolve the task lease supplied by the trusted lifecycle control plane."""
+    value = args.get("expected_nav_id")
+    if value is None or value == "":
+        raise ValueError("expected_nav_id_required")
+    if not isinstance(value, str):
+        raise ValueError("invalid_expected_nav_id")
+    nav_id = value.strip()
+    if not nav_id:
+        raise ValueError("expected_nav_id_required")
+    if len(nav_id) > 128:
+        raise ValueError("invalid_expected_nav_id")
+    return nav_id
+
+
 def _finite_number(value: Any, code: str) -> float:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise VelocityProposalValidationError(code)
@@ -205,37 +220,53 @@ class VelocityProposalGate:
         self.limits = limits
         self.connected_topic = ""
         self.armed = False
-        self.active_nav_id = ""
-        self.retired_nav_ids: list[str] = []
+        self.expected_nav_id = ""
+        self.retired_nav_ids: set[str] = set()
         self.last_sequence = -1
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = "not_connected"
 
-    def bind(self, topic: str) -> None:
+    def bind(self, topic: str, expected_nav_id: str) -> None:
+        nav_id = resolve_expected_nav_id({"expected_nav_id": expected_nav_id})
+        if self.is_bound_to(topic, nav_id):
+            return
+        if nav_id in self.retired_nav_ids:
+            raise ValueError("retired_nav_id_replay")
         self.connected_topic = topic
         self.armed = True
-        self.active_nav_id = ""
-        self.retired_nav_ids = []
+        self.expected_nav_id = nav_id
         self.last_sequence = -1
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = ""
 
     def unbind(self, reason: str = "canvas_stop") -> None:
+        self._retire_expected_nav_id()
         self.connected_topic = ""
         self.armed = False
-        self.active_nav_id = ""
-        self.retired_nav_ids = []
+        self.expected_nav_id = ""
         self.last_sequence = -1
         self.last_receive_monotonic = 0.0
         self.deadline_monotonic = 0.0
         self.last_reason = reason
 
     def disarm(self, reason: str) -> None:
+        self._retire_expected_nav_id()
         self.armed = False
         self.deadline_monotonic = 0.0
         self.last_reason = reason
+
+    def _retire_expected_nav_id(self) -> None:
+        if self.expected_nav_id:
+            self.retired_nav_ids.add(self.expected_nav_id)
+
+    def is_bound_to(self, topic: str, expected_nav_id: str) -> bool:
+        return bool(
+            self.armed
+            and self.connected_topic == topic
+            and self.expected_nav_id == expected_nav_id
+        )
 
     def accept(self, payload: Mapping[str, Any], now: float) -> ProposalDecision:
         if not self.connected_topic:
@@ -248,17 +279,7 @@ class VelocityProposalGate:
             self.disarm(exc.code)
             return ProposalDecision(stop=True, reason=exc.code)
 
-        if not self.active_nav_id:
-            if proposal.nav_id in self.retired_nav_ids:
-                self.disarm("retired_nav_id_replay")
-                return ProposalDecision(
-                    stop=True,
-                    reason="retired_nav_id_replay",
-                    proposal=proposal,
-                )
-            self.active_nav_id = proposal.nav_id
-            self.last_sequence = -1
-        elif proposal.nav_id != self.active_nav_id:
+        if proposal.nav_id != self.expected_nav_id:
             self.disarm("nav_id_mismatch")
             return ProposalDecision(stop=True, reason="nav_id_mismatch", proposal=proposal)
         if proposal.sequence <= self.last_sequence:
@@ -270,11 +291,9 @@ class VelocityProposalGate:
         if proposal.is_zero:
             self.deadline_monotonic = 0.0
             if proposal.is_terminal:
-                self.retired_nav_ids.append(proposal.nav_id)
-                del self.retired_nav_ids[:-32]
-                self.active_nav_id = ""
-                self.last_sequence = -1
-            self.last_reason = proposal.status
+                self.disarm("nav_task_terminal")
+            else:
+                self.last_reason = proposal.status
             return ProposalDecision(stop=True, reason="proposal_zero", proposal=proposal)
 
         duration = proposal.ttl_ms / 1000.0
@@ -296,7 +315,8 @@ class VelocityProposalGate:
             "connected": bool(self.connected_topic),
             "armed": self.armed,
             "topic": self.connected_topic or None,
-            "active_nav_id": self.active_nav_id or None,
+            "expected_nav_id": self.expected_nav_id or None,
+            "active_nav_id": self.expected_nav_id if self.armed else None,
             "last_sequence": self.last_sequence if self.last_sequence >= 0 else None,
             "last_message_age_ms": age_ms,
             "last_reason": self.last_reason or None,

--- a/unitree/g1/velocity_proposal.py
+++ b/unitree/g1/velocity_proposal.py
@@ -1,8 +1,8 @@
 """Pure validation and lease state for the N5 Nav2 velocity proposal gate.
 
 This module deliberately has no ROS 2 or Unitree dependency.  The SmartMotion
-subprocess owns physical execution; it may act only on a ProposalDecision
-returned here.
+subprocess owns validation and authorization; only a ProposalDecision returned
+here may be forwarded to the parent Driver RPC worker for physical execution.
 """
 
 from __future__ import annotations
@@ -268,7 +268,12 @@ class VelocityProposalGate:
             and self.expected_nav_id == expected_nav_id
         )
 
-    def accept(self, payload: Mapping[str, Any], now: float) -> ProposalDecision:
+    def accept(
+        self,
+        payload: Mapping[str, Any],
+        now: float,
+        now_unix_ms: Optional[float] = None,
+    ) -> ProposalDecision:
         if not self.connected_topic:
             return ProposalDecision(stop=True, reason="proposal_not_connected")
         if not self.armed:
@@ -286,6 +291,23 @@ class VelocityProposalGate:
             self.disarm("sequence_not_increasing")
             return ProposalDecision(stop=True, reason="sequence_not_increasing", proposal=proposal)
 
+        duration = proposal.ttl_ms / 1000.0
+        if now_unix_ms is not None:
+            remaining = (
+                proposal.issued_at_unix_ms
+                + proposal.ttl_ms
+                - float(now_unix_ms)
+            ) / 1000.0
+            if remaining <= 0.0:
+                self.disarm("proposal_ttl_expired")
+                return ProposalDecision(
+                    stop=True,
+                    reason="proposal_ttl_expired",
+                    proposal=proposal,
+                )
+            # A future producer timestamp may not extend the configured TTL.
+            duration = min(duration, remaining)
+
         self.last_sequence = proposal.sequence
         self.last_receive_monotonic = now
         if proposal.is_zero:
@@ -296,7 +318,6 @@ class VelocityProposalGate:
                 self.last_reason = proposal.status
             return ProposalDecision(stop=True, reason="proposal_zero", proposal=proposal)
 
-        duration = proposal.ttl_ms / 1000.0
         self.deadline_monotonic = now + duration
         self.last_reason = ""
         return ProposalDecision(execute=True, duration=duration, proposal=proposal)


### PR DESCRIPTION
## 变更概述

本 PR 只修复 G1 Driver 对导航速度提案的安全执行闭环：

- 为现有 `loco` 执行器接入 `phanthy.navigation.velocity_proposal.v1`；
- 使用 latest-only 队列执行最新速度，避免旧命令积压；
- 通过父进程 RPC 调用底层 `SetVelocity(continuous)`；
- 对终止、TTL 中断、普通障碍和硬故障执行分级停车与恢复；
- 通过新鲜零速里程计确认 `StopMove` 已真正生效。

本 PR **不再包含** `phanthy.g1.lidar_cloud.v2`、`phanthy.g1.loco_state.v2`、`PCLMETA2` 或重力对齐逆变换元数据。导航 LiDAR/IMU 标准输入由独立的 Driver PR #141 负责。

## 主要改动

### 速度提案输入与校验

- `loco` 暴露 `/ubuntu/navigation/nav2/velocity_proposal` 输入端口；
- 校验 schema、导航身份、序列号、TTL、坐标系、有限数值及速度上限；
- 容量为 1 的 latest-only 队列会合并等待中的旧提案；
- 启动默认保持未连接、未武装，只有合法导航会话才能执行速度。

### 执行与停车确认

- 速度通过 `RpcProxy -> LocoClient.SetVelocity(continuous)` 执行；
- 终止零速、Canvas 停止、TTL 中断、障碍和硬故障都会触发受限 `StopMove`；
- 停车完成必须由调用完成后的新鲜 odometry 样本确认；
- 普通障碍或单次 TTL 中断在停车确认后保留同一 lease，可接受下一条新鲜提案恢复；
- 身份、FSM、急停、传感器、RPC 或停车确认失败仍保持 fail-closed 并解除武装；
- 切换运动模式前会解除速度提案绑定。

### 诊断

`loco info` 增加：

- received / accepted / applied / rejected / coalesced 计数；
- 逐原因拒绝和 watchdog 统计；
- 最近一次停车请求、尝试和零速确认；
- RPC、排队、端到端时延及 p50/p95/p99/max。

### 与官方 main 同步

分支基于官方 `main@facd3887b8a70467b5a81ebda462e32ab9010687`，当前相对 main 落后 0、领先 11 个提交。

同步过程中保留了上游当前 SmartMotion 行为：

- 基于 `_req_id` 的并发结果路由；
- timed move 的异步 ACP 回执；
- 当前 `x-action-params` 模式动作；
- speaker 与 controlled-spatial 子进程架构。

新增回归测试覆盖并发请求乱序返回和 IPC 超时终止失去响应的运动控制进程。

## 验证结果

在最终清理后的代码树执行：

```bash
cd unitree/g1
PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. /Users/hanzebei/miniconda3/bin/pytest -q tests
PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile   main.py device.py safety_harness.py rpc_proxy.py velocity_proposal.py pointcloud_utils.py
cd ../..
git diff --check origin/main...HEAD
```

结果：

- G1 测试：**99 passed，67 subtests passed**
- Python 编译检查：**通过**
- `git diff --check`：**通过**
- PR 净差异：15 个文件，仅包含速度提案执行、停车确认、诊断、测试和对应文档
- Docker 镜像构建：**本轮未执行**
- 本轮未部署、重启或控制机器人

此前上海 G1 已基于同步前候选版本完成 owner-gated 实机验证：

- 有限时长运动与终止停车；
- 停车确认及解绑；
- 普通障碍停车后的纯旋转恢复；
- TTL 中断后的同 lease 恢复。

以上属于同步前实机证据；本 PR 最终 HEAD 尚未重新部署到机器人，不越级声明最终版本已通过真机回归。

## 安全性与兼容性

- 不绕过急停、FSM、传感器新鲜度或停车确认；
- 普通障碍/TTL 中断只有在停车确认成功后才允许恢复；
- 硬故障继续永久 disarm 当前 lease；
- 不修改现有 LiDAR、loco state 载荷或传感器 topic；
- 不修改 Agent Core、FAST-LIVO2 或 Nav2。

## 相关 PR

- 导航消费者与 FAST-LIVO2/Nav2：4paradigm/phanthymotus#96
- 独立导航 LiDAR/IMU Driver 卡片：#141

## 责任与评审重点

- 改动目录 Owner：G1 Driver 维护者；
- 最终行为 Owner：G1 导航集成人；
- 实际 Review/验收：需要具备 G1 Driver 写权限的 Reviewer，并在合并前确认最终镜像的 owner-gated 真机回归；
- 重点评审 latest-only 队列、父进程 RPC、停车确认、可恢复故障边界和硬故障 fail-closed 行为。

## 回滚方式

可直接 revert 本 PR；部署侧也可以关闭 `velocity_proposal_enabled`，恢复为不消费导航速度提案的 Driver。