### PR TITLE
新增 G1 导航 LiDAR 与 IMU Driver 卡片

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,12 @@ The read-only `navigation_sensors` Driver plugin launches an isolated worker
 process which subscribes directly to the MID360 raw DDS streams instead of
 converting the body `/ubuntu/state/imu` JSON. Keeping raw LiDAR conversion and
 IMU forwarding out of the full Driver process prevents the legacy LiDAR,
-camera, and MCP threads from starving the estimator input callbacks. The
-worker publishes the inputs expected by the Perception FAST-LIVO2 card:
+camera, and MCP threads from starving navigation input callbacks. The worker
+publishes two algorithm-independent navigation sensor topics:
 
-- `/ubuntu/navigation/lidar_fast_livo` — `sensor_msgs/msg/PointCloud2`,
+- `/ubuntu/navigation/lidar` — `sensor_msgs/msg/PointCloud2`,
   RELIABLE + KEEP_LAST(2), with `x/y/z/intensity/tag/line/timestamp` fields;
 - `/ubuntu/navigation/imu` — `sensor_msgs/msg/Imu`, RELIABLE + KEEP_LAST(200);
-- `/ubuntu/navigation/sensor_diagnostics` — clock warm-up/reset and drop
-  counters as `std_msgs/msg/String` JSON.
 
 LiDAR and IMU retain their shared MID360 source clock and are normalized into
 one ROS system-time domain. Samples are dropped while clock offset estimation
@@ -84,11 +82,12 @@ source timestamp. The fixed upside-down mounting rotation is applied equally
 to cloud and IMU. The existing `/ubuntu/lidar/cloud` legacy card remains
 enabled for Canvas and safety consumers.
 
-FAST-LIVO2 must connect to the two native topics above. The body IMU JSON is
-approximately 20 Hz, has no source timestamp, and is not a valid substitute
-for the MID360 built-in IMU. Before accepting a map, verify the isolated worker
-delivers approximately 10 Hz LiDAR and 200 Hz IMU; materially lower rates or
-repeated source-stamp gaps invalidate the mapping run.
+Navigation consumers such as LiDAR-inertial mapping and path planning can bind
+to these topics without the Driver naming or selecting a specific algorithm.
+The body IMU JSON is approximately 20 Hz, has no source timestamp, and is not a
+valid substitute for the MID360 built-in IMU. Before accepting a navigation
+run, verify the isolated worker delivers approximately 10 Hz LiDAR and 200 Hz
+IMU; materially lower rates or repeated source-stamp gaps invalidate the run.
 
 ## Writing a New Driver
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,30 @@ python main.py
 4. Tools become available to the LLM agent and appear in the Web Dashboard
 5. The LLM agent can invoke tools via MCP `tools/call`
 
+### G1 Navigation Sensors
+
+The read-only `navigation_sensors` Driver plugin subscribes directly to the
+MID360 raw DDS streams instead of converting the body `/ubuntu/state/imu`
+JSON. It publishes the estimator inputs expected by the Perception FAST-LIVO2
+card:
+
+- `/ubuntu/navigation/lidar_fast_livo` — `sensor_msgs/msg/PointCloud2`,
+  RELIABLE + KEEP_LAST(2), with `x/y/z/intensity/tag/line/timestamp` fields;
+- `/ubuntu/navigation/imu` — `sensor_msgs/msg/Imu`, RELIABLE + KEEP_LAST(200);
+- `/ubuntu/navigation/sensor_diagnostics` — clock warm-up/reset and drop
+  counters as `std_msgs/msg/String` JSON.
+
+LiDAR and IMU retain their shared MID360 source clock and are normalized into
+one ROS system-time domain. Samples are dropped while clock offset estimation
+is not ready or after an invalid/reset observation; the Driver never invents a
+source timestamp. The fixed upside-down mounting rotation is applied equally
+to cloud and IMU. The existing `/ubuntu/lidar/cloud` legacy card remains
+enabled for Canvas and safety consumers.
+
+FAST-LIVO2 must connect to the two native topics above. The body IMU JSON is
+approximately 20 Hz, has no source timestamp, and is not a valid substitute
+for the MID360 built-in IMU.
+
 ## Writing a New Driver
 
 Want to add support for new hardware? See the **[Driver Development Guide](README_dev.md)** for the full specification, including:

--- a/README.md
+++ b/README.md
@@ -64,10 +64,12 @@ python main.py
 
 ### G1 Navigation Sensors
 
-The read-only `navigation_sensors` Driver plugin subscribes directly to the
-MID360 raw DDS streams instead of converting the body `/ubuntu/state/imu`
-JSON. It publishes the estimator inputs expected by the Perception FAST-LIVO2
-card:
+The read-only `navigation_sensors` Driver plugin launches an isolated worker
+process which subscribes directly to the MID360 raw DDS streams instead of
+converting the body `/ubuntu/state/imu` JSON. Keeping raw LiDAR conversion and
+IMU forwarding out of the full Driver process prevents the legacy LiDAR,
+camera, and MCP threads from starving the estimator input callbacks. The
+worker publishes the inputs expected by the Perception FAST-LIVO2 card:
 
 - `/ubuntu/navigation/lidar_fast_livo` — `sensor_msgs/msg/PointCloud2`,
   RELIABLE + KEEP_LAST(2), with `x/y/z/intensity/tag/line/timestamp` fields;
@@ -84,7 +86,9 @@ enabled for Canvas and safety consumers.
 
 FAST-LIVO2 must connect to the two native topics above. The body IMU JSON is
 approximately 20 Hz, has no source timestamp, and is not a valid substitute
-for the MID360 built-in IMU.
+for the MID360 built-in IMU. Before accepting a map, verify the isolated worker
+delivers approximately 10 Hz LiDAR and 200 Hz IMU; materially lower rates or
+repeated source-stamp gaps invalidate the mapping run.
 
 ## Writing a New Driver
 

--- a/unitree/g1/Dockerfile
+++ b/unitree/g1/Dockerfile
@@ -55,6 +55,7 @@ COPY controlled_spatial.py /work/controlled_spatial.py
 COPY controlled_spatial_map.py /work/controlled_spatial_map.py
 COPY pointcloud_utils.py /work/pointcloud_utils.py
 COPY navigation_sensor_bridge.py /work/navigation_sensor_bridge.py
+COPY navigation_sensor_bridge_main.py /work/navigation_sensor_bridge_main.py
 COPY navigation_pointcloud.py /work/navigation_pointcloud.py
 COPY navigation_time.py /work/navigation_time.py
 COPY test_slam_rpc.py /work/test_slam_rpc.py

--- a/unitree/g1/Dockerfile
+++ b/unitree/g1/Dockerfile
@@ -54,6 +54,9 @@ COPY scan_context.py /work/scan_context.py
 COPY controlled_spatial.py /work/controlled_spatial.py
 COPY controlled_spatial_map.py /work/controlled_spatial_map.py
 COPY pointcloud_utils.py /work/pointcloud_utils.py
+COPY navigation_sensor_bridge.py /work/navigation_sensor_bridge.py
+COPY navigation_pointcloud.py /work/navigation_pointcloud.py
+COPY navigation_time.py /work/navigation_time.py
 COPY test_slam_rpc.py /work/test_slam_rpc.py
 COPY config.yaml /work/config.yaml
 COPY deploy/     /deploy/

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -21,6 +21,29 @@ plugins:
     enabled: true
   lidar:
     enabled: true
+  # MID360 raw DDS -> native ROS 2 topics used by FAST-LIVO2. This bridge is
+  # read-only and coexists with the legacy lidar card used by Canvas/safety.
+  navigation_sensors:
+    enabled: true
+    raw_cloud_topic: rt/utlidar/cloud_livox_mid360
+    raw_imu_topic: rt/utlidar/imu_livox_mid360
+    publish_raw_cloud: false
+    publish_fast_livo_cloud: true
+    fast_livo_cloud_topic: /ubuntu/navigation/lidar_fast_livo
+    imu_topic: /ubuntu/navigation/imu
+    diagnostics_topic: /ubuntu/navigation/sensor_diagnostics
+    raw_lidar_frame: livox_raw_frame
+    lidar_frame: livox_frame
+    imu_frame: livox_frame
+    # The G1 MID360 is mounted upside down. Apply the same fixed rotation to
+    # both the cloud and its built-in IMU; FAST-LIVO2 keeps identity extrinsics.
+    sensor_rotation_matrix: [1.0, 0.0, 0.0,
+                             0.0, -1.0, 0.0,
+                             0.0, 0.0, -1.0]
+    clock_warmup_samples: 32
+    clock_window_samples: 400
+    clock_reset_threshold_ms: 1000
+    clock_reset_confirm_samples: 8
   slam:
     enabled: false
     map_dir: /opt/phanthy-motus/data/maps

--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -21,22 +21,18 @@ plugins:
     enabled: true
   lidar:
     enabled: true
-  # MID360 raw DDS -> native ROS 2 topics used by FAST-LIVO2. This bridge is
-  # read-only and coexists with the legacy lidar card used by Canvas/safety.
+  # MID360 raw DDS -> native ROS 2 topics for navigation consumers. This
+  # read-only bridge coexists with the legacy lidar card used by Canvas/safety.
   navigation_sensors:
     enabled: true
     raw_cloud_topic: rt/utlidar/cloud_livox_mid360
     raw_imu_topic: rt/utlidar/imu_livox_mid360
-    publish_raw_cloud: false
-    publish_fast_livo_cloud: true
-    fast_livo_cloud_topic: /ubuntu/navigation/lidar_fast_livo
+    cloud_topic: /ubuntu/navigation/lidar
     imu_topic: /ubuntu/navigation/imu
-    diagnostics_topic: /ubuntu/navigation/sensor_diagnostics
-    raw_lidar_frame: livox_raw_frame
     lidar_frame: livox_frame
     imu_frame: livox_frame
     # The G1 MID360 is mounted upside down. Apply the same fixed rotation to
-    # both the cloud and its built-in IMU; FAST-LIVO2 keeps identity extrinsics.
+    # both the cloud and its built-in IMU so every consumer sees one frame.
     sensor_rotation_matrix: [1.0, 0.0, 0.0,
                              0.0, -1.0, 0.0,
                              0.0, 0.0, -1.0]

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -130,7 +130,10 @@ class G1DeviceBundle:
             from navigation_sensor_bridge import NavigationSensorPlugin
             self._plugins.append(
                 NavigationSensorPlugin(
-                    plugins_cfg["navigation_sensors"], namespace, executor
+                    plugins_cfg["navigation_sensors"],
+                    namespace,
+                    executor,
+                    network_iface,
                 )
             )
             print("[bundle] NavigationSensorPlugin loaded")

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -126,6 +126,15 @@ class G1DeviceBundle:
             self._plugins.append(LidarPlugin(plugins_cfg["lidar"], namespace, executor))
             print("[bundle] LidarPlugin loaded")
 
+        if plugins_cfg.get("navigation_sensors", {}).get("enabled", False):
+            from navigation_sensor_bridge import NavigationSensorPlugin
+            self._plugins.append(
+                NavigationSensorPlugin(
+                    plugins_cfg["navigation_sensors"], namespace, executor
+                )
+            )
+            print("[bundle] NavigationSensorPlugin loaded")
+
         if plugins_cfg.get("slam", {}).get("enabled", False):
             from device import SpatialPlugin
             self._plugins.append(SpatialPlugin(plugins_cfg["slam"], namespace, executor, slam_client, smart_motion=smart_motion))

--- a/unitree/g1/navigation_pointcloud.py
+++ b/unitree/g1/navigation_pointcloud.py
@@ -1,0 +1,241 @@
+"""MID360 PointCloud2 layout conversion for the FAST-LIVO2 ROS2 MID360 port."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+# sensor_msgs/msg/PointField datatype constants
+UINT8 = 2
+UINT16 = 4
+FLOAT32 = 7
+FLOAT64 = 8
+
+
+@dataclass(frozen=True)
+class PointFieldSpec:
+    name: str
+    offset: int
+    datatype: int
+    count: int = 1
+
+
+# Match the PCL point layout used by the ROS2 MID360 FAST-LIVO2 port:
+# PCL_ADD_POINT4D, intensity, tag, line, alignment padding, timestamp.
+FAST_LIVO_FIELDS = (
+    PointFieldSpec("x", 0, FLOAT32),
+    PointFieldSpec("y", 4, FLOAT32),
+    PointFieldSpec("z", 8, FLOAT32),
+    PointFieldSpec("intensity", 16, FLOAT32),
+    PointFieldSpec("tag", 20, UINT8),
+    PointFieldSpec("line", 21, UINT8),
+    PointFieldSpec("timestamp", 24, FLOAT64),
+)
+FAST_LIVO_POINT_STEP = 32
+_FAST_LIVO_DTYPE = np.dtype(
+    {
+        "names": [field.name for field in FAST_LIVO_FIELDS],
+        "formats": ["<f4", "<f4", "<f4", "<f4", "u1", "u1", "<f8"],
+        "offsets": [field.offset for field in FAST_LIVO_FIELDS],
+        "itemsize": FAST_LIVO_POINT_STEP,
+    }
+)
+
+_EXPECTED_INPUT_TYPES = {
+    "x": FLOAT32,
+    "y": FLOAT32,
+    "z": FLOAT32,
+    "intensity": FLOAT32,
+    "ring": UINT16,
+    "time": FLOAT32,
+}
+_INPUT_DTYPES = {
+    "x": "<f4",
+    "y": "<f4",
+    "z": "<f4",
+    "intensity": "<f4",
+    "ring": "<u2",
+    "time": "<f4",
+}
+
+
+def validated_rotation_matrix(values: object | None) -> np.ndarray:
+    """Return a proper 3x3 rotation matrix from a row-major config value."""
+    if values is None:
+        return np.eye(3, dtype=np.float64)
+
+    rotation = np.asarray(values, dtype=np.float64)
+    if rotation.size != 9:
+        raise ValueError("sensor_rotation_matrix must contain 9 values")
+    rotation = rotation.reshape(3, 3)
+    if not np.isfinite(rotation).all():
+        raise ValueError("sensor_rotation_matrix contains non-finite values")
+    if not np.allclose(rotation @ rotation.T, np.eye(3), atol=1e-6):
+        raise ValueError("sensor_rotation_matrix must be orthonormal")
+    if not np.isclose(np.linalg.det(rotation), 1.0, atol=1e-6):
+        raise ValueError("sensor_rotation_matrix must be a proper rotation")
+    return rotation
+
+
+def rotate_vector3(values: object, rotation: np.ndarray) -> tuple[float, float, float]:
+    """Rotate one xyz vector from the raw MID360 frame into navigation frame."""
+    vector = np.asarray(values, dtype=np.float64)
+    if vector.size != 3:
+        raise ValueError("vector must contain 3 values")
+    rotated = rotation @ vector.reshape(3)
+    return tuple(float(value) for value in rotated)
+
+
+def rotate_covariance9(values: object, rotation: np.ndarray) -> list[float]:
+    """Rotate a row-major 3x3 covariance into the navigation frame."""
+    covariance = np.asarray(values, dtype=np.float64)
+    if covariance.size != 9:
+        raise ValueError("covariance must contain 9 values")
+    rotated = rotation @ covariance.reshape(3, 3) @ rotation.T
+    return [float(value) for value in rotated.reshape(9)]
+
+
+def rotate_orientation_xyzw(
+    values: object, rotation: np.ndarray
+) -> tuple[float, float, float, float]:
+    """Express a raw-frame orientation quaternion in the corrected frame.
+
+    ``rotation`` maps raw sensor vectors into the corrected navigation frame.
+    An IMU orientation describes the raw sensor frame in the world, so the
+    corrected-frame orientation is ``R_world_raw * rotation.T``.
+    """
+    quaternion = np.asarray(values, dtype=np.float64)
+    if quaternion.size != 4:
+        raise ValueError("quaternion must contain 4 values")
+    norm = float(np.linalg.norm(quaternion))
+    if not np.isfinite(norm) or norm < 1e-12:
+        raise ValueError("quaternion must be finite and non-zero")
+    x, y, z, w = quaternion / norm
+    raw_to_world = np.array(
+        [
+            [1.0 - 2.0 * (y * y + z * z), 2.0 * (x * y - z * w), 2.0 * (x * z + y * w)],
+            [2.0 * (x * y + z * w), 1.0 - 2.0 * (x * x + z * z), 2.0 * (y * z - x * w)],
+            [2.0 * (x * z - y * w), 2.0 * (y * z + x * w), 1.0 - 2.0 * (x * x + y * y)],
+        ],
+        dtype=np.float64,
+    )
+    corrected_to_world = raw_to_world @ rotation.T
+
+    trace = float(np.trace(corrected_to_world))
+    if trace > 0.0:
+        scale = 2.0 * np.sqrt(trace + 1.0)
+        qw = 0.25 * scale
+        qx = (corrected_to_world[2, 1] - corrected_to_world[1, 2]) / scale
+        qy = (corrected_to_world[0, 2] - corrected_to_world[2, 0]) / scale
+        qz = (corrected_to_world[1, 0] - corrected_to_world[0, 1]) / scale
+    else:
+        index = int(np.argmax(np.diag(corrected_to_world)))
+        if index == 0:
+            scale = 2.0 * np.sqrt(
+                1.0 + corrected_to_world[0, 0]
+                - corrected_to_world[1, 1]
+                - corrected_to_world[2, 2]
+            )
+            qw = (corrected_to_world[2, 1] - corrected_to_world[1, 2]) / scale
+            qx = 0.25 * scale
+            qy = (corrected_to_world[0, 1] + corrected_to_world[1, 0]) / scale
+            qz = (corrected_to_world[0, 2] + corrected_to_world[2, 0]) / scale
+        elif index == 1:
+            scale = 2.0 * np.sqrt(
+                1.0 + corrected_to_world[1, 1]
+                - corrected_to_world[0, 0]
+                - corrected_to_world[2, 2]
+            )
+            qw = (corrected_to_world[0, 2] - corrected_to_world[2, 0]) / scale
+            qx = (corrected_to_world[0, 1] + corrected_to_world[1, 0]) / scale
+            qy = 0.25 * scale
+            qz = (corrected_to_world[1, 2] + corrected_to_world[2, 1]) / scale
+        else:
+            scale = 2.0 * np.sqrt(
+                1.0 + corrected_to_world[2, 2]
+                - corrected_to_world[0, 0]
+                - corrected_to_world[1, 1]
+            )
+            qw = (corrected_to_world[1, 0] - corrected_to_world[0, 1]) / scale
+            qx = (corrected_to_world[0, 2] + corrected_to_world[2, 0]) / scale
+            qy = (corrected_to_world[1, 2] + corrected_to_world[2, 1]) / scale
+            qz = 0.25 * scale
+
+    corrected = np.array([qx, qy, qz, qw], dtype=np.float64)
+    corrected /= np.linalg.norm(corrected)
+    return tuple(float(value) for value in corrected)
+
+
+def unitree_mid360_to_fast_livo(
+    *,
+    data: bytes,
+    point_count: int,
+    point_step: int,
+    fields: list[tuple[str, int, int, int]],
+    header_stamp_ns: int,
+    rotation_matrix: np.ndarray | None = None,
+) -> bytes:
+    """Convert Unitree's packed MID360 points to the ROS2 port's PCL schema.
+
+    Unitree provides ``time`` as a per-point offset in nanoseconds.  The target
+    FAST-LIVO2 MID360 handler expects ``timestamp`` as an absolute nanosecond
+    value and subtracts the ROS header internally.
+    """
+    point_count = int(point_count)
+    point_step = int(point_step)
+    header_stamp_ns = int(header_stamp_ns)
+    if point_count < 1 or point_step < 1 or header_stamp_ns <= 0:
+        raise ValueError("point_count, point_step and header_stamp_ns must be positive")
+    if len(data) < point_count * point_step:
+        raise ValueError("point cloud data is shorter than point_count * point_step")
+
+    field_map = {name: (int(offset), int(datatype), int(count)) for name, offset, datatype, count in fields}
+    for name, expected_type in _EXPECTED_INPUT_TYPES.items():
+        if name not in field_map:
+            raise ValueError(f"missing MID360 field: {name}")
+        offset, datatype, count = field_map[name]
+        if datatype != expected_type or count != 1:
+            raise ValueError(
+                f"unexpected MID360 field {name}: datatype={datatype}, count={count}"
+            )
+        if offset < 0 or offset + np.dtype(_INPUT_DTYPES[name]).itemsize > point_step:
+            raise ValueError(f"MID360 field {name} exceeds point_step")
+
+    def view(name: str) -> np.ndarray:
+        offset = field_map[name][0]
+        return np.ndarray(
+            shape=(point_count,),
+            dtype=_INPUT_DTYPES[name],
+            buffer=data,
+            offset=offset,
+            strides=(point_step,),
+        )
+
+    ring = view("ring")
+    if int(ring.max(initial=0)) > 255:
+        raise ValueError("MID360 ring value exceeds uint8 line range")
+
+    relative_time_ns = view("time")
+    if not np.isfinite(relative_time_ns).all() or float(relative_time_ns.min()) < 0:
+        raise ValueError("MID360 time contains negative or non-finite values")
+
+    rotation = validated_rotation_matrix(rotation_matrix)
+    xyz = np.column_stack((view("x"), view("y"), view("z"))).astype(
+        np.float32, copy=False
+    )
+    if not np.array_equal(rotation, np.eye(3)):
+        xyz = xyz @ rotation.astype(np.float32).T
+
+    converted = np.zeros(point_count, dtype=_FAST_LIVO_DTYPE)
+    converted["x"] = xyz[:, 0]
+    converted["y"] = xyz[:, 1]
+    converted["z"] = xyz[:, 2]
+    converted["intensity"] = view("intensity")
+    converted["tag"] = 0x10
+    converted["line"] = ring.astype(np.uint8, copy=False)
+    converted["timestamp"] = np.float64(header_stamp_ns) + relative_time_ns.astype(
+        np.float64, copy=False
+    )
+    return converted.tobytes(order="C")

--- a/unitree/g1/navigation_pointcloud.py
+++ b/unitree/g1/navigation_pointcloud.py
@@ -1,4 +1,4 @@
-"""MID360 PointCloud2 layout conversion for the FAST-LIVO2 ROS2 MID360 port."""
+"""MID360 PointCloud2 conversion for the generic navigation sensor contract."""
 
 from __future__ import annotations
 
@@ -22,9 +22,9 @@ class PointFieldSpec:
     count: int = 1
 
 
-# Match the PCL point layout used by the ROS2 MID360 FAST-LIVO2 port:
-# PCL_ADD_POINT4D, intensity, tag, line, alignment padding, timestamp.
-FAST_LIVO_FIELDS = (
+# Stable navigation layout: PCL_ADD_POINT4D, intensity, tag, line, alignment
+# padding and an absolute per-point timestamp in the normalized ROS clock.
+NAVIGATION_FIELDS = (
     PointFieldSpec("x", 0, FLOAT32),
     PointFieldSpec("y", 4, FLOAT32),
     PointFieldSpec("z", 8, FLOAT32),
@@ -33,13 +33,13 @@ FAST_LIVO_FIELDS = (
     PointFieldSpec("line", 21, UINT8),
     PointFieldSpec("timestamp", 24, FLOAT64),
 )
-FAST_LIVO_POINT_STEP = 32
-_FAST_LIVO_DTYPE = np.dtype(
+NAVIGATION_POINT_STEP = 32
+_NAVIGATION_DTYPE = np.dtype(
     {
-        "names": [field.name for field in FAST_LIVO_FIELDS],
+        "names": [field.name for field in NAVIGATION_FIELDS],
         "formats": ["<f4", "<f4", "<f4", "<f4", "u1", "u1", "<f8"],
-        "offsets": [field.offset for field in FAST_LIVO_FIELDS],
-        "itemsize": FAST_LIVO_POINT_STEP,
+        "offsets": [field.offset for field in NAVIGATION_FIELDS],
+        "itemsize": NAVIGATION_POINT_STEP,
     }
 )
 
@@ -168,7 +168,7 @@ def rotate_orientation_xyzw(
     return tuple(float(value) for value in corrected)
 
 
-def unitree_mid360_to_fast_livo(
+def unitree_mid360_to_navigation_cloud(
     *,
     data: bytes,
     point_count: int,
@@ -177,11 +177,11 @@ def unitree_mid360_to_fast_livo(
     header_stamp_ns: int,
     rotation_matrix: np.ndarray | None = None,
 ) -> bytes:
-    """Convert Unitree's packed MID360 points to the ROS2 port's PCL schema.
+    """Convert Unitree's packed MID360 points to the navigation PCL schema.
 
-    Unitree provides ``time`` as a per-point offset in nanoseconds.  The target
-    FAST-LIVO2 MID360 handler expects ``timestamp`` as an absolute nanosecond
-    value and subtracts the ROS header internally.
+    Unitree provides ``time`` as a per-point offset in nanoseconds.  The output
+    preserves it as an absolute nanosecond ``timestamp`` in the same normalized
+    clock domain as the ROS header and navigation IMU.
     """
     point_count = int(point_count)
     point_step = int(point_step)
@@ -228,7 +228,7 @@ def unitree_mid360_to_fast_livo(
     if not np.array_equal(rotation, np.eye(3)):
         xyz = xyz @ rotation.astype(np.float32).T
 
-    converted = np.zeros(point_count, dtype=_FAST_LIVO_DTYPE)
+    converted = np.zeros(point_count, dtype=_NAVIGATION_DTYPE)
     converted["x"] = xyz[:, 0]
     converted["y"] = xyz[:, 1]
     converted["z"] = xyz[:, 2]

--- a/unitree/g1/navigation_sensor_bridge.py
+++ b/unitree/g1/navigation_sensor_bridge.py
@@ -24,12 +24,12 @@ from sensor_msgs.msg import Imu, PointCloud2, PointField
 from std_msgs.msg import String
 
 from navigation_pointcloud import (
-    FAST_LIVO_FIELDS,
-    FAST_LIVO_POINT_STEP,
+    NAVIGATION_FIELDS,
+    NAVIGATION_POINT_STEP,
     rotate_covariance9,
     rotate_orientation_xyzw,
     rotate_vector3,
-    unitree_mid360_to_fast_livo,
+    unitree_mid360_to_navigation_cloud,
     validated_rotation_matrix,
 )
 from navigation_time import ClockOffsetEstimator, split_ns, stamp_to_ns
@@ -37,22 +37,15 @@ from unitree_sdk2py.core.channel import ChannelSubscriber
 from unitree_sdk2py.idl.sensor_msgs.msg.dds_ import Imu_, PointCloud2_
 
 
-_RAW_CLOUD_QOS = QoSProfile(
-    reliability=ReliabilityPolicy.BEST_EFFORT,
-    history=HistoryPolicy.KEEP_LAST,
-    depth=2,
-    durability=DurabilityPolicy.VOLATILE,
-)
-_FAST_LIVO_CLOUD_QOS = QoSProfile(
+_NAVIGATION_CLOUD_QOS = QoSProfile(
     reliability=ReliabilityPolicy.RELIABLE,
     history=HistoryPolicy.KEEP_LAST,
     depth=2,
     durability=DurabilityPolicy.VOLATILE,
 )
 _IMU_QOS = QoSProfile(
-    # The pinned FAST-LIVO2 port uses the ROS default reliable subscription.
-    # A reliable publisher remains compatible with best-effort diagnostics,
-    # while the inverse pairing silently disconnects the estimator input.
+    # Navigation estimators generally use a reliable IMU subscription.  Match
+    # that contract so the endpoint cannot silently disconnect on QoS.
     reliability=ReliabilityPolicy.RELIABLE,
     history=HistoryPolicy.KEEP_LAST,
     depth=200,
@@ -71,24 +64,14 @@ class _NavigationSensorNode(Node):
 
         prefix = f"/{namespace}/navigation"
         self.cloud_topic = _absolute_topic(config.get("cloud_topic"), f"{prefix}/lidar")
-        self.fast_livo_cloud_topic = _absolute_topic(
-            config.get("fast_livo_cloud_topic"), f"{prefix}/lidar_fast_livo"
-        )
-        self._publish_raw_cloud = bool(config.get("publish_raw_cloud", True))
-        self._publish_fast_livo_cloud = bool(
-            config.get("publish_fast_livo_cloud", True)
-        )
         self.imu_topic = _absolute_topic(config.get("imu_topic"), f"{prefix}/imu")
-        self.diagnostics_topic = _absolute_topic(
-            config.get("diagnostics_topic"), f"{prefix}/sensor_diagnostics"
-        )
+        self._status_topic = f"{prefix}/_bridge_status"
         self._raw_cloud_topic = config.get(
             "raw_cloud_topic", "rt/utlidar/cloud_livox_mid360"
         )
         self._raw_imu_topic = config.get(
             "raw_imu_topic", "rt/utlidar/imu_livox_mid360"
         )
-        self._raw_lidar_frame = config.get("raw_lidar_frame", "livox_raw_frame")
         self._lidar_frame = config.get("lidar_frame", "livox_frame")
         self._imu_frame = config.get("imu_frame", self._lidar_frame)
         self._sensor_rotation = validated_rotation_matrix(
@@ -106,22 +89,13 @@ class _NavigationSensorNode(Node):
             reset_confirm_samples=int(config.get("clock_reset_confirm_samples", 8)),
         )
 
-        self._cloud_pub = (
-            self.create_publisher(PointCloud2, self.cloud_topic, _RAW_CLOUD_QOS)
-            if self._publish_raw_cloud
-            else None
-        )
-        self._fast_livo_cloud_pub = (
-            self.create_publisher(
-                PointCloud2,
-                self.fast_livo_cloud_topic,
-                _FAST_LIVO_CLOUD_QOS,
-            )
-            if self._publish_fast_livo_cloud
-            else None
+        self._cloud_pub = self.create_publisher(
+            PointCloud2,
+            self.cloud_topic,
+            _NAVIGATION_CLOUD_QOS,
         )
         self._imu_pub = self.create_publisher(Imu, self.imu_topic, _IMU_QOS)
-        self._diagnostics_pub = self.create_publisher(String, self.diagnostics_topic, 10)
+        self._status_pub = self.create_publisher(String, self._status_topic, 10)
 
         self._cloud_queue: queue.Queue = queue.Queue(maxsize=2)
         self._imu_queue: queue.Queue = queue.Queue(maxsize=4)
@@ -136,13 +110,11 @@ class _NavigationSensorNode(Node):
         self._imu_worker.start()
 
         self._last_stamp_ns = {"cloud": 0, "imu": 0}
-        self._last_diagnostics_time = 0.0
+        self._last_status_time = 0.0
         self._counters = {
             "cloud_received": 0,
             "cloud_published": 0,
             "cloud_dropped": 0,
-            "fast_livo_cloud_published": 0,
-            "fast_livo_cloud_dropped": 0,
             "imu_received": 0,
             "imu_published": 0,
             "imu_dropped": 0,
@@ -156,16 +128,11 @@ class _NavigationSensorNode(Node):
         # Direct callback avoids the SDK BQueue dropping new samples when its
         # single slot is occupied.  This callback only timestamps and enqueues.
         self._imu_sub.Init(self._on_imu)
-        cloud_outputs = []
-        if self._publish_fast_livo_cloud:
-            cloud_outputs.append(self.fast_livo_cloud_topic)
-        if self._publish_raw_cloud:
-            cloud_outputs.append(self.cloud_topic)
         self.get_logger().info(
             f"Navigation sensors: {self._raw_cloud_topic} -> "
-            f"{','.join(cloud_outputs) or '(disabled)'}; "
+            f"{self.cloud_topic}; "
             f"{self._raw_imu_topic} -> {self.imu_topic}; "
-            f"raw_frame={self._raw_lidar_frame}, corrected_frame={self._lidar_frame}, "
+            f"frame={self._lidar_frame}, "
             f"sensor_rotation={self._sensor_rotation.reshape(9).tolist()}"
         )
 
@@ -199,7 +166,7 @@ class _NavigationSensorNode(Node):
         corrected_ns = self._correct_stamp(msg.header.stamp, "cloud")
         if corrected_ns is None:
             self._counters["cloud_dropped"] += 1
-            self._maybe_publish_diagnostics()
+            self._maybe_publish_status()
             return
 
         fields = [
@@ -226,7 +193,7 @@ class _NavigationSensorNode(Node):
                 pass
             self._counters["cloud_dropped"] += 1
             self._cloud_queue.put_nowait(item)
-        self._maybe_publish_diagnostics()
+        self._maybe_publish_status()
 
     def _cloud_loop(self) -> None:
         while not self._stop.is_set():
@@ -253,73 +220,43 @@ class _NavigationSensorNode(Node):
                 self._counters["cloud_dropped"] += 1
                 continue
 
-            # The estimator input is the priority path.  Publishing the raw and
-            # adapted 0.4/0.6 MB clouds together can saturate Python ROS2
-            # serialization on the live Jetson, so the raw diagnostic output is
-            # independently switchable.
-            if self._fast_livo_cloud_pub is not None:
-                try:
-                    converted = unitree_mid360_to_fast_livo(
-                        data=data,
-                        point_count=height * width,
-                        point_step=point_step,
-                        fields=fields,
-                        header_stamp_ns=corrected_ns,
-                        rotation_matrix=self._sensor_rotation,
-                    )
-                    fast_livo = PointCloud2()
-                    self._set_stamp(
-                        fast_livo.header, corrected_ns, self._lidar_frame
-                    )
-                    fast_livo.height = 1
-                    fast_livo.width = height * width
-                    fast_livo.fields = [
-                        PointField(
-                            name=field.name,
-                            offset=field.offset,
-                            datatype=field.datatype,
-                            count=field.count,
-                        )
-                        for field in FAST_LIVO_FIELDS
-                    ]
-                    fast_livo.is_bigendian = False
-                    fast_livo.point_step = FAST_LIVO_POINT_STEP
-                    fast_livo.row_step = FAST_LIVO_POINT_STEP * fast_livo.width
-                    # Humble's generated setter validates a bytes object one
-                    # element at a time in debug mode.  array('B') takes its
-                    # constant-time fast path for large PointCloud2 payloads.
-                    fast_livo.data = array("B", converted)
-                    fast_livo.is_dense = is_dense
-                    self._fast_livo_cloud_pub.publish(fast_livo)
-                    self._counters["fast_livo_cloud_published"] += 1
-                except (TypeError, ValueError) as exc:
-                    self._counters["fast_livo_cloud_dropped"] += 1
-                    if self._counters["fast_livo_cloud_dropped"] <= 3:
-                        self.get_logger().warning(
-                            f"FAST-LIVO cloud conversion failed: {exc}"
-                        )
-
-            if self._cloud_pub is not None:
+            try:
+                converted = unitree_mid360_to_navigation_cloud(
+                    data=data,
+                    point_count=height * width,
+                    point_step=point_step,
+                    fields=fields,
+                    header_stamp_ns=corrected_ns,
+                    rotation_matrix=self._sensor_rotation,
+                )
                 out = PointCloud2()
-                self._set_stamp(out.header, corrected_ns, self._raw_lidar_frame)
-                out.height = height
-                out.width = width
+                self._set_stamp(out.header, corrected_ns, self._lidar_frame)
+                out.height = 1
+                out.width = height * width
                 out.fields = [
                     PointField(
-                        name=name,
-                        offset=offset,
-                        datatype=datatype,
-                        count=count,
+                        name=field.name,
+                        offset=field.offset,
+                        datatype=field.datatype,
+                        count=field.count,
                     )
-                    for name, offset, datatype, count in fields
+                    for field in NAVIGATION_FIELDS
                 ]
-                out.is_bigendian = is_bigendian
-                out.point_step = point_step
-                out.row_step = row_step
-                out.data = array("B", data)
+                out.is_bigendian = False
+                out.point_step = NAVIGATION_POINT_STEP
+                out.row_step = NAVIGATION_POINT_STEP * out.width
+                # Humble's generated setter validates a bytes object one element
+                # at a time in debug mode. array('B') uses its constant-time path.
+                out.data = array("B", converted)
                 out.is_dense = is_dense
                 self._cloud_pub.publish(out)
                 self._counters["cloud_published"] += 1
+            except (TypeError, ValueError) as exc:
+                self._counters["cloud_dropped"] += 1
+                if self._counters["cloud_dropped"] <= 3:
+                    self.get_logger().warning(
+                        f"navigation cloud conversion failed: {exc}"
+                    )
 
     def _on_imu(self, msg) -> None:
         self._counters["imu_received"] += 1
@@ -327,7 +264,7 @@ class _NavigationSensorNode(Node):
         corrected_ns = self._correct_stamp(msg.header.stamp, "imu")
         if corrected_ns is None:
             self._counters["imu_dropped"] += 1
-            self._maybe_publish_diagnostics()
+            self._maybe_publish_status()
             return
 
         try:
@@ -340,7 +277,7 @@ class _NavigationSensorNode(Node):
                 pass
             self._counters["imu_dropped"] += 1
             self._imu_queue.put_nowait((corrected_ns, msg))
-        self._maybe_publish_diagnostics()
+        self._maybe_publish_status()
 
     def _imu_loop(self) -> None:
         while not self._stop.is_set():
@@ -411,11 +348,11 @@ class _NavigationSensorNode(Node):
             self._imu_pub.publish(out)
             self._counters["imu_published"] += 1
 
-    def _maybe_publish_diagnostics(self) -> None:
+    def _maybe_publish_status(self) -> None:
         now = time.monotonic()
-        if now - self._last_diagnostics_time < 1.0:
+        if now - self._last_status_time < 1.0:
             return
-        self._last_diagnostics_time = now
+        self._last_status_time = now
         status = self.status()
         clock = status["clock"]
         if clock["offset_ns"] is not None:
@@ -431,7 +368,6 @@ class _NavigationSensorNode(Node):
                     "imu": self._raw_imu_topic,
                 },
                 "frames": {
-                    "raw_lidar": self._raw_lidar_frame,
                     "lidar": self._lidar_frame,
                     "imu": self._imu_frame,
                 },
@@ -441,7 +377,7 @@ class _NavigationSensorNode(Node):
             },
             separators=(",", ":"),
         )
-        self._diagnostics_pub.publish(out)
+        self._status_pub.publish(out)
 
     def status(self) -> dict:
         now = time.monotonic()
@@ -461,10 +397,8 @@ class _NavigationSensorNode(Node):
             blockers.append("cloud_stale")
         if ages["imu"] is None or ages["imu"] > 100.0:
             blockers.append("imu_stale")
-        if self._publish_fast_livo_cloud and not self._counters[
-            "fast_livo_cloud_published"
-        ]:
-            blockers.append("fast_livo_cloud_not_published")
+        if not self._counters["cloud_published"]:
+            blockers.append("cloud_not_published")
         if not self._counters["imu_published"]:
             blockers.append("imu_not_published")
         return {
@@ -495,32 +429,23 @@ class _NavigationSensorNode(Node):
         self._imu_worker.join(timeout=2.0)
 
 
-class _NavigationSensorStatusNode(Node):
+class _NavigationSensorMonitorNode(Node):
     """Lightweight main-process monitor for the isolated bridge worker."""
 
     def __init__(self, config: dict, namespace: str):
         super().__init__("g1_navigation_sensor_status")
         prefix = f"/{namespace}/navigation"
         self.cloud_topic = _absolute_topic(config.get("cloud_topic"), f"{prefix}/lidar")
-        self.fast_livo_cloud_topic = _absolute_topic(
-            config.get("fast_livo_cloud_topic"), f"{prefix}/lidar_fast_livo"
-        )
         self.imu_topic = _absolute_topic(config.get("imu_topic"), f"{prefix}/imu")
-        self.diagnostics_topic = _absolute_topic(
-            config.get("diagnostics_topic"), f"{prefix}/sensor_diagnostics"
-        )
-        self._publish_raw_cloud = bool(config.get("publish_raw_cloud", True))
-        self._publish_fast_livo_cloud = bool(
-            config.get("publish_fast_livo_cloud", True)
-        )
+        self._status_topic = f"{prefix}/_bridge_status"
         self._lock = threading.RLock()
-        self._last_diagnostics = None
-        self._last_diagnostics_monotonic = 0.0
-        self._diagnostics_sub = self.create_subscription(
-            String, self.diagnostics_topic, self._on_diagnostics, 10
+        self._last_status = None
+        self._last_status_monotonic = 0.0
+        self._status_sub = self.create_subscription(
+            String, self._status_topic, self._on_status, 10
         )
 
-    def _on_diagnostics(self, msg) -> None:
+    def _on_status(self, msg) -> None:
         try:
             payload = json.loads(msg.data)
         except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
@@ -528,15 +453,15 @@ class _NavigationSensorStatusNode(Node):
         if not isinstance(payload, dict):
             return
         with self._lock:
-            self._last_diagnostics = payload
-            self._last_diagnostics_monotonic = time.monotonic()
+            self._last_status = payload
+            self._last_status_monotonic = time.monotonic()
 
     def status(self, worker_running: bool) -> dict:
         with self._lock:
-            payload = dict(self._last_diagnostics or {})
-            received_at = self._last_diagnostics_monotonic
+            payload = dict(self._last_status or {})
+            received_at = self._last_status_monotonic
 
-        diagnostics_age_ms = (
+        status_age_ms = (
             round((time.monotonic() - received_at) * 1000.0, 1)
             if received_at > 0.0
             else None
@@ -544,10 +469,10 @@ class _NavigationSensorStatusNode(Node):
         blockers = list(payload.get("blockers") or [])
         if not worker_running:
             blockers.append("worker_not_running")
-        if diagnostics_age_ms is None:
-            blockers.append("diagnostics_not_received")
-        elif diagnostics_age_ms > 2000.0:
-            blockers.append("diagnostics_stale")
+        if status_age_ms is None:
+            blockers.append("status_not_received")
+        elif status_age_ms > 2000.0:
+            blockers.append("status_stale")
 
         blockers = list(dict.fromkeys(blockers))
         return {
@@ -555,7 +480,7 @@ class _NavigationSensorStatusNode(Node):
             "ready": not blockers,
             "blockers": blockers,
             "worker_running": bool(worker_running),
-            "diagnostics_age_ms": diagnostics_age_ms,
+            "status_age_ms": status_age_ms,
         }
 
 
@@ -572,60 +497,32 @@ class NavigationSensorPlugin:
         self._executor = executor
         self._namespace = namespace
         self._network_iface = network_iface
-        self._status_node = _NavigationSensorStatusNode(plugin_config, namespace)
+        self._status_node = _NavigationSensorMonitorNode(plugin_config, namespace)
         executor.add_node(self._status_node)
         self._worker_path = Path(__file__).with_name("navigation_sensor_bridge_main.py")
         self._proc = None
 
     def get_tools(self) -> list[dict]:
-        tools = []
-        if self._status_node._publish_fast_livo_cloud:
-            tools.append(
-                self._tool(
-                    "navigation_lidar_fast_livo",
-                    "MID360 PointCloud2 adapted for the pinned FAST-LIVO2 ROS2 port",
-                    self._status_node.fast_livo_cloud_topic,
-                    "sensor/pointcloud",
-                    "sensor_msgs/msg/PointCloud2",
-                    "RELIABLE + KEEP_LAST(depth=2) + VOLATILE",
-                    "livox_frame",
-                )
-            )
-        if self._status_node._publish_raw_cloud:
-            tools.append(
-                self._tool(
-                    "navigation_lidar",
-                    "Standard PointCloud2 with raw MID360 fields and per-point time preserved",
-                    self._status_node.cloud_topic,
-                    "sensor/pointcloud",
-                    "sensor_msgs/msg/PointCloud2",
-                    "BEST_EFFORT + KEEP_LAST(depth=2) + VOLATILE",
-                    "livox_raw_frame",
-                )
-            )
-        tools.extend(
-            [
-                self._tool(
-                    "navigation_imu",
-                    "Standard IMU for FAST-LIVO2 in the same normalized clock domain as LiDAR",
-                    self._status_node.imu_topic,
-                    "sensor/imu",
-                    "sensor_msgs/msg/Imu",
-                    "RELIABLE + KEEP_LAST(depth=200) + VOLATILE",
-                    "livox_frame",
-                ),
-                self._tool(
-                    "navigation_sensor_diagnostics",
-                    "Navigation sensor clock and drop diagnostics",
-                    self._status_node.diagnostics_topic,
-                    "data/json",
-                    "std_msgs/msg/String",
-                    "RELIABLE + KEEP_LAST(depth=10) + VOLATILE",
-                    "",
-                ),
-            ]
-        )
-        return tools
+        return [
+            self._tool(
+                "navigation_lidar",
+                "Normalized MID360 PointCloud2 for navigation consumers",
+                self._status_node.cloud_topic,
+                "sensor/pointcloud",
+                "sensor_msgs/msg/PointCloud2",
+                "RELIABLE + KEEP_LAST(depth=2) + VOLATILE",
+                "livox_frame",
+            ),
+            self._tool(
+                "navigation_imu",
+                "Normalized MID360 IMU in the same clock domain as LiDAR",
+                self._status_node.imu_topic,
+                "sensor/imu",
+                "sensor_msgs/msg/Imu",
+                "RELIABLE + KEEP_LAST(depth=200) + VOLATILE",
+                "livox_frame",
+            ),
+        ]
 
     @staticmethod
     def _tool(
@@ -697,7 +594,7 @@ class NavigationSensorPlugin:
                 self.start()
             tool_name = args.get("_tool_name", "")
             tools = {tool["name"]: tool for tool in self.get_tools()}
-            selected = tools.get(tool_name, tools["navigation_sensor_diagnostics"])
+            selected = tools.get(tool_name, tools["navigation_lidar"])
             status = self._status_node.status(self._worker_running())
             return {
                 "state": "ready" if status["ready"] else "not_ready",

--- a/unitree/g1/navigation_sensor_bridge.py
+++ b/unitree/g1/navigation_sensor_bridge.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 from array import array
 import json
+import os
+from pathlib import Path
 import queue
+import subprocess
+import sys
 import threading
 import time
 
@@ -412,7 +416,8 @@ class _NavigationSensorNode(Node):
         if now - self._last_diagnostics_time < 1.0:
             return
         self._last_diagnostics_time = now
-        clock = self._clock_offset.snapshot().to_dict()
+        status = self.status()
+        clock = status["clock"]
         if clock["offset_ns"] is not None:
             clock["offset_sec"] = round(clock["offset_ns"] / 1_000_000_000, 6)
         if clock["residual_ns"] is not None:
@@ -420,8 +425,7 @@ class _NavigationSensorNode(Node):
         out = String()
         out.data = json.dumps(
             {
-                "clock": clock,
-                "counters": dict(self._counters),
+                **status,
                 "raw_topics": {
                     "cloud": self._raw_cloud_topic,
                     "imu": self._raw_imu_topic,
@@ -491,34 +495,108 @@ class _NavigationSensorNode(Node):
         self._imu_worker.join(timeout=2.0)
 
 
+class _NavigationSensorStatusNode(Node):
+    """Lightweight main-process monitor for the isolated bridge worker."""
+
+    def __init__(self, config: dict, namespace: str):
+        super().__init__("g1_navigation_sensor_status")
+        prefix = f"/{namespace}/navigation"
+        self.cloud_topic = _absolute_topic(config.get("cloud_topic"), f"{prefix}/lidar")
+        self.fast_livo_cloud_topic = _absolute_topic(
+            config.get("fast_livo_cloud_topic"), f"{prefix}/lidar_fast_livo"
+        )
+        self.imu_topic = _absolute_topic(config.get("imu_topic"), f"{prefix}/imu")
+        self.diagnostics_topic = _absolute_topic(
+            config.get("diagnostics_topic"), f"{prefix}/sensor_diagnostics"
+        )
+        self._publish_raw_cloud = bool(config.get("publish_raw_cloud", True))
+        self._publish_fast_livo_cloud = bool(
+            config.get("publish_fast_livo_cloud", True)
+        )
+        self._lock = threading.RLock()
+        self._last_diagnostics = None
+        self._last_diagnostics_monotonic = 0.0
+        self._diagnostics_sub = self.create_subscription(
+            String, self.diagnostics_topic, self._on_diagnostics, 10
+        )
+
+    def _on_diagnostics(self, msg) -> None:
+        try:
+            payload = json.loads(msg.data)
+        except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+            return
+        if not isinstance(payload, dict):
+            return
+        with self._lock:
+            self._last_diagnostics = payload
+            self._last_diagnostics_monotonic = time.monotonic()
+
+    def status(self, worker_running: bool) -> dict:
+        with self._lock:
+            payload = dict(self._last_diagnostics or {})
+            received_at = self._last_diagnostics_monotonic
+
+        diagnostics_age_ms = (
+            round((time.monotonic() - received_at) * 1000.0, 1)
+            if received_at > 0.0
+            else None
+        )
+        blockers = list(payload.get("blockers") or [])
+        if not worker_running:
+            blockers.append("worker_not_running")
+        if diagnostics_age_ms is None:
+            blockers.append("diagnostics_not_received")
+        elif diagnostics_age_ms > 2000.0:
+            blockers.append("diagnostics_stale")
+
+        blockers = list(dict.fromkeys(blockers))
+        return {
+            **payload,
+            "ready": not blockers,
+            "blockers": blockers,
+            "worker_running": bool(worker_running),
+            "diagnostics_age_ms": diagnostics_age_ms,
+        }
+
+
 class NavigationSensorPlugin:
     PREFIX = "navigation_sensors"
 
-    def __init__(self, plugin_config: dict, namespace: str, executor):
+    def __init__(
+        self,
+        plugin_config: dict,
+        namespace: str,
+        executor,
+        network_iface: str = "eth0",
+    ):
         self._executor = executor
-        self._node = _NavigationSensorNode(plugin_config, namespace)
-        executor.add_node(self._node)
+        self._namespace = namespace
+        self._network_iface = network_iface
+        self._status_node = _NavigationSensorStatusNode(plugin_config, namespace)
+        executor.add_node(self._status_node)
+        self._worker_path = Path(__file__).with_name("navigation_sensor_bridge_main.py")
+        self._proc = None
 
     def get_tools(self) -> list[dict]:
         tools = []
-        if self._node._publish_fast_livo_cloud:
+        if self._status_node._publish_fast_livo_cloud:
             tools.append(
                 self._tool(
                     "navigation_lidar_fast_livo",
                     "MID360 PointCloud2 adapted for the pinned FAST-LIVO2 ROS2 port",
-                    self._node.fast_livo_cloud_topic,
+                    self._status_node.fast_livo_cloud_topic,
                     "sensor/pointcloud",
                     "sensor_msgs/msg/PointCloud2",
                     "RELIABLE + KEEP_LAST(depth=2) + VOLATILE",
                     "livox_frame",
                 )
             )
-        if self._node._publish_raw_cloud:
+        if self._status_node._publish_raw_cloud:
             tools.append(
                 self._tool(
                     "navigation_lidar",
                     "Standard PointCloud2 with raw MID360 fields and per-point time preserved",
-                    self._node.cloud_topic,
+                    self._status_node.cloud_topic,
                     "sensor/pointcloud",
                     "sensor_msgs/msg/PointCloud2",
                     "BEST_EFFORT + KEEP_LAST(depth=2) + VOLATILE",
@@ -530,7 +608,7 @@ class NavigationSensorPlugin:
                 self._tool(
                     "navigation_imu",
                     "Standard IMU for FAST-LIVO2 in the same normalized clock domain as LiDAR",
-                    self._node.imu_topic,
+                    self._status_node.imu_topic,
                     "sensor/imu",
                     "sensor_msgs/msg/Imu",
                     "RELIABLE + KEEP_LAST(depth=200) + VOLATILE",
@@ -539,7 +617,7 @@ class NavigationSensorPlugin:
                 self._tool(
                     "navigation_sensor_diagnostics",
                     "Navigation sensor clock and drop diagnostics",
-                    self._node.diagnostics_topic,
+                    self._status_node.diagnostics_topic,
                     "data/json",
                     "std_msgs/msg/String",
                     "RELIABLE + KEEP_LAST(depth=10) + VOLATILE",
@@ -578,25 +656,53 @@ class NavigationSensorPlugin:
         }
 
     def start(self) -> None:
-        pass
+        if self._worker_running():
+            return
+        if not self._worker_path.is_file():
+            raise FileNotFoundError(f"navigation sensor worker missing: {self._worker_path}")
+        env = os.environ.copy()
+        env["ROS_NAMESPACE"] = self._namespace
+        self._proc = subprocess.Popen(
+            [sys.executable, str(self._worker_path), self._network_iface],
+            cwd=str(self._worker_path.parent),
+            env=env,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+        print(
+            f"[navigation-sensors] isolated worker started pid={self._proc.pid}",
+            flush=True,
+        )
+
+    def _worker_running(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
 
     def stop(self) -> None:
-        self._node.close()
+        if self._worker_running():
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                self._proc.wait(timeout=2.0)
         try:
-            self._executor.remove_node(self._node)
-            self._node.destroy_node()
+            self._executor.remove_node(self._status_node)
+            self._status_node.destroy_node()
         except Exception:
             pass
 
     def dispatch(self, action: str, args: dict) -> dict | None:
         if action in {"start", "info"}:
+            if action == "start" and not self._worker_running():
+                self.start()
             tool_name = args.get("_tool_name", "")
             tools = {tool["name"]: tool for tool in self.get_tools()}
             selected = tools.get(tool_name, tools["navigation_sensor_diagnostics"])
-            status = self._node.status()
+            status = self._status_node.status(self._worker_running())
             return {
                 "state": "ready" if status["ready"] else "not_ready",
                 "topic_out": selected["topic_out"],
+                "worker_pid": self._proc.pid if self._worker_running() else None,
                 **status,
             }
         if action == "stop":

--- a/unitree/g1/navigation_sensor_bridge.py
+++ b/unitree/g1/navigation_sensor_bridge.py
@@ -1,0 +1,604 @@
+"""Raw MID360 DDS to standard ROS2 sensor topics for traditional navigation.
+
+The bridge is intentionally independent from the dashboard-oriented LidarPlugin.
+It preserves raw PointCloud2 fields, normalizes LiDAR/IMU timestamps into the
+Jetson ROS clock domain, and applies one fixed mounting rotation to both the
+estimator point cloud and IMU.  It never applies dynamic gravity alignment.
+"""
+
+from __future__ import annotations
+
+from array import array
+import json
+import queue
+import threading
+import time
+
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import Imu, PointCloud2, PointField
+from std_msgs.msg import String
+
+from navigation_pointcloud import (
+    FAST_LIVO_FIELDS,
+    FAST_LIVO_POINT_STEP,
+    rotate_covariance9,
+    rotate_orientation_xyzw,
+    rotate_vector3,
+    unitree_mid360_to_fast_livo,
+    validated_rotation_matrix,
+)
+from navigation_time import ClockOffsetEstimator, split_ns, stamp_to_ns
+from unitree_sdk2py.core.channel import ChannelSubscriber
+from unitree_sdk2py.idl.sensor_msgs.msg.dds_ import Imu_, PointCloud2_
+
+
+_RAW_CLOUD_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=2,
+    durability=DurabilityPolicy.VOLATILE,
+)
+_FAST_LIVO_CLOUD_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=2,
+    durability=DurabilityPolicy.VOLATILE,
+)
+_IMU_QOS = QoSProfile(
+    # The pinned FAST-LIVO2 port uses the ROS default reliable subscription.
+    # A reliable publisher remains compatible with best-effort diagnostics,
+    # while the inverse pairing silently disconnects the estimator input.
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=200,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+
+def _absolute_topic(value: str | None, fallback: str) -> str:
+    topic = (value or fallback).strip()
+    return topic if topic.startswith("/") else f"/{topic}"
+
+
+class _NavigationSensorNode(Node):
+    def __init__(self, config: dict, namespace: str):
+        super().__init__("g1_navigation_sensor_bridge")
+
+        prefix = f"/{namespace}/navigation"
+        self.cloud_topic = _absolute_topic(config.get("cloud_topic"), f"{prefix}/lidar")
+        self.fast_livo_cloud_topic = _absolute_topic(
+            config.get("fast_livo_cloud_topic"), f"{prefix}/lidar_fast_livo"
+        )
+        self._publish_raw_cloud = bool(config.get("publish_raw_cloud", True))
+        self._publish_fast_livo_cloud = bool(
+            config.get("publish_fast_livo_cloud", True)
+        )
+        self.imu_topic = _absolute_topic(config.get("imu_topic"), f"{prefix}/imu")
+        self.diagnostics_topic = _absolute_topic(
+            config.get("diagnostics_topic"), f"{prefix}/sensor_diagnostics"
+        )
+        self._raw_cloud_topic = config.get(
+            "raw_cloud_topic", "rt/utlidar/cloud_livox_mid360"
+        )
+        self._raw_imu_topic = config.get(
+            "raw_imu_topic", "rt/utlidar/imu_livox_mid360"
+        )
+        self._raw_lidar_frame = config.get("raw_lidar_frame", "livox_raw_frame")
+        self._lidar_frame = config.get("lidar_frame", "livox_frame")
+        self._imu_frame = config.get("imu_frame", self._lidar_frame)
+        self._sensor_rotation = validated_rotation_matrix(
+            config.get("sensor_rotation_matrix")
+        )
+
+        # Do not use ``self._clock``: rclpy.node.Node owns that attribute and
+        # get_clock() returns it internally.
+        self._clock_offset = ClockOffsetEstimator(
+            warmup_samples=int(config.get("clock_warmup_samples", 32)),
+            window_samples=int(config.get("clock_window_samples", 400)),
+            reset_threshold_ns=int(
+                float(config.get("clock_reset_threshold_ms", 1000.0)) * 1_000_000
+            ),
+            reset_confirm_samples=int(config.get("clock_reset_confirm_samples", 8)),
+        )
+
+        self._cloud_pub = (
+            self.create_publisher(PointCloud2, self.cloud_topic, _RAW_CLOUD_QOS)
+            if self._publish_raw_cloud
+            else None
+        )
+        self._fast_livo_cloud_pub = (
+            self.create_publisher(
+                PointCloud2,
+                self.fast_livo_cloud_topic,
+                _FAST_LIVO_CLOUD_QOS,
+            )
+            if self._publish_fast_livo_cloud
+            else None
+        )
+        self._imu_pub = self.create_publisher(Imu, self.imu_topic, _IMU_QOS)
+        self._diagnostics_pub = self.create_publisher(String, self.diagnostics_topic, 10)
+
+        self._cloud_queue: queue.Queue = queue.Queue(maxsize=2)
+        self._imu_queue: queue.Queue = queue.Queue(maxsize=4)
+        self._stop = threading.Event()
+        self._cloud_worker = threading.Thread(
+            target=self._cloud_loop, name="navigation_cloud", daemon=True
+        )
+        self._imu_worker = threading.Thread(
+            target=self._imu_loop, name="navigation_imu", daemon=True
+        )
+        self._cloud_worker.start()
+        self._imu_worker.start()
+
+        self._last_stamp_ns = {"cloud": 0, "imu": 0}
+        self._last_diagnostics_time = 0.0
+        self._counters = {
+            "cloud_received": 0,
+            "cloud_published": 0,
+            "cloud_dropped": 0,
+            "fast_livo_cloud_published": 0,
+            "fast_livo_cloud_dropped": 0,
+            "imu_received": 0,
+            "imu_published": 0,
+            "imu_dropped": 0,
+            "stamp_clamped": 0,
+        }
+        self._last_receive_monotonic = {"cloud": 0.0, "imu": 0.0}
+
+        self._cloud_sub = ChannelSubscriber(self._raw_cloud_topic, PointCloud2_)
+        self._cloud_sub.Init(self._on_cloud, 1)
+        self._imu_sub = ChannelSubscriber(self._raw_imu_topic, Imu_)
+        # Direct callback avoids the SDK BQueue dropping new samples when its
+        # single slot is occupied.  This callback only timestamps and enqueues.
+        self._imu_sub.Init(self._on_imu)
+        cloud_outputs = []
+        if self._publish_fast_livo_cloud:
+            cloud_outputs.append(self.fast_livo_cloud_topic)
+        if self._publish_raw_cloud:
+            cloud_outputs.append(self.cloud_topic)
+        self.get_logger().info(
+            f"Navigation sensors: {self._raw_cloud_topic} -> "
+            f"{','.join(cloud_outputs) or '(disabled)'}; "
+            f"{self._raw_imu_topic} -> {self.imu_topic}; "
+            f"raw_frame={self._raw_lidar_frame}, corrected_frame={self._lidar_frame}, "
+            f"sensor_rotation={self._sensor_rotation.reshape(9).tolist()}"
+        )
+
+    def _correct_stamp(self, source_stamp, stream: str) -> int | None:
+        try:
+            source_ns = stamp_to_ns(source_stamp.sec, source_stamp.nanosec)
+            host_ns = self.get_clock().now().nanoseconds
+            corrected_ns = self._clock_offset.correct_observation(source_ns, host_ns)
+        except (AttributeError, TypeError, ValueError) as exc:
+            self.get_logger().warning(f"invalid {stream} timestamp: {exc}")
+            return None
+
+        if corrected_ns is None:
+            return None
+        if corrected_ns <= self._last_stamp_ns[stream]:
+            corrected_ns = self._last_stamp_ns[stream] + 1
+            self._counters["stamp_clamped"] += 1
+        self._last_stamp_ns[stream] = corrected_ns
+        return corrected_ns
+
+    @staticmethod
+    def _set_stamp(header, timestamp_ns: int, frame_id: str) -> None:
+        sec, nanosec = split_ns(timestamp_ns)
+        header.stamp.sec = sec
+        header.stamp.nanosec = nanosec
+        header.frame_id = frame_id
+
+    def _on_cloud(self, msg) -> None:
+        self._counters["cloud_received"] += 1
+        self._last_receive_monotonic["cloud"] = time.monotonic()
+        corrected_ns = self._correct_stamp(msg.header.stamp, "cloud")
+        if corrected_ns is None:
+            self._counters["cloud_dropped"] += 1
+            self._maybe_publish_diagnostics()
+            return
+
+        fields = [
+            (str(field.name), int(field.offset), int(field.datatype), int(field.count))
+            for field in msg.fields
+        ]
+        item = (
+            corrected_ns,
+            int(msg.height),
+            int(msg.width),
+            fields,
+            bool(msg.is_bigendian),
+            int(msg.point_step),
+            int(msg.row_step),
+            bytes(msg.data),
+            bool(msg.is_dense),
+        )
+        try:
+            self._cloud_queue.put_nowait(item)
+        except queue.Full:
+            try:
+                self._cloud_queue.get_nowait()
+            except queue.Empty:
+                pass
+            self._counters["cloud_dropped"] += 1
+            self._cloud_queue.put_nowait(item)
+        self._maybe_publish_diagnostics()
+
+    def _cloud_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                item = self._cloud_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if item is None:
+                break
+
+            (
+                corrected_ns,
+                height,
+                width,
+                fields,
+                is_bigendian,
+                point_step,
+                row_step,
+                data,
+                is_dense,
+            ) = item
+            expected_size = row_step * height
+            if point_step <= 0 or height <= 0 or width <= 0 or len(data) < expected_size:
+                self._counters["cloud_dropped"] += 1
+                continue
+
+            # The estimator input is the priority path.  Publishing the raw and
+            # adapted 0.4/0.6 MB clouds together can saturate Python ROS2
+            # serialization on the live Jetson, so the raw diagnostic output is
+            # independently switchable.
+            if self._fast_livo_cloud_pub is not None:
+                try:
+                    converted = unitree_mid360_to_fast_livo(
+                        data=data,
+                        point_count=height * width,
+                        point_step=point_step,
+                        fields=fields,
+                        header_stamp_ns=corrected_ns,
+                        rotation_matrix=self._sensor_rotation,
+                    )
+                    fast_livo = PointCloud2()
+                    self._set_stamp(
+                        fast_livo.header, corrected_ns, self._lidar_frame
+                    )
+                    fast_livo.height = 1
+                    fast_livo.width = height * width
+                    fast_livo.fields = [
+                        PointField(
+                            name=field.name,
+                            offset=field.offset,
+                            datatype=field.datatype,
+                            count=field.count,
+                        )
+                        for field in FAST_LIVO_FIELDS
+                    ]
+                    fast_livo.is_bigendian = False
+                    fast_livo.point_step = FAST_LIVO_POINT_STEP
+                    fast_livo.row_step = FAST_LIVO_POINT_STEP * fast_livo.width
+                    # Humble's generated setter validates a bytes object one
+                    # element at a time in debug mode.  array('B') takes its
+                    # constant-time fast path for large PointCloud2 payloads.
+                    fast_livo.data = array("B", converted)
+                    fast_livo.is_dense = is_dense
+                    self._fast_livo_cloud_pub.publish(fast_livo)
+                    self._counters["fast_livo_cloud_published"] += 1
+                except (TypeError, ValueError) as exc:
+                    self._counters["fast_livo_cloud_dropped"] += 1
+                    if self._counters["fast_livo_cloud_dropped"] <= 3:
+                        self.get_logger().warning(
+                            f"FAST-LIVO cloud conversion failed: {exc}"
+                        )
+
+            if self._cloud_pub is not None:
+                out = PointCloud2()
+                self._set_stamp(out.header, corrected_ns, self._raw_lidar_frame)
+                out.height = height
+                out.width = width
+                out.fields = [
+                    PointField(
+                        name=name,
+                        offset=offset,
+                        datatype=datatype,
+                        count=count,
+                    )
+                    for name, offset, datatype, count in fields
+                ]
+                out.is_bigendian = is_bigendian
+                out.point_step = point_step
+                out.row_step = row_step
+                out.data = array("B", data)
+                out.is_dense = is_dense
+                self._cloud_pub.publish(out)
+                self._counters["cloud_published"] += 1
+
+    def _on_imu(self, msg) -> None:
+        self._counters["imu_received"] += 1
+        self._last_receive_monotonic["imu"] = time.monotonic()
+        corrected_ns = self._correct_stamp(msg.header.stamp, "imu")
+        if corrected_ns is None:
+            self._counters["imu_dropped"] += 1
+            self._maybe_publish_diagnostics()
+            return
+
+        try:
+            self._imu_queue.put_nowait((corrected_ns, msg))
+        except queue.Full:
+            # Prefer fresh inertial data over completing a stale backlog.
+            try:
+                self._imu_queue.get_nowait()
+            except queue.Empty:
+                pass
+            self._counters["imu_dropped"] += 1
+            self._imu_queue.put_nowait((corrected_ns, msg))
+        self._maybe_publish_diagnostics()
+
+    def _imu_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                item = self._imu_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if item is None:
+                break
+            corrected_ns, msg = item
+
+            out = Imu()
+            self._set_stamp(out.header, corrected_ns, self._imu_frame)
+
+            q = msg.orientation
+            q_norm_sq = (
+                float(q.x) ** 2
+                + float(q.y) ** 2
+                + float(q.z) ** 2
+                + float(q.w) ** 2
+            )
+            if q_norm_sq > 0.25:
+                qx, qy, qz, qw = rotate_orientation_xyzw(
+                    (float(q.x), float(q.y), float(q.z), float(q.w)),
+                    self._sensor_rotation,
+                )
+                out.orientation.x = qx
+                out.orientation.y = qy
+                out.orientation.z = qz
+                out.orientation.w = qw
+                out.orientation_covariance = rotate_covariance9(
+                    msg.orientation_covariance, self._sensor_rotation
+                )
+            else:
+                # The live MID360 stream reports an all-zero quaternion.  Publish
+                # identity and mark orientation unavailable per REP-145.
+                out.orientation.w = 1.0
+                out.orientation_covariance[0] = -1.0
+
+            wx, wy, wz = rotate_vector3(
+                (
+                    float(msg.angular_velocity.x),
+                    float(msg.angular_velocity.y),
+                    float(msg.angular_velocity.z),
+                ),
+                self._sensor_rotation,
+            )
+            out.angular_velocity.x = wx
+            out.angular_velocity.y = wy
+            out.angular_velocity.z = wz
+            out.angular_velocity_covariance = rotate_covariance9(
+                msg.angular_velocity_covariance, self._sensor_rotation
+            )
+            ax, ay, az = rotate_vector3(
+                (
+                    float(msg.linear_acceleration.x),
+                    float(msg.linear_acceleration.y),
+                    float(msg.linear_acceleration.z),
+                ),
+                self._sensor_rotation,
+            )
+            out.linear_acceleration.x = ax
+            out.linear_acceleration.y = ay
+            out.linear_acceleration.z = az
+            out.linear_acceleration_covariance = rotate_covariance9(
+                msg.linear_acceleration_covariance, self._sensor_rotation
+            )
+            self._imu_pub.publish(out)
+            self._counters["imu_published"] += 1
+
+    def _maybe_publish_diagnostics(self) -> None:
+        now = time.monotonic()
+        if now - self._last_diagnostics_time < 1.0:
+            return
+        self._last_diagnostics_time = now
+        clock = self._clock_offset.snapshot().to_dict()
+        if clock["offset_ns"] is not None:
+            clock["offset_sec"] = round(clock["offset_ns"] / 1_000_000_000, 6)
+        if clock["residual_ns"] is not None:
+            clock["residual_ms"] = round(clock["residual_ns"] / 1_000_000, 3)
+        out = String()
+        out.data = json.dumps(
+            {
+                "clock": clock,
+                "counters": dict(self._counters),
+                "raw_topics": {
+                    "cloud": self._raw_cloud_topic,
+                    "imu": self._raw_imu_topic,
+                },
+                "frames": {
+                    "raw_lidar": self._raw_lidar_frame,
+                    "lidar": self._lidar_frame,
+                    "imu": self._imu_frame,
+                },
+                "sensor_rotation_matrix": [
+                    float(value) for value in self._sensor_rotation.reshape(9)
+                ],
+            },
+            separators=(",", ":"),
+        )
+        self._diagnostics_pub.publish(out)
+
+    def status(self) -> dict:
+        now = time.monotonic()
+        ages = {
+            stream: (
+                round((now - received_at) * 1000.0, 1)
+                if received_at > 0.0
+                else None
+            )
+            for stream, received_at in self._last_receive_monotonic.items()
+        }
+        clock = self._clock_offset.snapshot().to_dict()
+        blockers = []
+        if not clock["ready"]:
+            blockers.append("clock_not_ready")
+        if ages["cloud"] is None or ages["cloud"] > 500.0:
+            blockers.append("cloud_stale")
+        if ages["imu"] is None or ages["imu"] > 100.0:
+            blockers.append("imu_stale")
+        if self._publish_fast_livo_cloud and not self._counters[
+            "fast_livo_cloud_published"
+        ]:
+            blockers.append("fast_livo_cloud_not_published")
+        if not self._counters["imu_published"]:
+            blockers.append("imu_not_published")
+        return {
+            "ready": not blockers,
+            "blockers": blockers,
+            "receive_age_ms": ages,
+            "clock": clock,
+            "counters": dict(self._counters),
+        }
+
+    def close(self) -> None:
+        for subscriber in (self._cloud_sub, self._imu_sub):
+            try:
+                subscriber.Close()
+            except Exception:
+                pass
+        self._stop.set()
+        for work_queue in (self._cloud_queue, self._imu_queue):
+            try:
+                work_queue.put_nowait(None)
+            except queue.Full:
+                try:
+                    work_queue.get_nowait()
+                except queue.Empty:
+                    pass
+                work_queue.put_nowait(None)
+        self._cloud_worker.join(timeout=2.0)
+        self._imu_worker.join(timeout=2.0)
+
+
+class NavigationSensorPlugin:
+    PREFIX = "navigation_sensors"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor):
+        self._executor = executor
+        self._node = _NavigationSensorNode(plugin_config, namespace)
+        executor.add_node(self._node)
+
+    def get_tools(self) -> list[dict]:
+        tools = []
+        if self._node._publish_fast_livo_cloud:
+            tools.append(
+                self._tool(
+                    "navigation_lidar_fast_livo",
+                    "MID360 PointCloud2 adapted for the pinned FAST-LIVO2 ROS2 port",
+                    self._node.fast_livo_cloud_topic,
+                    "sensor/pointcloud",
+                    "sensor_msgs/msg/PointCloud2",
+                    "RELIABLE + KEEP_LAST(depth=2) + VOLATILE",
+                    "livox_frame",
+                )
+            )
+        if self._node._publish_raw_cloud:
+            tools.append(
+                self._tool(
+                    "navigation_lidar",
+                    "Standard PointCloud2 with raw MID360 fields and per-point time preserved",
+                    self._node.cloud_topic,
+                    "sensor/pointcloud",
+                    "sensor_msgs/msg/PointCloud2",
+                    "BEST_EFFORT + KEEP_LAST(depth=2) + VOLATILE",
+                    "livox_raw_frame",
+                )
+            )
+        tools.extend(
+            [
+                self._tool(
+                    "navigation_imu",
+                    "Standard IMU for FAST-LIVO2 in the same normalized clock domain as LiDAR",
+                    self._node.imu_topic,
+                    "sensor/imu",
+                    "sensor_msgs/msg/Imu",
+                    "RELIABLE + KEEP_LAST(depth=200) + VOLATILE",
+                    "livox_frame",
+                ),
+                self._tool(
+                    "navigation_sensor_diagnostics",
+                    "Navigation sensor clock and drop diagnostics",
+                    self._node.diagnostics_topic,
+                    "data/json",
+                    "std_msgs/msg/String",
+                    "RELIABLE + KEEP_LAST(depth=10) + VOLATILE",
+                    "",
+                ),
+            ]
+        )
+        return tools
+
+    @staticmethod
+    def _tool(
+        name: str,
+        description: str,
+        topic: str,
+        message_format: str,
+        ros_type: str,
+        qos: str,
+        frame_id: str,
+    ) -> dict:
+        descriptor = {
+            "topic": topic,
+            "format": message_format,
+            "ros_type": ros_type,
+            "qos": qos,
+            "timestamp": "MID360 source clock normalized to ROS system time",
+        }
+        if frame_id:
+            descriptor["frame_id"] = frame_id
+        return {
+            "name": name,
+            "type": "sensor",
+            "multiInstance": False,
+            "description": f"{description}. Publishes to {topic}",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [descriptor],
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        self._node.close()
+        try:
+            self._executor.remove_node(self._node)
+            self._node.destroy_node()
+        except Exception:
+            pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action in {"start", "info"}:
+            tool_name = args.get("_tool_name", "")
+            tools = {tool["name"]: tool for tool in self.get_tools()}
+            selected = tools.get(tool_name, tools["navigation_sensor_diagnostics"])
+            status = self._node.status()
+            return {
+                "state": "ready" if status["ready"] else "not_ready",
+                "topic_out": selected["topic_out"],
+                **status,
+            }
+        if action == "stop":
+            return {"state": "idle"}
+        return None

--- a/unitree/g1/navigation_sensor_bridge_main.py
+++ b/unitree/g1/navigation_sensor_bridge_main.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Isolated MID360 bridge worker for the G1 Driver navigation sensor card."""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import socket
+import sys
+import threading
+from pathlib import Path
+
+import rclpy
+from rclpy.executors import MultiThreadedExecutor
+import yaml
+
+from navigation_sensor_bridge import _NavigationSensorNode
+from unitree_sdk2py.core.channel import ChannelFactoryInitialize
+
+
+def _load_config() -> dict:
+    path = Path(os.environ.get("CONFIG_PATH", Path(__file__).with_name("config.yaml")))
+    with path.open() as stream:
+        config = yaml.safe_load(stream)
+    if not isinstance(config, dict):
+        raise ValueError(f"navigation bridge config must be a mapping: {path}")
+    return config
+
+
+def _resolve_namespace(config: dict) -> str:
+    value = os.environ.get("ROS_NAMESPACE", "").strip()
+    if not value:
+        value = str(config.get("ros_namespace", "")).strip()
+    if not value:
+        value = socket.gethostname()
+    value = re.sub(r"[^a-zA-Z0-9_]", "_", value.strip("/"))
+    if not value:
+        raise ValueError("ROS namespace resolves to an empty value")
+    return value
+
+
+def main() -> int:
+    network_interface = (
+        sys.argv[1] if len(sys.argv) > 1 else os.environ.get("NETWORK_INTERFACE", "eth0")
+    )
+    config = _load_config()
+    plugin_config = config.get("plugins", {}).get("navigation_sensors", {})
+    if not plugin_config.get("enabled", False):
+        raise RuntimeError("plugins.navigation_sensors.enabled must be true")
+
+    namespace = _resolve_namespace(config)
+    ChannelFactoryInitialize(0, network_interface)
+    print(
+        f"[navigation-sensors-worker] DDS initialized on {network_interface}; "
+        f"ROS namespace={namespace}",
+        flush=True,
+    )
+
+    rclpy.init()
+    executor = MultiThreadedExecutor(num_threads=3)
+    node = _NavigationSensorNode(plugin_config, namespace)
+    executor.add_node(node)
+    stop = threading.Event()
+
+    def _request_stop(signum, _frame):
+        print(
+            f"[navigation-sensors-worker] signal {signum}, shutting down",
+            flush=True,
+        )
+        stop.set()
+
+    signal.signal(signal.SIGTERM, _request_stop)
+    signal.signal(signal.SIGINT, _request_stop)
+
+    try:
+        while rclpy.ok() and not stop.is_set():
+            executor.spin_once(timeout_sec=0.2)
+    finally:
+        node.close()
+        executor.remove_node(node)
+        node.destroy_node()
+        executor.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unitree/g1/navigation_time.py
+++ b/unitree/g1/navigation_time.py
@@ -1,0 +1,150 @@
+"""Clock-domain normalization helpers for the G1 navigation sensor bridge.
+
+Unitree's MID360 publishes LiDAR and IMU headers in a shared sensor clock that
+is not guaranteed to match the Jetson system clock.  Estimators and planners
+must still receive ROS timestamps in one coherent clock domain.  This module is
+kept free of ROS dependencies so the correction policy can be unit tested on a
+development machine.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import asdict, dataclass
+import threading
+
+
+NSEC_PER_SEC = 1_000_000_000
+
+
+def stamp_to_ns(sec: int, nanosec: int) -> int:
+    """Convert a ROS-style ``sec``/``nanosec`` pair to integer nanoseconds."""
+    if not 0 <= int(nanosec) < NSEC_PER_SEC:
+        raise ValueError(f"nanosec out of range: {nanosec}")
+    return int(sec) * NSEC_PER_SEC + int(nanosec)
+
+
+def split_ns(timestamp_ns: int) -> tuple[int, int]:
+    """Split integer nanoseconds into a normalized ROS timestamp pair."""
+    sec, nanosec = divmod(int(timestamp_ns), NSEC_PER_SEC)
+    return sec, nanosec
+
+
+@dataclass(frozen=True)
+class ClockSnapshot:
+    ready: bool
+    samples: int
+    offset_ns: int | None
+    residual_ns: int | None
+    resets: int
+    rejected: int
+    pending_reset_samples: int
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class ClockOffsetEstimator:
+    """Estimate ``host_time - sensor_time`` from callback arrival times.
+
+    Transport and scheduling latency is non-negative, so the minimum candidate
+    in a rolling window is a better offset estimate than an average.  A single
+    late callback is rejected instead of shifting every subsequent timestamp.
+    Persistent jumps are treated as a source-clock reset and require a new
+    warm-up period.
+    """
+
+    def __init__(
+        self,
+        *,
+        warmup_samples: int = 32,
+        window_samples: int = 400,
+        reset_threshold_ns: int = NSEC_PER_SEC,
+        reset_confirm_samples: int = 8,
+    ) -> None:
+        if warmup_samples < 1:
+            raise ValueError("warmup_samples must be positive")
+        if window_samples < warmup_samples:
+            raise ValueError("window_samples must be >= warmup_samples")
+        if reset_threshold_ns < 1:
+            raise ValueError("reset_threshold_ns must be positive")
+        if reset_confirm_samples < 2:
+            raise ValueError("reset_confirm_samples must be >= 2")
+
+        self._warmup_samples = warmup_samples
+        self._reset_threshold_ns = reset_threshold_ns
+        self._reset_confirm_samples = reset_confirm_samples
+        self._candidates: deque[int] = deque(maxlen=window_samples)
+        self._pending_reset: list[int] = []
+        self._offset_ns: int | None = None
+        self._residual_ns: int | None = None
+        self._ready = False
+        self._resets = 0
+        self._rejected = 0
+        self._lock = threading.Lock()
+
+    def correct_observation(self, source_ns: int, host_arrival_ns: int) -> int | None:
+        """Observe one sample and return its corrected host timestamp when ready.
+
+        ``None`` means the sample must not be published: either the initial
+        offset is still warming up or the observation looks like a clock jump.
+        """
+        source_ns = int(source_ns)
+        host_arrival_ns = int(host_arrival_ns)
+        if source_ns <= 0 or host_arrival_ns <= 0:
+            raise ValueError("timestamps must be positive")
+
+        candidate = host_arrival_ns - source_ns
+        with self._lock:
+            if self._offset_ns is None:
+                self._accept_locked(candidate)
+            else:
+                delta = candidate - self._offset_ns
+                if delta < -self._reset_threshold_ns:
+                    # The source clock jumped forward.  Re-baseline immediately;
+                    # normal callback latency cannot make this candidate smaller.
+                    self._reset_locked(candidate)
+                elif delta > self._reset_threshold_ns:
+                    # This may be one delayed callback or a source clock that
+                    # jumped backwards.  Require consecutive evidence so a large
+                    # point-cloud callback cannot reset the IMU clock domain.
+                    self._pending_reset.append(candidate)
+                    self._rejected += 1
+                    self._residual_ns = delta
+                    if len(self._pending_reset) >= self._reset_confirm_samples:
+                        self._reset_locked(min(self._pending_reset))
+                    return None
+                else:
+                    self._pending_reset.clear()
+                    self._accept_locked(candidate)
+
+            if not self._ready:
+                return None
+            return source_ns + int(self._offset_ns)
+
+    def snapshot(self) -> ClockSnapshot:
+        with self._lock:
+            return ClockSnapshot(
+                ready=self._ready,
+                samples=len(self._candidates),
+                offset_ns=self._offset_ns,
+                residual_ns=self._residual_ns,
+                resets=self._resets,
+                rejected=self._rejected,
+                pending_reset_samples=len(self._pending_reset),
+            )
+
+    def _accept_locked(self, candidate: int) -> None:
+        self._candidates.append(candidate)
+        self._offset_ns = min(self._candidates)
+        self._residual_ns = candidate - self._offset_ns
+        self._ready = len(self._candidates) >= self._warmup_samples
+
+    def _reset_locked(self, candidate: int) -> None:
+        self._candidates.clear()
+        self._pending_reset.clear()
+        self._offset_ns = None
+        self._residual_ns = None
+        self._ready = False
+        self._resets += 1
+        self._accept_locked(candidate)

--- a/unitree/g1/tests/test_navigation_pointcloud.py
+++ b/unitree/g1/tests/test_navigation_pointcloud.py
@@ -1,0 +1,166 @@
+import struct
+import sys
+import unittest
+
+# Some legacy Driver tests install a minimal numpy import stub before importing
+# device.py. Restore the real dependency when the complete suite runs in one
+# interpreter so this numeric conversion test remains order-independent.
+if not hasattr(sys.modules.get("numpy"), "dtype"):
+    sys.modules.pop("numpy", None)
+import numpy as np
+
+from navigation_pointcloud import (
+    FAST_LIVO_FIELDS,
+    FAST_LIVO_POINT_STEP,
+    FLOAT32,
+    UINT16,
+    rotate_covariance9,
+    rotate_orientation_xyzw,
+    rotate_vector3,
+    unitree_mid360_to_fast_livo,
+    validated_rotation_matrix,
+)
+
+
+UNITREE_FIELDS = [
+    ("x", 0, FLOAT32, 1),
+    ("y", 4, FLOAT32, 1),
+    ("z", 8, FLOAT32, 1),
+    ("intensity", 12, FLOAT32, 1),
+    ("ring", 16, UINT16, 1),
+    ("time", 18, FLOAT32, 1),
+]
+
+
+class Mid360ConversionTest(unittest.TestCase):
+    def make_cloud(self):
+        data = bytearray(2 * 22)
+        struct.pack_into("<ffffHf", data, 0, 1.0, 2.0, 3.0, 42.0, 0, 5_000.0)
+        struct.pack_into(
+            "<ffffHf", data, 22, -1.0, -2.0, -3.0, 163.0, 3, 100_320_000.0
+        )
+        return bytes(data)
+
+    def decode(self, converted):
+        dtype = np.dtype(
+            {
+                "names": [field.name for field in FAST_LIVO_FIELDS],
+                "formats": ["<f4", "<f4", "<f4", "<f4", "u1", "u1", "<f8"],
+                "offsets": [field.offset for field in FAST_LIVO_FIELDS],
+                "itemsize": FAST_LIVO_POINT_STEP,
+            }
+        )
+        return np.frombuffer(converted, dtype=dtype)
+
+    def test_converts_relative_time_to_absolute_nanoseconds(self):
+        header_ns = 1_785_811_000_000_000_000
+        converted = unitree_mid360_to_fast_livo(
+            data=self.make_cloud(),
+            point_count=2,
+            point_step=22,
+            fields=UNITREE_FIELDS,
+            header_stamp_ns=header_ns,
+        )
+        points = self.decode(converted)
+
+        self.assertEqual(len(converted), 2 * FAST_LIVO_POINT_STEP)
+        np.testing.assert_allclose(points["x"], [1.0, -1.0])
+        np.testing.assert_allclose(points["intensity"], [42.0, 163.0])
+        np.testing.assert_array_equal(points["tag"], [0x10, 0x10])
+        np.testing.assert_array_equal(points["line"], [0, 3])
+        np.testing.assert_allclose(
+            points["timestamp"] - np.float64(header_ns),
+            [5_000.0, 100_320_000.0],
+            atol=256.0,
+        )
+
+    def test_rejects_missing_time_field(self):
+        with self.assertRaisesRegex(ValueError, "missing MID360 field: time"):
+            unitree_mid360_to_fast_livo(
+                data=self.make_cloud(),
+                point_count=2,
+                point_step=22,
+                fields=[field for field in UNITREE_FIELDS if field[0] != "time"],
+                header_stamp_ns=1_000_000_000,
+            )
+
+    def test_rejects_short_data(self):
+        with self.assertRaisesRegex(ValueError, "shorter"):
+            unitree_mid360_to_fast_livo(
+                data=b"short",
+                point_count=2,
+                point_step=22,
+                fields=UNITREE_FIELDS,
+                header_stamp_ns=1_000_000_000,
+            )
+
+    def test_applies_fixed_rotation_without_changing_auxiliary_fields(self):
+        rotation = validated_rotation_matrix(
+            [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                -1.0,
+                0.0,
+                0.0,
+                0.0,
+                -1.0,
+            ]
+        )
+        header_ns = 1_785_811_000_000_000_000
+        converted = unitree_mid360_to_fast_livo(
+            data=self.make_cloud(),
+            point_count=2,
+            point_step=22,
+            fields=UNITREE_FIELDS,
+            header_stamp_ns=header_ns,
+            rotation_matrix=rotation,
+        )
+        points = self.decode(converted)
+
+        np.testing.assert_allclose(points["x"], [1.0, -1.0])
+        np.testing.assert_allclose(points["y"], [-2.0, 2.0])
+        np.testing.assert_allclose(points["z"], [-3.0, 3.0])
+        np.testing.assert_allclose(points["intensity"], [42.0, 163.0])
+        np.testing.assert_array_equal(points["tag"], [0x10, 0x10])
+        np.testing.assert_array_equal(points["line"], [0, 3])
+        np.testing.assert_allclose(
+            points["timestamp"] - np.float64(header_ns),
+            [5_000.0, 100_320_000.0],
+            atol=256.0,
+        )
+
+    def test_rotation_helpers_use_the_same_corrected_frame(self):
+        rotation = validated_rotation_matrix(
+            [1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0]
+        )
+
+        np.testing.assert_allclose(
+            rotate_vector3((1.0, 2.0, 3.0), rotation),
+            (1.0, -2.0, -3.0),
+        )
+        np.testing.assert_allclose(
+            rotate_covariance9(
+                [1.0, 2.0, 3.0, 2.0, 4.0, 5.0, 3.0, 5.0, 6.0],
+                rotation,
+            ),
+            [1.0, -2.0, -3.0, -2.0, 4.0, 5.0, -3.0, 5.0, 6.0],
+        )
+        qx, qy, qz, qw = rotate_orientation_xyzw(
+            (0.0, 0.0, 0.0, 1.0), rotation
+        )
+        self.assertAlmostEqual(abs(qx), 1.0)
+        self.assertAlmostEqual(qy, 0.0)
+        self.assertAlmostEqual(qz, 0.0)
+        self.assertAlmostEqual(qw, 0.0)
+
+    def test_rejects_non_rotation_matrix(self):
+        with self.assertRaisesRegex(ValueError, "orthonormal"):
+            validated_rotation_matrix([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 2.0])
+        with self.assertRaisesRegex(ValueError, "proper rotation"):
+            validated_rotation_matrix([-1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_navigation_pointcloud.py
+++ b/unitree/g1/tests/test_navigation_pointcloud.py
@@ -10,14 +10,14 @@ if not hasattr(sys.modules.get("numpy"), "dtype"):
 import numpy as np
 
 from navigation_pointcloud import (
-    FAST_LIVO_FIELDS,
-    FAST_LIVO_POINT_STEP,
+    NAVIGATION_FIELDS,
+    NAVIGATION_POINT_STEP,
     FLOAT32,
     UINT16,
     rotate_covariance9,
     rotate_orientation_xyzw,
     rotate_vector3,
-    unitree_mid360_to_fast_livo,
+    unitree_mid360_to_navigation_cloud,
     validated_rotation_matrix,
 )
 
@@ -44,17 +44,17 @@ class Mid360ConversionTest(unittest.TestCase):
     def decode(self, converted):
         dtype = np.dtype(
             {
-                "names": [field.name for field in FAST_LIVO_FIELDS],
+                "names": [field.name for field in NAVIGATION_FIELDS],
                 "formats": ["<f4", "<f4", "<f4", "<f4", "u1", "u1", "<f8"],
-                "offsets": [field.offset for field in FAST_LIVO_FIELDS],
-                "itemsize": FAST_LIVO_POINT_STEP,
+                "offsets": [field.offset for field in NAVIGATION_FIELDS],
+                "itemsize": NAVIGATION_POINT_STEP,
             }
         )
         return np.frombuffer(converted, dtype=dtype)
 
     def test_converts_relative_time_to_absolute_nanoseconds(self):
         header_ns = 1_785_811_000_000_000_000
-        converted = unitree_mid360_to_fast_livo(
+        converted = unitree_mid360_to_navigation_cloud(
             data=self.make_cloud(),
             point_count=2,
             point_step=22,
@@ -63,7 +63,7 @@ class Mid360ConversionTest(unittest.TestCase):
         )
         points = self.decode(converted)
 
-        self.assertEqual(len(converted), 2 * FAST_LIVO_POINT_STEP)
+        self.assertEqual(len(converted), 2 * NAVIGATION_POINT_STEP)
         np.testing.assert_allclose(points["x"], [1.0, -1.0])
         np.testing.assert_allclose(points["intensity"], [42.0, 163.0])
         np.testing.assert_array_equal(points["tag"], [0x10, 0x10])
@@ -76,7 +76,7 @@ class Mid360ConversionTest(unittest.TestCase):
 
     def test_rejects_missing_time_field(self):
         with self.assertRaisesRegex(ValueError, "missing MID360 field: time"):
-            unitree_mid360_to_fast_livo(
+            unitree_mid360_to_navigation_cloud(
                 data=self.make_cloud(),
                 point_count=2,
                 point_step=22,
@@ -86,7 +86,7 @@ class Mid360ConversionTest(unittest.TestCase):
 
     def test_rejects_short_data(self):
         with self.assertRaisesRegex(ValueError, "shorter"):
-            unitree_mid360_to_fast_livo(
+            unitree_mid360_to_navigation_cloud(
                 data=b"short",
                 point_count=2,
                 point_step=22,
@@ -109,7 +109,7 @@ class Mid360ConversionTest(unittest.TestCase):
             ]
         )
         header_ns = 1_785_811_000_000_000_000
-        converted = unitree_mid360_to_fast_livo(
+        converted = unitree_mid360_to_navigation_cloud(
             data=self.make_cloud(),
             point_count=2,
             point_step=22,

--- a/unitree/g1/tests/test_navigation_sensor_card.py
+++ b/unitree/g1/tests/test_navigation_sensor_card.py
@@ -1,0 +1,157 @@
+import ast
+import importlib
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+G1_DIR = Path(__file__).resolve().parents[1]
+
+
+class NavigationSensorCardContractTest(unittest.TestCase):
+    @staticmethod
+    def load_bridge_module():
+        if not hasattr(sys.modules.get("numpy"), "dtype"):
+            sys.modules.pop("numpy", None)
+
+        rclpy = sys.modules.setdefault("rclpy", types.ModuleType("rclpy"))
+        rclpy_node = types.ModuleType("rclpy.node")
+        rclpy_node.Node = type("Node", (), {})
+        rclpy_qos = types.ModuleType("rclpy.qos")
+
+        class QoSProfile:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        policy = type(
+            "Policy",
+            (),
+            {
+                "BEST_EFFORT": "best_effort",
+                "RELIABLE": "reliable",
+                "KEEP_LAST": "keep_last",
+                "VOLATILE": "volatile",
+            },
+        )
+        rclpy_qos.QoSProfile = QoSProfile
+        rclpy_qos.ReliabilityPolicy = policy
+        rclpy_qos.HistoryPolicy = policy
+        rclpy_qos.DurabilityPolicy = policy
+        sys.modules["rclpy.node"] = rclpy_node
+        sys.modules["rclpy.qos"] = rclpy_qos
+        rclpy.node = rclpy_node
+        rclpy.qos = rclpy_qos
+
+        sensor_msgs = types.ModuleType("sensor_msgs")
+        sensor_msgs_msg = types.ModuleType("sensor_msgs.msg")
+        for name in ("Imu", "PointCloud2", "PointField"):
+            setattr(sensor_msgs_msg, name, type(name, (), {}))
+        sensor_msgs.msg = sensor_msgs_msg
+        sys.modules["sensor_msgs"] = sensor_msgs
+        sys.modules["sensor_msgs.msg"] = sensor_msgs_msg
+
+        std_msgs = sys.modules.setdefault("std_msgs", types.ModuleType("std_msgs"))
+        std_msgs_msg = sys.modules.setdefault(
+            "std_msgs.msg", types.ModuleType("std_msgs.msg")
+        )
+        std_msgs_msg.String = type("String", (), {})
+        std_msgs.msg = std_msgs_msg
+
+        channel = types.ModuleType("unitree_sdk2py.core.channel")
+        channel.ChannelSubscriber = type("ChannelSubscriber", (), {})
+        idl = types.ModuleType("unitree_sdk2py.idl.sensor_msgs.msg.dds_")
+        idl.Imu_ = type("Imu_", (), {})
+        idl.PointCloud2_ = type("PointCloud2_", (), {})
+        sys.modules["unitree_sdk2py.core.channel"] = channel
+        sys.modules["unitree_sdk2py.idl.sensor_msgs.msg.dds_"] = idl
+
+        sys.modules.pop("navigation_sensor_bridge", None)
+        return importlib.import_module("navigation_sensor_bridge")
+
+    def test_bundle_registers_the_read_only_sensor_plugin(self):
+        source = (G1_DIR / "main.py").read_text()
+        self.assertIn('plugins_cfg.get("navigation_sensors"', source)
+        self.assertIn("NavigationSensorPlugin", source)
+        ast.parse(source)
+
+    def test_default_config_uses_mid360_raw_dds_and_native_ros_topics(self):
+        config = (G1_DIR / "config.yaml").read_text()
+        for expected in (
+            "navigation_sensors:\n    enabled: true",
+            "raw_cloud_topic: rt/utlidar/cloud_livox_mid360",
+            "raw_imu_topic: rt/utlidar/imu_livox_mid360",
+            "fast_livo_cloud_topic: /ubuntu/navigation/lidar_fast_livo",
+            "imu_topic: /ubuntu/navigation/imu",
+            "publish_raw_cloud: false",
+            "publish_fast_livo_cloud: true",
+        ):
+            self.assertIn(expected, config)
+
+    def test_tools_declare_native_types_qos_and_fail_closed_status(self):
+        source = (G1_DIR / "navigation_sensor_bridge.py").read_text()
+        for expected in (
+            '"navigation_lidar_fast_livo"',
+            '"navigation_imu"',
+            '"navigation_sensor_diagnostics"',
+            '"sensor/pointcloud"',
+            '"sensor_msgs/msg/PointCloud2"',
+            '"sensor_msgs/msg/Imu"',
+            '"RELIABLE + KEEP_LAST(depth=2) + VOLATILE"',
+            '"RELIABLE + KEEP_LAST(depth=200) + VOLATILE"',
+            '"state": "ready" if status["ready"] else "not_ready"',
+            'blockers.append("clock_not_ready")',
+            'blockers.append("cloud_stale")',
+            'blockers.append("imu_stale")',
+        ):
+            self.assertIn(expected, source)
+        self.assertNotIn('"sensor/pointcloud2"', source)
+        ast.parse(source)
+
+    def test_runtime_tool_descriptors_match_fast_livo2_inputs(self):
+        module = self.load_bridge_module()
+        plugin = module.NavigationSensorPlugin.__new__(module.NavigationSensorPlugin)
+        plugin._node = types.SimpleNamespace(
+            _publish_fast_livo_cloud=True,
+            _publish_raw_cloud=False,
+            fast_livo_cloud_topic="/ubuntu/navigation/lidar_fast_livo",
+            cloud_topic="/ubuntu/navigation/lidar",
+            imu_topic="/ubuntu/navigation/imu",
+            diagnostics_topic="/ubuntu/navigation/sensor_diagnostics",
+            status=lambda: {
+                "ready": False,
+                "blockers": ["clock_not_ready"],
+                "receive_age_ms": {"cloud": None, "imu": None},
+                "clock": {"ready": False},
+                "counters": {},
+            },
+        )
+
+        tools = {tool["name"]: tool for tool in plugin.get_tools()}
+        lidar = tools["navigation_lidar_fast_livo"]["topic_out"][0]
+        imu = tools["navigation_imu"]["topic_out"][0]
+        self.assertEqual(lidar["format"], "sensor/pointcloud")
+        self.assertEqual(lidar["ros_type"], "sensor_msgs/msg/PointCloud2")
+        self.assertEqual(lidar["qos"], "RELIABLE + KEEP_LAST(depth=2) + VOLATILE")
+        self.assertEqual(imu["format"], "sensor/imu")
+        self.assertEqual(imu["ros_type"], "sensor_msgs/msg/Imu")
+        self.assertEqual(imu["qos"], "RELIABLE + KEEP_LAST(depth=200) + VOLATILE")
+
+        info = plugin.dispatch(
+            "info", {"_tool_name": "navigation_lidar_fast_livo"}
+        )
+        self.assertEqual(info["state"], "not_ready")
+        self.assertEqual(info["blockers"], ["clock_not_ready"])
+
+    def test_driver_image_contains_the_sensor_card_runtime(self):
+        dockerfile = (G1_DIR / "Dockerfile").read_text()
+        for filename in (
+            "navigation_sensor_bridge.py",
+            "navigation_pointcloud.py",
+            "navigation_time.py",
+        ):
+            self.assertIn(f"COPY {filename} /work/{filename}", dockerfile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_navigation_sensor_card.py
+++ b/unitree/g1/tests/test_navigation_sensor_card.py
@@ -2,8 +2,11 @@ import ast
 import importlib
 from pathlib import Path
 import sys
+import threading
+import time
 import types
 import unittest
+from unittest import mock
 
 
 G1_DIR = Path(__file__).resolve().parents[1]
@@ -73,6 +76,7 @@ class NavigationSensorCardContractTest(unittest.TestCase):
         source = (G1_DIR / "main.py").read_text()
         self.assertIn('plugins_cfg.get("navigation_sensors"', source)
         self.assertIn("NavigationSensorPlugin", source)
+        self.assertIn("network_iface,", source)
         ast.parse(source)
 
     def test_default_config_uses_mid360_raw_dds_and_native_ros_topics(self):
@@ -103,6 +107,8 @@ class NavigationSensorCardContractTest(unittest.TestCase):
             'blockers.append("clock_not_ready")',
             'blockers.append("cloud_stale")',
             'blockers.append("imu_stale")',
+            'blockers.append("worker_not_running")',
+            'subprocess.Popen(',
         ):
             self.assertIn(expected, source)
         self.assertNotIn('"sensor/pointcloud2"', source)
@@ -111,14 +117,14 @@ class NavigationSensorCardContractTest(unittest.TestCase):
     def test_runtime_tool_descriptors_match_fast_livo2_inputs(self):
         module = self.load_bridge_module()
         plugin = module.NavigationSensorPlugin.__new__(module.NavigationSensorPlugin)
-        plugin._node = types.SimpleNamespace(
+        plugin._status_node = types.SimpleNamespace(
             _publish_fast_livo_cloud=True,
             _publish_raw_cloud=False,
             fast_livo_cloud_topic="/ubuntu/navigation/lidar_fast_livo",
             cloud_topic="/ubuntu/navigation/lidar",
             imu_topic="/ubuntu/navigation/imu",
             diagnostics_topic="/ubuntu/navigation/sensor_diagnostics",
-            status=lambda: {
+            status=lambda worker_running: {
                 "ready": False,
                 "blockers": ["clock_not_ready"],
                 "receive_age_ms": {"cloud": None, "imu": None},
@@ -126,6 +132,7 @@ class NavigationSensorCardContractTest(unittest.TestCase):
                 "counters": {},
             },
         )
+        plugin._proc = types.SimpleNamespace(poll=lambda: None, pid=1234)
 
         tools = {tool["name"]: tool for tool in plugin.get_tools()}
         lidar = tools["navigation_lidar_fast_livo"]["topic_out"][0]
@@ -147,10 +154,62 @@ class NavigationSensorCardContractTest(unittest.TestCase):
         dockerfile = (G1_DIR / "Dockerfile").read_text()
         for filename in (
             "navigation_sensor_bridge.py",
+            "navigation_sensor_bridge_main.py",
             "navigation_pointcloud.py",
             "navigation_time.py",
         ):
             self.assertIn(f"COPY {filename} /work/{filename}", dockerfile)
+
+    def test_worker_entry_owns_the_heavy_sensor_node(self):
+        source = (G1_DIR / "navigation_sensor_bridge_main.py").read_text()
+        self.assertIn("_NavigationSensorNode(plugin_config, namespace)", source)
+        self.assertIn("ChannelFactoryInitialize(0, network_interface)", source)
+        self.assertNotIn("NavigationSensorPlugin(", source)
+        ast.parse(source)
+
+    def test_plugin_starts_and_stops_one_isolated_worker(self):
+        module = self.load_bridge_module()
+        plugin = module.NavigationSensorPlugin.__new__(module.NavigationSensorPlugin)
+        plugin._namespace = "ubuntu"
+        plugin._network_iface = "eth0"
+        plugin._worker_path = G1_DIR / "navigation_sensor_bridge_main.py"
+        plugin._proc = None
+        plugin._executor = mock.Mock()
+        plugin._status_node = mock.Mock()
+        proc = mock.Mock(pid=4321)
+        proc.poll.return_value = None
+
+        with mock.patch.object(module.subprocess, "Popen", return_value=proc) as popen:
+            plugin.start()
+            plugin.start()
+
+        popen.assert_called_once()
+        self.assertEqual(
+            popen.call_args.args[0],
+            [sys.executable, str(plugin._worker_path), "eth0"],
+        )
+        plugin.stop()
+        proc.terminate.assert_called_once_with()
+        proc.wait.assert_called_once_with(timeout=5.0)
+        plugin._executor.remove_node.assert_called_once_with(plugin._status_node)
+        plugin._status_node.destroy_node.assert_called_once_with()
+
+    def test_status_monitor_fails_closed_for_dead_or_stale_worker(self):
+        module = self.load_bridge_module()
+        node = module._NavigationSensorStatusNode.__new__(
+            module._NavigationSensorStatusNode
+        )
+        node._lock = threading.RLock()
+        node._last_diagnostics = {"ready": True, "blockers": []}
+        node._last_diagnostics_monotonic = time.monotonic() - 3.0
+
+        stale = node.status(worker_running=True)
+        self.assertFalse(stale["ready"])
+        self.assertIn("diagnostics_stale", stale["blockers"])
+
+        dead = node.status(worker_running=False)
+        self.assertFalse(dead["ready"])
+        self.assertIn("worker_not_running", dead["blockers"])
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_navigation_sensor_card.py
+++ b/unitree/g1/tests/test_navigation_sensor_card.py
@@ -85,19 +85,16 @@ class NavigationSensorCardContractTest(unittest.TestCase):
             "navigation_sensors:\n    enabled: true",
             "raw_cloud_topic: rt/utlidar/cloud_livox_mid360",
             "raw_imu_topic: rt/utlidar/imu_livox_mid360",
-            "fast_livo_cloud_topic: /ubuntu/navigation/lidar_fast_livo",
+            "cloud_topic: /ubuntu/navigation/lidar",
             "imu_topic: /ubuntu/navigation/imu",
-            "publish_raw_cloud: false",
-            "publish_fast_livo_cloud: true",
         ):
             self.assertIn(expected, config)
 
     def test_tools_declare_native_types_qos_and_fail_closed_status(self):
         source = (G1_DIR / "navigation_sensor_bridge.py").read_text()
         for expected in (
-            '"navigation_lidar_fast_livo"',
+            '"navigation_lidar"',
             '"navigation_imu"',
-            '"navigation_sensor_diagnostics"',
             '"sensor/pointcloud"',
             '"sensor_msgs/msg/PointCloud2"',
             '"sensor_msgs/msg/Imu"',
@@ -114,16 +111,12 @@ class NavigationSensorCardContractTest(unittest.TestCase):
         self.assertNotIn('"sensor/pointcloud2"', source)
         ast.parse(source)
 
-    def test_runtime_tool_descriptors_match_fast_livo2_inputs(self):
+    def test_runtime_exposes_only_generic_navigation_sensor_tools(self):
         module = self.load_bridge_module()
         plugin = module.NavigationSensorPlugin.__new__(module.NavigationSensorPlugin)
         plugin._status_node = types.SimpleNamespace(
-            _publish_fast_livo_cloud=True,
-            _publish_raw_cloud=False,
-            fast_livo_cloud_topic="/ubuntu/navigation/lidar_fast_livo",
             cloud_topic="/ubuntu/navigation/lidar",
             imu_topic="/ubuntu/navigation/imu",
-            diagnostics_topic="/ubuntu/navigation/sensor_diagnostics",
             status=lambda worker_running: {
                 "ready": False,
                 "blockers": ["clock_not_ready"],
@@ -135,7 +128,8 @@ class NavigationSensorCardContractTest(unittest.TestCase):
         plugin._proc = types.SimpleNamespace(poll=lambda: None, pid=1234)
 
         tools = {tool["name"]: tool for tool in plugin.get_tools()}
-        lidar = tools["navigation_lidar_fast_livo"]["topic_out"][0]
+        self.assertEqual(set(tools), {"navigation_lidar", "navigation_imu"})
+        lidar = tools["navigation_lidar"]["topic_out"][0]
         imu = tools["navigation_imu"]["topic_out"][0]
         self.assertEqual(lidar["format"], "sensor/pointcloud")
         self.assertEqual(lidar["ros_type"], "sensor_msgs/msg/PointCloud2")
@@ -144,9 +138,7 @@ class NavigationSensorCardContractTest(unittest.TestCase):
         self.assertEqual(imu["ros_type"], "sensor_msgs/msg/Imu")
         self.assertEqual(imu["qos"], "RELIABLE + KEEP_LAST(depth=200) + VOLATILE")
 
-        info = plugin.dispatch(
-            "info", {"_tool_name": "navigation_lidar_fast_livo"}
-        )
+        info = plugin.dispatch("info", {"_tool_name": "navigation_lidar"})
         self.assertEqual(info["state"], "not_ready")
         self.assertEqual(info["blockers"], ["clock_not_ready"])
 
@@ -196,16 +188,16 @@ class NavigationSensorCardContractTest(unittest.TestCase):
 
     def test_status_monitor_fails_closed_for_dead_or_stale_worker(self):
         module = self.load_bridge_module()
-        node = module._NavigationSensorStatusNode.__new__(
-            module._NavigationSensorStatusNode
+        node = module._NavigationSensorMonitorNode.__new__(
+            module._NavigationSensorMonitorNode
         )
         node._lock = threading.RLock()
-        node._last_diagnostics = {"ready": True, "blockers": []}
-        node._last_diagnostics_monotonic = time.monotonic() - 3.0
+        node._last_status = {"ready": True, "blockers": []}
+        node._last_status_monotonic = time.monotonic() - 3.0
 
         stale = node.status(worker_running=True)
         self.assertFalse(stale["ready"])
-        self.assertIn("diagnostics_stale", stale["blockers"])
+        self.assertIn("status_stale", stale["blockers"])
 
         dead = node.status(worker_running=False)
         self.assertFalse(dead["ready"])

--- a/unitree/g1/tests/test_navigation_time.py
+++ b/unitree/g1/tests/test_navigation_time.py
@@ -1,0 +1,104 @@
+import unittest
+
+from navigation_time import ClockOffsetEstimator, split_ns, stamp_to_ns
+
+
+class TimestampHelpersTest(unittest.TestCase):
+    def test_round_trip(self):
+        timestamp_ns = stamp_to_ns(1_769_941_368, 987_654_321)
+        self.assertEqual(split_ns(timestamp_ns), (1_769_941_368, 987_654_321))
+
+    def test_invalid_nanoseconds(self):
+        with self.assertRaises(ValueError):
+            stamp_to_ns(1, 1_000_000_000)
+
+
+class ClockOffsetEstimatorTest(unittest.TestCase):
+    def make_estimator(self):
+        return ClockOffsetEstimator(
+            warmup_samples=3,
+            window_samples=5,
+            reset_threshold_ns=1_000_000_000,
+            reset_confirm_samples=3,
+        )
+
+    def test_uses_minimum_arrival_latency_after_warmup(self):
+        estimator = self.make_estimator()
+        offset = 15_869_770_000_000_000
+        source = 1_769_941_368_000_000_000
+
+        self.assertIsNone(estimator.correct_observation(source, source + offset + 8_000_000))
+        self.assertIsNone(
+            estimator.correct_observation(source + 5_000_000, source + 5_000_000 + offset + 2_000_000)
+        )
+        corrected = estimator.correct_observation(
+            source + 10_000_000, source + 10_000_000 + offset + 5_000_000
+        )
+
+        self.assertEqual(corrected, source + 10_000_000 + offset + 2_000_000)
+        self.assertTrue(estimator.snapshot().ready)
+
+    def test_one_late_callback_is_rejected_without_reset(self):
+        estimator = self.make_estimator()
+        source = 10_000_000_000
+        offset = 20_000_000_000
+        for index in range(3):
+            estimator.correct_observation(
+                source + index * 10_000_000,
+                source + index * 10_000_000 + offset + 1_000_000,
+            )
+
+        late = estimator.correct_observation(
+            source + 30_000_000,
+            source + 30_000_000 + offset + 2_000_000_000,
+        )
+        recovered = estimator.correct_observation(
+            source + 40_000_000,
+            source + 40_000_000 + offset + 2_000_000,
+        )
+
+        self.assertIsNone(late)
+        self.assertIsNotNone(recovered)
+        self.assertEqual(estimator.snapshot().resets, 0)
+
+    def test_persistent_backward_clock_jump_restarts_warmup(self):
+        estimator = self.make_estimator()
+        source = 10_000_000_000
+        offset = 20_000_000_000
+        for index in range(3):
+            estimator.correct_observation(
+                source + index * 10_000_000,
+                source + index * 10_000_000 + offset,
+            )
+
+        for index in range(3):
+            self.assertIsNone(
+                estimator.correct_observation(
+                    source + 30_000_000 + index * 10_000_000,
+                    source + 30_000_000 + index * 10_000_000 + offset + 2_000_000_000,
+                )
+            )
+
+        snapshot = estimator.snapshot()
+        self.assertFalse(snapshot.ready)
+        self.assertEqual(snapshot.resets, 1)
+        self.assertEqual(snapshot.samples, 1)
+
+    def test_forward_clock_jump_restarts_immediately(self):
+        estimator = self.make_estimator()
+        source = 10_000_000_000
+        offset = 20_000_000_000
+        for index in range(3):
+            estimator.correct_observation(
+                source + index * 10_000_000,
+                source + index * 10_000_000 + offset,
+            )
+
+        self.assertIsNone(
+            estimator.correct_observation(source + 2_000_000_000, source + offset + 100_000_000)
+        )
+        self.assertEqual(estimator.snapshot().resets, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

Perception PR [4paradigm/phanthymotus#96](https://github.com/4paradigm/phanthymotus/pull/96) 中的 FAST-LIVO2 建图/里程计卡片需要同时消费 MID360 点云和内置 IMU。现有 Driver 的 `/ubuntu/lidar/cloud` 面向 Canvas 与安全逻辑，机身 `/ubuntu/state/imu` 又缺少可用于 LIO 的源时间戳，不能直接作为 FAST-LIVO2 输入。

## 主要改动

新增两个只读 Driver 传感器卡片：

### `navigation_lidar_fast_livo`

- 直接订阅 MID360 原始 DDS PointCloud2；
- 输出 `/ubuntu/navigation/lidar_fast_livo`；
- ROS 类型：`sensor_msgs/msg/PointCloud2`；
- QoS：`RELIABLE + KEEP_LAST(depth=2) + VOLATILE`；
- 输出 FAST-LIVO2 所需的 `x/y/z/intensity/tag/line/timestamp` 字段；
- 保留逐点相对时间，并统一应用 G1 MID360 倒装的固定旋转。

### `navigation_imu`

- 直接订阅 MID360 内置 IMU 原始 DDS；
- 输出 `/ubuntu/navigation/imu`；
- ROS 类型：`sensor_msgs/msg/Imu`；
- QoS：`RELIABLE + KEEP_LAST(depth=200) + VOLATILE`；
- 与 LiDAR 使用同一 MID360 源时钟和同一固定安装旋转；
- 原始四元数无效时按 REP-145 标记 orientation unavailable。

同时新增 `navigation_sensor_diagnostics` 配套诊断流，输出时钟 warm-up/reset、接收新鲜度和丢帧计数；它是诊断能力，不作为第三张导航业务卡片。

## 运行与安全边界

- 导航传感器桥为只读插件，不发送运动指令；
- 重型点云转换和 IMU 转发运行在独立 worker 进程，避免与旧 LiDAR、相机和 MCP 线程相互阻塞；
- LiDAR/IMU 源时钟通过同一个 offset estimator 映射到 ROS system-time 域；
- 时钟未就绪、观测异常、输入过期或 worker/诊断失活时明确返回 `not_ready`，不伪造时间戳或正常状态；
- 旧 `/ubuntu/lidar/cloud` 卡片保持启用，继续服务 Canvas 和 Driver 安全逻辑。

## 与其他 PR 的关系

- Perception 消费方：[4paradigm/phanthymotus#96](https://github.com/4paradigm/phanthymotus/pull/96)
- Driver 通用速度提案与传感器时间合同：[4paradigm/phanthymotus-driver#140](https://github.com/4paradigm/phanthymotus-driver/pull/140)

本 PR 只提供 FAST-LIVO2 所需的标准 LiDAR/IMU 输入，不包含 Nav2、FAST-LIVO2 算法、速度提案执行或机器人运动控制。

## 验证

在 `unitree/g1` 下执行：

```bash
PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py' -v
python3 -m py_compile \
  main.py \
  navigation_sensor_bridge.py \
  navigation_sensor_bridge_main.py \
  navigation_pointcloud.py \
  navigation_time.py
git diff --check origin/main...HEAD
```

结果：

- 导航传感器测试：**20/20 通过**
- Python 编译检查：**通过**
- 配置合同检查：**通过**
- `git diff --check`：**通过**
- 相对官方 main：**落后 0 / 领先 2**
- 四个运行文件与此前合并部署脚本使用的实机来源逐字一致
- Docker 镜像构建：**未执行**，本机当前无 Docker daemon 访问权限

此前上海 G1 的 FAST-LIVO2/Nav2 联调使用过相同的四个运行文件；本次从最新 main 建立的独立分支尚未重新构建镜像或执行 rebase 后实机部署，因此不把既有实机证据表述为本分支的重新验收结果。

## 兼容性与回滚

- 新插件与旧 LiDAR 卡片并存，不修改旧点云 topic；
- 默认只发布 FAST-LIVO2 点云，不额外发布大体积 raw cloud，避免重复序列化压力；
- 回滚时关闭 `plugins.navigation_sensors.enabled`，或直接 revert 本 PR；
- 不影响不使用导航传感器卡片的 Driver 部署。

## 评审重点

请重点检查：

- MID360 点字段到 FAST-LIVO2 字段的转换；
- LiDAR/IMU 同时钟域和单调时间保证；
- 固定安装旋转是否同时且一致地作用于点云与 IMU；
- worker 异常、时钟异常和输入过期时的 fail-closed 状态；
- 与 [Perception PR #96](https://github.com/4paradigm/phanthymotus/pull/96)、[Driver PR #140](https://github.com/4paradigm/phanthymotus-driver/pull/140) 合并后的配置和 Dockerfile 冲突处理。
