### PR TITLE
feat(通用遥操作): 新增 Driver 自主管理的 OpenXR/RTC 运行时

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Each driver is a standalone [MCP](https://modelcontextprotocol.io) HTTP server t
 | `unitree/g1` | Unitree G1 Humanoid | 15701 | Locomotion, arm control, mic, speaker, LED, state monitoring |
 | `engineai/t800` | EngineAI T800 Development Edition | 15708 | ROS2/Native SDK, full state, dance/gesture sequences, virtual gamepad, locomotion and low-level joint control |
 | `phanthy/remote_control` | Remote Control Bridge | 15710 | Remote control relay |
+| [`generic/teleop_shadow`](generic/teleop_shadow/README.md) | Robot-free OpenXR/WebRTC endpoint | 15711 | Driver-owned Meta/PICO capture, strict Frame v1, fenced Shadow sessions and watchdog diagnostics; zero actuation |
 
 ## Quick Start
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -13,6 +13,7 @@
 | `unitree/g1` | Unitree G1 人形机器人 | 15701 | 运动控制、机械臂、麦克风、扬声器、LED、状态监控 |
 | `engineai/t800` | 众擎 T800 开发版 | 15708 | ROS2/Native SDK、全身状态、舞蹈/手势序列、虚拟手柄、运动与高低层控制 |
 | `phanthy/remote_control` | 远程控制桥接 | 15710 | 远程控制中继 |
+| [`generic/teleop_shadow`](generic/teleop_shadow/README.md) | 无机器人 OpenXR/WebRTC 端点 | 15711 | Driver 自主管理 Meta/PICO 采集、严格 Frame v1、Shadow 会话与看门狗诊断；永不执行硬件动作 |
 
 ## 快速开始
 

--- a/generic/openxr_capture_native/.gitignore
+++ b/generic/openxr_capture_native/.gitignore
@@ -1,0 +1,6 @@
+.gradle/
+.idea/
+app/.cxx/
+app/build/
+build/
+local.properties

--- a/generic/openxr_capture_native/README.md
+++ b/generic/openxr_capture_native/README.md
@@ -1,0 +1,193 @@
+# PhanthyMotus Android OpenXR Capture
+
+This Driver-owned module provides the native, menu-free Android OpenXR pose
+endpoint for the generic teleoperation runtime. One shared codebase produces
+separate Meta Quest and PICO APKs. Both send the public
+`motus.teleop.rtc-frame.v1` contract directly to a Driver over WebRTC. The
+Capture app does not own the Driver's teleoperation session, lease, fence,
+operator authorization, start action, or robot-output configuration.
+
+## Supported build targets
+
+| Build target | Target device family | Application ID | Debug APK |
+| --- | --- | --- | --- |
+| `meta` | Meta Quest 3 | `com.phanthymotus.questcapture` | `app/build/outputs/apk/meta/debug/app-meta-debug.apk` |
+| `pico` | PICO 4 / 4 Enterprise / 4 Ultra / Ultra Enterprise | `com.phanthymotus.picocapture` | `app/build/outputs/apk/pico/debug/app-pico-debug.apk` |
+
+The application IDs intentionally remain compatible with the existing Meta and
+PICO lab packages. An in-place upgrade also requires the same signing key; a
+debug APK signed on another workstation may require uninstalling the old build,
+which clears the stored Capture credential.
+
+The PICO target uses the standard Khronos Android OpenXR loader, which PICO
+supports starting with PICO OS 5.9.0. Update the headset to at least that version
+before testing. See PICO's [standard-loader announcement][pico-loader] and
+[Native SDK release notes][pico-native].
+
+Use PICO OS 5.13.0 or newer as the shared acceptance baseline. At startup the
+same PICO APK enables only the controller extensions actually exposed by the
+runtime: `XR_BD_controller_interaction` for PICO 4-class controllers and
+`XR_BD_ultra_controller_interaction` for PICO 4 Ultra-class controllers. If
+neither current Khronos profile is available, the app stops instead of emitting
+apparently valid input from an unknown controller.
+
+The PICO APK has build and static validation, but has not yet completed hardware
+acceptance on a PICO headset. Do not claim device support until install, OpenXR
+session, controller profile, dual-squeeze deadman, tracking-loss HOLD, reconnect,
+and end-to-end Driver frame checks pass on each target device/OS combination.
+
+[pico-loader]: https://developer.picoxr.com/blog/muz6s63x/
+[pico-native]: https://developer.picoxr.com/document/native/
+
+## Operator flow
+
+1. In the PhanthyMotus Canvas, use the Driver's `teleop_session` card to create
+   a one-time Capture pairing.
+2. Install the correct APK once and launch it with the pairing bootstrap from
+   the PC. The pairing code is consumed once; the resulting credential is stored
+   in that application's private Android preferences.
+3. On subsequent days, start it from the PC with `launch_capture.sh --platform
+   meta --resume` or `--platform pico --resume`. The app calls `xrBeginSession`
+   automatically when the runtime enters `READY`; the wearer does not click a VR
+   page or menu.
+4. The PC operator alone performs session start, pairing/revocation,
+   Pause/HOLD, emergency stop, and release through the card. The wearer still
+   physically uses both squeeze controls as the motion deadman.
+
+An Android or OpenXR system permission prompt may still appear on first install.
+The application cannot collect controller poses while Android backgrounds it or
+OpenXR removes `FOCUSED` input ownership; that transition closes RTC locally and
+the Driver independently forces the teleoperation session into HOLD.
+
+The pairing binds the Capture credential to the exact Driver
+`wss://.../ws/teleop-capture` origin and deployment CA. Resume cannot override
+either value. WebRTC uses an ordered `teleop-control` DataChannel for liveness
+and an unordered, zero-retransmit `teleop-pose` DataChannel for current poses.
+Focus loss, tracking/reference-space recenter, RTC failure, or pose
+backpressure closes the local streaming path instead of continuing with stale
+authority or coordinates.
+
+The supplied RTC configuration is a direct-LAN path and does not configure
+STUN/TURN. Cross-NAT or SSH-tunnel operation is not an accepted deployment
+shape for this version.
+
+## Build
+
+Required versions are fixed in the project:
+
+- JDK 17
+- Android platform 35 and build-tools 35.0.1
+- NDK 27.0.12077973
+- CMake 3.22.1
+- Gradle 8.9 (downloaded and SHA-256 verified by the build script)
+- OpenXR Android loader 1.1.60 (AAR SHA-256 verified by Gradle)
+- libdatachannel 0.24.3 and Mbed TLS 3.6.7 (immutable Git revisions)
+
+构建脚本不会执行可预测路径里预先展开的 Gradle 程序，也不会在校验后重新打开共享
+缓存文件；每次都会先把发行 ZIP 复制或下载到本次构建的私有临时目录，再校验并从
+同一个文件解压执行。
+
+After accepting the Android SDK/NDK licenses in your own SDK installation, build
+both APKs (the default):
+
+```sh
+export JAVA_HOME=/path/to/jdk-17
+export ANDROID_SDK_ROOT=/path/to/android-sdk
+./scripts/build_android.sh
+```
+
+For a shorter incremental build, select one target explicitly:
+
+```sh
+./scripts/build_android.sh --platform meta
+./scripts/build_android.sh --platform pico
+```
+
+The flavors pass `MOTUS_CAPTURE_HEADSET=meta` or
+`MOTUS_CAPTURE_HEADSET=pico` to the native build. The Meta APK accepts only the
+Oculus Touch profile; the PICO APK dynamically accepts the current PICO 4 and
+PICO 4 Ultra profiles described above.
+
+## Install and first pairing
+
+Install the APK that matches the headset:
+
+```sh
+adb install -r app/build/outputs/apk/meta/debug/app-meta-debug.apk
+# Or:
+adb install -r app/build/outputs/apk/pico/debug/app-pico-debug.apk
+```
+
+Then launch and pair it from the PC:
+
+```sh
+export DRIVER_CAPTURE_WSS_URL='wss://driver-host:8443/ws/teleop-capture'
+export PAIRING_ID='the-id-shown-on-the-PC'
+export CA_CERT_BASE64='the-public-value-shown-on-the-PC'
+./scripts/launch_capture.sh --platform meta
+# Or: ./scripts/launch_capture.sh --platform pico
+```
+
+The script prompts without terminal echo for the one-time pairing code. Resume a
+previously paired app with:
+
+```sh
+./scripts/launch_capture.sh --platform meta --resume
+./scripts/launch_capture.sh --platform pico --resume
+```
+
+When multiple or wireless-ADB devices are visible, target one explicitly without
+changing the command:
+
+```sh
+ADB_SERIAL='<headset-adb-ip>:5555' \
+  ./scripts/launch_capture.sh --platform meta --resume
+```
+
+`CA_CERT_FILE=/path/to/public-chain.pem` may be used instead of the Base64 field.
+The public PEM chain is limited to 32 KiB after decoding; its canonical Base64
+form is therefore at most 43,692 characters. The launcher rejects both encoded
+text and decoded PEM that exceed those bounds before invoking ADB.
+If the Driver was reinstalled or the enrollment was revoked, generate a new
+pairing from the card and run the first-pairing command again. An explicit new
+bootstrap replaces the stored credential; clearing app data or using a headset
+menu is not required. The exported NativeActivity requires the platform-only
+`android.permission.DUMP` caller permission, so ordinary headset apps cannot
+inject a pairing origin or replace an enrollment; the ADB shell is the intended
+laboratory bootstrap caller. Meta and PICO use different application IDs, so
+their credentials cannot be mixed accidentally. Confirm the ADB launch
+permission on each target headset OS before treating that SKU as accepted.
+The one-time code is intentionally passed as an `adb shell am start` argument;
+it is absent from script stdout but can be observed by trusted ADB-host/device
+process inspection during its 60-second, single-use lifetime.
+
+No G1 connection or robot output is involved in build, pairing, or Shadow
+validation.
+
+## Host protocol and launcher tests
+
+```sh
+./tests/launch_capture_test.sh
+
+NLOHMANN_JSON_INCLUDE=/path/to/nlohmann/include \
+PHANTHYMOTUS_DRIVER_G1_ROOT=/path/to/teleop-driver/unitree/g1 \
+./tests/run_host_tests.sh
+```
+
+After building both APKs, verify package identity, permissions, PICO-only
+metadata, ABI, ELF dependencies, alignment and signature:
+
+```sh
+ANDROID_SDK_ROOT=/path/to/android-sdk \
+JAVA_HOME=/path/to/jdk-17 \
+python3 ./tests/verify_android_apks.py
+```
+
+The launcher test uses a fake ADB executable and covers exact Meta/PICO package
+selection, `ADB_SERIAL`, resume, first pairing, secret-free output, CA PEM/Base64
+size boundaries, and malformed arguments. The protocol checks cover
+release-neutral-regrip, reconnect watermarks, terminal authentication/protocol
+error classification, retryable operational errors, exact WSS envelopes,
+duplicate-key rejection, one-shot SDP,
+exported-Activity origin/CA pinning, and the real G1 Driver's strict RTC frame
+parser without starting a publisher.

--- a/generic/openxr_capture_native/THIRD_PARTY_NOTICES.md
+++ b/generic/openxr_capture_native/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,14 @@
+# Third-party components
+
+- Khronos OpenXR Android loader 1.1.60, Apache-2.0. The Android lifecycle,
+  loader initialization, and session-state handling follow the public
+  `hello_xr` sample from OpenXR-SDK-Source release 1.1.60.
+- libdatachannel 0.24.3 (`c47f5d77...`), MPL-2.0, built without media support.
+- Mbed TLS 3.6.7 (`068ff080...`), Apache-2.0 or GPL-2.0-or-later; this build
+  consumes it under Apache-2.0.
+- nlohmann/json is consumed at libdatachannel's pinned submodule revision and
+  is MIT licensed.
+
+All dependencies are pinned by immutable source revision or Maven version in
+the build files. Their complete license texts remain available from their
+respective distributions.

--- a/generic/openxr_capture_native/app/build.gradle.kts
+++ b/generic/openxr_capture_native/app/build.gradle.kts
@@ -1,0 +1,100 @@
+import java.security.MessageDigest
+
+plugins {
+    id("com.android.application")
+}
+
+android {
+    namespace = "com.phanthymotus.questcapture"
+    compileSdk = 35
+    ndkVersion = "27.0.12077973"
+
+    defaultConfig {
+        applicationId = "com.phanthymotus.questcapture"
+        minSdk = 29
+        targetSdk = 35
+        versionCode = 2
+        versionName = "0.2.0"
+
+        ndk {
+            abiFilters += "arm64-v8a"
+        }
+        externalNativeBuild {
+            cmake {
+                cppFlags += listOf("-std=c++20", "-fexceptions", "-frtti")
+                arguments += listOf(
+                    "-DANDROID_STL=c++_shared",
+                    "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                )
+                targets += "motus_openxr_capture"
+            }
+        }
+    }
+
+    flavorDimensions += "headset"
+    productFlavors {
+        create("meta") {
+            dimension = "headset"
+            applicationId = "com.phanthymotus.questcapture"
+            externalNativeBuild {
+                cmake {
+                    arguments += "-DMOTUS_CAPTURE_HEADSET=meta"
+                }
+            }
+        }
+        create("pico") {
+            dimension = "headset"
+            applicationId = "com.phanthymotus.picocapture"
+            externalNativeBuild {
+                cmake {
+                    arguments += "-DMOTUS_CAPTURE_HEADSET=pico"
+                }
+            }
+        }
+    }
+
+    buildFeatures {
+        prefab = true
+    }
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+            version = "3.22.1"
+        }
+    }
+    buildTypes {
+        debug {
+            isJniDebuggable = true
+        }
+        release {
+            isMinifyEnabled = false
+        }
+    }
+    packaging {
+        jniLibs.useLegacyPackaging = true
+    }
+}
+
+dependencies {
+    implementation("org.khronos.openxr:openxr_loader_for_android:1.1.60")
+}
+
+val verifyOpenXrArtifact by tasks.registering {
+    val artifact = configurations.detachedConfiguration(
+        dependencies.create("org.khronos.openxr:openxr_loader_for_android:1.1.60"),
+    )
+    inputs.files(artifact)
+    doLast {
+        val file = artifact.singleFile
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(file.readBytes())
+            .joinToString("") { "%02x".format(it) }
+        check(digest == "9a21ecea6b308d3a7fcf261412bec4cb1ae9148ba053d6b24da468fef96029c7") {
+            "OpenXR Android loader checksum mismatch: $digest"
+        }
+    }
+}
+
+tasks.named("preBuild").configure {
+    dependsOn(verifyOpenXrArtifact)
+}

--- a/generic/openxr_capture_native/app/src/main/AndroidManifest.xml
+++ b/generic/openxr_capture_native/app/src/main/AndroidManifest.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <uses-feature
+        android:name="android.hardware.vr.headtracking"
+        android:required="true"
+        android:version="1" />
+    <uses-feature
+        android:glEsVersion="0x00030000"
+        android:required="true" />
+
+    <application
+        android:allowBackup="false"
+        android:hasCode="false"
+        android:label="@string/app_name"
+        android:supportsRtl="false"
+        android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
+        <activity
+            android:name="android.app.NativeActivity"
+            android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode|density"
+            android:excludeFromRecents="false"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:permission="android.permission.DUMP"
+            android:resizeableActivity="false"
+            android:screenOrientation="landscape">
+            <meta-data
+                android:name="android.app.lib_name"
+                android:value="motus_openxr_capture" />
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/generic/openxr_capture_native/app/src/main/cpp/CMakeLists.txt
+++ b/generic/openxr_capture_native/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,119 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(motus_openxr_capture LANGUAGES C CXX)
+
+include(FetchContent)
+
+set(MOTUS_CAPTURE_HEADSET "meta" CACHE STRING "OpenXR headset target: meta or pico")
+set_property(CACHE MOTUS_CAPTURE_HEADSET PROPERTY STRINGS meta pico)
+if(MOTUS_CAPTURE_HEADSET STREQUAL "meta")
+    set(motus_capture_headset_definition MOTUS_CAPTURE_HEADSET_META=1)
+elseif(MOTUS_CAPTURE_HEADSET STREQUAL "pico")
+    set(motus_capture_headset_definition MOTUS_CAPTURE_HEADSET_PICO=1)
+else()
+    message(FATAL_ERROR "MOTUS_CAPTURE_HEADSET must be 'meta' or 'pico'")
+endif()
+
+# This is an Android application build, not an installable CMake package.  In
+# particular, libdatachannel's install export cannot describe our in-tree
+# static Mbed TLS target.  Suppress dependency install/export rules instead of
+# weakening the TLS linkage or patching third-party sources.
+set(CMAKE_SKIP_INSTALL_RULES ON CACHE BOOL "" FORCE)
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+set(ENABLE_PROGRAMS OFF CACHE BOOL "" FORCE)
+set(ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+set(MBEDTLS_FATAL_WARNINGS OFF CACHE BOOL "" FORCE)
+set(DISABLE_PACKAGE_CONFIG_AND_INSTALL ON CACHE BOOL "" FORCE)
+set(
+    MBEDTLS_USER_CONFIG_FILE
+    "${CMAKE_CURRENT_LIST_DIR}/mbedtls_user_config.h"
+    CACHE FILEPATH "" FORCE
+)
+FetchContent_Declare(
+    mbedtls
+    GIT_REPOSITORY https://github.com/Mbed-TLS/mbedtls.git
+    GIT_TAG 068ff080b369adfac81509f9b57b2afabaf82dc5
+    GIT_SUBMODULES_RECURSE TRUE
+)
+FetchContent_MakeAvailable(mbedtls)
+if(NOT TARGET MbedTLS::MbedTLS)
+    add_library(MbedTLS::MbedTLS ALIAS mbedtls)
+endif()
+
+set(USE_MBEDTLS ON CACHE BOOL "" FORCE)
+set(NO_MEDIA ON CACHE BOOL "" FORCE)
+set(NO_EXAMPLES ON CACHE BOOL "" FORCE)
+set(NO_TESTS ON CACHE BOOL "" FORCE)
+set(WARNINGS_AS_ERRORS OFF CACHE BOOL "" FORCE)
+set(BUILD_SHARED_DEPS_LIBS OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    libdatachannel
+    GIT_REPOSITORY https://github.com/paullouisageneau/libdatachannel.git
+    GIT_TAG c47f5d77c124c35c31ac8378ad613295a124d354
+    GIT_SUBMODULES
+        deps/json
+        deps/libjuice
+        deps/plog
+        deps/usrsctp
+    GIT_SUBMODULES_RECURSE TRUE
+)
+FetchContent_MakeAvailable(libdatachannel)
+if(NOT TARGET nlohmann_json::nlohmann_json)
+    set(JSON_BuildTests OFF CACHE INTERNAL "")
+    add_subdirectory(
+        "${libdatachannel_SOURCE_DIR}/deps/json"
+        "${libdatachannel_BINARY_DIR}/deps/json"
+        EXCLUDE_FROM_ALL
+    )
+endif()
+
+find_package(OpenXR REQUIRED CONFIG)
+find_library(android-lib android REQUIRED)
+find_library(egl-lib EGL REQUIRED)
+find_library(gles-lib GLESv3 REQUIRED)
+find_library(log-lib log REQUIRED)
+
+set(project_root "${CMAKE_CURRENT_LIST_DIR}/../../../..")
+set(native_app_glue "${ANDROID_NDK}/sources/android/native_app_glue")
+
+add_library(android_native_app_glue STATIC "${native_app_glue}/android_native_app_glue.c")
+target_include_directories(android_native_app_glue PUBLIC "${native_app_glue}")
+
+add_library(motus_openxr_capture SHARED
+    android_main.cpp
+    capture_transport.cpp
+    openxr_capture.cpp
+    runtime_profile.cpp
+    "${project_root}/src/capture_session.cpp"
+    "${project_root}/src/capture_wire.cpp"
+    "${project_root}/src/enrollment.cpp"
+    "${project_root}/src/frame_v1.cpp"
+)
+target_include_directories(motus_openxr_capture PRIVATE
+    "${project_root}/include"
+)
+target_compile_features(motus_openxr_capture PRIVATE cxx_std_20)
+target_compile_definitions(motus_openxr_capture PRIVATE
+    ${motus_capture_headset_definition}
+    XR_USE_PLATFORM_ANDROID
+    XR_USE_GRAPHICS_API_OPENGL_ES
+)
+target_compile_options(motus_openxr_capture PRIVATE
+    -Wall
+    -Wextra
+    -Werror
+    -Wpedantic
+    # OpenXR's C structs intentionally use aggregate initialization with the
+    # mandatory type tag while every remaining member is zero-initialized.
+    -Wno-missing-field-initializers
+)
+target_link_options(motus_openxr_capture PRIVATE "-uANativeActivity_onCreate")
+target_link_libraries(motus_openxr_capture PRIVATE
+    android_native_app_glue
+    OpenXR::openxr_loader
+    LibDataChannel::LibDataChannelStatic
+    nlohmann_json::nlohmann_json
+    ${android-lib}
+    ${egl-lib}
+    ${gles-lib}
+    ${log-lib}
+)

--- a/generic/openxr_capture_native/app/src/main/cpp/android_main.cpp
+++ b/generic/openxr_capture_native/app/src/main/cpp/android_main.cpp
@@ -1,0 +1,392 @@
+#include <android/log.h>
+#include <android/native_activity.h>
+#include <android/window.h>
+#include <android_native_app_glue.h>
+#include <jni.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+
+#include "capture_transport.hpp"
+#include "motus/openxr_capture/enrollment.hpp"
+#include "openxr_capture.hpp"
+
+namespace motus::openxr_capture {
+namespace {
+
+constexpr char kLogTag[] = "MotusOpenXrCapture";
+constexpr char kPreferencesName[] = "motus_capture";
+constexpr char kAppVersion[] = "0.2.0";
+
+struct AndroidLifecycle {
+  bool resumed{false};
+  bool window_ready{false};
+};
+
+void Log(android_LogPriority priority, const std::string& message) {
+  __android_log_write(priority, kLogTag, message.c_str());
+}
+
+void ThrowIfJavaException(JNIEnv* environment, const char* operation) {
+  if (environment->ExceptionCheck() == JNI_FALSE) {
+    return;
+  }
+  environment->ExceptionClear();
+  throw std::runtime_error(std::string(operation) + " raised a Java exception");
+}
+
+std::string JavaString(JNIEnv* environment, jstring value) {
+  if (value == nullptr) {
+    return {};
+  }
+  const char* characters = environment->GetStringUTFChars(value, nullptr);
+  ThrowIfJavaException(environment, "GetStringUTFChars");
+  std::string result = characters == nullptr ? std::string{} : std::string(characters);
+  if (characters != nullptr) {
+    environment->ReleaseStringUTFChars(value, characters);
+  }
+  return result;
+}
+
+jstring NewJavaString(JNIEnv* environment, const std::string& value) {
+  jstring result = environment->NewStringUTF(value.c_str());
+  ThrowIfJavaException(environment, "NewStringUTF");
+  return result;
+}
+
+std::string IntentExtra(
+    JNIEnv* environment,
+    jobject activity,
+    const std::string& name) {
+  jclass activity_class = environment->GetObjectClass(activity);
+  jmethodID get_intent = environment->GetMethodID(
+      activity_class, "getIntent", "()Landroid/content/Intent;");
+  jobject intent = environment->CallObjectMethod(activity, get_intent);
+  ThrowIfJavaException(environment, "Activity.getIntent");
+  jclass intent_class = environment->GetObjectClass(intent);
+  jmethodID get_string_extra = environment->GetMethodID(
+      intent_class,
+      "getStringExtra",
+      "(Ljava/lang/String;)Ljava/lang/String;");
+  jstring key = NewJavaString(environment, name);
+  auto value = static_cast<jstring>(
+      environment->CallObjectMethod(intent, get_string_extra, key));
+  ThrowIfJavaException(environment, "Intent.getStringExtra");
+  const std::string result = JavaString(environment, value);
+  if (value != nullptr) {
+    environment->DeleteLocalRef(value);
+  }
+  environment->DeleteLocalRef(key);
+  environment->DeleteLocalRef(intent_class);
+  environment->DeleteLocalRef(intent);
+  environment->DeleteLocalRef(activity_class);
+  return result;
+}
+
+jobject Preferences(JNIEnv* environment, jobject activity) {
+  jclass activity_class = environment->GetObjectClass(activity);
+  jmethodID get_preferences = environment->GetMethodID(
+      activity_class,
+      "getSharedPreferences",
+      "(Ljava/lang/String;I)Landroid/content/SharedPreferences;");
+  jstring name = NewJavaString(environment, kPreferencesName);
+  jobject preferences = environment->CallObjectMethod(
+      activity, get_preferences, name, 0);
+  ThrowIfJavaException(environment, "Activity.getSharedPreferences");
+  environment->DeleteLocalRef(name);
+  environment->DeleteLocalRef(activity_class);
+  return preferences;
+}
+
+std::string GetPreference(
+    JNIEnv* environment,
+    jobject activity,
+    const std::string& key_name) {
+  jobject preferences = Preferences(environment, activity);
+  jclass preferences_class = environment->GetObjectClass(preferences);
+  jmethodID get_string = environment->GetMethodID(
+      preferences_class,
+      "getString",
+      "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
+  jstring key = NewJavaString(environment, key_name);
+  jstring fallback = NewJavaString(environment, "");
+  auto value = static_cast<jstring>(environment->CallObjectMethod(
+      preferences, get_string, key, fallback));
+  ThrowIfJavaException(environment, "SharedPreferences.getString");
+  const std::string result = JavaString(environment, value);
+  environment->DeleteLocalRef(value);
+  environment->DeleteLocalRef(fallback);
+  environment->DeleteLocalRef(key);
+  environment->DeleteLocalRef(preferences_class);
+  environment->DeleteLocalRef(preferences);
+  return result;
+}
+
+void PutCaptureEnrollment(
+    JNIEnv* environment,
+    jobject activity,
+    const CaptureIdentity& identity,
+    const std::string& websocket_url,
+    const std::string& ca_certificate_pem) {
+  jobject preferences = Preferences(environment, activity);
+  jclass preferences_class = environment->GetObjectClass(preferences);
+  jmethodID edit = environment->GetMethodID(
+      preferences_class, "edit", "()Landroid/content/SharedPreferences$Editor;");
+  jobject editor = environment->CallObjectMethod(preferences, edit);
+  ThrowIfJavaException(environment, "SharedPreferences.edit");
+  jclass editor_class = environment->GetObjectClass(editor);
+  jmethodID put_string = environment->GetMethodID(
+      editor_class,
+      "putString",
+      "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;");
+  jmethodID commit = environment->GetMethodID(editor_class, "commit", "()Z");
+  const auto put = [&](const char* key_text, const std::string& value_text) {
+    jstring key = NewJavaString(environment, key_text);
+    jstring value = NewJavaString(environment, value_text);
+    static_cast<void>(environment->CallObjectMethod(editor, put_string, key, value));
+    ThrowIfJavaException(environment, "SharedPreferences.Editor.putString");
+    environment->DeleteLocalRef(value);
+    environment->DeleteLocalRef(key);
+  };
+  // Commit identity and its pinned transport origin as one editor transaction.
+  // A stored credential is never valid independently of these exact values.
+  put("capture_id", identity.capture_id);
+  put("capture_credential", identity.capture_credential);
+  put("driver_capture_wss_url", websocket_url);
+  put("ca_certificate_pem", ca_certificate_pem);
+  const jboolean committed = environment->CallBooleanMethod(editor, commit);
+  ThrowIfJavaException(environment, "SharedPreferences.Editor.commit");
+  if (committed != JNI_TRUE) {
+    throw std::runtime_error("capture preference commit failed");
+  }
+  environment->DeleteLocalRef(editor_class);
+  environment->DeleteLocalRef(editor);
+  environment->DeleteLocalRef(preferences_class);
+  environment->DeleteLocalRef(preferences);
+}
+
+std::string Base64Decode(const std::string& encoded) {
+  static constexpr std::string_view alphabet =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  if (encoded.empty() || encoded.size() > 64 * 1024 || encoded.size() % 4 != 0) {
+    throw std::invalid_argument("CA certificate base64 is invalid");
+  }
+  std::string result;
+  result.reserve((encoded.size() / 4) * 3);
+  std::uint32_t accumulator = 0;
+  int bits = 0;
+  bool padding = false;
+  for (const char character : encoded) {
+    if (character == '=') {
+      padding = true;
+      continue;
+    }
+    if (padding) {
+      throw std::invalid_argument("CA certificate base64 padding is invalid");
+    }
+    const auto position = alphabet.find(character);
+    if (position == std::string_view::npos) {
+      throw std::invalid_argument("CA certificate base64 character is invalid");
+    }
+    accumulator = (accumulator << 6U) | static_cast<std::uint32_t>(position);
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      result.push_back(static_cast<char>((accumulator >> bits) & 0xffU));
+    }
+  }
+  if (result.find("-----BEGIN CERTIFICATE-----") == std::string::npos ||
+      result.size() > 32 * 1024) {
+    throw std::invalid_argument("CA certificate PEM is invalid");
+  }
+  return result;
+}
+
+CaptureTransportConfiguration LoadConfiguration(
+    JNIEnv* environment,
+    jobject activity) {
+  CaptureTransportConfiguration configuration;
+  configuration.app_version = kAppVersion;
+
+  const auto pairing_id = IntentExtra(environment, activity, "pairing_id");
+  const auto pairing_code = IntentExtra(environment, activity, "pairing_code");
+  const auto launch_websocket_url = IntentExtra(
+      environment, activity, "driver_capture_wss_url");
+  const auto launch_ca_base64 = IntentExtra(
+      environment, activity, "ca_certificate_base64");
+  const bool pairing_present = !pairing_id.empty() || !pairing_code.empty();
+  const CaptureLaunchBootstrap launch{
+      .pairing_id = pairing_id,
+      .pairing_code = pairing_code,
+      .websocket_url = launch_websocket_url,
+      .ca_certificate_pem = pairing_present && !launch_ca_base64.empty()
+          ? Base64Decode(launch_ca_base64)
+          : std::string{},
+      .transport_override_present =
+          !launch_websocket_url.empty() || !launch_ca_base64.empty(),
+  };
+  StoredCaptureEnrollment stored;
+  if (!pairing_present) {
+    stored = StoredCaptureEnrollment{
+        .capture_id = GetPreference(environment, activity, "capture_id"),
+        .capture_credential = GetPreference(
+            environment, activity, "capture_credential"),
+        .websocket_url = GetPreference(
+            environment, activity, "driver_capture_wss_url"),
+        .ca_certificate_pem = GetPreference(
+            environment, activity, "ca_certificate_pem"),
+    };
+  }
+  auto selected = SelectCaptureEnrollment(stored, launch);
+  configuration.identity = std::move(selected.identity);
+  configuration.pairing = std::move(selected.pairing);
+  configuration.websocket_url = std::move(selected.websocket_url);
+  configuration.ca_certificate_pem =
+      std::move(selected.ca_certificate_pem);
+  return configuration;
+}
+
+void HandleAppCommand(android_app* app, std::int32_t command) {
+  auto* lifecycle = static_cast<AndroidLifecycle*>(app->userData);
+  if (lifecycle == nullptr) {
+    return;
+  }
+  switch (command) {
+    case APP_CMD_RESUME:
+      lifecycle->resumed = true;
+      break;
+    case APP_CMD_PAUSE:
+    case APP_CMD_STOP:
+      lifecycle->resumed = false;
+      break;
+    case APP_CMD_INIT_WINDOW:
+      lifecycle->window_ready = true;
+      break;
+    case APP_CMD_TERM_WINDOW:
+    case APP_CMD_DESTROY:
+      lifecycle->window_ready = false;
+      break;
+    default:
+      break;
+  }
+}
+
+}  // namespace
+}  // namespace motus::openxr_capture
+
+void android_main(android_app* app) {
+  using namespace motus::openxr_capture;
+  JNIEnv* environment = nullptr;
+  bool attached = false;
+  try {
+    if (app == nullptr || app->activity == nullptr || app->activity->vm == nullptr) {
+      throw std::runtime_error("NativeActivity is unavailable");
+    }
+    const jint environment_result = app->activity->vm->GetEnv(
+        reinterpret_cast<void**>(&environment), JNI_VERSION_1_6);
+    if (environment_result == JNI_EDETACHED) {
+      if (app->activity->vm->AttachCurrentThread(&environment, nullptr) != JNI_OK) {
+        throw std::runtime_error("AttachCurrentThread failed");
+      }
+      attached = true;
+    } else if (environment_result != JNI_OK || environment == nullptr) {
+      throw std::runtime_error("JNI environment unavailable");
+    }
+
+    ANativeActivity_setWindowFlags(
+        app->activity,
+        AWINDOW_FLAG_KEEP_SCREEN_ON,
+        0);
+    AndroidLifecycle lifecycle;
+    app->userData = &lifecycle;
+    app->onAppCmd = HandleAppCommand;
+
+    auto configuration = LoadConfiguration(
+        environment, app->activity->clazz);
+    // Construct the transport after OpenXR so stack unwinding always tears
+    // down WSS/RTC before destroying the runtime and its swapchains.
+    OpenXrCapture xr;
+    xr.Initialize(app);
+    const std::string enrollment_websocket_url = configuration.websocket_url;
+    const std::string enrollment_ca_certificate_pem =
+        configuration.ca_certificate_pem;
+    auto transport = std::make_shared<CaptureTransport>(
+        std::move(configuration),
+        [environment,
+         activity = app->activity->clazz,
+         enrollment_websocket_url,
+         enrollment_ca_certificate_pem](const CaptureIdentity& identity) {
+          PutCaptureEnrollment(
+              environment,
+              activity,
+              identity,
+              enrollment_websocket_url,
+              enrollment_ca_certificate_pem);
+        },
+        [](const std::string& message) { Log(ANDROID_LOG_INFO, message); });
+    transport->Start();
+
+    bool last_focused = false;
+    while (app->destroyRequested == 0 && !xr.exit_requested()) {
+      for (;;) {
+        int events = 0;
+        android_poll_source* source = nullptr;
+        const int timeout_ms = xr.session_running() ? 0 : 50;
+        if (ALooper_pollOnce(
+                timeout_ms,
+                nullptr,
+                &events,
+                reinterpret_cast<void**>(&source)) < 0) {
+          break;
+        }
+        if (source != nullptr) {
+          source->process(app, source);
+        }
+        if (timeout_ms != 0) {
+          break;
+        }
+      }
+
+      xr.PollEvents();
+      const bool focused = lifecycle.resumed && xr.focused();
+      if (focused != last_focused) {
+        transport->SetXrFocused(focused);
+        last_focused = focused;
+      }
+      transport->Tick();
+
+      if (xr.session_running()) {
+        FrameSample sample;
+        if (xr.RenderFrame(&sample) && focused) {
+          transport->SendFrame(sample);
+        }
+      } else {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      }
+    }
+    transport->SetXrFocused(false);
+    transport->Shutdown();
+    ANativeActivity_finish(app->activity);
+  } catch (const std::exception& error) {
+    Log(ANDROID_LOG_ERROR, std::string("capture app stopped: ") + error.what());
+    if (app != nullptr && app->activity != nullptr) {
+      ANativeActivity_finish(app->activity);
+    }
+  } catch (...) {
+    Log(ANDROID_LOG_ERROR, "capture app stopped: unknown error");
+    if (app != nullptr && app->activity != nullptr) {
+      ANativeActivity_finish(app->activity);
+    }
+  }
+  if (attached && app != nullptr && app->activity != nullptr &&
+      app->activity->vm != nullptr) {
+    app->activity->vm->DetachCurrentThread();
+  }
+}

--- a/generic/openxr_capture_native/app/src/main/cpp/capture_transport.cpp
+++ b/generic/openxr_capture_native/app/src/main/cpp/capture_transport.cpp
@@ -1,0 +1,647 @@
+#include "capture_transport.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+#include <variant>
+
+#include "motus/openxr_capture/capture_wire.hpp"
+
+namespace motus::openxr_capture {
+namespace {
+
+constexpr std::size_t kPoseBackpressureBytes = 16 * 1024;
+constexpr auto kPeerPingInterval = std::chrono::seconds(1);
+constexpr auto kMaximumReconnectDelay = std::chrono::milliseconds(5'000);
+constexpr auto kRtcNegotiationTimeout = std::chrono::seconds(10);
+
+bool SafeWebSocketUrl(const std::string& value) {
+  return value.size() >= 8 && value.size() <= 2'048 && value.starts_with("wss://") &&
+      value.find('?') == std::string::npos && value.find('#') == std::string::npos &&
+      value.find('@') == std::string::npos &&
+      value.ends_with("/ws/teleop-capture");
+}
+
+}  // namespace
+
+CaptureTransport::CaptureTransport(
+    CaptureTransportConfiguration configuration,
+    IdentitySink identity_sink,
+    LogSink log_sink)
+    : configuration_(std::move(configuration)),
+      identity_sink_(std::move(identity_sink)),
+      log_sink_(std::move(log_sink)) {
+  if (!SafeWebSocketUrl(configuration_.websocket_url) ||
+      configuration_.app_version.empty() ||
+      configuration_.ca_certificate_pem.size() > 32 * 1024 ||
+      configuration_.ca_certificate_pem.find("-----BEGIN CERTIFICATE-----") ==
+          std::string::npos ||
+      (!configuration_.identity && !configuration_.pairing)) {
+    throw std::invalid_argument("capture transport configuration is invalid");
+  }
+  state_.identity = configuration_.identity;
+  state_.pairing = configuration_.pairing;
+}
+
+CaptureTransport::~CaptureTransport() {
+  Shutdown();
+}
+
+void CaptureTransport::Start() {
+  if (started_ || shutting_down_) {
+    return;
+  }
+  if (weak_from_this().expired()) {
+    throw std::logic_error("capture transport must have shared ownership");
+  }
+  started_ = true;
+  rtc::InitLogger(rtc::LogLevel::Warning);
+  ConnectNow();
+}
+
+void CaptureTransport::Shutdown() {
+  if (shutting_down_.exchange(true)) {
+    return;
+  }
+  CloseRtc("capture_shutdown");
+  CloseWebSocket();
+  {
+    std::lock_guard lock(event_mutex_);
+    events_.clear();
+  }
+  static_cast<void>(rtc::Cleanup().wait_for(std::chrono::seconds(5)));
+}
+
+void CaptureTransport::Tick() {
+  if (!started_ || shutting_down_) {
+    return;
+  }
+  std::deque<Event> pending;
+  {
+    std::lock_guard lock(event_mutex_);
+    pending.swap(events_);
+  }
+  for (const auto& event : pending) {
+    HandleEvent(event);
+  }
+
+  const auto now = std::chrono::steady_clock::now();
+  if (state_.link == CaptureLinkState::kOffline && now >= next_reconnect_) {
+    ConnectNow();
+    return;
+  }
+  if (state_.authenticated && now >= next_presence_) {
+    Apply(CapturePresenceTick(state_, state_.connection_epoch));
+    next_presence_ = now + presence_interval_;
+  }
+  if (
+      state_.link == CaptureLinkState::kNegotiating && state_.assignment &&
+      now >= rtc_negotiation_deadline_) {
+    Apply(CaptureRtcFailed(
+        state_,
+        state_.connection_epoch,
+        state_.assignment->id,
+        "rtc_negotiation_timeout"));
+    return;
+  }
+  if (streaming() && now >= next_ping_) {
+    SendPeerPing();
+    next_ping_ = now + kPeerPingInterval;
+  }
+}
+
+void CaptureTransport::SetXrFocused(bool focused) {
+  if (!started_ || shutting_down_ || focused == state_.xr_focused) {
+    return;
+  }
+  if (focused) {
+    Apply(CaptureXrFocused(state_, state_.connection_epoch));
+  } else {
+    Apply(CaptureXrEnded(
+        state_, state_.connection_epoch, "openxr_focus_lost"));
+  }
+}
+
+void CaptureTransport::SendFrame(const FrameSample& sample) {
+  if (!streaming() || !state_.assignment || !pose_ || !pose_->isOpen()) {
+    return;
+  }
+  if (pose_->bufferedAmount() > kPoseBackpressureBytes) {
+    Apply(CaptureRtcFailed(
+        state_,
+        state_.connection_epoch,
+        state_.assignment->id,
+        "pose_backpressure"));
+    return;
+  }
+  try {
+    auto result = BuildFrameV1(
+        state_.frame_state,
+        sample,
+        state_.assignment->frame_configuration);
+    state_.frame_state = result.state;
+    if (!pose_->send(SerializeFrameV1(result.frame))) {
+      Apply(CaptureRtcFailed(
+          state_,
+          state_.connection_epoch,
+          state_.assignment->id,
+          "pose_send_buffered"));
+    }
+  } catch (const std::exception& error) {
+    Apply(CaptureRtcFailed(
+        state_,
+        state_.connection_epoch,
+        state_.assignment->id,
+        std::string("pose_frame_invalid:") + error.what()));
+  }
+}
+
+void CaptureTransport::ConnectNow() {
+  if (shutting_down_) {
+    return;
+  }
+  Apply(BeginCaptureConnection(state_));
+  const auto epoch = state_.connection_epoch;
+  rtc::WebSocket::Configuration websocket_configuration;
+  websocket_configuration.disableTlsVerification = false;
+  websocket_configuration.connectionTimeout = std::chrono::seconds(5);
+  websocket_configuration.pingInterval = std::chrono::seconds(2);
+  websocket_configuration.maxOutstandingPings = 2;
+  websocket_configuration.maxMessageSize = kMaxCaptureWireBytes;
+  // libdatachannel's Mbed TLS backend does not import Android's system trust
+  // store. Pin the deployment CA content explicitly and keep verification on.
+  websocket_configuration.caCertificatePemFile =
+      configuration_.ca_certificate_pem;
+  websocket_ = std::make_shared<rtc::WebSocket>(websocket_configuration);
+  const std::weak_ptr<CaptureTransport> weak_self = weak_from_this();
+  websocket_->onOpen([weak_self, epoch] {
+    const auto self = weak_self.lock();
+    if (!self) {
+      return;
+    }
+    self->Enqueue(Event{
+        .kind = EventKind::kWebSocketOpen,
+        .connection_epoch = epoch,
+    });
+  });
+  websocket_->onMessage([weak_self, epoch](rtc::message_variant message) {
+    const auto self = weak_self.lock();
+    if (!self) {
+      return;
+    }
+    if (!std::holds_alternative<std::string>(message)) {
+      self->Enqueue(Event{
+          .kind = EventKind::kWebSocketError,
+          .connection_epoch = epoch,
+          .value = "capture_binary_message_rejected",
+      });
+      return;
+    }
+    self->Enqueue(Event{
+        .kind = EventKind::kWebSocketMessage,
+        .connection_epoch = epoch,
+        .value = std::get<std::string>(std::move(message)),
+    });
+  });
+  websocket_->onClosed([weak_self, epoch] {
+    const auto self = weak_self.lock();
+    if (!self) {
+      return;
+    }
+    self->Enqueue(Event{
+        .kind = EventKind::kWebSocketClosed,
+        .connection_epoch = epoch,
+        .value = "capture_wss_closed",
+    });
+  });
+  websocket_->onError([weak_self, epoch](std::string error) {
+    const auto self = weak_self.lock();
+    if (!self) {
+      return;
+    }
+    self->Enqueue(Event{
+        .kind = EventKind::kWebSocketError,
+        .connection_epoch = epoch,
+        .value = std::move(error),
+    });
+  });
+  websocket_->open(configuration_.websocket_url);
+}
+
+void CaptureTransport::Enqueue(Event event) {
+  std::lock_guard lock(event_mutex_);
+  if (!shutting_down_) {
+    events_.push_back(std::move(event));
+  }
+}
+
+void CaptureTransport::HandleEvent(const Event& event) {
+  if (event.connection_epoch != state_.connection_epoch) {
+    return;
+  }
+  switch (event.kind) {
+    case EventKind::kWebSocketOpen:
+      if (pending_authentication_) {
+        const auto action = *pending_authentication_;
+        pending_authentication_.reset();
+        ApplyAction(action);
+      }
+      break;
+    case EventKind::kWebSocketMessage:
+      HandleServerMessage(event.value);
+      break;
+    case EventKind::kWebSocketClosed:
+    case EventKind::kWebSocketError:
+      Apply(CaptureTransportLost(
+          state_,
+          state_.connection_epoch,
+          event.value.empty() ? "capture_wss_lost" : event.value));
+      break;
+    case EventKind::kRtcOfferReady:
+      Apply(CaptureOfferCreated(
+          state_,
+          state_.connection_epoch,
+          event.assignment_id,
+          event.value));
+      break;
+    case EventKind::kRtcStateFailed:
+      Apply(CaptureRtcFailed(
+          state_,
+          state_.connection_epoch,
+          event.assignment_id,
+          event.value));
+      break;
+    case EventKind::kControlOpened:
+    case EventKind::kControlClosed:
+    case EventKind::kPoseOpened:
+    case EventKind::kPoseClosed: {
+      const bool control_open = event.kind == EventKind::kControlOpened
+          ? true
+          : event.kind == EventKind::kControlClosed ? false : state_.control_open;
+      const bool pose_open = event.kind == EventKind::kPoseOpened
+          ? true
+          : event.kind == EventKind::kPoseClosed ? false : state_.pose_open;
+      Apply(CaptureChannelState(
+          state_,
+          state_.connection_epoch,
+          event.assignment_id,
+          control_open,
+          pose_open));
+      break;
+    }
+  }
+}
+
+void CaptureTransport::HandleServerMessage(const std::string& payload) {
+  try {
+    const auto message = ParseCaptureServerMessage(payload, state_.identity);
+    std::visit([this](const auto& item) {
+      using Message = std::decay_t<decltype(item)>;
+      if constexpr (std::is_same_v<Message, CaptureAuthenticatedMessage>) {
+        if (item.presence_timeout_ms <= item.presence_interval_ms) {
+          throw std::invalid_argument("presence timeout must exceed interval");
+        }
+        presence_interval_ = std::chrono::milliseconds(item.presence_interval_ms);
+        next_presence_ = std::chrono::steady_clock::now() + presence_interval_;
+        reconnect_delay_ = std::chrono::milliseconds(250);
+        Apply(CaptureAuthenticated(
+            state_,
+            state_.connection_epoch,
+            item.identity,
+            item.fresh_credential));
+      } else if constexpr (std::is_same_v<Message, CaptureAssignmentMessage>) {
+        Apply(CaptureAssigned(
+            state_, state_.connection_epoch, item.assignment));
+      } else if constexpr (std::is_same_v<Message, CaptureSignalingAnswerMessage>) {
+        Apply(CaptureAnswerReceived(
+            state_,
+            state_.connection_epoch,
+            item.assignment_id,
+            item.answer_sdp));
+      } else if constexpr (std::is_same_v<Message, CaptureAssignmentRevokedMessage>) {
+        Apply(CaptureAssignmentRevoked(
+            state_,
+            state_.connection_epoch,
+            item.assignment_id,
+            item.reason));
+      } else if constexpr (std::is_same_v<Message, CaptureTerminalMessage>) {
+        Apply(CaptureTransportLost(
+            state_, state_.connection_epoch, item.reason));
+        if (item.type == "capture_revoked") {
+          next_reconnect_ = std::chrono::steady_clock::time_point::max();
+        }
+      } else if constexpr (std::is_same_v<Message, CapturePresenceAcknowledgedMessage>) {
+        static_cast<void>(item);
+      } else if constexpr (std::is_same_v<Message, CaptureErrorMessage>) {
+        // The Driver intentionally closes WSS after a signaling error. Close
+        // locally now so headset-to-Driver RTC cannot outlive that decision.
+        Apply(CaptureTransportLost(
+            state_, state_.connection_epoch, item.code));
+        if (CaptureErrorStopsReconnect(item.code)) {
+          next_reconnect_ = std::chrono::steady_clock::time_point::max();
+        }
+        CloseWebSocket();
+      }
+    }, message);
+  } catch (const std::exception& error) {
+    Apply(CaptureTransportLost(
+        state_,
+        state_.connection_epoch,
+        std::string("capture_wire_rejected:") + error.what()));
+    CloseWebSocket();
+  }
+}
+
+void CaptureTransport::Apply(CaptureTransition transition) {
+  state_ = std::move(transition.state);
+  for (const auto& action : transition.actions) {
+    ApplyAction(action);
+  }
+}
+
+void CaptureTransport::ApplyAction(const CaptureAction& action) {
+  if (action.connection_epoch != state_.connection_epoch &&
+      action.kind != CaptureActionKind::kCloseRtc) {
+    return;
+  }
+  switch (action.kind) {
+    case CaptureActionKind::kSendPairAuthentication:
+    case CaptureActionKind::kSendCredentialAuthentication:
+      if (!websocket_ || !websocket_->isOpen()) {
+        pending_authentication_ = action;
+        return;
+      }
+      if (action.kind == CaptureActionKind::kSendPairAuthentication) {
+        if (!state_.pairing) {
+          throw std::logic_error("pair authentication requested without pairing");
+        }
+        SendWebSocket(SerializePairAuthentication(
+            *state_.pairing, configuration_.app_version));
+      } else {
+        if (!state_.identity) {
+          throw std::logic_error("credential authentication requested without identity");
+        }
+        SendWebSocket(SerializeCredentialAuthentication(
+            *state_.identity, configuration_.app_version));
+      }
+      break;
+    case CaptureActionKind::kPersistCredential:
+      if (state_.identity && identity_sink_) {
+        try {
+          identity_sink_(*state_.identity);
+          configuration_.identity = state_.identity;
+          configuration_.pairing.reset();
+        } catch (...) {
+          // The server has already consumed the one-time pairing and enabled
+          // this credential.  Continuing only in memory would look healthy
+          // until the next app restart.  Forget both identities and disable
+          // reconnect so the failure is immediately visible and requires an
+          // explicit new pairing.
+          credential_persistence_failed_ = true;
+          state_.identity.reset();
+          state_.pairing.reset();
+          configuration_.identity.reset();
+          configuration_.pairing.reset();
+          throw;
+        }
+      }
+      break;
+    case CaptureActionKind::kSendPresence:
+      if (!action.presence) {
+        throw std::logic_error("presence action is missing state");
+      }
+      SendWebSocket(SerializeCapturePresence(
+          *action.presence, action.assignment_id));
+      break;
+    case CaptureActionKind::kCreateRtcOffer:
+      StartRtc(action.assignment_id);
+      break;
+    case CaptureActionKind::kSendSignalingOffer:
+      SendWebSocket(SerializeCaptureSignalingOffer(
+          action.assignment_id, action.value));
+      break;
+    case CaptureActionKind::kApplyRtcAnswer:
+      if (!peer_) {
+        throw std::logic_error("RTC answer received without peer");
+      }
+      peer_->setRemoteDescription(rtc::Description(action.value, "answer"));
+      break;
+    case CaptureActionKind::kCloseRtc:
+      CloseRtc(action.value);
+      break;
+    case CaptureActionKind::kScheduleReconnect:
+      ScheduleReconnect(action.value);
+      break;
+    case CaptureActionKind::kReportFault:
+      Log(std::string("capture fault: ") + action.value);
+      break;
+  }
+}
+
+void CaptureTransport::StartRtc(const std::string& assignment_id) {
+  CloseRtc("rtc_replaced");
+  rtc_negotiation_deadline_ =
+      std::chrono::steady_clock::now() + kRtcNegotiationTimeout;
+  const auto epoch = state_.connection_epoch;
+  rtc::Configuration peer_configuration;
+  peer_configuration.disableAutoNegotiation = true;
+  peer_configuration.disableFingerprintVerification = false;
+  peer_configuration.maxMessageSize = kMaxRtcMessageBytes;
+  peer_ = std::make_shared<rtc::PeerConnection>(peer_configuration);
+  const std::weak_ptr<rtc::PeerConnection> weak_peer = peer_;
+  const std::weak_ptr<CaptureTransport> weak_self = weak_from_this();
+
+  rtc::DataChannelInit control_init;
+  control_init.reliability.unordered = false;
+  control_ = peer_->createDataChannel("teleop-control", control_init);
+  rtc::DataChannelInit pose_init;
+  pose_init.reliability.unordered = true;
+  pose_init.reliability.maxRetransmits = 0;
+  pose_ = peer_->createDataChannel("teleop-pose", pose_init);
+
+  peer_->onGatheringStateChange([weak_self, epoch, assignment_id, weak_peer](
+                                     rtc::PeerConnection::GatheringState state) {
+    const auto self = weak_self.lock();
+    const auto peer = weak_peer.lock();
+    if (state != rtc::PeerConnection::GatheringState::Complete || !self || !peer) {
+      return;
+    }
+    const auto description = peer->localDescription();
+    if (!description || description->type() != rtc::Description::Type::Offer) {
+      self->Enqueue(Event{
+          .kind = EventKind::kRtcStateFailed,
+          .connection_epoch = epoch,
+          .assignment_id = assignment_id,
+          .value = "rtc_local_offer_missing",
+      });
+      return;
+    }
+    self->Enqueue(Event{
+        .kind = EventKind::kRtcOfferReady,
+        .connection_epoch = epoch,
+        .assignment_id = assignment_id,
+        .value = std::string(*description),
+    });
+  });
+  peer_->onStateChange([weak_self, epoch, assignment_id](
+                           rtc::PeerConnection::State state) {
+    if (state == rtc::PeerConnection::State::Disconnected ||
+        state == rtc::PeerConnection::State::Failed ||
+        state == rtc::PeerConnection::State::Closed) {
+      const auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->Enqueue(Event{
+          .kind = EventKind::kRtcStateFailed,
+          .connection_epoch = epoch,
+          .assignment_id = assignment_id,
+          .value = "rtc_peer_lost",
+      });
+    }
+  });
+  const auto channel_callbacks = [weak_self, epoch, assignment_id](
+                                     const std::shared_ptr<rtc::DataChannel>& channel,
+                                     EventKind opened,
+                                     EventKind closed) {
+    channel->onOpen([weak_self, epoch, assignment_id, opened] {
+      const auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->Enqueue(Event{
+          .kind = opened,
+          .connection_epoch = epoch,
+          .assignment_id = assignment_id,
+      });
+    });
+    channel->onClosed([weak_self, epoch, assignment_id, closed] {
+      const auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->Enqueue(Event{
+          .kind = closed,
+          .connection_epoch = epoch,
+          .assignment_id = assignment_id,
+      });
+    });
+    channel->onError([weak_self, epoch, assignment_id, closed](std::string error) {
+      const auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->Enqueue(Event{
+          .kind = closed,
+          .connection_epoch = epoch,
+          .assignment_id = assignment_id,
+          .value = std::move(error),
+      });
+    });
+  };
+  channel_callbacks(
+      control_, EventKind::kControlOpened, EventKind::kControlClosed);
+  channel_callbacks(pose_, EventKind::kPoseOpened, EventKind::kPoseClosed);
+  control_->onMessage([weak_self](rtc::message_variant message) {
+    const auto self = weak_self.lock();
+    if (self) {
+      self->HandleControlMessage(message);
+    }
+  });
+  peer_->setLocalDescription(rtc::Description::Type::Offer);
+}
+
+void CaptureTransport::CloseRtc(const std::string& reason) {
+  rtc_negotiation_deadline_ = std::chrono::steady_clock::time_point::max();
+  if (pose_) {
+    pose_->resetCallbacks();
+    pose_->close();
+    pose_.reset();
+  }
+  if (control_) {
+    control_->resetCallbacks();
+    control_->close();
+    control_.reset();
+  }
+  if (peer_) {
+    peer_->resetCallbacks();
+    peer_->close();
+    peer_.reset();
+  }
+  if (!reason.empty()) {
+    Log(std::string("RTC closed: ") + reason);
+  }
+}
+
+void CaptureTransport::CloseWebSocket() {
+  pending_authentication_.reset();
+  if (websocket_) {
+    websocket_->resetCallbacks();
+    websocket_->close();
+    websocket_.reset();
+  }
+}
+
+void CaptureTransport::SendWebSocket(const std::string& payload) {
+  if (!websocket_ || !websocket_->isOpen() || !websocket_->send(payload)) {
+    throw std::runtime_error("capture WSS send failed");
+  }
+}
+
+void CaptureTransport::ScheduleReconnect(const std::string& reason) {
+  CloseWebSocket();
+  if (credential_persistence_failed_) {
+    next_reconnect_ = std::chrono::steady_clock::time_point::max();
+    Log("capture reconnect disabled: credential persistence failed");
+    return;
+  }
+  const auto now = std::chrono::steady_clock::now();
+  next_reconnect_ = now + reconnect_delay_;
+  reconnect_delay_ = std::min(reconnect_delay_ * 2, kMaximumReconnectDelay);
+  Log(std::string("capture reconnect scheduled: ") + reason);
+}
+
+void CaptureTransport::SendPeerPing() {
+  if (!control_ || !control_->isOpen()) {
+    return;
+  }
+  ++peer_ping_sequence_;
+  const nlohmann::json payload = {
+      {"type", "peer_ping"},
+      {"request_id", "native-" + std::to_string(peer_ping_sequence_)},
+  };
+  if (!control_->send(payload.dump())) {
+    Apply(CaptureRtcFailed(
+        state_,
+        state_.connection_epoch,
+        state_.assignment ? state_.assignment->id : std::string{},
+        "control_ping_buffered"));
+  }
+}
+
+void CaptureTransport::HandleControlMessage(const rtc::message_variant& message) {
+  if (!std::holds_alternative<std::string>(message)) {
+    return;
+  }
+  try {
+    const auto payload = nlohmann::json::parse(std::get<std::string>(message));
+    if (payload.is_object() && payload.value("type", "") == "peer_pong") {
+      return;
+    }
+    if (payload.is_object() && payload.contains("error")) {
+      Log("Driver RTC returned an error");
+    }
+  } catch (const nlohmann::json::exception&) {
+    Log("Driver RTC returned malformed control JSON");
+  }
+}
+
+void CaptureTransport::Log(const std::string& message) const {
+  if (log_sink_) {
+    log_sink_(message);
+  }
+}
+
+}  // namespace motus::openxr_capture

--- a/generic/openxr_capture_native/app/src/main/cpp/capture_transport.hpp
+++ b/generic/openxr_capture_native/app/src/main/cpp/capture_transport.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <rtc/rtc.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+
+#include "motus/openxr_capture/capture_session.hpp"
+
+namespace motus::openxr_capture {
+
+struct CaptureTransportConfiguration {
+  std::string websocket_url;
+  std::string app_version;
+  std::optional<CaptureIdentity> identity;
+  std::optional<PairingBootstrap> pairing;
+  std::string ca_certificate_pem;
+};
+
+class CaptureTransport final
+    : public std::enable_shared_from_this<CaptureTransport> {
+ public:
+  using IdentitySink = std::function<void(const CaptureIdentity&)>;
+  using LogSink = std::function<void(const std::string&)>;
+
+  CaptureTransport(
+      CaptureTransportConfiguration configuration,
+      IdentitySink identity_sink,
+      LogSink log_sink);
+  ~CaptureTransport();
+
+  CaptureTransport(const CaptureTransport&) = delete;
+  CaptureTransport& operator=(const CaptureTransport&) = delete;
+
+  void Start();
+  void Shutdown();
+  void Tick();
+  void SetXrFocused(bool focused);
+  void SendFrame(const FrameSample& sample);
+
+  [[nodiscard]] CaptureLinkState link_state() const { return state_.link; }
+  [[nodiscard]] bool streaming() const {
+    return state_.link == CaptureLinkState::kStreaming;
+  }
+  [[nodiscard]] const std::optional<CaptureAssignmentV1>& assignment() const {
+    return state_.assignment;
+  }
+
+ private:
+  enum class EventKind {
+    kWebSocketOpen,
+    kWebSocketMessage,
+    kWebSocketClosed,
+    kWebSocketError,
+    kRtcOfferReady,
+    kRtcStateFailed,
+    kControlOpened,
+    kControlClosed,
+    kPoseOpened,
+    kPoseClosed,
+  };
+
+  struct Event {
+    EventKind kind{EventKind::kWebSocketClosed};
+    std::int64_t connection_epoch{0};
+    std::string assignment_id;
+    std::string value;
+  };
+
+  void ConnectNow();
+  void Enqueue(Event event);
+  void HandleEvent(const Event& event);
+  void HandleServerMessage(const std::string& payload);
+  void Apply(CaptureTransition transition);
+  void ApplyAction(const CaptureAction& action);
+  void StartRtc(const std::string& assignment_id);
+  void CloseRtc(const std::string& reason);
+  void CloseWebSocket();
+  void SendWebSocket(const std::string& payload);
+  void ScheduleReconnect(const std::string& reason);
+  void SendPeerPing();
+  void HandleControlMessage(const rtc::message_variant& message);
+  void Log(const std::string& message) const;
+
+  CaptureTransportConfiguration configuration_;
+  IdentitySink identity_sink_;
+  LogSink log_sink_;
+  CaptureSessionState state_;
+
+  mutable std::mutex event_mutex_;
+  std::deque<Event> events_;
+  std::shared_ptr<rtc::WebSocket> websocket_;
+  std::shared_ptr<rtc::PeerConnection> peer_;
+  std::shared_ptr<rtc::DataChannel> control_;
+  std::shared_ptr<rtc::DataChannel> pose_;
+  std::optional<CaptureAction> pending_authentication_;
+
+  bool started_{false};
+  std::atomic_bool shutting_down_{false};
+  std::chrono::steady_clock::time_point next_presence_{};
+  std::chrono::steady_clock::time_point next_reconnect_{};
+  std::chrono::steady_clock::time_point next_ping_{};
+  std::chrono::steady_clock::time_point rtc_negotiation_deadline_{
+      std::chrono::steady_clock::time_point::max()};
+  std::chrono::milliseconds presence_interval_{2'000};
+  std::chrono::milliseconds reconnect_delay_{250};
+  std::uint64_t peer_ping_sequence_{0};
+  bool credential_persistence_failed_{false};
+};
+
+}  // namespace motus::openxr_capture

--- a/generic/openxr_capture_native/app/src/main/cpp/mbedtls_user_config.h
+++ b/generic/openxr_capture_native/app/src/main/cpp/mbedtls_user_config.h
@@ -1,0 +1,9 @@
+#ifndef MOTUS_OPENXR_CAPTURE_MBEDTLS_USER_CONFIG_H_
+#define MOTUS_OPENXR_CAPTURE_MBEDTLS_USER_CONFIG_H_
+
+// libdatachannel's WebRTC transport negotiates DTLS-SRTP (RFC 5764).
+// Mbed TLS 3.6 keeps this optional in its default configuration, so the APK
+// enables it explicitly through the supported user-config hook.
+#define MBEDTLS_SSL_DTLS_SRTP
+
+#endif  // MOTUS_OPENXR_CAPTURE_MBEDTLS_USER_CONFIG_H_

--- a/generic/openxr_capture_native/app/src/main/cpp/openxr_capture.cpp
+++ b/generic/openxr_capture_native/app/src/main/cpp/openxr_capture.cpp
@@ -1,0 +1,793 @@
+// OpenXR Android lifecycle and graphics initialization follow Khronos hello_xr
+// release 1.1.60 (Apache-2.0), reduced here to a capture-only GLES session.
+
+#include "openxr_capture.hpp"
+
+#include <GLES3/gl3.h>
+#include <android_native_app_glue.h>
+#include <openxr/openxr_platform.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace motus::openxr_capture {
+namespace {
+
+constexpr XrViewConfigurationType kViewConfiguration =
+    XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
+
+void CopyName(char* target, std::size_t size, std::string_view value) {
+  if (value.size() >= size) {
+    throw std::invalid_argument("OpenXR name is too long");
+  }
+  std::memset(target, 0, size);
+  std::memcpy(target, value.data(), value.size());
+}
+
+bool SupportsExtension(
+    const std::vector<XrExtensionProperties>& properties,
+    const char* extension) {
+  return std::any_of(properties.begin(), properties.end(), [&](const auto& item) {
+    return std::strcmp(item.extensionName, extension) == 0;
+  });
+}
+
+XrPosef IdentityPose() {
+  XrPosef pose{};
+  pose.orientation.w = 1.0F;
+  return pose;
+}
+
+bool FullyTracked(XrSpaceLocationFlags flags) {
+  constexpr XrSpaceLocationFlags required =
+      XR_SPACE_LOCATION_POSITION_VALID_BIT |
+      XR_SPACE_LOCATION_ORIENTATION_VALID_BIT |
+      XR_SPACE_LOCATION_POSITION_TRACKED_BIT |
+      XR_SPACE_LOCATION_ORIENTATION_TRACKED_BIT;
+  return (flags & required) == required;
+}
+
+}  // namespace
+
+OpenXrCapture::~OpenXrCapture() {
+  Destroy();
+}
+
+void OpenXrCapture::Initialize(android_app* app) {
+  if (app == nullptr || app->activity == nullptr) {
+    throw std::invalid_argument("android_app is required");
+  }
+  monotonic_origin_ = std::chrono::steady_clock::now();
+  InitializeLoader(app);
+  CreateInstance(app);
+  CreateEglContext();
+  CreateSession();
+  CreateSpaces();
+  CreateActions();
+  CreateSwapchains();
+}
+
+void OpenXrCapture::InitializeLoader(android_app* app) {
+  PFN_xrInitializeLoaderKHR initialize_loader = nullptr;
+  const XrResult get_result = xrGetInstanceProcAddr(
+      XR_NULL_HANDLE,
+      "xrInitializeLoaderKHR",
+      reinterpret_cast<PFN_xrVoidFunction*>(&initialize_loader));
+  if (XR_FAILED(get_result) || initialize_loader == nullptr) {
+    throw std::runtime_error("xrInitializeLoaderKHR is unavailable");
+  }
+  XrLoaderInitInfoAndroidKHR loader_info{XR_TYPE_LOADER_INIT_INFO_ANDROID_KHR};
+  loader_info.applicationVM = app->activity->vm;
+  loader_info.applicationContext = app->activity->clazz;
+  Check(
+      initialize_loader(
+          reinterpret_cast<const XrLoaderInitInfoBaseHeaderKHR*>(&loader_info)),
+      "xrInitializeLoaderKHR");
+}
+
+void OpenXrCapture::CreateInstance(android_app* app) {
+  std::uint32_t extension_count = 0;
+  Check(xrEnumerateInstanceExtensionProperties(
+            nullptr, 0, &extension_count, nullptr),
+        "xrEnumerateInstanceExtensionProperties(count)");
+  std::vector<XrExtensionProperties> extensions(
+      extension_count, XrExtensionProperties{XR_TYPE_EXTENSION_PROPERTIES});
+  Check(xrEnumerateInstanceExtensionProperties(
+            nullptr, extension_count, &extension_count, extensions.data()),
+        "xrEnumerateInstanceExtensionProperties(values)");
+  const std::array<const char*, 2> required_extensions = {
+      XR_KHR_ANDROID_CREATE_INSTANCE_EXTENSION_NAME,
+      XR_KHR_OPENGL_ES_ENABLE_EXTENSION_NAME,
+  };
+  for (const char* extension : required_extensions) {
+    if (!SupportsExtension(extensions, extension)) {
+      throw std::runtime_error(std::string("required OpenXR extension missing: ") + extension);
+    }
+  }
+  std::vector<std::string_view> available_extensions;
+  available_extensions.reserve(extensions.size());
+  for (const auto& extension : extensions) {
+    available_extensions.emplace_back(extension.extensionName);
+  }
+  runtime_selection_ = SelectRuntime(
+      CompiledRuntimeProfile(), available_extensions);
+  std::vector<const char*> enabled_extensions(
+      required_extensions.begin(), required_extensions.end());
+  enabled_extensions.reserve(
+      required_extensions.size() + runtime_selection_.optional_extensions.size());
+  for (const std::string_view extension :
+       runtime_selection_.optional_extensions) {
+    enabled_extensions.push_back(extension.data());
+  }
+
+  XrInstanceCreateInfoAndroidKHR android_info{
+      XR_TYPE_INSTANCE_CREATE_INFO_ANDROID_KHR};
+  android_info.applicationVM = app->activity->vm;
+  android_info.applicationActivity = app->activity->clazz;
+
+  XrInstanceCreateInfo create_info{XR_TYPE_INSTANCE_CREATE_INFO};
+  create_info.next = &android_info;
+  CopyName(
+      create_info.applicationInfo.applicationName,
+      sizeof(create_info.applicationInfo.applicationName),
+      CompiledRuntimeProfile().application_name);
+  create_info.applicationInfo.applicationVersion = 1;
+  CopyName(
+      create_info.applicationInfo.engineName,
+      sizeof(create_info.applicationInfo.engineName),
+      "phanthymotus-native");
+  create_info.applicationInfo.engineVersion = 1;
+  // This client uses only OpenXR 1.0 core commands plus explicit extensions;
+  // requesting 1.0 keeps it compatible with runtimes that have not promoted
+  // their loader/runtime interface to 1.1.
+  create_info.applicationInfo.apiVersion = XR_API_VERSION_1_0;
+  create_info.enabledExtensionCount = enabled_extensions.size();
+  create_info.enabledExtensionNames = enabled_extensions.data();
+  Check(xrCreateInstance(&create_info, &instance_), "xrCreateInstance");
+
+  XrSystemGetInfo system_info{XR_TYPE_SYSTEM_GET_INFO};
+  system_info.formFactor = XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY;
+  Check(xrGetSystem(instance_, &system_info, &system_id_), "xrGetSystem");
+}
+
+void OpenXrCapture::CreateEglContext() {
+  PFN_xrGetOpenGLESGraphicsRequirementsKHR get_requirements = nullptr;
+  Check(xrGetInstanceProcAddr(
+            instance_,
+            "xrGetOpenGLESGraphicsRequirementsKHR",
+            reinterpret_cast<PFN_xrVoidFunction*>(&get_requirements)),
+        "xrGetInstanceProcAddr(OpenGLES requirements)");
+  if (get_requirements == nullptr) {
+    throw std::runtime_error("OpenGL ES graphics requirements function is missing");
+  }
+  XrGraphicsRequirementsOpenGLESKHR requirements{
+      XR_TYPE_GRAPHICS_REQUIREMENTS_OPENGL_ES_KHR};
+  Check(get_requirements(instance_, system_id_, &requirements),
+        "xrGetOpenGLESGraphicsRequirementsKHR");
+  constexpr XrVersion requested_gles = XR_MAKE_VERSION(3, 0, 0);
+  if (requested_gles < requirements.minApiVersionSupported ||
+      requested_gles > requirements.maxApiVersionSupported) {
+    throw std::runtime_error("OpenGL ES 3.0 is outside runtime graphics requirements");
+  }
+
+  egl_display_ = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+  if (egl_display_ == EGL_NO_DISPLAY || eglInitialize(egl_display_, nullptr, nullptr) != EGL_TRUE) {
+    throw std::runtime_error("eglInitialize failed");
+  }
+  const EGLint config_attributes[] = {
+      EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
+      EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+      EGL_RED_SIZE, 8,
+      EGL_GREEN_SIZE, 8,
+      EGL_BLUE_SIZE, 8,
+      EGL_ALPHA_SIZE, 8,
+      EGL_DEPTH_SIZE, 0,
+      EGL_NONE,
+  };
+  EGLint config_count = 0;
+  if (eglChooseConfig(
+          egl_display_, config_attributes, &egl_config_, 1, &config_count) != EGL_TRUE ||
+      config_count != 1) {
+    throw std::runtime_error("eglChooseConfig failed");
+  }
+  const EGLint context_attributes[] = {
+      EGL_CONTEXT_CLIENT_VERSION, 3,
+      EGL_NONE,
+  };
+  egl_context_ = eglCreateContext(
+      egl_display_, egl_config_, EGL_NO_CONTEXT, context_attributes);
+  const EGLint surface_attributes[] = {
+      EGL_WIDTH, 16,
+      EGL_HEIGHT, 16,
+      EGL_NONE,
+  };
+  egl_surface_ = eglCreatePbufferSurface(
+      egl_display_, egl_config_, surface_attributes);
+  if (egl_context_ == EGL_NO_CONTEXT || egl_surface_ == EGL_NO_SURFACE ||
+      eglMakeCurrent(
+          egl_display_, egl_surface_, egl_surface_, egl_context_) != EGL_TRUE) {
+    throw std::runtime_error("OpenGL ES context creation failed");
+  }
+}
+
+void OpenXrCapture::CreateSession() {
+  XrGraphicsBindingOpenGLESAndroidKHR graphics_binding{
+      XR_TYPE_GRAPHICS_BINDING_OPENGL_ES_ANDROID_KHR};
+  graphics_binding.display = egl_display_;
+  graphics_binding.config = egl_config_;
+  graphics_binding.context = egl_context_;
+  XrSessionCreateInfo create_info{XR_TYPE_SESSION_CREATE_INFO};
+  create_info.next = &graphics_binding;
+  create_info.systemId = system_id_;
+  Check(xrCreateSession(instance_, &create_info, &session_), "xrCreateSession");
+}
+
+void OpenXrCapture::CreateSpaces() {
+  std::uint32_t space_count = 0;
+  Check(xrEnumerateReferenceSpaces(session_, 0, &space_count, nullptr),
+        "xrEnumerateReferenceSpaces(count)");
+  std::vector<XrReferenceSpaceType> spaces(space_count);
+  Check(xrEnumerateReferenceSpaces(
+            session_, space_count, &space_count, spaces.data()),
+        "xrEnumerateReferenceSpaces(values)");
+  const bool local_floor_available = std::find(
+      spaces.begin(), spaces.end(), XR_REFERENCE_SPACE_TYPE_LOCAL_FLOOR_EXT) !=
+      spaces.end();
+  const bool stage_available = std::find(
+      spaces.begin(), spaces.end(), XR_REFERENCE_SPACE_TYPE_STAGE) !=
+      spaces.end();
+  const FloorReferenceSpace selected_space = SelectFloorReferenceSpace(
+      runtime_selection_.local_floor_extension_enabled,
+      local_floor_available,
+      stage_available);
+  const XrReferenceSpaceType floor_space_type =
+      selected_space == FloorReferenceSpace::kLocalFloor
+      ? XR_REFERENCE_SPACE_TYPE_LOCAL_FLOOR_EXT
+      : XR_REFERENCE_SPACE_TYPE_STAGE;
+  XrReferenceSpaceCreateInfo floor_info{XR_TYPE_REFERENCE_SPACE_CREATE_INFO};
+  floor_info.referenceSpaceType = floor_space_type;
+  floor_info.poseInReferenceSpace = IdentityPose();
+  Check(xrCreateReferenceSpace(session_, &floor_info, &floor_space_),
+        selected_space == FloorReferenceSpace::kLocalFloor
+            ? "xrCreateReferenceSpace(local_floor)"
+            : "xrCreateReferenceSpace(stage)");
+
+  XrReferenceSpaceCreateInfo view_info{XR_TYPE_REFERENCE_SPACE_CREATE_INFO};
+  view_info.referenceSpaceType = XR_REFERENCE_SPACE_TYPE_VIEW;
+  view_info.poseInReferenceSpace = IdentityPose();
+  Check(xrCreateReferenceSpace(session_, &view_info, &view_space_),
+        "xrCreateReferenceSpace(view)");
+}
+
+void OpenXrCapture::CreateActions() {
+  Check(xrStringToPath(instance_, "/user/hand/left", &hand_paths_[0]),
+        "xrStringToPath(left hand)");
+  Check(xrStringToPath(instance_, "/user/hand/right", &hand_paths_[1]),
+        "xrStringToPath(right hand)");
+
+  XrActionSetCreateInfo set_info{XR_TYPE_ACTION_SET_CREATE_INFO};
+  CopyName(set_info.actionSetName, sizeof(set_info.actionSetName), "teleop_capture");
+  CopyName(
+      set_info.localizedActionSetName,
+      sizeof(set_info.localizedActionSetName),
+      "Teleoperation capture");
+  set_info.priority = 0;
+  Check(xrCreateActionSet(instance_, &set_info, &action_set_), "xrCreateActionSet");
+
+  const auto create_action = [this](
+                                 XrActionType type,
+                                 std::string_view name,
+                                 std::string_view localized,
+                                 XrAction* action) {
+    XrActionCreateInfo info{XR_TYPE_ACTION_CREATE_INFO};
+    info.actionType = type;
+    CopyName(info.actionName, sizeof(info.actionName), name);
+    CopyName(info.localizedActionName, sizeof(info.localizedActionName), localized);
+    info.countSubactionPaths = hand_paths_.size();
+    info.subactionPaths = hand_paths_.data();
+    Check(xrCreateAction(action_set_, &info, action), "xrCreateAction");
+  };
+  create_action(
+      XR_ACTION_TYPE_POSE_INPUT,
+      "grip_pose",
+      "Grip pose",
+      &grip_pose_action_);
+  create_action(
+      XR_ACTION_TYPE_FLOAT_INPUT,
+      "squeeze_value",
+      "Squeeze value",
+      &squeeze_action_);
+  create_action(
+      XR_ACTION_TYPE_VECTOR2F_INPUT,
+      "thumbstick",
+      "Thumbstick",
+      &thumbstick_action_);
+
+  std::vector<XrActionSuggestedBinding> bindings;
+  bindings.reserve(6);
+  for (std::size_t index = 0; index < hand_paths_.size(); ++index) {
+    const char* hand = index == 0 ? "left" : "right";
+    const auto binding_path = [&](const char* suffix) {
+      XrPath path = XR_NULL_PATH;
+      const std::string value = std::string("/user/hand/") + hand + suffix;
+      Check(xrStringToPath(instance_, value.c_str(), &path), "xrStringToPath(binding)");
+      return path;
+    };
+    bindings.push_back({grip_pose_action_, binding_path("/input/grip/pose")});
+    bindings.push_back({squeeze_action_, binding_path("/input/squeeze/value")});
+    bindings.push_back({thumbstick_action_, binding_path("/input/thumbstick")});
+  }
+  allowed_interaction_profiles_.clear();
+  allowed_interaction_profiles_.reserve(
+      runtime_selection_.interaction_profile_paths.size());
+  for (const std::string_view interaction_profile :
+       runtime_selection_.interaction_profile_paths) {
+    XrPath profile_path = XR_NULL_PATH;
+    Check(xrStringToPath(
+              instance_, interaction_profile.data(), &profile_path),
+          "xrStringToPath(interaction profile)");
+    XrInteractionProfileSuggestedBinding suggested{
+        XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING};
+    suggested.interactionProfile = profile_path;
+    suggested.countSuggestedBindings = bindings.size();
+    suggested.suggestedBindings = bindings.data();
+    Check(xrSuggestInteractionProfileBindings(instance_, &suggested),
+          "xrSuggestInteractionProfileBindings");
+    allowed_interaction_profiles_.push_back(profile_path);
+  }
+
+  XrSessionActionSetsAttachInfo attach_info{
+      XR_TYPE_SESSION_ACTION_SETS_ATTACH_INFO};
+  attach_info.countActionSets = 1;
+  attach_info.actionSets = &action_set_;
+  Check(xrAttachSessionActionSets(session_, &attach_info),
+        "xrAttachSessionActionSets");
+
+  for (std::size_t index = 0; index < grip_spaces_.size(); ++index) {
+    XrActionSpaceCreateInfo space_info{XR_TYPE_ACTION_SPACE_CREATE_INFO};
+    space_info.action = grip_pose_action_;
+    space_info.subactionPath = hand_paths_[index];
+    space_info.poseInActionSpace = IdentityPose();
+    Check(xrCreateActionSpace(session_, &space_info, &grip_spaces_[index]),
+          "xrCreateActionSpace");
+  }
+}
+
+void OpenXrCapture::CreateSwapchains() {
+  std::uint32_t view_count = 0;
+  Check(xrEnumerateViewConfigurationViews(
+            instance_, system_id_, kViewConfiguration, 0, &view_count, nullptr),
+        "xrEnumerateViewConfigurationViews(count)");
+  if (view_count == 0 || view_count > 4) {
+    throw std::runtime_error("unexpected primary stereo view count");
+  }
+  view_configuration_.assign(
+      view_count, XrViewConfigurationView{XR_TYPE_VIEW_CONFIGURATION_VIEW});
+  Check(xrEnumerateViewConfigurationViews(
+            instance_,
+            system_id_,
+            kViewConfiguration,
+            view_count,
+            &view_count,
+            view_configuration_.data()),
+        "xrEnumerateViewConfigurationViews(values)");
+
+  std::uint32_t format_count = 0;
+  Check(xrEnumerateSwapchainFormats(session_, 0, &format_count, nullptr),
+        "xrEnumerateSwapchainFormats(count)");
+  std::vector<std::int64_t> formats(format_count);
+  Check(xrEnumerateSwapchainFormats(
+            session_, format_count, &format_count, formats.data()),
+        "xrEnumerateSwapchainFormats(values)");
+  constexpr std::array<std::int64_t, 2> preferred = {
+      GL_SRGB8_ALPHA8,
+      GL_RGBA8,
+  };
+  for (const auto candidate : preferred) {
+    if (std::find(formats.begin(), formats.end(), candidate) != formats.end()) {
+      color_format_ = candidate;
+      break;
+    }
+  }
+  if (color_format_ == 0) {
+    throw std::runtime_error("no supported RGBA OpenGL ES swapchain format");
+  }
+
+  swapchains_.reserve(view_count);
+  for (const auto& view : view_configuration_) {
+    XrSwapchainCreateInfo create_info{XR_TYPE_SWAPCHAIN_CREATE_INFO};
+    create_info.usageFlags = XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT |
+        XR_SWAPCHAIN_USAGE_SAMPLED_BIT;
+    create_info.format = color_format_;
+    // The capture renderer attaches a plain GL_TEXTURE_2D and does not create
+    // a multisample resolve target. Khronos hello_xr's GLES backend likewise
+    // advertises one supported sample for this path.
+    create_info.sampleCount = 1;
+    create_info.width = view.recommendedImageRectWidth;
+    create_info.height = view.recommendedImageRectHeight;
+    create_info.faceCount = 1;
+    create_info.arraySize = 1;
+    create_info.mipCount = 1;
+    Swapchain swapchain;
+    swapchain.width = static_cast<std::int32_t>(create_info.width);
+    swapchain.height = static_cast<std::int32_t>(create_info.height);
+    Check(
+        xrCreateSwapchain(session_, &create_info, &swapchain.handle),
+        "xrCreateSwapchain");
+    std::uint32_t image_count = 0;
+    Check(xrEnumerateSwapchainImages(
+              swapchain.handle, 0, &image_count, nullptr),
+          "xrEnumerateSwapchainImages(count)");
+    swapchain.images.assign(
+        image_count,
+        XrSwapchainImageOpenGLESKHR{XR_TYPE_SWAPCHAIN_IMAGE_OPENGL_ES_KHR});
+    Check(xrEnumerateSwapchainImages(
+              swapchain.handle,
+              image_count,
+              &image_count,
+              reinterpret_cast<XrSwapchainImageBaseHeader*>(swapchain.images.data())),
+          "xrEnumerateSwapchainImages(values)");
+    swapchains_.push_back(std::move(swapchain));
+  }
+}
+
+void OpenXrCapture::PollEvents() {
+  if (instance_ == XR_NULL_HANDLE) {
+    return;
+  }
+  XrEventDataBuffer event{XR_TYPE_EVENT_DATA_BUFFER};
+  for (;;) {
+    const XrResult result = xrPollEvent(instance_, &event);
+    if (result == XR_EVENT_UNAVAILABLE) {
+      break;
+    }
+    Check(result, "xrPollEvent");
+    if (event.type == XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED) {
+      const auto* changed =
+          reinterpret_cast<const XrEventDataSessionStateChanged*>(&event);
+      if (changed->session == session_) {
+        HandleSessionState(changed->state);
+      }
+    } else if (event.type == XR_TYPE_EVENT_DATA_INSTANCE_LOSS_PENDING) {
+      exit_requested_ = true;
+    } else if (event.type == XR_TYPE_EVENT_DATA_REFERENCE_SPACE_CHANGE_PENDING) {
+      const auto* changed =
+          reinterpret_cast<const XrEventDataReferenceSpaceChangePending*>(&event);
+      if (changed->session == session_) {
+        // A recenter changes the robot-space transform discontinuously. Make
+        // focused() false in this iteration so no post-reset pose is emitted,
+        // then let the Activity close RTC/WSS and require a new PC session.
+        session_state_ = XR_SESSION_STATE_UNKNOWN;
+        exit_requested_ = true;
+      }
+    }
+    event = XrEventDataBuffer{XR_TYPE_EVENT_DATA_BUFFER};
+  }
+}
+
+void OpenXrCapture::HandleSessionState(XrSessionState state) {
+  session_state_ = state;
+  if (state == XR_SESSION_STATE_READY && !session_running_) {
+    XrSessionBeginInfo begin_info{XR_TYPE_SESSION_BEGIN_INFO};
+    begin_info.primaryViewConfigurationType = kViewConfiguration;
+    Check(xrBeginSession(session_, &begin_info), "xrBeginSession");
+    session_running_ = true;
+  } else if (state == XR_SESSION_STATE_STOPPING && session_running_) {
+    session_running_ = false;
+    Check(xrEndSession(session_), "xrEndSession");
+  } else if (state == XR_SESSION_STATE_EXITING ||
+             state == XR_SESSION_STATE_LOSS_PENDING) {
+    exit_requested_ = true;
+  }
+}
+
+bool OpenXrCapture::RenderFrame(FrameSample* sample) {
+  if (!session_running_) {
+    return false;
+  }
+  XrFrameWaitInfo wait_info{XR_TYPE_FRAME_WAIT_INFO};
+  XrFrameState frame_state{XR_TYPE_FRAME_STATE};
+  Check(xrWaitFrame(session_, &wait_info, &frame_state), "xrWaitFrame");
+  XrFrameBeginInfo begin_info{XR_TYPE_FRAME_BEGIN_INFO};
+  Check(xrBeginFrame(session_, &begin_info), "xrBeginFrame");
+
+  std::vector<XrCompositionLayerProjectionView> projection_views;
+  if (frame_state.shouldRender == XR_TRUE) {
+    RenderProjection(frame_state.predictedDisplayTime, &projection_views);
+  }
+
+  const bool sample_ready = focused() && sample != nullptr;
+  if (sample_ready) {
+    SyncActions(frame_state.predictedDisplayTime, sample);
+  }
+
+  XrCompositionLayerProjection projection{XR_TYPE_COMPOSITION_LAYER_PROJECTION};
+  projection.space = floor_space_;
+  projection.viewCount = projection_views.size();
+  projection.views = projection_views.data();
+  const XrCompositionLayerBaseHeader* layer =
+      projection_views.empty()
+      ? nullptr
+      : reinterpret_cast<const XrCompositionLayerBaseHeader*>(&projection);
+  XrFrameEndInfo end_info{XR_TYPE_FRAME_END_INFO};
+  end_info.displayTime = frame_state.predictedDisplayTime;
+  end_info.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+  end_info.layerCount = layer == nullptr ? 0 : 1;
+  end_info.layers = layer == nullptr ? nullptr : &layer;
+  Check(xrEndFrame(session_, &end_info), "xrEndFrame");
+  return sample_ready;
+}
+
+void OpenXrCapture::SyncActions(XrTime predicted_display_time, FrameSample* sample) {
+  XrActiveActionSet active{action_set_, XR_NULL_PATH};
+  XrActionsSyncInfo sync_info{XR_TYPE_ACTIONS_SYNC_INFO};
+  sync_info.countActiveActionSets = 1;
+  sync_info.activeActionSets = &active;
+  Check(xrSyncActions(session_, &sync_info), "xrSyncActions");
+
+  sample->head = LocatePose(view_space_, predicted_display_time, true);
+  const auto fill_hand = [&](std::size_t index, PoseSample* pose, ControllerSample* input) {
+    const bool interaction_profile_allowed =
+        HasAllowedInteractionProfile(index);
+    XrActionStateGetInfo get_info{XR_TYPE_ACTION_STATE_GET_INFO};
+    get_info.subactionPath = hand_paths_[index];
+
+    get_info.action = grip_pose_action_;
+    XrActionStatePose pose_state{XR_TYPE_ACTION_STATE_POSE};
+    Check(xrGetActionStatePose(session_, &get_info, &pose_state),
+          "xrGetActionStatePose");
+    *pose = LocatePose(
+        grip_spaces_[index],
+        predicted_display_time,
+        interaction_profile_allowed && pose_state.isActive == XR_TRUE);
+
+    get_info.action = squeeze_action_;
+    XrActionStateFloat squeeze{XR_TYPE_ACTION_STATE_FLOAT};
+    Check(xrGetActionStateFloat(session_, &get_info, &squeeze),
+          "xrGetActionStateFloat");
+    get_info.action = thumbstick_action_;
+    XrActionStateVector2f thumbstick{XR_TYPE_ACTION_STATE_VECTOR2F};
+    Check(xrGetActionStateVector2f(session_, &get_info, &thumbstick),
+          "xrGetActionStateVector2f");
+
+    const double squeeze_value = interaction_profile_allowed &&
+            squeeze.isActive == XR_TRUE
+        ? std::clamp(static_cast<double>(squeeze.currentState), 0.0, 1.0)
+        : 0.0;
+    const double axis_x = interaction_profile_allowed &&
+            thumbstick.isActive == XR_TRUE
+        ? std::clamp(static_cast<double>(thumbstick.currentState.x), -1.0, 1.0)
+        : 0.0;
+    const double axis_y = interaction_profile_allowed &&
+            thumbstick.isActive == XR_TRUE
+        ? std::clamp(static_cast<double>(thumbstick.currentState.y), -1.0, 1.0)
+        : 0.0;
+    *input = ControllerSample{
+        .active = interaction_profile_allowed && pose->valid &&
+            squeeze.isActive == XR_TRUE &&
+            thumbstick.isActive == XR_TRUE,
+        .xr_standard = true,
+        .correct_handedness = interaction_profile_allowed,
+        .tracked_pointer = pose->valid,
+        .has_grip_space = pose->valid,
+        .squeeze_pressed = squeeze_value >= 0.75,
+        .axes = {0.0, 0.0, axis_x, axis_y},
+        .buttons = {0.0, squeeze_value},
+    };
+  };
+  fill_hand(0, &sample->left_controller, &sample->left_input);
+  fill_hand(1, &sample->right_controller, &sample->right_input);
+  sample->distinct_input_sources =
+      sample->left_input.correct_handedness &&
+      sample->right_input.correct_handedness;
+  sample->monotonic_ns = MonotonicNanoseconds();
+}
+
+bool OpenXrCapture::HasAllowedInteractionProfile(
+    std::size_t hand_index) const {
+  if (hand_index >= hand_paths_.size()) {
+    throw std::out_of_range("OpenXR hand index is out of range");
+  }
+  XrInteractionProfileState state{XR_TYPE_INTERACTION_PROFILE_STATE};
+  Check(xrGetCurrentInteractionProfile(
+            session_, hand_paths_[hand_index], &state),
+        "xrGetCurrentInteractionProfile");
+  if (state.interactionProfile == XR_NULL_PATH) {
+    return false;
+  }
+  return std::find(
+             allowed_interaction_profiles_.begin(),
+             allowed_interaction_profiles_.end(),
+             state.interactionProfile) != allowed_interaction_profiles_.end();
+}
+
+PoseSample OpenXrCapture::LocatePose(
+    XrSpace space,
+    XrTime predicted_display_time,
+    bool active) const {
+  if (!active || space == XR_NULL_HANDLE) {
+    return {};
+  }
+  XrSpaceLocation location{XR_TYPE_SPACE_LOCATION};
+  Check(xrLocateSpace(
+            space, floor_space_, predicted_display_time, &location),
+        "xrLocateSpace");
+  if (!FullyTracked(location.locationFlags)) {
+    return {};
+  }
+  return PoseSample{
+      .valid = true,
+      .emulated = false,
+      .position = {
+          location.pose.position.x,
+          location.pose.position.y,
+          location.pose.position.z,
+      },
+      .orientation = {
+          location.pose.orientation.x,
+          location.pose.orientation.y,
+          location.pose.orientation.z,
+          location.pose.orientation.w,
+      },
+  };
+}
+
+void OpenXrCapture::RenderProjection(
+    XrTime predicted_display_time,
+    std::vector<XrCompositionLayerProjectionView>* projection_views) {
+  std::vector<XrView> views(
+      view_configuration_.size(), XrView{XR_TYPE_VIEW});
+  XrViewLocateInfo locate_info{XR_TYPE_VIEW_LOCATE_INFO};
+  locate_info.viewConfigurationType = kViewConfiguration;
+  locate_info.displayTime = predicted_display_time;
+  locate_info.space = floor_space_;
+  XrViewState view_state{XR_TYPE_VIEW_STATE};
+  std::uint32_t view_count = 0;
+  Check(xrLocateViews(
+            session_,
+            &locate_info,
+            &view_state,
+            views.size(),
+            &view_count,
+            views.data()),
+        "xrLocateViews");
+  constexpr XrViewStateFlags required =
+      XR_VIEW_STATE_POSITION_VALID_BIT | XR_VIEW_STATE_ORIENTATION_VALID_BIT;
+  if ((view_state.viewStateFlags & required) != required ||
+      view_count != swapchains_.size()) {
+    return;
+  }
+
+  projection_views->assign(
+      view_count, XrCompositionLayerProjectionView{
+                      XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW});
+  for (std::size_t index = 0; index < swapchains_.size(); ++index) {
+    auto& swapchain = swapchains_[index];
+    std::uint32_t image_index = 0;
+    XrSwapchainImageAcquireInfo acquire_info{
+        XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
+    Check(xrAcquireSwapchainImage(
+              swapchain.handle, &acquire_info, &image_index),
+          "xrAcquireSwapchainImage");
+    XrSwapchainImageWaitInfo wait_info{XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
+    wait_info.timeout = XR_INFINITE_DURATION;
+    Check(xrWaitSwapchainImage(swapchain.handle, &wait_info),
+          "xrWaitSwapchainImage");
+
+    GLuint framebuffer = 0;
+    glGenFramebuffers(1, &framebuffer);
+    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+    glFramebufferTexture2D(
+        GL_FRAMEBUFFER,
+        GL_COLOR_ATTACHMENT0,
+        GL_TEXTURE_2D,
+        swapchain.images.at(image_index).image,
+        0);
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+      glDeleteFramebuffers(1, &framebuffer);
+      throw std::runtime_error("OpenXR swapchain framebuffer is incomplete");
+    }
+    glViewport(0, 0, swapchain.width, swapchain.height);
+    const float streaming = focused() ? 0.08F : 0.02F;
+    glClearColor(0.01F, streaming, 0.10F, 1.0F);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glDeleteFramebuffers(1, &framebuffer);
+
+    XrSwapchainImageReleaseInfo release_info{
+        XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+    Check(xrReleaseSwapchainImage(swapchain.handle, &release_info),
+          "xrReleaseSwapchainImage");
+    auto& projection_view = projection_views->at(index);
+    projection_view.pose = views[index].pose;
+    projection_view.fov = views[index].fov;
+    projection_view.subImage.swapchain = swapchain.handle;
+    projection_view.subImage.imageRect.offset = {0, 0};
+    projection_view.subImage.imageRect.extent = {
+        swapchain.width,
+        swapchain.height,
+    };
+    projection_view.subImage.imageArrayIndex = 0;
+  }
+}
+
+std::int64_t OpenXrCapture::MonotonicNanoseconds() const {
+  const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      std::chrono::steady_clock::now() - monotonic_origin_).count();
+  if (elapsed < 0 || elapsed >= kMaxSafeWireInteger) {
+    throw std::range_error("native monotonic clock exhausted wire range");
+  }
+  return elapsed + 1;
+}
+
+void OpenXrCapture::Check(XrResult result, const char* operation) const {
+  if (XR_SUCCEEDED(result)) {
+    return;
+  }
+  char result_name[XR_MAX_RESULT_STRING_SIZE] = {};
+  if (instance_ != XR_NULL_HANDLE) {
+    static_cast<void>(xrResultToString(instance_, result, result_name));
+  }
+  const std::string message = std::string(operation) + " failed: " +
+      (result_name[0] == '\0' ? std::to_string(result) : result_name);
+  throw std::runtime_error(message);
+}
+
+void OpenXrCapture::Destroy() noexcept {
+  const auto destroy_space = [](XrSpace* space) {
+    if (*space != XR_NULL_HANDLE) {
+      static_cast<void>(xrDestroySpace(*space));
+      *space = XR_NULL_HANDLE;
+    }
+  };
+  for (auto& space : grip_spaces_) {
+    destroy_space(&space);
+  }
+  destroy_space(&view_space_);
+  destroy_space(&floor_space_);
+  for (auto& swapchain : swapchains_) {
+    if (swapchain.handle != XR_NULL_HANDLE) {
+      static_cast<void>(xrDestroySwapchain(swapchain.handle));
+      swapchain.handle = XR_NULL_HANDLE;
+    }
+  }
+  swapchains_.clear();
+  if (action_set_ != XR_NULL_HANDLE) {
+    static_cast<void>(xrDestroyActionSet(action_set_));
+    action_set_ = XR_NULL_HANDLE;
+  }
+  if (session_ != XR_NULL_HANDLE) {
+    if (session_running_) {
+      static_cast<void>(xrEndSession(session_));
+    }
+    static_cast<void>(xrDestroySession(session_));
+    session_ = XR_NULL_HANDLE;
+    session_running_ = false;
+  }
+  if (instance_ != XR_NULL_HANDLE) {
+    static_cast<void>(xrDestroyInstance(instance_));
+    instance_ = XR_NULL_HANDLE;
+  }
+  if (egl_display_ != EGL_NO_DISPLAY) {
+    static_cast<void>(eglMakeCurrent(
+        egl_display_, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT));
+    if (egl_surface_ != EGL_NO_SURFACE) {
+      static_cast<void>(eglDestroySurface(egl_display_, egl_surface_));
+      egl_surface_ = EGL_NO_SURFACE;
+    }
+    if (egl_context_ != EGL_NO_CONTEXT) {
+      static_cast<void>(eglDestroyContext(egl_display_, egl_context_));
+      egl_context_ = EGL_NO_CONTEXT;
+    }
+    static_cast<void>(eglTerminate(egl_display_));
+    egl_display_ = EGL_NO_DISPLAY;
+  }
+}
+
+}  // namespace motus::openxr_capture

--- a/generic/openxr_capture_native/app/src/main/cpp/openxr_capture.hpp
+++ b/generic/openxr_capture_native/app/src/main/cpp/openxr_capture.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <EGL/egl.h>
+#include <jni.h>
+#include <openxr/openxr_platform.h>
+
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "motus/openxr_capture/frame_v1.hpp"
+#include "runtime_profile.hpp"
+
+struct android_app;
+
+namespace motus::openxr_capture {
+
+class OpenXrCapture final {
+ public:
+  OpenXrCapture() = default;
+  ~OpenXrCapture();
+
+  OpenXrCapture(const OpenXrCapture&) = delete;
+  OpenXrCapture& operator=(const OpenXrCapture&) = delete;
+
+  void Initialize(android_app* app);
+  void PollEvents();
+
+  // Drives xrWaitFrame/xrBeginFrame/xrEndFrame and returns a controller sample
+  // only while the runtime grants FOCUSED input ownership.
+  bool RenderFrame(FrameSample* sample);
+
+  [[nodiscard]] bool session_running() const { return session_running_; }
+  [[nodiscard]] bool focused() const { return session_state_ == XR_SESSION_STATE_FOCUSED; }
+  [[nodiscard]] bool exit_requested() const { return exit_requested_; }
+
+ private:
+  struct Swapchain {
+    XrSwapchain handle{XR_NULL_HANDLE};
+    std::int32_t width{0};
+    std::int32_t height{0};
+    std::vector<XrSwapchainImageOpenGLESKHR> images;
+  };
+
+  void InitializeLoader(android_app* app);
+  void CreateInstance(android_app* app);
+  void CreateEglContext();
+  void CreateSession();
+  void CreateSpaces();
+  void CreateActions();
+  void CreateSwapchains();
+  void Destroy() noexcept;
+
+  void HandleSessionState(XrSessionState state);
+  void SyncActions(XrTime predicted_display_time, FrameSample* sample);
+  [[nodiscard]] bool HasAllowedInteractionProfile(std::size_t hand_index) const;
+  PoseSample LocatePose(XrSpace space, XrTime predicted_display_time, bool active) const;
+  void RenderProjection(
+      XrTime predicted_display_time,
+      std::vector<XrCompositionLayerProjectionView>* projection_views);
+  std::int64_t MonotonicNanoseconds() const;
+
+  void Check(XrResult result, const char* operation) const;
+
+  XrInstance instance_{XR_NULL_HANDLE};
+  XrSystemId system_id_{XR_NULL_SYSTEM_ID};
+  XrSession session_{XR_NULL_HANDLE};
+  XrSessionState session_state_{XR_SESSION_STATE_UNKNOWN};
+  bool session_running_{false};
+  bool exit_requested_{false};
+
+  EGLDisplay egl_display_{EGL_NO_DISPLAY};
+  EGLConfig egl_config_{nullptr};
+  EGLContext egl_context_{EGL_NO_CONTEXT};
+  EGLSurface egl_surface_{EGL_NO_SURFACE};
+
+  XrSpace floor_space_{XR_NULL_HANDLE};
+  XrSpace view_space_{XR_NULL_HANDLE};
+  XrActionSet action_set_{XR_NULL_HANDLE};
+  XrAction grip_pose_action_{XR_NULL_HANDLE};
+  XrAction squeeze_action_{XR_NULL_HANDLE};
+  XrAction thumbstick_action_{XR_NULL_HANDLE};
+  std::array<XrPath, 2> hand_paths_{};
+  std::array<XrSpace, 2> grip_spaces_{XR_NULL_HANDLE, XR_NULL_HANDLE};
+  RuntimeSelection runtime_selection_{};
+  std::vector<XrPath> allowed_interaction_profiles_;
+
+  std::vector<XrViewConfigurationView> view_configuration_;
+  std::vector<Swapchain> swapchains_;
+  std::int64_t color_format_{0};
+  std::chrono::steady_clock::time_point monotonic_origin_{};
+};
+
+}  // namespace motus::openxr_capture

--- a/generic/openxr_capture_native/app/src/main/cpp/runtime_profile.cpp
+++ b/generic/openxr_capture_native/app/src/main/cpp/runtime_profile.cpp
@@ -1,0 +1,136 @@
+#include "runtime_profile.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace motus::openxr_capture {
+namespace {
+
+constexpr std::string_view kLocalFloorExtension = "XR_EXT_local_floor";
+constexpr std::string_view kPico4ControllerExtension =
+    "XR_BD_controller_interaction";
+constexpr std::string_view kPicoUltraControllerExtension =
+    "XR_BD_ultra_controller_interaction";
+constexpr std::string_view kOculusTouchProfile =
+    "/interaction_profiles/oculus/touch_controller";
+constexpr std::string_view kPico4ControllerProfile =
+    "/interaction_profiles/bytedance/pico4_controller";
+constexpr std::string_view kPicoUltraControllerProfile =
+    "/interaction_profiles/bytedance/pico_ultra_controller_bd";
+
+bool Contains(
+    const std::vector<std::string_view>& values,
+    std::string_view value) {
+  return std::find(values.begin(), values.end(), value) != values.end();
+}
+
+}  // namespace
+
+const RuntimeProfile& MetaRuntimeProfile() {
+  static const RuntimeProfile profile{
+      .target = HeadsetTarget::kMeta,
+      .application_name = "PhanthyMotus Meta Capture",
+      .interaction_profiles = {
+          {
+              .extension_name = {},
+              .interaction_profile_path = kOculusTouchProfile,
+          },
+      },
+      .require_any_interaction_extension = false,
+  };
+  return profile;
+}
+
+const RuntimeProfile& PicoRuntimeProfile() {
+  static const RuntimeProfile profile{
+      .target = HeadsetTarget::kPico,
+      .application_name = "PhanthyMotus PICO Capture",
+      .interaction_profiles = {
+          {
+              .extension_name = kPico4ControllerExtension,
+              .interaction_profile_path = kPico4ControllerProfile,
+          },
+          {
+              .extension_name = kPicoUltraControllerExtension,
+              .interaction_profile_path = kPicoUltraControllerProfile,
+          },
+      },
+      .require_any_interaction_extension = true,
+  };
+  return profile;
+}
+
+const RuntimeProfile& CompiledRuntimeProfile() {
+#if defined(MOTUS_CAPTURE_HEADSET_META) && defined(MOTUS_CAPTURE_HEADSET_PICO)
+#error "Only one MOTUS capture headset target may be compiled"
+#elif defined(MOTUS_CAPTURE_HEADSET_META)
+  return MetaRuntimeProfile();
+#elif defined(MOTUS_CAPTURE_HEADSET_PICO)
+  return PicoRuntimeProfile();
+#else
+#error "MOTUS_CAPTURE_HEADSET_META or MOTUS_CAPTURE_HEADSET_PICO is required"
+#endif
+}
+
+RuntimeSelection SelectRuntime(
+    const RuntimeProfile& profile,
+    const std::vector<std::string_view>& available_extensions) {
+  RuntimeSelection selection{
+      .optional_extensions = {},
+      .interaction_profile_paths = {},
+      .local_floor_extension_enabled =
+          Contains(available_extensions, kLocalFloorExtension),
+  };
+  if (selection.local_floor_extension_enabled) {
+    selection.optional_extensions.push_back(kLocalFloorExtension);
+  }
+
+  bool interaction_extension_enabled = false;
+  for (const auto& candidate : profile.interaction_profiles) {
+    if (candidate.extension_name.empty()) {
+      selection.interaction_profile_paths.push_back(
+          candidate.interaction_profile_path);
+      continue;
+    }
+    if (!Contains(available_extensions, candidate.extension_name)) {
+      continue;
+    }
+    selection.optional_extensions.push_back(candidate.extension_name);
+    selection.interaction_profile_paths.push_back(
+        candidate.interaction_profile_path);
+    interaction_extension_enabled = true;
+  }
+
+  if (profile.require_any_interaction_extension &&
+      !interaction_extension_enabled) {
+    throw std::runtime_error(
+        "no supported PICO controller interaction extension is available");
+  }
+  if (selection.interaction_profile_paths.empty()) {
+    throw std::runtime_error("no allowed controller interaction profile selected");
+  }
+  return selection;
+}
+
+FloorReferenceSpace SelectFloorReferenceSpace(
+    bool local_floor_extension_enabled,
+    bool local_floor_space_available,
+    bool stage_space_available) {
+  if (local_floor_extension_enabled && local_floor_space_available) {
+    return FloorReferenceSpace::kLocalFloor;
+  }
+  if (stage_space_available) {
+    return FloorReferenceSpace::kStage;
+  }
+  throw std::runtime_error(
+      "no floor-relative OpenXR reference space is available");
+}
+
+bool IsInteractionProfileAllowed(
+    const RuntimeSelection& selection,
+    std::string_view interaction_profile_path) {
+  return Contains(
+      selection.interaction_profile_paths, interaction_profile_path);
+}
+
+}  // namespace motus::openxr_capture

--- a/generic/openxr_capture_native/app/src/main/cpp/runtime_profile.hpp
+++ b/generic/openxr_capture_native/app/src/main/cpp/runtime_profile.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <string_view>
+#include <vector>
+
+namespace motus::openxr_capture {
+
+enum class HeadsetTarget {
+  kMeta,
+  kPico,
+};
+
+struct InteractionProfileRequirement {
+  // Empty for interaction profiles which are part of OpenXR core.
+  std::string_view extension_name;
+  std::string_view interaction_profile_path;
+};
+
+struct RuntimeProfile {
+  HeadsetTarget target;
+  std::string_view application_name;
+  std::vector<InteractionProfileRequirement> interaction_profiles;
+  bool require_any_interaction_extension;
+};
+
+struct RuntimeSelection {
+  // Optional extensions are enabled only when the runtime enumerates them.
+  std::vector<std::string_view> optional_extensions;
+  std::vector<std::string_view> interaction_profile_paths;
+  bool local_floor_extension_enabled;
+};
+
+enum class FloorReferenceSpace {
+  kLocalFloor,
+  kStage,
+};
+
+[[nodiscard]] const RuntimeProfile& MetaRuntimeProfile();
+[[nodiscard]] const RuntimeProfile& PicoRuntimeProfile();
+[[nodiscard]] const RuntimeProfile& CompiledRuntimeProfile();
+
+// Selects the optional extensions and interaction profiles which this build may
+// use. PICO builds fail closed unless at least one supported PICO controller
+// extension is present. Meta builds accept only the core Oculus Touch profile.
+[[nodiscard]] RuntimeSelection SelectRuntime(
+    const RuntimeProfile& profile,
+    const std::vector<std::string_view>& available_extensions);
+
+// Robot poses must always be expressed in a floor-relative reference space.
+// LOCAL is deliberately not an accepted fallback because its origin is tied to
+// the headset start/recenter pose rather than the physical floor.
+[[nodiscard]] FloorReferenceSpace SelectFloorReferenceSpace(
+    bool local_floor_extension_enabled,
+    bool local_floor_space_available,
+    bool stage_space_available);
+
+[[nodiscard]] bool IsInteractionProfileAllowed(
+    const RuntimeSelection& selection,
+    std::string_view interaction_profile_path);
+
+}  // namespace motus::openxr_capture

--- a/generic/openxr_capture_native/app/src/main/res/values/strings.xml
+++ b/generic/openxr_capture_native/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">PhanthyMotus OpenXR Capture</string>
+</resources>

--- a/generic/openxr_capture_native/app/src/meta/res/values/strings.xml
+++ b/generic/openxr_capture_native/app/src/meta/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">PhanthyMotus Meta Capture</string>
+</resources>

--- a/generic/openxr_capture_native/app/src/pico/AndroidManifest.xml
+++ b/generic/openxr_capture_native/app/src/pico/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <meta-data
+            android:name="pvr.app.type"
+            android:value="vr" />
+    </application>
+</manifest>

--- a/generic/openxr_capture_native/app/src/pico/res/values/strings.xml
+++ b/generic/openxr_capture_native/app/src/pico/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">PhanthyMotus PICO Capture</string>
+</resources>

--- a/generic/openxr_capture_native/build.gradle.kts
+++ b/generic/openxr_capture_native/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("com.android.application") version "8.7.3" apply false
+}

--- a/generic/openxr_capture_native/gradle.properties
+++ b/generic/openxr_capture_native/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
+android.useAndroidX=false
+android.nonTransitiveRClass=true

--- a/generic/openxr_capture_native/include/motus/openxr_capture/capture_session.hpp
+++ b/generic/openxr_capture_native/include/motus/openxr_capture/capture_session.hpp
@@ -1,0 +1,178 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "motus/openxr_capture/frame_v1.hpp"
+
+namespace motus::openxr_capture {
+
+inline constexpr char kCaptureProtocol[] = "motus.teleop.capture.v1";
+inline constexpr char kFrameProtocol[] = "motus.teleop.rtc-frame.v1";
+inline constexpr char kNativeClientKind[] = "native_openxr";
+
+enum class CaptureLinkState {
+  kOffline,
+  kAuthenticating,
+  kStandby,
+  kNegotiating,
+  kStreaming,
+  kFaulted,
+};
+
+enum class PresenceState {
+  kBrowserReady,
+  kError,
+  kRtcConnecting,
+  kStreaming,
+  kXrEnded,
+  kXrStandby,
+};
+
+enum class CaptureActionKind {
+  kSendPairAuthentication,
+  kSendCredentialAuthentication,
+  kPersistCredential,
+  kSendPresence,
+  kCreateRtcOffer,
+  kSendSignalingOffer,
+  kApplyRtcAnswer,
+  kCloseRtc,
+  kScheduleReconnect,
+  kReportFault,
+};
+
+struct CaptureIdentity {
+  std::string capture_id;
+  std::string capture_credential;
+};
+
+struct PairingBootstrap {
+  std::string pairing_id;
+  std::string pairing_code;
+};
+
+struct CaptureAssignmentV1 {
+  std::string id;
+  std::int64_t generation{0};
+  std::string session_id;
+  FrameMode mode{FrameMode::kShadow};
+  std::string profile_id;
+  std::string capability_digest;
+  FrameConfiguration frame_configuration;
+};
+
+struct CaptureAction {
+  CaptureActionKind kind{CaptureActionKind::kReportFault};
+  std::int64_t connection_epoch{0};
+  std::optional<PresenceState> presence;
+  std::string assignment_id;
+  std::string value;
+};
+
+struct CaptureSessionState {
+  CaptureLinkState link{CaptureLinkState::kOffline};
+  std::int64_t connection_epoch{0};
+  std::optional<CaptureIdentity> identity;
+  std::optional<PairingBootstrap> pairing;
+  std::optional<CaptureAssignmentV1> assignment;
+  std::int64_t highest_assignment_generation{0};
+  bool authenticated{false};
+  bool xr_focused{false};
+  bool control_open{false};
+  bool pose_open{false};
+  bool offer_sent{false};
+  bool answer_applied{false};
+  std::string frame_session_id;
+  FrameState frame_state;
+};
+
+struct CaptureTransition {
+  CaptureSessionState state;
+  std::vector<CaptureAction> actions;
+};
+
+// Authentication and protocol incompatibilities cannot recover by retrying the
+// same enrollment. Keep this policy in the dependency-free session contract so
+// both the Android transport and host tests consume one exact classification.
+bool CaptureErrorStopsReconnect(std::string_view code);
+
+// Start one WSS connection. Authentication is always sent in-band and the
+// returned epoch must be supplied to all callbacks so stale sockets are inert.
+CaptureTransition BeginCaptureConnection(const CaptureSessionState& previous);
+
+// Apply the exact paired/connected server acknowledgement. A freshly paired
+// credential is persisted before it can be used for a later reconnect.
+CaptureTransition CaptureAuthenticated(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const CaptureIdentity& identity,
+    bool persist_credential);
+
+// The native Activity calls this from the OpenXR session state machine. Merely
+// becoming focused never creates robot authority; it only advertises standby.
+CaptureTransition CaptureXrFocused(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch);
+
+// A PC-authorized assignment is the only event that may start RTC signaling.
+// In particular there is no native action for starting or releasing the
+// Driver-owned session.
+CaptureTransition CaptureAssigned(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const CaptureAssignmentV1& assignment);
+
+CaptureTransition CaptureOfferCreated(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& offer_sdp);
+
+CaptureTransition CaptureAnswerReceived(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& answer_sdp);
+
+CaptureTransition CaptureChannelState(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    bool control_open,
+    bool pose_open);
+
+// Presence timers use this to renew only capture presence. This is not and
+// must never become the Driver's robot-control lease heartbeat.
+CaptureTransition CapturePresenceTick(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch);
+
+// These loss paths close the headset-to-Driver peer locally before reconnecting
+// or notifying the Driver. The frame deadman is relatched immediately.
+CaptureTransition CaptureTransportLost(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& reason);
+
+CaptureTransition CaptureRtcFailed(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& reason);
+
+CaptureTransition CaptureXrEnded(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& reason);
+
+CaptureTransition CaptureAssignmentRevoked(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& reason);
+
+}  // namespace motus::openxr_capture

--- a/generic/openxr_capture_native/include/motus/openxr_capture/capture_wire.hpp
+++ b/generic/openxr_capture_native/include/motus/openxr_capture/capture_wire.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "motus/openxr_capture/capture_session.hpp"
+
+namespace motus::openxr_capture {
+
+inline constexpr std::size_t kMaxCaptureWireBytes = 128 * 1024;
+inline constexpr std::size_t kMaxSignalingSdpBytes = 120 * 1024;
+inline constexpr std::size_t kMaxRtcMessageBytes = 64 * 1024;
+
+struct CaptureAuthenticatedMessage {
+  CaptureIdentity identity;
+  bool fresh_credential{false};
+  std::int64_t presence_interval_ms{0};
+  std::int64_t presence_timeout_ms{0};
+};
+
+struct CaptureAssignmentMessage {
+  CaptureAssignmentV1 assignment;
+};
+
+struct CaptureSignalingAnswerMessage {
+  std::string assignment_id;
+  std::string answer_sdp;
+};
+
+struct CaptureAssignmentRevokedMessage {
+  std::string assignment_id;
+  std::string reason;
+};
+
+struct CaptureTerminalMessage {
+  std::string type;
+  std::string reason;
+};
+
+struct CapturePresenceAcknowledgedMessage {
+  PresenceState state{PresenceState::kXrStandby};
+};
+
+struct CaptureErrorMessage {
+  std::string code;
+};
+
+using CaptureServerMessage = std::variant<
+    CaptureAuthenticatedMessage,
+    CaptureAssignmentMessage,
+    CaptureSignalingAnswerMessage,
+    CaptureAssignmentRevokedMessage,
+    CaptureTerminalMessage,
+    CapturePresenceAcknowledgedMessage,
+    CaptureErrorMessage>;
+
+std::string SerializePairAuthentication(
+    const PairingBootstrap& pairing,
+    const std::string& app_version);
+
+std::string SerializeCredentialAuthentication(
+    const CaptureIdentity& identity,
+    const std::string& app_version);
+
+std::string SerializeCapturePresence(
+    PresenceState state,
+    const std::string& assignment_id);
+
+std::string SerializeCaptureSignalingOffer(
+    const std::string& assignment_id,
+    const std::string& offer_sdp);
+
+// existing_identity is required for the credential reconnect acknowledgement,
+// because the Driver deliberately does not echo the long-lived credential.
+CaptureServerMessage ParseCaptureServerMessage(
+    const std::string& payload,
+    const std::optional<CaptureIdentity>& existing_identity = std::nullopt);
+
+}  // namespace motus::openxr_capture

--- a/generic/openxr_capture_native/include/motus/openxr_capture/enrollment.hpp
+++ b/generic/openxr_capture_native/include/motus/openxr_capture/enrollment.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "motus/openxr_capture/capture_session.hpp"
+
+namespace motus::openxr_capture {
+
+struct StoredCaptureEnrollment {
+  std::string capture_id;
+  std::string capture_credential;
+  std::string websocket_url;
+  std::string ca_certificate_pem;
+};
+
+struct CaptureLaunchBootstrap {
+  std::string pairing_id;
+  std::string pairing_code;
+  std::string websocket_url;
+  std::string ca_certificate_pem;
+  bool transport_override_present{false};
+};
+
+struct CaptureEnrollmentSelection {
+  std::optional<CaptureIdentity> identity;
+  std::optional<PairingBootstrap> pairing;
+  std::string websocket_url;
+  std::string ca_certificate_pem;
+};
+
+// An exported NativeActivity may receive Intents from any local application.
+// Existing bearer credentials are therefore inseparable from the WSS origin
+// and trust material stored in the same successful pairing transaction.
+CaptureEnrollmentSelection SelectCaptureEnrollment(
+    const StoredCaptureEnrollment& stored,
+    const CaptureLaunchBootstrap& launch);
+
+}  // namespace motus::openxr_capture

--- a/generic/openxr_capture_native/include/motus/openxr_capture/frame_v1.hpp
+++ b/generic/openxr_capture_native/include/motus/openxr_capture/frame_v1.hpp
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace motus::openxr_capture {
+
+inline constexpr std::int64_t kMaxSafeWireInteger = 9'007'199'254'740'991LL;
+
+enum class FrameMode {
+  kShadow,
+  kLive,
+};
+
+struct PoseSample {
+  bool valid{false};
+  bool emulated{false};
+  std::array<double, 3> position{};
+  std::array<double, 4> orientation{0.0, 0.0, 0.0, 1.0};
+};
+
+struct ControllerSample {
+  bool active{false};
+  bool xr_standard{false};
+  bool correct_handedness{false};
+  bool tracked_pointer{false};
+  bool has_grip_space{false};
+  bool squeeze_pressed{false};
+  std::vector<double> axes;
+  std::vector<double> buttons;
+};
+
+struct AxisBinding {
+  enum class Hand {
+    kLeft,
+    kRight,
+  };
+
+  Hand hand{Hand::kLeft};
+  std::size_t axis{0};
+  double scale{0.0};
+  double deadzone{0.0};
+  int direction{1};
+};
+
+struct BaseTwistBinding {
+  AxisBinding linear_x;
+  AxisBinding linear_y;
+  AxisBinding angular_z;
+};
+
+struct FrameConfiguration {
+  FrameMode mode{FrameMode::kShadow};
+  std::optional<BaseTwistBinding> base_twist;
+};
+
+struct FrameSample {
+  PoseSample head;
+  PoseSample left_controller;
+  PoseSample right_controller;
+  ControllerSample left_input;
+  ControllerSample right_input;
+  bool distinct_input_sources{true};
+  std::optional<std::int64_t> monotonic_ns;
+};
+
+struct FrameState {
+  std::int64_t next_sequence{0};
+  std::int64_t clutch_sequence{0};
+  bool deadman_active{false};
+  bool rearm_required{true};
+  std::int64_t last_monotonic_ns{0};
+};
+
+struct WirePose {
+  std::array<double, 3> position{};
+  std::array<double, 4> orientation{};
+};
+
+struct WireController {
+  std::vector<double> axes;
+  std::vector<double> buttons;
+};
+
+struct TrackingState {
+  bool head{false};
+  bool left_controller{false};
+  bool right_controller{false};
+};
+
+struct BaseTwist {
+  std::array<double, 3> linear{};
+  std::array<double, 3> angular{};
+};
+
+struct FrameV1 {
+  std::int64_t sequence{0};
+  std::int64_t client_monotonic_ns{0};
+  FrameMode mode{FrameMode::kShadow};
+  bool deadman{false};
+  std::int64_t clutch_sequence{0};
+  TrackingState tracking;
+  std::optional<WirePose> head;
+  std::optional<WirePose> left_controller;
+  std::optional<WirePose> right_controller;
+  WireController left_input;
+  WireController right_input;
+  std::optional<BaseTwist> base_twist;
+};
+
+struct FrameResult {
+  FrameV1 frame;
+  FrameState state;
+};
+
+// Validate and reduce one native OpenXR sample into the public
+// motus.teleop.rtc-frame.v1 contract. Session authority is deliberately absent.
+FrameResult BuildFrameV1(
+    const FrameState& previous,
+    const FrameSample& sample,
+    const FrameConfiguration& configuration);
+
+// Preserve sequence/clutch watermarks across RTC reconnects while forcing a
+// physical release-neutral-regrip before motion can resume.
+FrameState MarkDeadmanReleased(const FrameState& previous);
+
+// Compact JSON suitable for the unordered teleop-pose DataChannel.
+std::string SerializeFrameV1(const FrameV1& frame);
+
+}  // namespace motus::openxr_capture

--- a/generic/openxr_capture_native/scripts/build_android.sh
+++ b/generic/openxr_capture_native/scripts/build_android.sh
@@ -1,0 +1,132 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: build_android.sh [--platform meta|pico|all]
+
+Builds both Android OpenXR APKs by default. Select one platform to shorten an
+incremental build.
+EOF
+}
+
+platform=all
+platform_seen=false
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --platform)
+      if [ "$platform_seen" = true ] || [ "$#" -lt 2 ]; then
+        usage
+        exit 2
+      fi
+      platform=$2
+      platform_seen=true
+      shift 2
+      ;;
+    --platform=*)
+      if [ "$platform_seen" = true ]; then
+        usage
+        exit 2
+      fi
+      platform=${1#--platform=}
+      platform_seen=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+case "$platform" in
+  meta|pico|all) ;;
+  *)
+    echo "Unsupported platform: $platform (expected meta, pico, or all)" >&2
+    exit 2
+    ;;
+esac
+
+project_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+android_sdk_root=${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}
+if [ -z "$android_sdk_root" ]; then
+  echo "ANDROID_SDK_ROOT is required" >&2
+  exit 2
+fi
+if [ -z "${JAVA_HOME:-}" ] || [ ! -x "$JAVA_HOME/bin/java" ]; then
+  echo "JAVA_HOME must point to JDK 17" >&2
+  exit 2
+fi
+
+for required in \
+  "$android_sdk_root/platforms/android-35/android.jar" \
+  "$android_sdk_root/build-tools/35.0.1/aapt2" \
+  "$android_sdk_root/ndk/27.0.12077973/build/cmake/android.toolchain.cmake" \
+  "$android_sdk_root/cmake/3.22.1/bin/cmake"
+do
+  if [ ! -e "$required" ]; then
+    echo "Android build dependency missing: $required" >&2
+    exit 2
+  fi
+done
+
+gradle_version=8.9
+gradle_sha256=d725d707bfabd4dfdc958c624003b3c80accc03f7037b5122c4b1d0ef15cecab
+tool_cache=${MOTUS_ANDROID_TOOL_CACHE:-${TMPDIR:-/tmp}/motus-android-tools}
+archive="$tool_cache/gradle-$gradle_version-bin.zip"
+
+# The reusable cache is only an untrusted byte source.  Copy or download the
+# archive into a private build-scoped directory, then checksum and extract that
+# same private file.  A concurrent cache replacement can therefore only cause
+# a checksum failure; it can never change the program we execute after verify.
+verified_gradle_root=$(mktemp -d "${TMPDIR:-/tmp}/motus-gradle-$gradle_version.verified.XXXXXX")
+chmod 700 "$verified_gradle_root"
+trap 'rm -rf "$verified_gradle_root"' EXIT HUP INT TERM
+verified_archive="$verified_gradle_root/gradle-$gradle_version-bin.zip"
+
+if [ -f "$archive" ]; then
+  cp "$archive" "$verified_archive"
+else
+  curl --fail --location --silent --show-error \
+    "https://services.gradle.org/distributions/gradle-$gradle_version-bin.zip" \
+    --output "$verified_archive"
+fi
+actual=$(shasum -a 256 "$verified_archive" | awk '{print $1}')
+if [ "$actual" != "$gradle_sha256" ]; then
+  echo "Gradle checksum mismatch: $actual" >&2
+  exit 3
+fi
+
+unzip -q "$verified_archive" -d "$verified_gradle_root"
+verified_gradle="$verified_gradle_root/gradle-$gradle_version/bin/gradle"
+if [ ! -x "$verified_gradle" ]; then
+  echo "Verified Gradle archive did not contain the expected executable" >&2
+  exit 3
+fi
+
+case "$platform" in
+  meta)
+    "$verified_gradle" \
+      --no-daemon \
+      --project-dir "$project_dir" \
+      :app:assembleMetaDebug
+    ;;
+  pico)
+    "$verified_gradle" \
+      --no-daemon \
+      --project-dir "$project_dir" \
+      :app:assemblePicoDebug
+    ;;
+  all)
+    "$verified_gradle" \
+      --no-daemon \
+      --project-dir "$project_dir" \
+      :app:assembleMetaDebug \
+      :app:assemblePicoDebug
+    ;;
+esac

--- a/generic/openxr_capture_native/scripts/launch_capture.sh
+++ b/generic/openxr_capture_native/scripts/launch_capture.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: launch_capture.sh --platform meta|pico [--resume]
+
+Set ADB_SERIAL when more than one Android device is connected. First pairing
+also requires DRIVER_CAPTURE_WSS_URL, PAIRING_ID, and CA_CERT_BASE64 or
+CA_CERT_FILE.
+EOF
+}
+
+platform=
+resume=false
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --platform)
+      if [ -n "$platform" ] || [ "$#" -lt 2 ]; then
+        usage
+        exit 2
+      fi
+      platform=$2
+      shift 2
+      ;;
+    --platform=*)
+      if [ -n "$platform" ]; then
+        usage
+        exit 2
+      fi
+      platform=${1#--platform=}
+      shift
+      ;;
+    --resume)
+      if [ "$resume" = true ]; then
+        usage
+        exit 2
+      fi
+      resume=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+case "$platform" in
+  meta)
+    package_activity=com.phanthymotus.questcapture/android.app.NativeActivity
+    ;;
+  pico)
+    package_activity=com.phanthymotus.picocapture/android.app.NativeActivity
+    ;;
+  '')
+    echo "--platform meta|pico is required" >&2
+    usage
+    exit 2
+    ;;
+  *)
+    echo "Unsupported platform: $platform (expected meta or pico)" >&2
+    exit 2
+    ;;
+esac
+
+adb_bin=${ADB:-}
+if [ -z "$adb_bin" ]; then
+  adb_bin=$(command -v adb || true)
+elif [ "${adb_bin#*/}" = "$adb_bin" ]; then
+  adb_bin=$(command -v "$adb_bin" || true)
+fi
+if [ -z "$adb_bin" ] && [ -n "${ANDROID_SDK_ROOT:-}" ]; then
+  adb_bin="$ANDROID_SDK_ROOT/platform-tools/adb"
+fi
+if [ -z "$adb_bin" ] || [ ! -x "$adb_bin" ]; then
+  echo "adb is required; set ADB or ANDROID_SDK_ROOT" >&2
+  exit 2
+fi
+
+set -- "$adb_bin"
+if [ -n "${ADB_SERIAL:-}" ]; then
+  set -- "$@" -s "$ADB_SERIAL"
+fi
+
+if [ "$resume" = true ]; then
+  exec "$@" shell am start -S -n "$package_activity"
+fi
+
+if [ -z "${DRIVER_CAPTURE_WSS_URL:-}" ] || [ -z "${PAIRING_ID:-}" ] || \
+   { [ -z "${CA_CERT_BASE64:-}" ] && [ -z "${CA_CERT_FILE:-}" ]; }; then
+  echo "DRIVER_CAPTURE_WSS_URL, PAIRING_ID and CA_CERT_BASE64 (or CA_CERT_FILE) are required for first pairing" >&2
+  exit 2
+fi
+if [ -n "${CA_CERT_FILE:-}" ] && [ ! -f "$CA_CERT_FILE" ]; then
+  echo "CA_CERT_FILE must be a readable PEM file" >&2
+  exit 2
+fi
+
+if [ -z "${PAIRING_CODE:-}" ]; then
+  if [ ! -t 0 ]; then
+    echo "PAIRING_CODE is required when stdin is not a terminal" >&2
+    exit 2
+  fi
+  printf "One-time pairing code: " >&2
+  restore_echo() {
+    stty echo 2>/dev/null || true
+  }
+  trap restore_echo EXIT HUP INT TERM
+  stty -echo
+  IFS= read -r PAIRING_CODE
+  stty echo
+  trap - EXIT HUP INT TERM
+  printf "\n" >&2
+fi
+if [ -n "${CA_CERT_BASE64:-}" ]; then
+  ca_base64=$CA_CERT_BASE64
+else
+  ca_base64=$(base64 < "$CA_CERT_FILE" | tr -d '\r\n')
+fi
+case "$ca_base64" in
+  ''|*[!A-Za-z0-9+/=]*)
+    echo "CA certificate base64 is invalid" >&2
+    exit 2
+    ;;
+esac
+# Android accepts at most 32 KiB of decoded PEM. Standard base64 for exactly
+# 32,768 bytes is 43,692 characters including padding.
+max_ca_base64_chars=43692
+case "$ca_base64" in
+  *==)
+    ca_base64_body=${ca_base64%==}
+    ca_base64_padding=2
+    ;;
+  *=)
+    ca_base64_body=${ca_base64%=}
+    ca_base64_padding=1
+    ;;
+  *)
+    ca_base64_body=$ca_base64
+    ca_base64_padding=0
+    ;;
+esac
+case "$ca_base64_body" in
+  *=*)
+    echo "CA certificate base64 is invalid" >&2
+    exit 2
+    ;;
+esac
+ca_pem_bytes=$((${#ca_base64} / 4 * 3 - ca_base64_padding))
+if [ $((${#ca_base64} % 4)) -ne 0 ] || \
+   [ ${#ca_base64} -gt "$max_ca_base64_chars" ] || \
+   [ "$ca_pem_bytes" -gt 32768 ]; then
+  echo "CA certificate base64 has an invalid size" >&2
+  exit 2
+fi
+
+# The pairing code is a 60-second, one-use secret. It is supplied only as an
+# Activity extra and is never placed in the WSS URL or Android log output.
+exec "$@" shell am start -S \
+  -n "$package_activity" \
+  --es driver_capture_wss_url "$DRIVER_CAPTURE_WSS_URL" \
+  --es pairing_id "$PAIRING_ID" \
+  --es pairing_code "$PAIRING_CODE" \
+  --es ca_certificate_base64 "$ca_base64"

--- a/generic/openxr_capture_native/settings.gradle.kts
+++ b/generic/openxr_capture_native/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "MotusOpenXrCapture"
+include(":app")

--- a/generic/openxr_capture_native/src/capture_session.cpp
+++ b/generic/openxr_capture_native/src/capture_session.cpp
@@ -1,0 +1,433 @@
+#include "motus/openxr_capture/capture_session.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+namespace motus::openxr_capture {
+namespace {
+
+bool CurrentEpoch(const CaptureSessionState& state, std::int64_t epoch) {
+  return epoch > 0 && epoch == state.connection_epoch;
+}
+
+void RequireText(const std::string& value, const char* name) {
+  if (value.empty()) {
+    throw std::invalid_argument(std::string(name) + " is required");
+  }
+}
+
+CaptureTransition Unchanged(const CaptureSessionState& previous) {
+  return CaptureTransition{.state = previous};
+}
+
+CaptureAction Action(
+    CaptureActionKind kind,
+    std::int64_t epoch,
+    std::string assignment_id = {},
+    std::string value = {}) {
+  return CaptureAction{
+      .kind = kind,
+      .connection_epoch = epoch,
+      .assignment_id = std::move(assignment_id),
+      .value = std::move(value),
+  };
+}
+
+CaptureAction Presence(
+    std::int64_t epoch,
+    PresenceState presence,
+    std::string assignment_id = {}) {
+  return CaptureAction{
+      .kind = CaptureActionKind::kSendPresence,
+      .connection_epoch = epoch,
+      .presence = presence,
+      .assignment_id = std::move(assignment_id),
+  };
+}
+
+void ReleaseLocalMotion(CaptureSessionState& state) {
+  state.frame_state = MarkDeadmanReleased(state.frame_state);
+  state.control_open = false;
+  state.pose_open = false;
+  state.offer_sent = false;
+  state.answer_applied = false;
+}
+
+void ClearAssignment(CaptureSessionState& state) {
+  state.assignment.reset();
+  ReleaseLocalMotion(state);
+}
+
+bool AssignmentMatches(
+    const CaptureSessionState& state,
+    const std::string& assignment_id) {
+  return state.assignment && state.assignment->id == assignment_id;
+}
+
+CaptureTransition Faulted(
+    const CaptureSessionState& previous,
+    const std::string& code) {
+  CaptureTransition transition{.state = previous};
+  ReleaseLocalMotion(transition.state);
+  transition.state.link = CaptureLinkState::kFaulted;
+  transition.actions.push_back(Action(
+      CaptureActionKind::kReportFault,
+      previous.connection_epoch,
+      previous.assignment ? previous.assignment->id : std::string{},
+      code));
+  return transition;
+}
+
+}  // namespace
+
+bool CaptureErrorStopsReconnect(std::string_view code) {
+  return code == "capture_credential_invalid" ||
+      code == "capture_pairing_invalid" ||
+      code == "capture_protocol_unsupported" ||
+      code == "frame_protocol_unsupported" ||
+      code == "capture_client_unsupported" ||
+      // Retain compatibility with Driver builds that used the earlier names.
+      code == "capture_auth_invalid" ||
+      code == "capture_protocol_mismatch";
+}
+
+CaptureTransition BeginCaptureConnection(const CaptureSessionState& previous) {
+  CaptureTransition transition{.state = previous};
+  if (previous.connection_epoch >= kMaxSafeWireInteger) {
+    throw std::range_error("connection_epoch exhausted the safe wire integer range");
+  }
+  if (!previous.identity && !previous.pairing) {
+    return Faulted(previous, "capture_enrollment_missing");
+  }
+  if (previous.link != CaptureLinkState::kOffline &&
+      previous.link != CaptureLinkState::kFaulted) {
+    transition.actions.push_back(Action(
+        CaptureActionKind::kCloseRtc,
+        previous.connection_epoch,
+        previous.assignment ? previous.assignment->id : std::string{},
+        "connection_replaced"));
+  }
+  ClearAssignment(transition.state);
+  ++transition.state.connection_epoch;
+  transition.state.authenticated = false;
+  transition.state.link = CaptureLinkState::kAuthenticating;
+  const auto kind = transition.state.identity
+      ? CaptureActionKind::kSendCredentialAuthentication
+      : CaptureActionKind::kSendPairAuthentication;
+  transition.actions.push_back(Action(kind, transition.state.connection_epoch));
+  return transition;
+}
+
+CaptureTransition CaptureAuthenticated(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const CaptureIdentity& identity,
+    bool persist_credential) {
+  if (!CurrentEpoch(previous, connection_epoch) ||
+      previous.link != CaptureLinkState::kAuthenticating) {
+    return Unchanged(previous);
+  }
+  RequireText(identity.capture_id, "capture_id");
+  RequireText(identity.capture_credential, "capture_credential");
+  if (previous.identity && previous.identity->capture_id != identity.capture_id) {
+    return Faulted(previous, "capture_identity_mismatch");
+  }
+
+  CaptureTransition transition{.state = previous};
+  transition.state.identity = identity;
+  transition.state.pairing.reset();
+  transition.state.authenticated = true;
+  transition.state.link = CaptureLinkState::kStandby;
+  if (persist_credential) {
+    transition.actions.push_back(Action(
+        CaptureActionKind::kPersistCredential,
+        connection_epoch,
+        {},
+        identity.capture_id));
+  }
+  transition.actions.push_back(Presence(
+      connection_epoch,
+      transition.state.xr_focused
+          ? PresenceState::kXrStandby
+          : PresenceState::kBrowserReady));
+  return transition;
+}
+
+CaptureTransition CaptureXrFocused(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch) {
+  if (!CurrentEpoch(previous, connection_epoch)) {
+    return Unchanged(previous);
+  }
+  CaptureTransition transition{.state = previous};
+  transition.state.xr_focused = true;
+  if (previous.authenticated && previous.link == CaptureLinkState::kStandby) {
+    transition.actions.push_back(Presence(
+        connection_epoch,
+        PresenceState::kXrStandby));
+  }
+  return transition;
+}
+
+CaptureTransition CaptureAssigned(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const CaptureAssignmentV1& assignment) {
+  if (!CurrentEpoch(previous, connection_epoch) || !previous.authenticated) {
+    return Unchanged(previous);
+  }
+  RequireText(assignment.id, "assignment.id");
+  RequireText(assignment.session_id, "assignment.session_id");
+  RequireText(assignment.profile_id, "assignment.profile_id");
+  RequireText(assignment.capability_digest, "assignment.capability_digest");
+  if (assignment.generation <= 0 ||
+      (assignment.session_id == previous.frame_session_id &&
+       assignment.generation <= previous.highest_assignment_generation)) {
+    return Faulted(previous, "capture_assignment_stale");
+  }
+  if (previous.link != CaptureLinkState::kStandby || !previous.xr_focused ||
+      previous.assignment) {
+    return Faulted(previous, "capture_assignment_unexpected");
+  }
+  if (assignment.frame_configuration.mode != assignment.mode) {
+    return Faulted(previous, "capture_assignment_mode_mismatch");
+  }
+
+  CaptureTransition transition{.state = previous};
+  transition.state.assignment = assignment;
+  transition.state.highest_assignment_generation = assignment.generation;
+  transition.state.link = CaptureLinkState::kNegotiating;
+  ReleaseLocalMotion(transition.state);
+  if (transition.state.frame_session_id != assignment.session_id) {
+    transition.state.frame_session_id = assignment.session_id;
+    transition.state.frame_state = FrameState{};
+  }
+  transition.actions.push_back(Presence(
+      connection_epoch,
+      PresenceState::kRtcConnecting,
+      assignment.id));
+  transition.actions.push_back(Action(
+      CaptureActionKind::kCreateRtcOffer,
+      connection_epoch,
+      assignment.id));
+  return transition;
+}
+
+CaptureTransition CaptureOfferCreated(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& offer_sdp) {
+  if (!CurrentEpoch(previous, connection_epoch) ||
+      previous.link != CaptureLinkState::kNegotiating ||
+      !AssignmentMatches(previous, assignment_id) || previous.offer_sent) {
+    return Unchanged(previous);
+  }
+  RequireText(offer_sdp, "offer_sdp");
+  CaptureTransition transition{.state = previous};
+  transition.state.offer_sent = true;
+  transition.actions.push_back(Action(
+      CaptureActionKind::kSendSignalingOffer,
+      connection_epoch,
+      assignment_id,
+      offer_sdp));
+  return transition;
+}
+
+CaptureTransition CaptureAnswerReceived(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& answer_sdp) {
+  if (!CurrentEpoch(previous, connection_epoch) ||
+      previous.link != CaptureLinkState::kNegotiating ||
+      !AssignmentMatches(previous, assignment_id) || !previous.offer_sent ||
+      previous.answer_applied) {
+    return Unchanged(previous);
+  }
+  RequireText(answer_sdp, "answer_sdp");
+  CaptureTransition transition{.state = previous};
+  transition.state.answer_applied = true;
+  transition.actions.push_back(Action(
+      CaptureActionKind::kApplyRtcAnswer,
+      connection_epoch,
+      assignment_id,
+      answer_sdp));
+  return transition;
+}
+
+CaptureTransition CaptureChannelState(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    bool control_open,
+    bool pose_open) {
+  if (!CurrentEpoch(previous, connection_epoch) ||
+      !AssignmentMatches(previous, assignment_id) ||
+      (previous.link != CaptureLinkState::kNegotiating &&
+       previous.link != CaptureLinkState::kStreaming)) {
+    return Unchanged(previous);
+  }
+  CaptureTransition transition{.state = previous};
+  transition.state.control_open = control_open;
+  transition.state.pose_open = pose_open;
+  if (control_open && pose_open && previous.answer_applied) {
+    transition.state.link = CaptureLinkState::kStreaming;
+    transition.actions.push_back(Presence(
+        connection_epoch,
+        PresenceState::kStreaming,
+        assignment_id));
+  } else if (previous.link == CaptureLinkState::kStreaming) {
+    return CaptureRtcFailed(
+        previous,
+        connection_epoch,
+        assignment_id,
+        "capture_data_channel_lost");
+  }
+  return transition;
+}
+
+CaptureTransition CapturePresenceTick(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch) {
+  if (!CurrentEpoch(previous, connection_epoch) || !previous.authenticated) {
+    return Unchanged(previous);
+  }
+  CaptureTransition transition{.state = previous};
+  if (previous.link == CaptureLinkState::kStreaming && previous.assignment) {
+    transition.actions.push_back(Presence(
+        connection_epoch,
+        PresenceState::kStreaming,
+        previous.assignment->id));
+  } else if (previous.link == CaptureLinkState::kNegotiating && previous.assignment) {
+    transition.actions.push_back(Presence(
+        connection_epoch,
+        PresenceState::kRtcConnecting,
+        previous.assignment->id));
+  } else if (previous.link == CaptureLinkState::kStandby) {
+    transition.actions.push_back(Presence(
+        connection_epoch,
+        previous.xr_focused
+            ? PresenceState::kXrStandby
+            : PresenceState::kBrowserReady));
+  }
+  return transition;
+}
+
+CaptureTransition CaptureTransportLost(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& reason) {
+  if (!CurrentEpoch(previous, connection_epoch)) {
+    return Unchanged(previous);
+  }
+  RequireText(reason, "reason");
+  CaptureTransition transition{.state = previous};
+  const std::string assignment_id = previous.assignment
+      ? previous.assignment->id
+      : std::string{};
+  ClearAssignment(transition.state);
+  transition.state.authenticated = false;
+  transition.state.link = CaptureLinkState::kOffline;
+  transition.actions.push_back(Action(
+      CaptureActionKind::kCloseRtc,
+      connection_epoch,
+      assignment_id,
+      reason));
+  transition.actions.push_back(Action(
+      CaptureActionKind::kScheduleReconnect,
+      connection_epoch,
+      {},
+      reason));
+  return transition;
+}
+
+CaptureTransition CaptureRtcFailed(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& reason) {
+  if (!CurrentEpoch(previous, connection_epoch) ||
+      !AssignmentMatches(previous, assignment_id)) {
+    return Unchanged(previous);
+  }
+  RequireText(reason, "reason");
+  CaptureTransition transition{.state = previous};
+  ReleaseLocalMotion(transition.state);
+  transition.state.link = CaptureLinkState::kFaulted;
+  transition.actions.push_back(Action(
+      CaptureActionKind::kCloseRtc,
+      connection_epoch,
+      assignment_id,
+      reason));
+  transition.actions.push_back(Presence(
+      connection_epoch,
+      PresenceState::kError,
+      assignment_id));
+  transition.actions.push_back(Action(
+      CaptureActionKind::kReportFault,
+      connection_epoch,
+      assignment_id,
+      reason));
+  return transition;
+}
+
+CaptureTransition CaptureXrEnded(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& reason) {
+  if (!CurrentEpoch(previous, connection_epoch)) {
+    return Unchanged(previous);
+  }
+  RequireText(reason, "reason");
+  CaptureTransition transition{.state = previous};
+  const std::string assignment_id = previous.assignment
+      ? previous.assignment->id
+      : std::string{};
+  ClearAssignment(transition.state);
+  transition.state.xr_focused = false;
+  transition.state.link = previous.authenticated
+      ? CaptureLinkState::kStandby
+      : CaptureLinkState::kOffline;
+  transition.actions.push_back(Action(
+      CaptureActionKind::kCloseRtc,
+      connection_epoch,
+      assignment_id,
+      reason));
+  if (previous.authenticated) {
+    transition.actions.push_back(Presence(
+        connection_epoch,
+        PresenceState::kXrEnded));
+  }
+  return transition;
+}
+
+CaptureTransition CaptureAssignmentRevoked(
+    const CaptureSessionState& previous,
+    std::int64_t connection_epoch,
+    const std::string& assignment_id,
+    const std::string& reason) {
+  if (!CurrentEpoch(previous, connection_epoch) ||
+      !AssignmentMatches(previous, assignment_id)) {
+    return Unchanged(previous);
+  }
+  RequireText(reason, "reason");
+  CaptureTransition transition{.state = previous};
+  ClearAssignment(transition.state);
+  transition.state.link = previous.authenticated
+      ? CaptureLinkState::kStandby
+      : CaptureLinkState::kOffline;
+  transition.actions.push_back(Action(
+      CaptureActionKind::kCloseRtc,
+      connection_epoch,
+      assignment_id,
+      reason));
+  if (previous.authenticated && previous.xr_focused) {
+    transition.actions.push_back(Presence(
+        connection_epoch,
+        PresenceState::kXrStandby));
+  }
+  return transition;
+}
+
+}  // namespace motus::openxr_capture

--- a/generic/openxr_capture_native/src/capture_wire.cpp
+++ b/generic/openxr_capture_native/src/capture_wire.cpp
@@ -1,0 +1,537 @@
+#include "motus/openxr_capture/capture_wire.hpp"
+
+#include <cmath>
+#include <regex>
+#include <set>
+#include <stdexcept>
+#include <string_view>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace motus::openxr_capture {
+namespace {
+
+using Json = nlohmann::json;
+
+const std::regex kUuidV4(
+    "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$");
+const std::regex kSafeId("^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$");
+const std::regex kAppVersion("^[A-Za-z0-9][A-Za-z0-9_.+-]{0,31}$");
+const std::regex kDigest("^[0-9a-f]{64}$");
+
+[[noreturn]] void Invalid(const std::string& field) {
+  throw std::invalid_argument("invalid capture wire field: " + field);
+}
+
+void ExactKeys(
+    const Json& value,
+    std::initializer_list<std::string_view> expected,
+    const std::string& field) {
+  if (!value.is_object() || value.size() != expected.size()) {
+    Invalid(field);
+  }
+  for (const auto key : expected) {
+    if (!value.contains(std::string(key))) {
+      Invalid(field);
+    }
+  }
+}
+
+std::string StringMatching(
+    const Json& value,
+    const std::regex& pattern,
+    const std::string& field) {
+  if (!value.is_string()) {
+    Invalid(field);
+  }
+  const auto result = value.get<std::string>();
+  if (!std::regex_match(result, pattern)) {
+    Invalid(field);
+  }
+  return result;
+}
+
+std::string BoundedString(
+    const Json& value,
+    std::size_t minimum,
+    std::size_t maximum,
+    const std::string& field) {
+  if (!value.is_string()) {
+    Invalid(field);
+  }
+  auto result = value.get<std::string>();
+  if (result.size() < minimum || result.size() > maximum ||
+      result.find('\0') != std::string::npos) {
+    Invalid(field);
+  }
+  return result;
+}
+
+std::int64_t SafeInteger(
+    const Json& value,
+    std::int64_t minimum,
+    std::int64_t maximum,
+    const std::string& field) {
+  if (!value.is_number_integer()) {
+    Invalid(field);
+  }
+  const auto result = value.get<std::int64_t>();
+  if (result < minimum || result > maximum) {
+    Invalid(field);
+  }
+  return result;
+}
+
+double FiniteNumber(
+    const Json& value,
+    double minimum,
+    double maximum,
+    const std::string& field) {
+  if (!value.is_number()) {
+    Invalid(field);
+  }
+  const auto result = value.get<double>();
+  if (!std::isfinite(result) || result < minimum || result > maximum) {
+    Invalid(field);
+  }
+  return result;
+}
+
+bool StrictBoolean(const Json& value, const std::string& field) {
+  if (!value.is_boolean()) {
+    Invalid(field);
+  }
+  return value.get<bool>();
+}
+
+Json ParseStrict(const std::string& payload) {
+  if (payload.empty() || payload.size() > kMaxCaptureWireBytes ||
+      payload.find('\0') != std::string::npos) {
+    Invalid("message");
+  }
+  bool duplicate = false;
+  std::vector<std::unordered_set<std::string>> object_keys;
+  const auto callback = [&duplicate, &object_keys](
+                            int,
+                            Json::parse_event_t event,
+                            Json& parsed) {
+    if (event == Json::parse_event_t::object_start) {
+      object_keys.emplace_back();
+    } else if (event == Json::parse_event_t::key) {
+      if (object_keys.empty() ||
+          !object_keys.back().insert(parsed.get<std::string>()).second) {
+        duplicate = true;
+      }
+    } else if (event == Json::parse_event_t::object_end) {
+      if (object_keys.empty()) {
+        duplicate = true;
+      } else {
+        object_keys.pop_back();
+      }
+    }
+    return true;
+  };
+  Json result;
+  try {
+    result = Json::parse(payload, callback, true, true);
+  } catch (const Json::exception&) {
+    Invalid("message");
+  }
+  if (duplicate || !object_keys.empty() || !result.is_object()) {
+    Invalid("message");
+  }
+  return result;
+}
+
+std::string PresenceName(PresenceState state) {
+  switch (state) {
+    case PresenceState::kBrowserReady:
+      return "browser_ready";
+    case PresenceState::kError:
+      return "error";
+    case PresenceState::kRtcConnecting:
+      return "rtc_connecting";
+    case PresenceState::kStreaming:
+      return "streaming";
+    case PresenceState::kXrEnded:
+      return "xr_ended";
+    case PresenceState::kXrStandby:
+      return "xr_standby";
+  }
+  Invalid("presence.state");
+}
+
+PresenceState ParsePresence(const Json& value) {
+  if (!value.is_string()) {
+    Invalid("presence.state");
+  }
+  const auto state = value.get<std::string>();
+  if (state == "browser_ready") {
+    return PresenceState::kBrowserReady;
+  }
+  if (state == "error") {
+    return PresenceState::kError;
+  }
+  if (state == "rtc_connecting") {
+    return PresenceState::kRtcConnecting;
+  }
+  if (state == "streaming") {
+    return PresenceState::kStreaming;
+  }
+  if (state == "xr_ended") {
+    return PresenceState::kXrEnded;
+  }
+  if (state == "xr_standby") {
+    return PresenceState::kXrStandby;
+  }
+  Invalid("presence.state");
+}
+
+AxisBinding ParseAxisBinding(const Json& value, const std::string& field) {
+  ExactKeys(value, {"hand", "axis", "scale", "deadzone", "direction"}, field);
+  AxisBinding binding;
+  const auto hand = BoundedString(value.at("hand"), 4, 5, field + ".hand");
+  if (hand == "left") {
+    binding.hand = AxisBinding::Hand::kLeft;
+  } else if (hand == "right") {
+    binding.hand = AxisBinding::Hand::kRight;
+  } else {
+    Invalid(field + ".hand");
+  }
+  binding.axis = static_cast<std::size_t>(SafeInteger(
+      value.at("axis"), 0, 7, field + ".axis"));
+  binding.scale = FiniteNumber(value.at("scale"), 0.0, 10.0, field + ".scale");
+  binding.deadzone = FiniteNumber(
+      value.at("deadzone"), 0.0, 0.95, field + ".deadzone");
+  binding.direction = static_cast<int>(SafeInteger(
+      value.at("direction"), -1, 1, field + ".direction"));
+  if (binding.direction == 0) {
+    Invalid(field + ".direction");
+  }
+  return binding;
+}
+
+FrameConfiguration ParseCapabilities(
+    const Json& value,
+    const std::string& profile_id,
+    FrameMode mode,
+    const Json& top_effectors) {
+  ExactKeys(
+      value,
+      {"profile_id", "input_bindings", "outputs", "effectors"},
+      "assignment.capabilities");
+  if (StringMatching(value.at("profile_id"), kSafeId, "capabilities.profile_id") !=
+      profile_id) {
+    Invalid("capabilities.profile_id");
+  }
+  const auto& inputs = value.at("input_bindings");
+  const auto& outputs = value.at("outputs");
+  const auto& effectors = value.at("effectors");
+  if (!inputs.is_object() || inputs.size() > 16 || !outputs.is_object() ||
+      outputs.empty() || outputs.size() > 16 || !effectors.is_array() ||
+      effectors.size() > 16 || effectors != top_effectors) {
+    Invalid("capabilities");
+  }
+
+  std::set<std::string> enabled_outputs;
+  for (const auto& [name, output] : outputs.items()) {
+    if (!std::regex_match(name, kSafeId) || !output.is_object() ||
+        output.empty() || output.size() > 2 || !output.contains("enabled")) {
+      Invalid("capabilities.outputs");
+    }
+    for (const auto& [key, ignored] : output.items()) {
+      static_cast<void>(ignored);
+      if (key != "enabled" && key != "joint_count") {
+        Invalid("capabilities.outputs");
+      }
+    }
+    if (output.contains("joint_count")) {
+      static_cast<void>(SafeInteger(
+          output.at("joint_count"), 0, 128, "capabilities.outputs.joint_count"));
+    }
+    if (StrictBoolean(output.at("enabled"), "capabilities.outputs.enabled")) {
+      enabled_outputs.insert(name);
+    }
+  }
+
+  std::set<std::string> declared_effectors;
+  for (const auto& effector : effectors) {
+    declared_effectors.insert(StringMatching(
+        effector, kSafeId, "capabilities.effectors"));
+  }
+  if (declared_effectors.size() != effectors.size() ||
+      declared_effectors != enabled_outputs) {
+    Invalid("capabilities.effectors");
+  }
+
+  for (const auto& [name, binding] : inputs.items()) {
+    if (!std::regex_match(name, kSafeId)) {
+      Invalid("capabilities.input_bindings");
+    }
+    if (name == "base_twist") {
+      continue;
+    }
+    ExactKeys(binding, {"required", "role"}, "capabilities.input_bindings.role");
+    static_cast<void>(StrictBoolean(
+        binding.at("required"), "capabilities.input_bindings.required"));
+    static_cast<void>(StringMatching(
+        binding.at("role"), kSafeId, "capabilities.input_bindings.role"));
+  }
+
+  const bool base_enabled = enabled_outputs.contains("base");
+  const bool has_base_binding = inputs.contains("base_twist");
+  if (base_enabled != has_base_binding) {
+    Invalid("capabilities.input_bindings.base_twist");
+  }
+  FrameConfiguration configuration{.mode = mode};
+  if (has_base_binding) {
+    const auto& base = inputs.at("base_twist");
+    ExactKeys(base, {"linear_x", "linear_y", "angular_z"}, "base_twist");
+    configuration.base_twist = BaseTwistBinding{
+        .linear_x = ParseAxisBinding(base.at("linear_x"), "base_twist.linear_x"),
+        .linear_y = ParseAxisBinding(base.at("linear_y"), "base_twist.linear_y"),
+        .angular_z = ParseAxisBinding(base.at("angular_z"), "base_twist.angular_z"),
+    };
+  }
+  return configuration;
+}
+
+CaptureAssignmentV1 ParseAssignment(const Json& value) {
+  ExactKeys(
+      value,
+      {"id", "generation", "session_id", "mode", "profile_id",
+       "capability_digest", "capabilities", "effectors", "state",
+       "created_at", "updated_at", "failure_code"},
+      "assignment");
+  if (value.at("state") != "issued" || !value.at("failure_code").is_null()) {
+    Invalid("assignment.state");
+  }
+  static_cast<void>(FiniteNumber(
+      value.at("created_at"), 0.0, 1.0e13, "assignment.created_at"));
+  static_cast<void>(FiniteNumber(
+      value.at("updated_at"), 0.0, 1.0e13, "assignment.updated_at"));
+  const auto mode_name = BoundedString(value.at("mode"), 4, 6, "assignment.mode");
+  FrameMode mode;
+  if (mode_name == "shadow") {
+    mode = FrameMode::kShadow;
+  } else if (mode_name == "live") {
+    mode = FrameMode::kLive;
+  } else {
+    Invalid("assignment.mode");
+  }
+  const auto profile_id = StringMatching(
+      value.at("profile_id"), kSafeId, "assignment.profile_id");
+  if (!value.at("effectors").is_array()) {
+    Invalid("assignment.effectors");
+  }
+  const auto configuration = ParseCapabilities(
+      value.at("capabilities"), profile_id, mode, value.at("effectors"));
+  return CaptureAssignmentV1{
+      .id = StringMatching(value.at("id"), kUuidV4, "assignment.id"),
+      .generation = SafeInteger(
+          value.at("generation"), 1, kMaxSafeWireInteger, "assignment.generation"),
+      .session_id = StringMatching(
+          value.at("session_id"), kUuidV4, "assignment.session_id"),
+      .mode = mode,
+      .profile_id = profile_id,
+      .capability_digest = StringMatching(
+          value.at("capability_digest"), kDigest, "assignment.capability_digest"),
+      .frame_configuration = configuration,
+  };
+}
+
+void ValidateAuthenticationInputs(
+    const std::string& app_version,
+    const std::string& id,
+    const std::string& secret,
+    const std::string& id_field) {
+  if (!std::regex_match(app_version, kAppVersion) ||
+      !std::regex_match(id, kUuidV4) || secret.size() < 32 || secret.size() > 128 ||
+      secret.find('\0') != std::string::npos) {
+    Invalid(id_field);
+  }
+}
+
+}  // namespace
+
+std::string SerializePairAuthentication(
+    const PairingBootstrap& pairing,
+    const std::string& app_version) {
+  ValidateAuthenticationInputs(
+      app_version, pairing.pairing_id, pairing.pairing_code, "pairing");
+  return Json{
+      {"type", "pair"},
+      {"pairing_id", pairing.pairing_id},
+      {"pairing_code", pairing.pairing_code},
+      {"capture_protocol", kCaptureProtocol},
+      {"frame_protocol", kFrameProtocol},
+      {"client_kind", kNativeClientKind},
+      {"app_version", app_version},
+  }.dump();
+}
+
+std::string SerializeCredentialAuthentication(
+    const CaptureIdentity& identity,
+    const std::string& app_version) {
+  ValidateAuthenticationInputs(
+      app_version,
+      identity.capture_id,
+      identity.capture_credential,
+      "capture_identity");
+  return Json{
+      {"type", "credential"},
+      {"capture_id", identity.capture_id},
+      {"capture_credential", identity.capture_credential},
+      {"capture_protocol", kCaptureProtocol},
+      {"frame_protocol", kFrameProtocol},
+      {"client_kind", kNativeClientKind},
+      {"app_version", app_version},
+  }.dump();
+}
+
+std::string SerializeCapturePresence(
+    PresenceState state,
+    const std::string& assignment_id) {
+  const bool assignment_bound = state == PresenceState::kError ||
+      state == PresenceState::kRtcConnecting || state == PresenceState::kStreaming;
+  if (assignment_bound != !assignment_id.empty() ||
+      (!assignment_id.empty() && !std::regex_match(assignment_id, kUuidV4))) {
+    Invalid("presence.assignment_id");
+  }
+  return Json{
+      {"type", "presence"},
+      {"state", PresenceName(state)},
+      {"assignment_id", assignment_id.empty() ? Json(nullptr) : Json(assignment_id)},
+  }.dump();
+}
+
+std::string SerializeCaptureSignalingOffer(
+    const std::string& assignment_id,
+    const std::string& offer_sdp) {
+  if (!std::regex_match(assignment_id, kUuidV4) || offer_sdp.empty() ||
+      offer_sdp.size() > kMaxSignalingSdpBytes ||
+      offer_sdp.find('\0') != std::string::npos) {
+    Invalid("signaling_offer");
+  }
+  const auto payload = Json{
+      {"type", "signaling_offer"},
+      {"assignment_id", assignment_id},
+      {"offer", {{"type", "offer"}, {"sdp", offer_sdp}}},
+  }.dump();
+  if (payload.size() > kMaxCaptureWireBytes) {
+    Invalid("signaling_offer");
+  }
+  return payload;
+}
+
+CaptureServerMessage ParseCaptureServerMessage(
+    const std::string& payload,
+    const std::optional<CaptureIdentity>& existing_identity) {
+  const auto message = ParseStrict(payload);
+  if (!message.contains("type") || !message.at("type").is_string()) {
+    Invalid("type");
+  }
+  const auto type = message.at("type").get<std::string>();
+  if (type == "paired") {
+    ExactKeys(
+        message,
+        {"type", "capture_id", "capture_credential", "capture_protocol",
+         "frame_protocol", "presence_interval_ms", "presence_timeout_ms"},
+        "paired");
+    if (message.at("capture_protocol") != kCaptureProtocol ||
+        message.at("frame_protocol") != kFrameProtocol) {
+      Invalid("paired.protocol");
+    }
+    return CaptureAuthenticatedMessage{
+        .identity = CaptureIdentity{
+            .capture_id = StringMatching(
+                message.at("capture_id"), kUuidV4, "paired.capture_id"),
+            .capture_credential = BoundedString(
+                message.at("capture_credential"), 32, 128, "paired.credential"),
+        },
+        .fresh_credential = true,
+        .presence_interval_ms = SafeInteger(
+            message.at("presence_interval_ms"), 250, 10'000, "presence_interval_ms"),
+        .presence_timeout_ms = SafeInteger(
+            message.at("presence_timeout_ms"), 1'000, 30'000, "presence_timeout_ms"),
+    };
+  }
+  if (type == "connected") {
+    ExactKeys(
+        message,
+        {"type", "capture_id", "capture_protocol", "frame_protocol",
+         "presence_interval_ms", "presence_timeout_ms"},
+        "connected");
+    if (!existing_identity || message.at("capture_protocol") != kCaptureProtocol ||
+        message.at("frame_protocol") != kFrameProtocol ||
+        StringMatching(message.at("capture_id"), kUuidV4, "connected.capture_id") !=
+            existing_identity->capture_id) {
+      Invalid("connected.identity");
+    }
+    return CaptureAuthenticatedMessage{
+        .identity = *existing_identity,
+        .fresh_credential = false,
+        .presence_interval_ms = SafeInteger(
+            message.at("presence_interval_ms"), 250, 10'000, "presence_interval_ms"),
+        .presence_timeout_ms = SafeInteger(
+            message.at("presence_timeout_ms"), 1'000, 30'000, "presence_timeout_ms"),
+    };
+  }
+  if (type == "assignment") {
+    ExactKeys(message, {"type", "assignment"}, "assignment_message");
+    return CaptureAssignmentMessage{.assignment = ParseAssignment(message.at("assignment"))};
+  }
+  if (type == "signaling_answer") {
+    ExactKeys(
+        message,
+        {"type", "assignment_id", "answer"},
+        "signaling_answer");
+    const auto& answer = message.at("answer");
+    ExactKeys(answer, {"type", "sdp"}, "signaling_answer.answer");
+    if (answer.at("type") != "answer") {
+      Invalid("signaling_answer.answer.type");
+    }
+    return CaptureSignalingAnswerMessage{
+        .assignment_id = StringMatching(
+            message.at("assignment_id"), kUuidV4, "signaling_answer.assignment_id"),
+        .answer_sdp = BoundedString(
+            answer.at("sdp"), 1, kMaxSignalingSdpBytes, "signaling_answer.sdp"),
+    };
+  }
+  if (type == "assignment_revoked") {
+    ExactKeys(
+        message,
+        {"type", "assignment_id", "reason"},
+        "assignment_revoked");
+    return CaptureAssignmentRevokedMessage{
+        .assignment_id = StringMatching(
+            message.at("assignment_id"), kUuidV4, "assignment_revoked.assignment_id"),
+        .reason = BoundedString(message.at("reason"), 1, 128, "assignment_revoked.reason"),
+    };
+  }
+  if (type == "capture_revoked" || type == "capture_stale") {
+    ExactKeys(message, {"type", "reason"}, type);
+    return CaptureTerminalMessage{
+        .type = type,
+        .reason = BoundedString(message.at("reason"), 1, 128, type + ".reason"),
+    };
+  }
+  if (type == "presence_ack") {
+    ExactKeys(message, {"type", "state"}, "presence_ack");
+    return CapturePresenceAcknowledgedMessage{
+        .state = ParsePresence(message.at("state")),
+    };
+  }
+  if (type == "error") {
+    ExactKeys(message, {"type", "code"}, "error");
+    return CaptureErrorMessage{
+        .code = StringMatching(message.at("code"), kSafeId, "error.code"),
+    };
+  }
+  Invalid("type");
+}
+
+}  // namespace motus::openxr_capture

--- a/generic/openxr_capture_native/src/enrollment.cpp
+++ b/generic/openxr_capture_native/src/enrollment.cpp
@@ -1,0 +1,48 @@
+#include "motus/openxr_capture/enrollment.hpp"
+
+#include <stdexcept>
+
+namespace motus::openxr_capture {
+
+CaptureEnrollmentSelection SelectCaptureEnrollment(
+    const StoredCaptureEnrollment& stored,
+    const CaptureLaunchBootstrap& launch) {
+  const bool pairing_present =
+      !launch.pairing_id.empty() || !launch.pairing_code.empty();
+  if (pairing_present) {
+    if (
+        launch.pairing_id.empty() || launch.pairing_code.empty() ||
+        launch.websocket_url.empty() || launch.ca_certificate_pem.empty()) {
+      throw std::invalid_argument("capture pairing bootstrap is incomplete");
+    }
+    return CaptureEnrollmentSelection{
+        .identity = std::nullopt,
+        .pairing = PairingBootstrap{
+            .pairing_id = launch.pairing_id,
+            .pairing_code = launch.pairing_code,
+        },
+        .websocket_url = launch.websocket_url,
+        .ca_certificate_pem = launch.ca_certificate_pem,
+    };
+  }
+
+  if (launch.transport_override_present) {
+    throw std::invalid_argument("stored capture transport cannot be overridden");
+  }
+  if (
+      stored.capture_id.empty() || stored.capture_credential.empty() ||
+      stored.websocket_url.empty() || stored.ca_certificate_pem.empty()) {
+    throw std::invalid_argument("stored capture enrollment is incomplete");
+  }
+  return CaptureEnrollmentSelection{
+      .identity = CaptureIdentity{
+          .capture_id = stored.capture_id,
+          .capture_credential = stored.capture_credential,
+      },
+      .pairing = std::nullopt,
+      .websocket_url = stored.websocket_url,
+      .ca_certificate_pem = stored.ca_certificate_pem,
+  };
+}
+
+}  // namespace motus::openxr_capture

--- a/generic/openxr_capture_native/src/frame_v1.cpp
+++ b/generic/openxr_capture_native/src/frame_v1.cpp
@@ -1,0 +1,447 @@
+#include "motus/openxr_capture/frame_v1.hpp"
+
+#include <algorithm>
+#include <charconv>
+#include <cmath>
+#include <stdexcept>
+#include <string_view>
+
+namespace motus::openxr_capture {
+namespace {
+
+constexpr std::size_t kMaxAxes = 8;
+constexpr std::size_t kMaxButtons = 16;
+constexpr double kMaxPositionMetres = 100.0;
+constexpr double kQuaternionNormMin = 0.5;
+constexpr double kQuaternionNormMax = 1.5;
+constexpr double kQuaternionComponentLimit = 1.000001;
+
+enum class SqueezeState {
+  kInvalid,
+  kReleased,
+  kTransition,
+  kPressed,
+};
+
+struct NormalizedController {
+  WireController wire;
+  bool valid{false};
+  SqueezeState squeeze{SqueezeState::kInvalid};
+};
+
+void RequireCounter(std::int64_t value, std::string_view name, bool allow_maximum = true) {
+  const auto maximum = allow_maximum ? kMaxSafeWireInteger : kMaxSafeWireInteger - 1;
+  if (value < 0 || value > maximum) {
+    throw std::range_error(std::string(name) + " is outside the safe wire integer range");
+  }
+}
+
+bool IsFinite(double value) {
+  return std::isfinite(value);
+}
+
+double Clamp(double value, double minimum, double maximum) {
+  return std::min(maximum, std::max(minimum, value));
+}
+
+std::optional<WirePose> NormalizePose(const PoseSample& sample) {
+  if (!sample.valid || sample.emulated) {
+    return std::nullopt;
+  }
+  for (double value : sample.position) {
+    if (!IsFinite(value) || std::abs(value) > kMaxPositionMetres) {
+      return std::nullopt;
+    }
+  }
+  double norm_squared = 0.0;
+  for (double value : sample.orientation) {
+    if (!IsFinite(value) || std::abs(value) > kQuaternionComponentLimit) {
+      return std::nullopt;
+    }
+    norm_squared += value * value;
+  }
+  const double norm = std::sqrt(norm_squared);
+  if (!IsFinite(norm) || norm < kQuaternionNormMin || norm > kQuaternionNormMax) {
+    return std::nullopt;
+  }
+
+  WirePose pose;
+  pose.position = sample.position;
+  double normalized_norm_squared = 0.0;
+  for (std::size_t index = 0; index < pose.orientation.size(); ++index) {
+    pose.orientation[index] = sample.orientation[index] / norm;
+    normalized_norm_squared += pose.orientation[index] * pose.orientation[index];
+  }
+  const double normalized_norm = std::sqrt(normalized_norm_squared);
+  if (!IsFinite(normalized_norm) || normalized_norm == 0.0) {
+    return std::nullopt;
+  }
+  for (double& value : pose.orientation) {
+    value = Clamp(value / normalized_norm, -1.0, 1.0);
+    if (!IsFinite(value)) {
+      return std::nullopt;
+    }
+  }
+  return pose;
+}
+
+NormalizedController NormalizeController(const ControllerSample& sample) {
+  NormalizedController result;
+  result.valid = sample.active && sample.xr_standard && sample.correct_handedness &&
+      sample.tracked_pointer && sample.has_grip_space && sample.axes.size() <= kMaxAxes &&
+      sample.buttons.size() >= 2 && sample.buttons.size() <= kMaxButtons;
+
+  const auto axis_count = std::min(sample.axes.size(), kMaxAxes);
+  result.wire.axes.reserve(axis_count);
+  for (std::size_t index = 0; index < axis_count; ++index) {
+    const double raw = sample.axes[index];
+    result.wire.axes.push_back(IsFinite(raw) ? Clamp(raw, -1.0, 1.0) : 0.0);
+    result.valid = result.valid && IsFinite(raw) && raw >= -1.0 && raw <= 1.0;
+  }
+
+  const auto button_count = std::min(sample.buttons.size(), kMaxButtons);
+  result.wire.buttons.reserve(button_count);
+  for (std::size_t index = 0; index < button_count; ++index) {
+    const double raw = sample.buttons[index];
+    result.wire.buttons.push_back(IsFinite(raw) ? Clamp(raw, 0.0, 1.0) : 0.0);
+    result.valid = result.valid && IsFinite(raw) && raw >= 0.0 && raw <= 1.0;
+  }
+
+  if (sample.buttons.size() < 2 || !IsFinite(sample.buttons[1]) || sample.buttons[1] < 0.0 ||
+      sample.buttons[1] > 1.0) {
+    result.squeeze = SqueezeState::kInvalid;
+  } else if (sample.squeeze_pressed && sample.buttons[1] >= 0.75) {
+    result.squeeze = SqueezeState::kPressed;
+  } else if (!sample.squeeze_pressed && sample.buttons[1] < 0.75) {
+    result.squeeze = SqueezeState::kReleased;
+  } else {
+    result.squeeze = SqueezeState::kTransition;
+  }
+  return result;
+}
+
+void ValidateBinding(const AxisBinding& binding) {
+  if (binding.axis >= kMaxAxes || !IsFinite(binding.scale) || binding.scale < 0.0 ||
+      binding.scale > 10.0 || !IsFinite(binding.deadzone) || binding.deadzone < 0.0 ||
+      binding.deadzone > 0.95 || (binding.direction != -1 && binding.direction != 1)) {
+    throw std::invalid_argument("base_twist axis binding is invalid");
+  }
+}
+
+const std::vector<double>& AxesFor(
+    const AxisBinding& binding,
+    const NormalizedController& left,
+    const NormalizedController& right) {
+  return binding.hand == AxisBinding::Hand::kLeft ? left.wire.axes : right.wire.axes;
+}
+
+std::optional<double> BoundAxis(
+    const AxisBinding& binding,
+    const NormalizedController& left,
+    const NormalizedController& right) {
+  const auto& axes = AxesFor(binding, left, right);
+  if (binding.axis >= axes.size()) {
+    return std::nullopt;
+  }
+  return axes[binding.axis];
+}
+
+std::optional<double> RemapAxis(double value, double deadzone) {
+  if (!IsFinite(value) || value < -1.0 || value > 1.0) {
+    return std::nullopt;
+  }
+  const double magnitude = std::abs(value);
+  if (magnitude <= deadzone) {
+    return 0.0;
+  }
+  return std::copysign((magnitude - deadzone) / (1.0 - deadzone), value);
+}
+
+bool BoundInputsAvailable(
+    const BaseTwistBinding& binding,
+    const NormalizedController& left,
+    const NormalizedController& right) {
+  return BoundAxis(binding.linear_x, left, right).has_value() &&
+      BoundAxis(binding.linear_y, left, right).has_value() &&
+      BoundAxis(binding.angular_z, left, right).has_value();
+}
+
+bool BoundInputsNeutral(
+    const BaseTwistBinding& binding,
+    const NormalizedController& left,
+    const NormalizedController& right) {
+  const auto neutral = [&](const AxisBinding& axis) {
+    const auto value = BoundAxis(axis, left, right);
+    const auto remapped = value ? RemapAxis(*value, axis.deadzone) : std::nullopt;
+    return remapped.has_value() && *remapped == 0.0;
+  };
+  return neutral(binding.linear_x) && neutral(binding.linear_y) && neutral(binding.angular_z);
+}
+
+double ScaledAxis(
+    const AxisBinding& binding,
+    const NormalizedController& left,
+    const NormalizedController& right) {
+  const auto value = BoundAxis(binding, left, right);
+  const auto remapped = value ? RemapAxis(*value, binding.deadzone) : std::nullopt;
+  if (!remapped || *remapped == 0.0) {
+    return 0.0;
+  }
+  return *remapped * binding.scale * static_cast<double>(binding.direction);
+}
+
+BaseTwist BuildBaseTwist(
+    bool deadman,
+    bool inputs_valid,
+    const BaseTwistBinding& binding,
+    const NormalizedController& left,
+    const NormalizedController& right) {
+  BaseTwist twist;
+  if (!deadman || !inputs_valid) {
+    return twist;
+  }
+  twist.linear = {
+      ScaledAxis(binding.linear_x, left, right),
+      ScaledAxis(binding.linear_y, left, right),
+      0.0,
+  };
+  twist.angular = {0.0, 0.0, ScaledAxis(binding.angular_z, left, right)};
+  return twist;
+}
+
+std::int64_t NextMonotonicNanoseconds(std::int64_t previous, std::optional<std::int64_t> value) {
+  if (value && *value >= 0 && *value <= kMaxSafeWireInteger && *value > previous) {
+    return *value;
+  }
+  if (previous >= kMaxSafeWireInteger) {
+    throw std::range_error("client_monotonic_ns exhausted the safe wire integer range");
+  }
+  return previous + 1;
+}
+
+std::string_view ModeName(FrameMode mode) {
+  switch (mode) {
+    case FrameMode::kShadow:
+      return "shadow";
+    case FrameMode::kLive:
+      return "live";
+  }
+  throw std::invalid_argument("unknown frame mode");
+}
+
+void AppendInteger(std::string& output, std::int64_t value) {
+  std::array<char, 32> buffer{};
+  const auto result = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value);
+  if (result.ec != std::errc{}) {
+    throw std::runtime_error("failed to serialize integer");
+  }
+  output.append(buffer.data(), result.ptr);
+}
+
+void AppendNumber(std::string& output, double value) {
+  if (!IsFinite(value)) {
+    throw std::runtime_error("refusing to serialize a non-finite number");
+  }
+  if (value == 0.0) {
+    output.push_back('0');
+    return;
+  }
+  std::array<char, 64> buffer{};
+  const auto result = std::to_chars(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      value,
+      std::chars_format::general);
+  if (result.ec != std::errc{}) {
+    throw std::runtime_error("failed to serialize number");
+  }
+  output.append(buffer.data(), result.ptr);
+}
+
+template <std::size_t Size>
+void AppendArray(std::string& output, const std::array<double, Size>& values) {
+  output.push_back('[');
+  for (std::size_t index = 0; index < values.size(); ++index) {
+    if (index != 0) {
+      output.push_back(',');
+    }
+    AppendNumber(output, values[index]);
+  }
+  output.push_back(']');
+}
+
+void AppendVector(std::string& output, const std::vector<double>& values) {
+  output.push_back('[');
+  for (std::size_t index = 0; index < values.size(); ++index) {
+    if (index != 0) {
+      output.push_back(',');
+    }
+    AppendNumber(output, values[index]);
+  }
+  output.push_back(']');
+}
+
+void AppendPose(std::string& output, const std::optional<WirePose>& pose) {
+  if (!pose) {
+    output.append("null");
+    return;
+  }
+  output.append("{\"position\":");
+  AppendArray(output, pose->position);
+  output.append(",\"orientation\":");
+  AppendArray(output, pose->orientation);
+  output.push_back('}');
+}
+
+void AppendController(std::string& output, const WireController& controller) {
+  output.append("{\"axes\":");
+  AppendVector(output, controller.axes);
+  output.append(",\"buttons\":");
+  AppendVector(output, controller.buttons);
+  output.push_back('}');
+}
+
+}  // namespace
+
+FrameResult BuildFrameV1(
+    const FrameState& previous,
+    const FrameSample& sample,
+    const FrameConfiguration& configuration) {
+  RequireCounter(previous.next_sequence, "next_sequence", false);
+  RequireCounter(previous.clutch_sequence, "clutch_sequence");
+  RequireCounter(previous.last_monotonic_ns, "last_monotonic_ns");
+  if (configuration.base_twist) {
+    ValidateBinding(configuration.base_twist->linear_x);
+    ValidateBinding(configuration.base_twist->linear_y);
+    ValidateBinding(configuration.base_twist->angular_z);
+  }
+
+  FrameResult result;
+  result.frame.sequence = previous.next_sequence;
+  result.frame.client_monotonic_ns =
+      NextMonotonicNanoseconds(previous.last_monotonic_ns, sample.monotonic_ns);
+  result.frame.mode = configuration.mode;
+  result.frame.head = NormalizePose(sample.head);
+  result.frame.left_controller = NormalizePose(sample.left_controller);
+  result.frame.right_controller = NormalizePose(sample.right_controller);
+  result.frame.tracking = {
+      result.frame.head.has_value(),
+      result.frame.left_controller.has_value(),
+      result.frame.right_controller.has_value(),
+  };
+
+  const auto left = NormalizeController(sample.left_input);
+  const auto right = NormalizeController(sample.right_input);
+  result.frame.left_input = left.wire;
+  result.frame.right_input = right.wire;
+
+  const bool all_tracked = result.frame.tracking.head &&
+      result.frame.tracking.left_controller && result.frame.tracking.right_controller;
+  const bool squeeze_requested = sample.distinct_input_sources &&
+      left.squeeze == SqueezeState::kPressed && right.squeeze == SqueezeState::kPressed;
+  const bool base_inputs_available = !configuration.base_twist ||
+      BoundInputsAvailable(*configuration.base_twist, left, right);
+  const bool inputs_valid = left.valid && right.valid && sample.distinct_input_sources &&
+      base_inputs_available;
+  const bool explicit_release_observed = inputs_valid &&
+      left.squeeze != SqueezeState::kInvalid && right.squeeze != SqueezeState::kInvalid &&
+      (left.squeeze == SqueezeState::kReleased || right.squeeze == SqueezeState::kReleased);
+  const bool motion_inputs_neutral = !configuration.base_twist ||
+      BoundInputsNeutral(*configuration.base_twist, left, right);
+  const bool non_neutral_engagement_attempt =
+      !previous.deadman_active && squeeze_requested && !motion_inputs_neutral;
+
+  bool rearm_required = previous.rearm_required;
+  if (!all_tracked || !inputs_valid) {
+    rearm_required = true;
+  } else if (explicit_release_observed) {
+    rearm_required = !motion_inputs_neutral;
+  } else if ((previous.deadman_active && !squeeze_requested) ||
+             non_neutral_engagement_attempt) {
+    rearm_required = true;
+  }
+
+  result.frame.deadman =
+      all_tracked && inputs_valid && squeeze_requested && !rearm_required;
+  result.frame.clutch_sequence = previous.clutch_sequence;
+  if (result.frame.deadman && !previous.deadman_active) {
+    if (result.frame.clutch_sequence >= kMaxSafeWireInteger) {
+      throw std::range_error("clutch_sequence exhausted the safe wire integer range");
+    }
+    ++result.frame.clutch_sequence;
+  }
+  if (configuration.base_twist) {
+    result.frame.base_twist = BuildBaseTwist(
+        result.frame.deadman,
+        inputs_valid,
+        *configuration.base_twist,
+        left,
+        right);
+  }
+
+  result.state = {
+      previous.next_sequence + 1,
+      result.frame.clutch_sequence,
+      result.frame.deadman,
+      rearm_required,
+      result.frame.client_monotonic_ns,
+  };
+  return result;
+}
+
+FrameState MarkDeadmanReleased(const FrameState& previous) {
+  RequireCounter(previous.next_sequence, "next_sequence");
+  RequireCounter(previous.clutch_sequence, "clutch_sequence");
+  RequireCounter(previous.last_monotonic_ns, "last_monotonic_ns");
+  FrameState released = previous;
+  released.deadman_active = false;
+  released.rearm_required = true;
+  return released;
+}
+
+std::string SerializeFrameV1(const FrameV1& frame) {
+  RequireCounter(frame.sequence, "sequence");
+  RequireCounter(frame.client_monotonic_ns, "client_monotonic_ns");
+  RequireCounter(frame.clutch_sequence, "clutch_sequence");
+
+  std::string output;
+  output.reserve(1024);
+  output.append("{\"schema_version\":1,\"sequence\":");
+  AppendInteger(output, frame.sequence);
+  output.append(",\"client_monotonic_ns\":");
+  AppendInteger(output, frame.client_monotonic_ns);
+  output.append(",\"mode\":\"");
+  output.append(ModeName(frame.mode));
+  output.append("\",\"deadman\":");
+  output.append(frame.deadman ? "true" : "false");
+  output.append(",\"clutch_sequence\":");
+  AppendInteger(output, frame.clutch_sequence);
+  output.append(",\"tracking\":{\"head\":");
+  output.append(frame.tracking.head ? "true" : "false");
+  output.append(",\"left_controller\":");
+  output.append(frame.tracking.left_controller ? "true" : "false");
+  output.append(",\"right_controller\":");
+  output.append(frame.tracking.right_controller ? "true" : "false");
+  output.append("},\"head\":");
+  AppendPose(output, frame.head);
+  output.append(",\"left_controller\":");
+  AppendPose(output, frame.left_controller);
+  output.append(",\"right_controller\":");
+  AppendPose(output, frame.right_controller);
+  output.append(",\"controllers\":{\"left\":");
+  AppendController(output, frame.left_input);
+  output.append(",\"right\":");
+  AppendController(output, frame.right_input);
+  output.push_back('}');
+  if (frame.base_twist) {
+    output.append(",\"base_twist\":{\"linear\":");
+    AppendArray(output, frame.base_twist->linear);
+    output.append(",\"angular\":");
+    AppendArray(output, frame.base_twist->angular);
+    output.push_back('}');
+  }
+  output.push_back('}');
+  return output;
+}
+
+}  // namespace motus::openxr_capture

--- a/generic/openxr_capture_native/tests/capture_session_test.cpp
+++ b/generic/openxr_capture_native/tests/capture_session_test.cpp
@@ -1,0 +1,316 @@
+#include "motus/openxr_capture/capture_session.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace {
+
+using motus::openxr_capture::BeginCaptureConnection;
+using motus::openxr_capture::CaptureActionKind;
+using motus::openxr_capture::CaptureAnswerReceived;
+using motus::openxr_capture::CaptureAssigned;
+using motus::openxr_capture::CaptureAssignmentRevoked;
+using motus::openxr_capture::CaptureAssignmentV1;
+using motus::openxr_capture::CaptureAuthenticated;
+using motus::openxr_capture::CaptureChannelState;
+using motus::openxr_capture::CaptureErrorStopsReconnect;
+using motus::openxr_capture::CaptureIdentity;
+using motus::openxr_capture::CaptureLinkState;
+using motus::openxr_capture::CaptureOfferCreated;
+using motus::openxr_capture::CapturePresenceTick;
+using motus::openxr_capture::CaptureRtcFailed;
+using motus::openxr_capture::CaptureSessionState;
+using motus::openxr_capture::CaptureTransportLost;
+using motus::openxr_capture::CaptureXrEnded;
+using motus::openxr_capture::CaptureXrFocused;
+using motus::openxr_capture::FrameConfiguration;
+using motus::openxr_capture::FrameMode;
+using motus::openxr_capture::PairingBootstrap;
+using motus::openxr_capture::PresenceState;
+
+[[noreturn]] void Fail(const std::string& message) {
+  std::cerr << "capture_session_test: " << message << '\n';
+  std::exit(1);
+}
+
+void Check(bool condition, const std::string& message) {
+  if (!condition) {
+    Fail(message);
+  }
+}
+
+CaptureAssignmentV1 Assignment(
+    std::int64_t generation = 1,
+    std::string session_id = "session-a") {
+  return CaptureAssignmentV1{
+      .id = "assignment-a",
+      .generation = generation,
+      .session_id = std::move(session_id),
+      .mode = FrameMode::kLive,
+      .profile_id = "unitree_g1_23_dual_arm_controller_v1",
+      .capability_digest = std::string(64, 'a'),
+      .frame_configuration = FrameConfiguration{
+          .mode = FrameMode::kLive,
+          .base_twist = std::nullopt,
+      },
+  };
+}
+
+CaptureSessionState PairedStandby() {
+  CaptureSessionState initial{
+      .pairing = PairingBootstrap{
+          .pairing_id = "pairing-a",
+          .pairing_code = std::string(43, 'p'),
+      },
+  };
+  auto begun = BeginCaptureConnection(initial);
+  Check(begun.actions.size() == 1 &&
+            begun.actions[0].kind == CaptureActionKind::kSendPairAuthentication,
+        "first connection must authenticate with the one-time pairing code");
+  auto paired = CaptureAuthenticated(
+      begun.state,
+      begun.state.connection_epoch,
+      CaptureIdentity{
+          .capture_id = "capture-a",
+          .capture_credential = std::string(43, 'c'),
+      },
+      true);
+  Check(paired.state.identity.has_value() && !paired.state.pairing.has_value(),
+        "pairing must become a persistent capture identity");
+  Check(paired.actions.size() == 2 &&
+            paired.actions[0].kind == CaptureActionKind::kPersistCredential &&
+            paired.actions[1].presence == PresenceState::kBrowserReady,
+        "fresh credential must persist and immediately start unbound presence");
+  return CaptureXrFocused(paired.state, paired.state.connection_epoch).state;
+}
+
+CaptureSessionState Streaming() {
+  auto standby = PairedStandby();
+  auto assigned = CaptureAssigned(
+      standby,
+      standby.connection_epoch,
+      Assignment());
+  Check(assigned.state.link == CaptureLinkState::kNegotiating,
+        "PC assignment must start negotiation");
+  Check(assigned.actions.size() == 2 &&
+            assigned.actions[0].presence == PresenceState::kRtcConnecting &&
+            assigned.actions[1].kind == CaptureActionKind::kCreateRtcOffer,
+        "assignment must emit connecting presence and exactly one RTC start action");
+  const auto offered = CaptureOfferCreated(
+      assigned.state,
+      assigned.state.connection_epoch,
+      "assignment-a",
+      "v=0\r\na=offer");
+  Check(offered.actions.size() == 1 &&
+            offered.actions[0].kind == CaptureActionKind::kSendSignalingOffer,
+        "gathered SDP must be sent exactly once over capture WSS");
+  const auto duplicate_offer = CaptureOfferCreated(
+      offered.state,
+      offered.state.connection_epoch,
+      "assignment-a",
+      "v=0\r\na=duplicate");
+  Check(duplicate_offer.actions.empty(),
+        "duplicate gathering callback must not consume the one-shot Driver offer twice");
+  auto answered = CaptureAnswerReceived(
+      offered.state,
+      offered.state.connection_epoch,
+      "assignment-a",
+      "v=0\r\na=answer");
+  Check(answered.state.answer_applied &&
+            answered.actions[0].kind == CaptureActionKind::kApplyRtcAnswer,
+        "matching answer must be applied");
+  auto streaming = CaptureChannelState(
+      answered.state,
+      answered.state.connection_epoch,
+      "assignment-a",
+      true,
+      true);
+  Check(streaming.state.link == CaptureLinkState::kStreaming,
+        "both exact data channels must enter streaming");
+  Check(streaming.actions.size() == 1 &&
+            streaming.actions[0].presence == PresenceState::kStreaming,
+        "streaming presence must bind the active assignment");
+  return streaming.state;
+}
+
+void PcAssignmentIsTheOnlyRtcAuthorityTrigger() {
+  const auto standby = PairedStandby();
+  Check(standby.link == CaptureLinkState::kStandby && standby.xr_focused,
+        "focused native OpenXR must settle in standby");
+  const auto tick = CapturePresenceTick(standby, standby.connection_epoch);
+  Check(tick.actions.size() == 1 &&
+            tick.actions[0].presence == PresenceState::kXrStandby,
+        "standby heartbeat must not create RTC or robot authority");
+  for (const auto& action : tick.actions) {
+    Check(action.kind != CaptureActionKind::kCreateRtcOffer,
+          "presence alone must never start Driver RTC");
+  }
+
+  auto not_focused = standby;
+  not_focused.xr_focused = false;
+  const auto background_tick = CapturePresenceTick(
+      not_focused, not_focused.connection_epoch);
+  Check(background_tick.actions.size() == 1 &&
+            background_tick.actions[0].presence == PresenceState::kBrowserReady,
+        "authenticated native app must remain observable while XR is not focused");
+}
+
+void SocketLossClosesRtcLocallyAndStaleCallbacksAreInert() {
+  auto streaming = Streaming();
+  streaming.frame_state.deadman_active = true;
+  streaming.frame_state.rearm_required = false;
+  const auto old_epoch = streaming.connection_epoch;
+  const auto lost = CaptureTransportLost(streaming, old_epoch, "wss_disconnected");
+  Check(lost.state.link == CaptureLinkState::kOffline && !lost.state.assignment,
+        "WSS loss must synchronously discard the local assignment");
+  Check(!lost.state.frame_state.deadman_active && lost.state.frame_state.rearm_required,
+        "WSS loss must relatch physical deadman before reconnect");
+  Check(lost.actions.size() == 2 &&
+            lost.actions[0].kind == CaptureActionKind::kCloseRtc &&
+            lost.actions[1].kind == CaptureActionKind::kScheduleReconnect,
+        "WSS loss must close Driver RTC before reconnecting");
+
+  auto reconnecting = BeginCaptureConnection(lost.state);
+  Check(reconnecting.actions[0].kind ==
+            CaptureActionKind::kSendCredentialAuthentication,
+        "reconnect must use persisted credential, never replay pairing");
+  const auto stale = CaptureAnswerReceived(
+      reconnecting.state,
+      old_epoch,
+      "assignment-a",
+      "stale-answer");
+  Check(stale.actions.empty() &&
+            stale.state.connection_epoch == reconnecting.state.connection_epoch,
+        "events from an old socket epoch must be ignored");
+}
+
+void RtcAndXrLossFailClosed() {
+  auto streaming = Streaming();
+  const auto failed = CaptureRtcFailed(
+      streaming,
+      streaming.connection_epoch,
+      "assignment-a",
+      "pose_channel_closed");
+  Check(failed.state.link == CaptureLinkState::kFaulted,
+        "RTC failure must latch a local fault");
+  Check(failed.actions.size() == 3 &&
+            failed.actions[0].kind == CaptureActionKind::kCloseRtc &&
+            failed.actions[1].presence == PresenceState::kError,
+        "RTC failure must close peer before reporting assignment-bound error");
+
+  streaming = Streaming();
+  const auto ended = CaptureXrEnded(
+      streaming,
+      streaming.connection_epoch,
+      "openxr_not_focused");
+  Check(!ended.state.assignment && !ended.state.xr_focused,
+        "OpenXR focus loss must revoke local streaming state");
+  Check(ended.actions.size() == 2 &&
+            ended.actions[0].kind == CaptureActionKind::kCloseRtc &&
+            ended.actions[1].presence == PresenceState::kXrEnded &&
+            ended.actions[1].assignment_id.empty(),
+        "XR end must close RTC and use terminal unbound presence contract");
+}
+
+void CaptureErrorRetryPolicyMatchesDriverContract() {
+  for (const std::string code : {
+           "capture_credential_invalid",
+           "capture_pairing_invalid",
+           "capture_protocol_unsupported",
+           "frame_protocol_unsupported",
+           "capture_client_unsupported",
+           // Compatibility with deployments that emitted the old spellings.
+           "capture_auth_invalid",
+           "capture_protocol_mismatch",
+       }) {
+    Check(CaptureErrorStopsReconnect(code),
+          code + " must stop reconnecting the unchanged enrollment");
+  }
+
+  for (const std::string code : {
+           "capture_busy",
+           "capture_state_unavailable",
+           "capture_stale",
+           "capture_presence_timeout",
+           "capture_message_invalid",
+           "capture_assignment_mismatch",
+           "invalid_signaling_offer",
+       }) {
+    Check(!CaptureErrorStopsReconnect(code),
+          code + " must remain retryable after the transport closes safely");
+  }
+}
+
+void GenerationAndSessionWatermarksPreventReplay() {
+  auto streaming = Streaming();
+  streaming.frame_state = {
+      .next_sequence = 41,
+      .clutch_sequence = 3,
+      .deadman_active = true,
+      .rearm_required = false,
+      .last_monotonic_ns = 99,
+  };
+  const auto revoked = CaptureAssignmentRevoked(
+      streaming,
+      streaming.connection_epoch,
+      "assignment-a",
+      "operator_pause");
+  Check(revoked.state.frame_state.next_sequence == 41 &&
+            revoked.state.frame_state.clutch_sequence == 3 &&
+            revoked.state.frame_state.rearm_required,
+        "same-session retry must retain sequence watermarks and require regrip");
+
+  auto retry = Assignment(2);
+  retry.id = "assignment-b";
+  const auto retried = CaptureAssigned(
+      revoked.state,
+      revoked.state.connection_epoch,
+      retry);
+  Check(retried.state.frame_state.next_sequence == 41 &&
+            retried.state.frame_state.clutch_sequence == 3,
+        "same session must not rewind Driver sequence");
+
+  const auto stale = CaptureAssignmentRevoked(
+      retried.state,
+      retried.state.connection_epoch,
+      "assignment-b",
+      "retry_failed");
+  auto replay = Assignment(1);
+  replay.id = "assignment-replay";
+  const auto rejected = CaptureAssigned(
+      stale.state,
+      stale.state.connection_epoch,
+      replay);
+  Check(rejected.state.link == CaptureLinkState::kFaulted,
+        "old assignment generation must fail closed");
+
+  auto next_session_state = stale.state;
+  // The Driver owns the assignment counter and may restart between sessions.
+  // A new session may therefore restart at generation 1, while the same
+  // session remains strictly monotonic.
+  auto next = Assignment(1, "session-b");
+  next.id = "assignment-c";
+  const auto next_session = CaptureAssigned(
+      next_session_state,
+      next_session_state.connection_epoch,
+      next);
+  Check(next_session.state.frame_state.next_sequence == 0 &&
+            next_session.state.frame_state.clutch_sequence == 0,
+        "a new Driver session gets fresh RTC sequence watermarks");
+  Check(next_session.state.link == CaptureLinkState::kNegotiating &&
+            next_session.state.highest_assignment_generation == 1,
+        "a new Driver session may restart its assignment generation watermark");
+}
+
+}  // namespace
+
+int main() {
+  PcAssignmentIsTheOnlyRtcAuthorityTrigger();
+  SocketLossClosesRtcLocallyAndStaleCallbacksAreInert();
+  RtcAndXrLossFailClosed();
+  CaptureErrorRetryPolicyMatchesDriverContract();
+  GenerationAndSessionWatermarksPreventReplay();
+  std::cout << "openxr-capture session: all host tests passed\n";
+  return 0;
+}

--- a/generic/openxr_capture_native/tests/capture_wire_test.cpp
+++ b/generic/openxr_capture_native/tests/capture_wire_test.cpp
@@ -1,0 +1,176 @@
+#include "motus/openxr_capture/capture_wire.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+namespace {
+
+using motus::openxr_capture::CaptureAssignmentMessage;
+using motus::openxr_capture::CaptureAuthenticatedMessage;
+using motus::openxr_capture::CaptureIdentity;
+using motus::openxr_capture::CaptureSignalingAnswerMessage;
+using motus::openxr_capture::FrameMode;
+using motus::openxr_capture::PairingBootstrap;
+using motus::openxr_capture::ParseCaptureServerMessage;
+using motus::openxr_capture::PresenceState;
+using motus::openxr_capture::SerializeCapturePresence;
+using motus::openxr_capture::SerializeCaptureSignalingOffer;
+using motus::openxr_capture::SerializeCredentialAuthentication;
+using motus::openxr_capture::SerializePairAuthentication;
+
+constexpr char kCaptureId[] = "3f32ff2f-ed55-44d1-8ee3-87f3576c1a6f";
+constexpr char kAssignmentId[] = "441b5d6c-ee37-419c-bd00-c4ed0c1962a8";
+constexpr char kSessionId[] = "7ad3de66-64f2-4d47-89a2-c8da2940eb97";
+
+[[noreturn]] void Fail(const std::string& message) {
+  std::cerr << "capture_wire_test: " << message << '\n';
+  std::exit(1);
+}
+
+void Check(bool condition, const std::string& message) {
+  if (!condition) {
+    Fail(message);
+  }
+}
+
+template <typename Callback>
+void CheckInvalid(Callback callback, const std::string& message) {
+  try {
+    callback();
+  } catch (const std::invalid_argument&) {
+    return;
+  }
+  Fail(message);
+}
+
+std::string AssignmentMessage(bool base = false) {
+  const std::string input_bindings = base
+      ? R"({"base_twist":{"linear_x":{"hand":"left","axis":3,"scale":0.5,"deadzone":0.2,"direction":-1},"linear_y":{"hand":"left","axis":2,"scale":0.3,"deadzone":0.2,"direction":-1},"angular_z":{"hand":"right","axis":2,"scale":0.6,"deadzone":0.2,"direction":-1}}})"
+      : "{}";
+  const std::string outputs = base
+      ? R"({"dual_arm":{"enabled":true,"joint_count":10},"base":{"enabled":true}})"
+      : R"({"dual_arm":{"enabled":true,"joint_count":10}})";
+  const std::string effectors = base ? R"(["dual_arm","base"])" : R"(["dual_arm"])";
+  return std::string(R"({"type":"assignment","assignment":{"id":")") +
+      kAssignmentId + R"(","generation":1,"session_id":")" + kSessionId +
+      R"(","mode":"live","profile_id":"unitree_g1_23_dual_arm_controller_v1","capability_digest":")" +
+      std::string(64, 'a') + R"(","capabilities":{"profile_id":"unitree_g1_23_dual_arm_controller_v1","input_bindings":)" +
+      input_bindings + R"(,"outputs":)" + outputs + R"(,"effectors":)" + effectors +
+      R"(},"effectors":)" + effectors +
+      R"(,"state":"issued","created_at":1000,"updated_at":1001,"failure_code":null}})";
+}
+
+void AuthenticationNeverMovesSecretsIntoUrls() {
+  const PairingBootstrap pairing{
+      .pairing_id = "f922333d-88f7-42a9-b140-56fbf7f670f3",
+      .pairing_code = std::string(43, 'p'),
+  };
+  const auto pair = SerializePairAuthentication(pairing, "0.1.0");
+  Check(pair.find("motus.teleop.capture.v1") != std::string::npos,
+        "pair auth must bind capture protocol");
+  Check(pair.find("native_openxr") != std::string::npos,
+        "pair auth must identify native OpenXR client");
+
+  const CaptureIdentity identity{
+      .capture_id = kCaptureId,
+      .capture_credential = std::string(43, 'c'),
+  };
+  const auto credential = SerializeCredentialAuthentication(identity, "0.1.0");
+  Check(credential.find(identity.capture_credential) != std::string::npos,
+        "credential belongs only in the in-band first message");
+}
+
+void AuthAndAssignmentAreStrictlyProjected() {
+  const auto paired = ParseCaptureServerMessage(
+      std::string(R"({"type":"paired","capture_id":")") + kCaptureId +
+      R"(","capture_credential":")" + std::string(43, 'c') +
+      R"(","capture_protocol":"motus.teleop.capture.v1","frame_protocol":"motus.teleop.rtc-frame.v1","presence_interval_ms":2000,"presence_timeout_ms":5000})");
+  const auto& authenticated = std::get<CaptureAuthenticatedMessage>(paired);
+  Check(authenticated.fresh_credential &&
+            authenticated.identity.capture_id == kCaptureId &&
+            authenticated.presence_interval_ms == 2000,
+        "paired response must expose exact persisted identity and timers");
+
+  const auto connected = ParseCaptureServerMessage(
+      std::string(R"({"type":"connected","capture_id":")") + kCaptureId +
+      R"(","capture_protocol":"motus.teleop.capture.v1","frame_protocol":"motus.teleop.rtc-frame.v1","presence_interval_ms":2000,"presence_timeout_ms":5000})",
+      authenticated.identity);
+  Check(!std::get<CaptureAuthenticatedMessage>(connected).fresh_credential,
+        "reconnect acknowledgement must reuse rather than echo credential");
+
+  const auto assignment = std::get<CaptureAssignmentMessage>(
+      ParseCaptureServerMessage(AssignmentMessage())).assignment;
+  Check(assignment.id == kAssignmentId && assignment.session_id == kSessionId &&
+            assignment.mode == FrameMode::kLive &&
+            !assignment.frame_configuration.base_twist.has_value(),
+        "arm-only assignment must map to exact native frame configuration");
+
+  const auto base_assignment = std::get<CaptureAssignmentMessage>(
+      ParseCaptureServerMessage(AssignmentMessage(true))).assignment;
+  Check(base_assignment.frame_configuration.base_twist.has_value() &&
+            base_assignment.frame_configuration.base_twist->linear_x.axis == 3,
+        "descriptor-provided base mapping must survive strict projection");
+}
+
+void SignalingAndPresenceUseExactPublicEnvelopes() {
+  const auto standby = SerializeCapturePresence(PresenceState::kXrStandby, {});
+  Check(standby == R"({"assignment_id":null,"state":"xr_standby","type":"presence"})",
+        "standby presence must be explicitly unbound");
+  const auto streaming = SerializeCapturePresence(
+      PresenceState::kStreaming, kAssignmentId);
+  Check(streaming.find(kAssignmentId) != std::string::npos,
+        "streaming presence must bind assignment");
+  CheckInvalid(
+      [] { static_cast<void>(SerializeCapturePresence(PresenceState::kStreaming, {})); },
+      "assignment-bound presence without id must fail closed");
+
+  const auto offer = SerializeCaptureSignalingOffer(kAssignmentId, "v=0\r\na=offer");
+  Check(offer.find("signaling_offer") != std::string::npos &&
+            offer.find("pairing") == std::string::npos,
+        "SDP message must not contain enrollment authority");
+  const auto answer = ParseCaptureServerMessage(
+      std::string(R"({"type":"signaling_answer","assignment_id":")") +
+      kAssignmentId + R"(","answer":{"type":"answer","sdp":"v=0\r\na=answer"}})");
+  Check(std::get<CaptureSignalingAnswerMessage>(answer).answer_sdp == "v=0\r\na=answer",
+        "answer SDP must parse for matching state-machine binding");
+}
+
+void AmbiguousOrContradictoryJsonFailsClosed() {
+  CheckInvalid(
+      [] {
+        static_cast<void>(ParseCaptureServerMessage(
+            R"({"type":"error","type":"presence_ack","code":"bad"})"));
+      },
+      "duplicate JSON keys must be rejected");
+  CheckInvalid(
+      [] {
+        static_cast<void>(ParseCaptureServerMessage(
+            R"({"type":"error","code":"bad","extra":true})"));
+      },
+      "unknown fields must be rejected");
+
+  auto contradictory = AssignmentMessage();
+  const auto marker = contradictory.find(R"("effectors":["dual_arm"],"state")");
+  Check(marker != std::string::npos, "test fixture marker missing");
+  contradictory.replace(
+      marker,
+      std::string(R"("effectors":["dual_arm"])" ).size(),
+      R"("effectors":[])" );
+  CheckInvalid(
+      [&contradictory] { static_cast<void>(ParseCaptureServerMessage(contradictory)); },
+      "top-level and capability effectors must agree");
+}
+
+}  // namespace
+
+int main() {
+  AuthenticationNeverMovesSecretsIntoUrls();
+  AuthAndAssignmentAreStrictlyProjected();
+  SignalingAndPresenceUseExactPublicEnvelopes();
+  AmbiguousOrContradictoryJsonFailsClosed();
+  std::cout << "openxr-capture wire: all host tests passed\n";
+  return 0;
+}

--- a/generic/openxr_capture_native/tests/emit_frame_fixture.cpp
+++ b/generic/openxr_capture_native/tests/emit_frame_fixture.cpp
@@ -1,0 +1,61 @@
+#include "motus/openxr_capture/frame_v1.hpp"
+
+#include <iostream>
+
+namespace {
+
+using motus::openxr_capture::BuildFrameV1;
+using motus::openxr_capture::ControllerSample;
+using motus::openxr_capture::FrameConfiguration;
+using motus::openxr_capture::FrameMode;
+using motus::openxr_capture::FrameSample;
+using motus::openxr_capture::FrameState;
+using motus::openxr_capture::PoseSample;
+using motus::openxr_capture::SerializeFrameV1;
+
+PoseSample Pose(double x, double y, double z) {
+  return PoseSample{
+      .valid = true,
+      .emulated = false,
+      .position = {x, y, z},
+      .orientation = {0.0, 0.0, 0.0, 1.0},
+  };
+}
+
+ControllerSample Controller(bool pressed) {
+  return ControllerSample{
+      .active = true,
+      .xr_standard = true,
+      .correct_handedness = true,
+      .tracked_pointer = true,
+      .has_grip_space = true,
+      .squeeze_pressed = pressed,
+      .axes = {0.0, 0.0, 0.0, 0.0},
+      .buttons = {0.0, pressed ? 1.0 : 0.0},
+  };
+}
+
+FrameSample Sample(bool pressed, std::int64_t monotonic_ns) {
+  return FrameSample{
+      .head = Pose(0.0, 1.6, 0.0),
+      .left_controller = Pose(-0.2, 1.2, -0.3),
+      .right_controller = Pose(0.2, 1.2, -0.3),
+      .left_input = Controller(pressed),
+      .right_input = Controller(pressed),
+      .distinct_input_sources = true,
+      .monotonic_ns = monotonic_ns,
+  };
+}
+
+}  // namespace
+
+int main() {
+  const FrameConfiguration configuration{
+      .mode = FrameMode::kLive,
+      .base_twist = std::nullopt,
+  };
+  const auto released = BuildFrameV1(FrameState{}, Sample(false, 1'000'000), configuration);
+  const auto active = BuildFrameV1(released.state, Sample(true, 2'000'000), configuration);
+  std::cout << SerializeFrameV1(active.frame) << '\n';
+  return 0;
+}

--- a/generic/openxr_capture_native/tests/enrollment_test.cpp
+++ b/generic/openxr_capture_native/tests/enrollment_test.cpp
@@ -1,0 +1,113 @@
+#include "motus/openxr_capture/enrollment.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+using motus::openxr_capture::CaptureLaunchBootstrap;
+using motus::openxr_capture::SelectCaptureEnrollment;
+using motus::openxr_capture::StoredCaptureEnrollment;
+
+[[noreturn]] void Fail(const std::string& message) {
+  std::cerr << "enrollment_test: " << message << '\n';
+  std::exit(1);
+}
+
+void Check(bool condition, const std::string& message) {
+  if (!condition) {
+    Fail(message);
+  }
+}
+
+template <typename Callback>
+void CheckRejected(Callback callback, const std::string& message) {
+  try {
+    callback();
+  } catch (const std::invalid_argument&) {
+    return;
+  }
+  Fail(message);
+}
+
+StoredCaptureEnrollment Stored() {
+  return StoredCaptureEnrollment{
+      .capture_id = "capture-a",
+      .capture_credential = "credential-a",
+      .websocket_url = "wss://trusted.example/ws/teleop-capture",
+      .ca_certificate_pem = "trusted-ca",
+  };
+}
+
+void ResumeIsPinnedToTheStoredOrigin() {
+  const auto selected = SelectCaptureEnrollment(Stored(), {});
+  Check(selected.identity.has_value() && !selected.pairing.has_value(),
+        "resume must select the stored identity");
+  Check(selected.websocket_url == "wss://trusted.example/ws/teleop-capture" &&
+            selected.ca_certificate_pem == "trusted-ca",
+        "resume must atomically reuse the stored WSS origin and CA");
+
+  CheckRejected(
+      [] {
+        static_cast<void>(SelectCaptureEnrollment(
+            Stored(),
+            CaptureLaunchBootstrap{
+                .websocket_url = "wss://attacker.example/ws/teleop-capture",
+                .ca_certificate_pem = "attacker-ca",
+                .transport_override_present = true,
+            }));
+      },
+      "an exported Activity must reject transport injection on resume");
+}
+
+void ExplicitCompletePairingMayReplaceTheEnrollment() {
+  const auto selected = SelectCaptureEnrollment(
+      Stored(),
+      CaptureLaunchBootstrap{
+          .pairing_id = "pairing-b",
+          .pairing_code = "pairing-secret-b",
+          .websocket_url = "wss://replacement.example/ws/teleop-capture",
+          .ca_certificate_pem = "replacement-ca",
+          .transport_override_present = true,
+      });
+  Check(!selected.identity.has_value() && selected.pairing.has_value(),
+        "a complete new pairing must not send the old credential");
+  Check(selected.websocket_url ==
+            "wss://replacement.example/ws/teleop-capture",
+        "a complete new pairing may bind a replacement origin");
+
+  CheckRejected(
+      [] {
+        static_cast<void>(SelectCaptureEnrollment(
+            Stored(),
+            CaptureLaunchBootstrap{
+                .pairing_id = "pairing-only",
+                .websocket_url = "wss://replacement.example/ws/teleop-capture",
+                .ca_certificate_pem = "replacement-ca",
+                .transport_override_present = true,
+            }));
+      },
+      "partial pairing bootstrap must fail closed");
+}
+
+void IncompleteStoredEnrollmentFailsClosed() {
+  auto stored = Stored();
+  stored.capture_credential.clear();
+  CheckRejected(
+      [&stored] {
+        static_cast<void>(SelectCaptureEnrollment(stored, {}));
+      },
+      "identity without its credential and transport binding must be unusable");
+}
+
+}  // namespace
+
+int main() {
+  ResumeIsPinnedToTheStoredOrigin();
+  ExplicitCompletePairingMayReplaceTheEnrollment();
+  IncompleteStoredEnrollmentFailsClosed();
+  std::cout << "openxr-capture enrollment: all host tests passed\n";
+  return 0;
+}

--- a/generic/openxr_capture_native/tests/frame_v1_test.cpp
+++ b/generic/openxr_capture_native/tests/frame_v1_test.cpp
@@ -1,0 +1,237 @@
+#include "motus/openxr_capture/frame_v1.hpp"
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+using motus::openxr_capture::AxisBinding;
+using motus::openxr_capture::BaseTwistBinding;
+using motus::openxr_capture::BuildFrameV1;
+using motus::openxr_capture::ControllerSample;
+using motus::openxr_capture::FrameConfiguration;
+using motus::openxr_capture::FrameMode;
+using motus::openxr_capture::FrameSample;
+using motus::openxr_capture::FrameState;
+using motus::openxr_capture::MarkDeadmanReleased;
+using motus::openxr_capture::PoseSample;
+using motus::openxr_capture::SerializeFrameV1;
+
+[[noreturn]] void Fail(const std::string& message) {
+  std::cerr << "frame_v1_test: " << message << '\n';
+  std::exit(1);
+}
+
+void Check(bool condition, const std::string& message) {
+  if (!condition) {
+    Fail(message);
+  }
+}
+
+void CheckNear(double actual, double expected, const std::string& message) {
+  if (std::abs(actual - expected) > 1e-12) {
+    Fail(message);
+  }
+}
+
+PoseSample TrackedPose(double x = 0.0, double y = 1.5, double z = 0.0) {
+  return PoseSample{
+      .valid = true,
+      .emulated = false,
+      .position = {x, y, z},
+      .orientation = {0.0, 0.0, 0.0, 1.0},
+  };
+}
+
+ControllerSample Controller(bool pressed, double squeeze_value, double x = 0.0, double y = 0.0) {
+  return ControllerSample{
+      .active = true,
+      .xr_standard = true,
+      .correct_handedness = true,
+      .tracked_pointer = true,
+      .has_grip_space = true,
+      .squeeze_pressed = pressed,
+      .axes = {0.0, 0.0, x, y},
+      .buttons = {0.0, squeeze_value},
+  };
+}
+
+FrameSample Sample(bool pressed, double squeeze_value) {
+  return FrameSample{
+      .head = TrackedPose(0.0, 1.6, 0.0),
+      .left_controller = TrackedPose(-0.2, 1.2, -0.3),
+      .right_controller = TrackedPose(0.2, 1.2, -0.3),
+      .left_input = Controller(pressed, squeeze_value),
+      .right_input = Controller(pressed, squeeze_value),
+      .distinct_input_sources = true,
+      .monotonic_ns = 1'000'000,
+  };
+}
+
+FrameConfiguration ArmOnly(FrameMode mode = FrameMode::kLive) {
+  return FrameConfiguration{.mode = mode, .base_twist = std::nullopt};
+}
+
+FrameConfiguration WithBase() {
+  return FrameConfiguration{
+      .mode = FrameMode::kLive,
+      .base_twist = BaseTwistBinding{
+          .linear_x = AxisBinding{
+              .hand = AxisBinding::Hand::kLeft,
+              .axis = 3,
+              .scale = 0.5,
+              .deadzone = 0.2,
+              .direction = -1,
+          },
+          .linear_y = AxisBinding{
+              .hand = AxisBinding::Hand::kLeft,
+              .axis = 2,
+              .scale = 0.3,
+              .deadzone = 0.2,
+              .direction = -1,
+          },
+          .angular_z = AxisBinding{
+              .hand = AxisBinding::Hand::kRight,
+              .axis = 2,
+              .scale = 0.6,
+              .deadzone = 0.2,
+              .direction = -1,
+          },
+      },
+  };
+}
+
+void InitialHeldGripCannotArm() {
+  const auto held = BuildFrameV1(FrameState{}, Sample(true, 1.0), ArmOnly());
+  Check(!held.frame.deadman, "initial held squeeze must not arm");
+  Check(held.state.rearm_required, "initial held squeeze must retain rearm latch");
+  Check(held.frame.clutch_sequence == 0, "initial held squeeze must not advance clutch");
+  Check(held.frame.sequence == 0 && held.state.next_sequence == 1, "sequence must advance once");
+}
+
+void ReleaseNeutralRegripArmsAndMapsXrStandardAxes() {
+  FrameState state;
+  auto released_sample = Sample(false, 0.0);
+  const auto released = BuildFrameV1(state, released_sample, WithBase());
+  Check(!released.frame.deadman, "release frame must be inactive");
+  Check(!released.state.rearm_required, "neutral explicit release must clear rearm latch");
+
+  auto pressed_sample = Sample(true, 1.0);
+  pressed_sample.monotonic_ns = 2'000'000;
+  const auto pressed = BuildFrameV1(released.state, pressed_sample, WithBase());
+  Check(pressed.frame.deadman, "release-neutral-regrip must arm");
+  Check(pressed.frame.clutch_sequence == 1, "first deliberate grip must increment clutch");
+  Check(pressed.frame.base_twist.has_value(), "base-enabled frame must include base_twist");
+
+  auto motion_sample = Sample(true, 1.0);
+  motion_sample.monotonic_ns = 3'000'000;
+  motion_sample.left_input.axes = {0.7, -0.6, -1.0, -1.0};
+  motion_sample.right_input.axes = {-0.8, 0.9, -1.0, 0.5};
+  const auto motion = BuildFrameV1(pressed.state, motion_sample, WithBase());
+  Check(motion.frame.deadman, "motion after neutral engagement must remain armed");
+  CheckNear(motion.frame.base_twist->linear[0], 0.5, "left axes[3] must drive linear_x");
+  CheckNear(motion.frame.base_twist->linear[1], 0.3, "left axes[2] must drive linear_y");
+  CheckNear(motion.frame.base_twist->angular[2], 0.6, "right axes[2] must drive angular_z");
+}
+
+void ReconnectAndTrackingLossRequireHigherClutch() {
+  auto released = BuildFrameV1(FrameState{}, Sample(false, 0.0), ArmOnly());
+  auto active_sample = Sample(true, 1.0);
+  active_sample.monotonic_ns = 2'000'000;
+  auto active = BuildFrameV1(released.state, active_sample, ArmOnly());
+  Check(active.frame.deadman && active.frame.clutch_sequence == 1, "test precondition failed");
+
+  const auto reconnect_state = MarkDeadmanReleased(active.state);
+  auto held_sample = Sample(true, 1.0);
+  held_sample.monotonic_ns = 3'000'000;
+  auto held = BuildFrameV1(reconnect_state, held_sample, ArmOnly());
+  Check(!held.frame.deadman && held.frame.clutch_sequence == 1,
+        "holding squeeze across reconnect must stay inhibited");
+
+  auto second_release_sample = Sample(false, 0.0);
+  second_release_sample.monotonic_ns = 4'000'000;
+  auto second_release = BuildFrameV1(held.state, second_release_sample, ArmOnly());
+  auto second_grip_sample = Sample(true, 1.0);
+  second_grip_sample.monotonic_ns = 5'000'000;
+  auto second_grip = BuildFrameV1(second_release.state, second_grip_sample, ArmOnly());
+  Check(second_grip.frame.deadman && second_grip.frame.clutch_sequence == 2,
+        "reconnect must require and prove a higher clutch sequence");
+
+  auto lost_tracking_sample = Sample(true, 1.0);
+  lost_tracking_sample.left_controller.valid = false;
+  lost_tracking_sample.monotonic_ns = 6'000'000;
+  auto lost = BuildFrameV1(second_grip.state, lost_tracking_sample, ArmOnly());
+  Check(!lost.frame.deadman && lost.state.rearm_required,
+        "tracking loss must release deadman and relatch rearm");
+}
+
+void MalformedInputFailsClosedAndMonotonicNeverRegresses() {
+  auto malformed = Sample(false, 0.0);
+  malformed.left_input.buttons = {0.0};
+  malformed.head.orientation = {0.0, 0.0, 0.0, 2.0};
+  malformed.monotonic_ns = -4;
+  const auto result = BuildFrameV1(
+      FrameState{.last_monotonic_ns = 41}, malformed, ArmOnly(FrameMode::kShadow));
+  Check(!result.frame.deadman && result.state.rearm_required,
+        "malformed input must fail closed");
+  Check(!result.frame.head.has_value() && !result.frame.tracking.head,
+        "invalid pose must be projected as null and untracked");
+  Check(result.frame.client_monotonic_ns == 42,
+        "invalid or regressing monotonic sample must advance from watermark");
+}
+
+void JsonHasExactPublicEnvelopeAndNoAuthority() {
+  auto released = BuildFrameV1(FrameState{}, Sample(false, 0.0), ArmOnly(FrameMode::kShadow));
+  const std::string json = SerializeFrameV1(released.frame);
+  Check(json.find("\"schema_version\":1") != std::string::npos, "schema_version missing");
+  Check(json.find("\"mode\":\"shadow\"") != std::string::npos, "mode missing");
+  Check(json.find("\"controllers\":{\"left\":{\"axes\":[0,0,0,0],\"buttons\":[0,0]}") !=
+            std::string::npos,
+        "xr-standard controller slots must be serialized exactly");
+  Check(json.find("session_id") == std::string::npos, "frame must not contain session authority");
+  Check(json.find("fence") == std::string::npos, "frame must not contain fence authority");
+  Check(json.find("token") == std::string::npos, "frame must not contain credentials");
+  Check(json.find("base_twist") == std::string::npos,
+        "arm-only capabilities must omit base_twist");
+}
+
+void SafeIntegerExhaustionThrows() {
+  bool sequence_threw = false;
+  try {
+    static_cast<void>(BuildFrameV1(
+        FrameState{.next_sequence = motus::openxr_capture::kMaxSafeWireInteger},
+        Sample(false, 0.0),
+        ArmOnly()));
+  } catch (const std::range_error&) {
+    sequence_threw = true;
+  }
+  Check(sequence_threw, "exhausted sequence must throw instead of wrapping");
+
+  bool monotonic_threw = false;
+  try {
+    static_cast<void>(BuildFrameV1(
+        FrameState{.last_monotonic_ns = motus::openxr_capture::kMaxSafeWireInteger},
+        Sample(false, 0.0),
+        ArmOnly()));
+  } catch (const std::range_error&) {
+    monotonic_threw = true;
+  }
+  Check(monotonic_threw, "exhausted monotonic watermark must throw instead of wrapping");
+}
+
+}  // namespace
+
+int main() {
+  InitialHeldGripCannotArm();
+  ReleaseNeutralRegripArmsAndMapsXrStandardAxes();
+  ReconnectAndTrackingLossRequireHigherClutch();
+  MalformedInputFailsClosedAndMonotonicNeverRegresses();
+  JsonHasExactPublicEnvelopeAndNoAuthority();
+  SafeIntegerExhaustionThrows();
+  std::cout << "openxr-capture frame_v1: all host tests passed\n";
+  return 0;
+}

--- a/generic/openxr_capture_native/tests/launch_capture_test.sh
+++ b/generic/openxr_capture_native/tests/launch_capture_test.sh
@@ -1,0 +1,160 @@
+#!/bin/sh
+set -eu
+
+if [ "${MOTUS_FAKE_ADB:-}" = 1 ]; then
+  : "${MOTUS_FAKE_ADB_CAPTURE:?}"
+  umask 077
+  : > "$MOTUS_FAKE_ADB_CAPTURE"
+  for argument in "$@"; do
+    printf '%s\n' "$argument" >> "$MOTUS_FAKE_ADB_CAPTURE"
+  done
+  exit 0
+fi
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+project_dir=$(CDPATH= cd -- "$script_dir/.." && pwd)
+launch_script="$project_dir/scripts/launch_capture.sh"
+test_dir=$(mktemp -d "${TMPDIR:-/tmp}/motus-launch-capture.XXXXXX")
+trap 'rm -rf "$test_dir"' EXIT HUP INT TERM
+
+fail() {
+  echo "launch_capture_test: $*" >&2
+  exit 1
+}
+
+assert_line() {
+  capture=$1
+  line_number=$2
+  expected=$3
+  actual=$(sed -n "${line_number}p" "$capture")
+  [ "$actual" = "$expected" ] || \
+    fail "line $line_number: expected '$expected', got '$actual'"
+}
+
+run_fake() {
+  capture=$1
+  shift
+  MOTUS_FAKE_ADB=1 \
+  MOTUS_FAKE_ADB_CAPTURE="$capture" \
+  ADB="$0" \
+  "$launch_script" "$@"
+}
+
+meta_resume="$test_dir/meta-resume.args"
+ADB_SERIAL='meta-serial' run_fake "$meta_resume" --platform meta --resume
+assert_line "$meta_resume" 1 -s
+assert_line "$meta_resume" 2 meta-serial
+assert_line "$meta_resume" 3 shell
+assert_line "$meta_resume" 6 -S
+assert_line "$meta_resume" 7 -n
+assert_line "$meta_resume" 8 \
+  com.phanthymotus.questcapture/android.app.NativeActivity
+
+pico_resume="$test_dir/pico-resume.args"
+ADB_SERIAL= run_fake "$pico_resume" --resume --platform=pico
+assert_line "$pico_resume" 1 shell
+assert_line "$pico_resume" 4 -S
+assert_line "$pico_resume" 5 -n
+assert_line "$pico_resume" 6 \
+  com.phanthymotus.picocapture/android.app.NativeActivity
+
+pico_pair="$test_dir/pico-pair.args"
+pico_output="$test_dir/pico-pair.output"
+MOTUS_FAKE_ADB=1 \
+MOTUS_FAKE_ADB_CAPTURE="$pico_pair" \
+ADB="$0" \
+ADB_SERIAL='pico-serial' \
+DRIVER_CAPTURE_WSS_URL='wss://driver.example/ws/teleop-capture' \
+PAIRING_ID='pairing-id' \
+PAIRING_CODE='one-time-secret' \
+CA_CERT_BASE64='VEVTVA==' \
+  "$launch_script" --platform pico > "$pico_output" 2>&1
+[ ! -s "$pico_output" ] || fail "launch output must not disclose bootstrap values"
+assert_line "$pico_pair" 1 -s
+assert_line "$pico_pair" 2 pico-serial
+assert_line "$pico_pair" 7 -n
+assert_line "$pico_pair" 8 \
+  com.phanthymotus.picocapture/android.app.NativeActivity
+grep -Fx -- one-time-secret "$pico_pair" >/dev/null || \
+  fail "pairing code was not passed as an Activity extra"
+grep -Fx -- wss://driver.example/ws/teleop-capture "$pico_pair" >/dev/null || \
+  fail "Driver Capture URL was not passed as an Activity extra"
+grep -Fx -- driver_capture_wss_url "$pico_pair" >/dev/null || \
+  fail "Driver Capture URL did not use the expected Activity extra"
+
+meta_pair="$test_dir/meta-pair.args"
+MOTUS_FAKE_ADB=1 \
+MOTUS_FAKE_ADB_CAPTURE="$meta_pair" \
+ADB="$0" \
+DRIVER_CAPTURE_WSS_URL='wss://driver.example/ws/teleop-capture' \
+PAIRING_ID='pairing-id' \
+PAIRING_CODE='meta-secret' \
+CA_CERT_BASE64='VEVTVA==' \
+  "$launch_script" --platform=meta
+assert_line "$meta_pair" 6 \
+  com.phanthymotus.questcapture/android.app.NativeActivity
+
+# The launcher must enforce the same 32 KiB decoded-PEM boundary as Android.
+# Exactly 32,768 bytes encode to 43,692 characters with one padding byte.
+ca_at_limit=$(awk 'BEGIN { for (i = 0; i < 43691; ++i) printf "A"; printf "=" }')
+ca_limit_pair="$test_dir/ca-limit.args"
+MOTUS_FAKE_ADB=1 \
+MOTUS_FAKE_ADB_CAPTURE="$ca_limit_pair" \
+ADB="$0" \
+DRIVER_CAPTURE_WSS_URL='wss://driver.example/ws/teleop-capture' \
+PAIRING_ID='pairing-id' \
+PAIRING_CODE='ca-limit-secret' \
+CA_CERT_BASE64="$ca_at_limit" \
+  "$launch_script" --platform meta
+
+# A 43,692-character value without padding decodes to 32,769 bytes and must be
+# rejected even though its encoded length alone is at the nominal maximum.
+ca_decoded_over_limit=$(awk 'BEGIN { for (i = 0; i < 43692; ++i) printf "A" }')
+set +e
+MOTUS_FAKE_ADB=1 \
+MOTUS_FAKE_ADB_CAPTURE="$test_dir/ca-decoded-over.args" \
+ADB="$0" \
+DRIVER_CAPTURE_WSS_URL='wss://driver.example/ws/teleop-capture' \
+PAIRING_ID='pairing-id' \
+PAIRING_CODE='ca-over-secret' \
+CA_CERT_BASE64="$ca_decoded_over_limit" \
+  "$launch_script" --platform meta > "$test_dir/ca-decoded-over.output" 2>&1
+status=$?
+set -e
+[ "$status" -eq 2 ] || fail "decoded CA over 32 KiB returned $status"
+grep -F 'CA certificate base64 has an invalid size' \
+  "$test_dir/ca-decoded-over.output" >/dev/null || \
+  fail "decoded CA over 32 KiB did not report the size boundary"
+
+ca_text_over_limit="${ca_decoded_over_limit}AAAA"
+set +e
+MOTUS_FAKE_ADB=1 \
+MOTUS_FAKE_ADB_CAPTURE="$test_dir/ca-text-over.args" \
+ADB="$0" \
+DRIVER_CAPTURE_WSS_URL='wss://driver.example/ws/teleop-capture' \
+PAIRING_ID='pairing-id' \
+PAIRING_CODE='ca-text-over-secret' \
+CA_CERT_BASE64="$ca_text_over_limit" \
+  "$launch_script" --platform pico > "$test_dir/ca-text-over.output" 2>&1
+status=$?
+set -e
+[ "$status" -eq 2 ] || fail "CA base64 over 43,692 characters returned $status"
+grep -F 'CA certificate base64 has an invalid size' \
+  "$test_dir/ca-text-over.output" >/dev/null || \
+  fail "encoded CA over 43,692 characters did not report the size boundary"
+
+for invalid in \
+  '' \
+  '--platform unknown' \
+  '--platform meta extra' \
+  '--platform meta --platform pico'
+do
+  set +e
+  # Intentional word splitting exercises the CLI parser with each invalid form.
+  ADB="$0" "$launch_script" $invalid > "$test_dir/invalid.output" 2>&1
+  status=$?
+  set -e
+  [ "$status" -eq 2 ] || fail "invalid arguments '$invalid' returned $status"
+done
+
+echo "launch_capture_test: Meta/PICO CLI contract passed"

--- a/generic/openxr_capture_native/tests/run_host_tests.sh
+++ b/generic/openxr_capture_native/tests/run_host_tests.sh
@@ -1,0 +1,143 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+project_dir=$(CDPATH= cd -- "$script_dir/.." && pwd)
+build_dir=$(mktemp -d /tmp/motus-openxr-capture-host.XXXXXX)
+trap 'rm -r "$build_dir"' EXIT HUP INT TERM
+
+manifest="$project_dir/app/src/main/AndroidManifest.xml"
+grep -F 'android:exported="true"' "$manifest" >/dev/null
+grep -F 'android:permission="android.permission.DUMP"' "$manifest" >/dev/null
+
+# The build must execute Gradle only from a fresh extraction of a private,
+# verified archive, never by reopening or executing a shared cache path.
+build_script="$project_dir/scripts/build_android.sh"
+grep -F 'verified_gradle_root=$(mktemp -d "${TMPDIR:-/tmp}/motus-gradle-' \
+  "$build_script" >/dev/null
+grep -F 'cp "$archive" "$verified_archive"' "$build_script" >/dev/null
+grep -F 'actual=$(shasum -a 256 "$verified_archive"' "$build_script" >/dev/null
+grep -F 'unzip -q "$verified_archive" -d "$verified_gradle_root"' \
+  "$build_script" >/dev/null
+verified_line=$(grep -n -F 'actual=$(shasum -a 256 "$verified_archive"' \
+  "$build_script" | cut -d: -f1)
+unzip_line=$(grep -n -F 'unzip -q "$verified_archive"' "$build_script" | cut -d: -f1)
+if [ -z "$verified_line" ] || [ -z "$unzip_line" ] || [ "$verified_line" -ge "$unzip_line" ]; then
+  echo "build_android.sh must verify the private archive before extracting it" >&2
+  exit 1
+fi
+grep -F 'verified_gradle="$verified_gradle_root/gradle-$gradle_version/bin/gradle"' \
+  "$build_script" >/dev/null
+if grep -F 'gradle_home="$tool_cache/gradle-$gradle_version"' "$build_script" >/dev/null; then
+  echo "build_android.sh must not execute a predictable expanded Gradle cache" >&2
+  exit 1
+fi
+
+"$project_dir/tests/launch_capture_test.sh"
+
+for headset in meta pico; do
+  case "$headset" in
+    meta)
+      headset_definition=-DMOTUS_CAPTURE_HEADSET_META=1
+      test_definition=-DTEST_EXPECT_META=1
+      ;;
+    pico)
+      headset_definition=-DMOTUS_CAPTURE_HEADSET_PICO=1
+      test_definition=-DTEST_EXPECT_PICO=1
+      ;;
+  esac
+  "${CXX:-clang++}" \
+    -std=c++20 \
+    -Wall \
+    -Wextra \
+    -Werror \
+    -pedantic \
+    "$headset_definition" \
+    "$test_definition" \
+    -I"$project_dir/app/src/main/cpp" \
+    "$project_dir/app/src/main/cpp/runtime_profile.cpp" \
+    "$project_dir/tests/runtime_profile_test.cpp" \
+    -o "$build_dir/runtime_profile_test_$headset"
+
+  "$build_dir/runtime_profile_test_$headset"
+done
+
+"${CXX:-clang++}" \
+  -std=c++20 \
+  -Wall \
+  -Wextra \
+  -Werror \
+  -pedantic \
+  -I"$project_dir/include" \
+  "$project_dir/src/frame_v1.cpp" \
+  "$project_dir/tests/frame_v1_test.cpp" \
+  -o "$build_dir/frame_v1_test"
+
+"$build_dir/frame_v1_test"
+
+"${CXX:-clang++}" \
+  -std=c++20 \
+  -Wall \
+  -Wextra \
+  -Werror \
+  -pedantic \
+  -I"$project_dir/include" \
+  "$project_dir/src/frame_v1.cpp" \
+  "$project_dir/src/capture_session.cpp" \
+  "$project_dir/tests/capture_session_test.cpp" \
+  -o "$build_dir/capture_session_test"
+
+"$build_dir/capture_session_test"
+
+"${CXX:-clang++}" \
+  -std=c++20 \
+  -Wall \
+  -Wextra \
+  -Werror \
+  -pedantic \
+  -I"$project_dir/include" \
+  "$project_dir/src/enrollment.cpp" \
+  "$project_dir/tests/enrollment_test.cpp" \
+  -o "$build_dir/enrollment_test"
+
+"$build_dir/enrollment_test"
+
+if [ -n "${NLOHMANN_JSON_INCLUDE:-}" ]; then
+  "${CXX:-clang++}" \
+    -std=c++20 \
+    -Wall \
+    -Wextra \
+    -Werror \
+    -pedantic \
+    -I"$project_dir/include" \
+    -I"$NLOHMANN_JSON_INCLUDE" \
+    "$project_dir/src/frame_v1.cpp" \
+    "$project_dir/src/capture_session.cpp" \
+    "$project_dir/src/capture_wire.cpp" \
+    "$project_dir/tests/capture_wire_test.cpp" \
+    -o "$build_dir/capture_wire_test"
+
+  "$build_dir/capture_wire_test"
+else
+  echo "capture_wire_test: SKIP (set NLOHMANN_JSON_INCLUDE)" >&2
+fi
+
+"${CXX:-clang++}" \
+  -std=c++20 \
+  -Wall \
+  -Wextra \
+  -Werror \
+  -pedantic \
+  -I"$project_dir/include" \
+  "$project_dir/src/frame_v1.cpp" \
+  "$project_dir/tests/emit_frame_fixture.cpp" \
+  -o "$build_dir/emit_frame_fixture"
+
+"$build_dir/emit_frame_fixture" > "$build_dir/frame_v1.json"
+python3 "$project_dir/tests/verify_frame_fixture.py" "$build_dir/frame_v1.json"
+
+if [ -n "${PHANTHYMOTUS_DRIVER_G1_ROOT:-}" ]; then
+  python3 "$project_dir/tests/verify_frame_fixture.py" \
+    "$build_dir/frame_v1.json" \
+    --driver-root "$PHANTHYMOTUS_DRIVER_G1_ROOT"
+fi

--- a/generic/openxr_capture_native/tests/runtime_profile_test.cpp
+++ b/generic/openxr_capture_native/tests/runtime_profile_test.cpp
@@ -1,0 +1,153 @@
+#include "runtime_profile.hpp"
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using motus::openxr_capture::FloorReferenceSpace;
+using motus::openxr_capture::HeadsetTarget;
+using motus::openxr_capture::IsInteractionProfileAllowed;
+using motus::openxr_capture::SelectFloorReferenceSpace;
+using motus::openxr_capture::SelectRuntime;
+
+constexpr std::string_view kLocalFloorExtension = "XR_EXT_local_floor";
+constexpr std::string_view kPico4Extension = "XR_BD_controller_interaction";
+constexpr std::string_view kPicoUltraExtension =
+    "XR_BD_ultra_controller_interaction";
+constexpr std::string_view kOculusTouchProfile =
+    "/interaction_profiles/oculus/touch_controller";
+constexpr std::string_view kPico4Profile =
+    "/interaction_profiles/bytedance/pico4_controller";
+constexpr std::string_view kPicoUltraProfile =
+    "/interaction_profiles/bytedance/pico_ultra_controller_bd";
+
+[[noreturn]] void Fail(std::string_view message) {
+  std::cerr << "FAIL: " << message << '\n';
+  std::exit(1);
+}
+
+void Check(bool condition, std::string_view message) {
+  if (!condition) {
+    Fail(message);
+  }
+}
+
+template <typename Function>
+void CheckThrows(Function&& function, std::string_view message) {
+  try {
+    function();
+  } catch (const std::exception&) {
+    return;
+  }
+  Fail(message);
+}
+
+void TestMetaSelection() {
+  const auto selection = SelectRuntime(
+      motus::openxr_capture::MetaRuntimeProfile(),
+      {kLocalFloorExtension, kPico4Extension, kPicoUltraExtension});
+  Check(selection.local_floor_extension_enabled,
+        "Meta selection should enable available local-floor support");
+  Check(selection.optional_extensions.size() == 1,
+        "Meta selection must not enable PICO controller extensions");
+  Check(IsInteractionProfileAllowed(selection, kOculusTouchProfile),
+        "Meta selection should allow Oculus Touch");
+  Check(!IsInteractionProfileAllowed(selection, kPico4Profile),
+        "Meta selection must reject PICO 4 controllers");
+  Check(!IsInteractionProfileAllowed(selection, kPicoUltraProfile),
+        "Meta selection must reject PICO Ultra controllers");
+}
+
+void TestPicoSelection() {
+  const auto both = SelectRuntime(
+      motus::openxr_capture::PicoRuntimeProfile(),
+      {kLocalFloorExtension, kPico4Extension, kPicoUltraExtension});
+  Check(both.local_floor_extension_enabled,
+        "PICO selection should enable available local-floor support");
+  Check(both.optional_extensions.size() == 3,
+        "PICO selection should enable both available controller extensions");
+  Check(IsInteractionProfileAllowed(both, kPico4Profile),
+        "PICO selection should allow PICO 4 when its extension is enabled");
+  Check(IsInteractionProfileAllowed(both, kPicoUltraProfile),
+        "PICO selection should allow PICO Ultra when its extension is enabled");
+  Check(!IsInteractionProfileAllowed(both, kOculusTouchProfile),
+        "PICO selection must reject Oculus Touch");
+
+  const auto pico4_only = SelectRuntime(
+      motus::openxr_capture::PicoRuntimeProfile(), {kPico4Extension});
+  Check(IsInteractionProfileAllowed(pico4_only, kPico4Profile),
+        "PICO 4-only runtime should select PICO 4");
+  Check(!IsInteractionProfileAllowed(pico4_only, kPicoUltraProfile),
+        "PICO 4-only runtime must not allow PICO Ultra");
+
+  const auto ultra_only = SelectRuntime(
+      motus::openxr_capture::PicoRuntimeProfile(), {kPicoUltraExtension});
+  Check(!IsInteractionProfileAllowed(ultra_only, kPico4Profile),
+        "PICO Ultra-only runtime must not allow PICO 4");
+  Check(IsInteractionProfileAllowed(ultra_only, kPicoUltraProfile),
+        "PICO Ultra-only runtime should select PICO Ultra");
+
+  CheckThrows(
+      [] {
+        static_cast<void>(SelectRuntime(
+            motus::openxr_capture::PicoRuntimeProfile(),
+            {kLocalFloorExtension}));
+      },
+      "PICO runtime without either controller extension must fail closed");
+}
+
+void TestFloorSelection() {
+  Check(
+      SelectFloorReferenceSpace(true, true, true) ==
+          FloorReferenceSpace::kLocalFloor,
+      "local-floor should take priority over stage");
+  Check(
+      SelectFloorReferenceSpace(false, true, true) ==
+          FloorReferenceSpace::kStage,
+      "an unenabled local-floor extension must not be used");
+  Check(
+      SelectFloorReferenceSpace(true, false, true) ==
+          FloorReferenceSpace::kStage,
+      "stage should be the floor-relative fallback");
+  CheckThrows(
+      [] {
+        static_cast<void>(SelectFloorReferenceSpace(false, false, false));
+      },
+      "absence of local-floor and stage must fail closed");
+  CheckThrows(
+      [] {
+        static_cast<void>(SelectFloorReferenceSpace(true, false, false));
+      },
+      "enumerated local-floor space is required before use");
+}
+
+void TestCompiledTarget() {
+#if defined(TEST_EXPECT_META)
+  Check(
+      motus::openxr_capture::CompiledRuntimeProfile().target ==
+          HeadsetTarget::kMeta,
+      "Meta compile macro should select the Meta runtime profile");
+#elif defined(TEST_EXPECT_PICO)
+  Check(
+      motus::openxr_capture::CompiledRuntimeProfile().target ==
+          HeadsetTarget::kPico,
+      "PICO compile macro should select the PICO runtime profile");
+#else
+#error "runtime_profile_test requires TEST_EXPECT_META or TEST_EXPECT_PICO"
+#endif
+}
+
+}  // namespace
+
+int main() {
+  TestMetaSelection();
+  TestPicoSelection();
+  TestFloorSelection();
+  TestCompiledTarget();
+  std::cout << "runtime_profile_test: PASS\n";
+  return 0;
+}

--- a/generic/openxr_capture_native/tests/verify_android_apks.py
+++ b/generic/openxr_capture_native/tests/verify_android_apks.py
@@ -1,0 +1,192 @@
+"""Verify both Android OpenXR Capture APKs without installing a headset."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
+
+PROJECT = Path(__file__).resolve().parents[1]
+EXPECTED_PERMISSIONS = {
+    "android.permission.ACCESS_NETWORK_STATE",
+    "android.permission.INTERNET",
+    "android.permission.WAKE_LOCK",
+    "org.khronos.openxr.permission.OPENXR",
+    "org.khronos.openxr.permission.OPENXR_SYSTEM",
+}
+EXPECTED_LIBRARIES = {
+    "lib/arm64-v8a/libc++_shared.so",
+    "lib/arm64-v8a/libmotus_openxr_capture.so",
+    "lib/arm64-v8a/libopenxr_loader.so",
+}
+ANDROID_LIBRARIES = {
+    "libandroid.so",
+    "libc.so",
+    "libdl.so",
+    "libEGL.so",
+    "libGLESv3.so",
+    "liblog.so",
+    "libm.so",
+}
+FLAVORS = {
+    "meta": {
+        "package": "com.phanthymotus.questcapture",
+        "label": "PhanthyMotus Meta Capture",
+        "pico_metadata": False,
+    },
+    "pico": {
+        "package": "com.phanthymotus.picocapture",
+        "label": "PhanthyMotus PICO Capture",
+        "pico_metadata": True,
+    },
+}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def run(*arguments: str) -> str:
+    completed = subprocess.run(
+        arguments,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return completed.stdout
+
+
+def android_tools() -> tuple[Path, Path]:
+    sdk = Path(os.environ.get("ANDROID_SDK_ROOT", ""))
+    require(sdk.is_dir(), "ANDROID_SDK_ROOT must point to the pinned Android SDK")
+    build_tools = sdk / "build-tools" / "35.0.1"
+    prebuilt = (
+        sdk
+        / "ndk"
+        / "27.0.12077973"
+        / "toolchains"
+        / "llvm"
+        / "prebuilt"
+    )
+    readelf_candidates = list(prebuilt.glob("*/bin/llvm-readelf"))
+    for tool in ("aapt2", "apksigner", "zipalign"):
+        require((build_tools / tool).is_file(), f"missing Android tool: {tool}")
+    require(len(readelf_candidates) == 1, "missing or ambiguous NDK llvm-readelf")
+    return build_tools, readelf_candidates[0]
+
+
+def verify_elf(readelf: Path, library: Path, packaged_names: set[str]) -> None:
+    header = run(str(readelf), "-h", str(library))
+    require("Class:                             ELF64" in header, f"{library.name} is not ELF64")
+    require("Machine:                           AArch64" in header, f"{library.name} is not AArch64")
+    dynamic = run(str(readelf), "-d", str(library))
+    needed = set(re.findall(r"Shared library: \[([^]]+)]", dynamic))
+    unexpected = needed - packaged_names - ANDROID_LIBRARIES
+    require(not unexpected, f"{library.name} has unbundled dependencies: {sorted(unexpected)}")
+
+
+def verify_apk(
+    flavor: str,
+    expected: dict[str, object],
+    build_tools: Path,
+    readelf: Path,
+) -> dict[str, object]:
+    apk = PROJECT / "app" / "build" / "outputs" / "apk" / flavor / "debug" / f"app-{flavor}-debug.apk"
+    require(apk.is_file(), f"missing {flavor} APK: {apk}")
+
+    badging = run(str(build_tools / "aapt2"), "dump", "badging", str(apk))
+    for fragment in (
+        f"package: name='{expected['package']}'",
+        "versionCode='2'",
+        "versionName='0.2.0'",
+        "minSdkVersion:'29'",
+        "targetSdkVersion:'35'",
+        f"application-label:'{expected['label']}'",
+        "native-code: 'arm64-v8a'",
+    ):
+        require(fragment in badging, f"{flavor} badging is missing {fragment!r}")
+
+    permissions = run(str(build_tools / "aapt2"), "dump", "permissions", str(apk))
+    actual_permissions = set(re.findall(r"uses-permission: name='([^']+)'", permissions))
+    require(
+        actual_permissions == EXPECTED_PERMISSIONS,
+        f"{flavor} permission mismatch: {sorted(actual_permissions)}",
+    )
+
+    manifest = run(
+        str(build_tools / "aapt2"),
+        "dump",
+        "xmltree",
+        "--file",
+        "AndroidManifest.xml",
+        str(apk),
+    )
+    require('="android.app.lib_name"' in manifest, f"{flavor} lacks NativeActivity library metadata")
+    require('="org.khronos.openxr.intent.category.IMMERSIVE_HMD"' in manifest, f"{flavor} lacks OpenXR launch category")
+    require(
+        '="android.permission.DUMP"' in manifest,
+        f"{flavor} NativeActivity is not restricted to the ADB/system caller boundary",
+    )
+    pico_metadata = re.search(
+        r'="pvr\.app\.type".*\n\s+A: .*="vr"',
+        manifest,
+    ) is not None
+    require(
+        pico_metadata == expected["pico_metadata"],
+        f"{flavor} pvr.app.type presence is incorrect",
+    )
+
+    run(str(build_tools / "zipalign"), "-c", "-P", "16", "-v", "4", str(apk))
+    signature = run(
+        str(build_tools / "apksigner"),
+        "verify",
+        "--verbose",
+        "--print-certs",
+        str(apk),
+    )
+    require(
+        "Verified using v2 scheme (APK Signature Scheme v2): true" in signature,
+        f"{flavor} APK lacks a valid v2 signature",
+    )
+
+    with zipfile.ZipFile(apk) as archive:
+        libraries = {name for name in archive.namelist() if name.startswith("lib/")}
+        require(libraries == EXPECTED_LIBRARIES, f"{flavor} native library set mismatch: {sorted(libraries)}")
+        with tempfile.TemporaryDirectory(prefix=f"motus-{flavor}-apk-") as directory:
+            extracted = Path(directory)
+            packaged_names = {Path(name).name for name in libraries}
+            for name in libraries:
+                archive.extract(name, extracted)
+                verify_elf(readelf, extracted / name, packaged_names)
+
+    digest = hashlib.sha256(apk.read_bytes()).hexdigest()
+    return {
+        "bytes": apk.stat().st_size,
+        "package": expected["package"],
+        "pvr_app_type": pico_metadata,
+        "sha256": digest,
+    }
+
+
+def main() -> None:
+    build_tools, readelf = android_tools()
+    results = {
+        flavor: verify_apk(flavor, expected, build_tools, readelf)
+        for flavor, expected in FLAVORS.items()
+    }
+    require(
+        results["meta"]["sha256"] != results["pico"]["sha256"],
+        "Meta and PICO APKs must be distinct artifacts",
+    )
+    print(json.dumps({"artifacts": results, "result": "PASS"}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/generic/openxr_capture_native/tests/verify_frame_fixture.py
+++ b/generic/openxr_capture_native/tests/verify_frame_fixture.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+import uuid
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('fixture', type=pathlib.Path)
+    parser.add_argument('--driver-root', type=pathlib.Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    arguments = _arguments()
+    frame = json.loads(arguments.fixture.read_text(encoding='utf-8'))
+    assert set(frame) == {
+        'schema_version',
+        'sequence',
+        'client_monotonic_ns',
+        'mode',
+        'deadman',
+        'clutch_sequence',
+        'tracking',
+        'head',
+        'left_controller',
+        'right_controller',
+        'controllers',
+    }
+    assert frame['schema_version'] == 1
+    assert frame['mode'] == 'live'
+    assert frame['deadman'] is True
+    assert frame['clutch_sequence'] == 1
+    assert frame['tracking'] == {
+        'head': True,
+        'left_controller': True,
+        'right_controller': True,
+    }
+    assert frame['controllers']['left'] == {
+        'axes': [0, 0, 0, 0],
+        'buttons': [0, 1],
+    }
+    assert frame['controllers']['right'] == frame['controllers']['left']
+
+    if arguments.driver_root is None:
+        print('openxr-capture fixture: public JSON contract passed')
+        return
+
+    driver_root = arguments.driver_root.resolve()
+    if not (driver_root / 'teleop' / 'protocol.py').is_file():
+        raise SystemExit(f'G1 Driver root is invalid: {driver_root}')
+    sys.path.insert(0, str(driver_root))
+    from teleop.protocol import bind_rtc_frame_v1  # noqa: PLC0415
+
+    session_id = str(uuid.UUID('d097eb8f-b386-455f-9e2b-23f1ad6a1ee3'))
+    bound = bind_rtc_frame_v1(
+        frame,
+        authority={
+            'boot_id': str(uuid.UUID('6e6973a9-5b32-4d10-b1b8-c0331800a4aa')),
+            'session_id': session_id,
+            'epoch': 1,
+            'fence': 'f' * 32,
+        },
+        expected_mode='live',
+    )
+    assert bound['session_id'] == session_id
+    assert bound['deadman'] is True
+    assert bound['clutch_sequence'] == 1
+    print('openxr-capture fixture: G1 Driver strict contract passed')
+
+
+if __name__ == '__main__':
+    main()

--- a/generic/teleop_shadow/Dockerfile
+++ b/generic/teleop_shadow/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.12-slim-bookworm
+
+WORKDIR /work
+
+COPY requirements.txt /tmp/teleop-shadow-requirements.txt
+RUN pip install --no-cache-dir -r /tmp/teleop-shadow-requirements.txt
+
+COPY main.py protocol.py runtime.py dispatch.py rtc.py capture.py smoke_recording.py config.yaml driver.yaml /work/
+COPY deploy/ /deploy/
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV CONFIG_PATH=/work/config.yaml
+ENV MOTUS_MCP_PORT=15711
+
+EXPOSE 15711
+EXPOSE 15712
+
+RUN useradd --create-home --uid 10001 teleop
+USER teleop
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD ["python", "-c", "import json,os,urllib.request; p=int(os.environ['MOTUS_MCP_PORT']); d=os.environ.get('MOTUS_DRIVER_ID','teleop-shadow-driver'); s=json.load(urllib.request.urlopen(f'http://127.0.0.1:{p}/health', timeout=2)); assert s['driver_id']==d and s['actuation_enabled'] is False and s['ready'] is True and s['rtc_enabled'] is True"]
+
+CMD ["python", "/work/main.py"]

--- a/generic/teleop_shadow/README.md
+++ b/generic/teleop_shadow/README.md
@@ -1,0 +1,116 @@
+# 通用遥操作 Shadow Driver
+
+这是一个不连接机器人的 Driver-only 遥操作实现，用来先验证 Meta Quest / PICO
+原生 OpenXR 客户端、配对、WebRTC 双 DataChannel、帧校验、租约和最终安全停止。
+它永久保持 `actuation_enabled=false`，最终输出只记录 `would_apply` 和
+`would_stop`。
+
+## 与未修改 Core 的边界
+
+- Core 只按现有 MCP 协议注册和调用卡片，不签发 session、epoch、fence、心跳或
+  RTC ticket。
+- MCP HTTP 固定监听 loopback，兼容 stock Core 不发送 `Authorization` 的行为；
+  非 loopback 请求会被拒绝。
+- Driver 本地创建独占 session、单调 epoch、私有 fence 和一次性短效 RTC ticket。
+- 头显只连接独立的 TLS/WSS Capture 端口；`/offer` 不对外提供兼容降级路径。
+- 只有已配对 Capture WSS 上的合法聚焦状态能够续租。Pose 和 RTC DataChannel
+  `heartbeat` 都不能续租。
+
+## 卡片操作
+
+`teleop_session` 是标准 actuator 卡，支持：
+
+- `start`：创建或返回当前 Driver-owned Shadow session；接受 Core 自动注入的
+  `instance_id`。
+- `info` / `status`：返回卡片、Capture、RTC、Pose、lease 和 final-dispatch 状态。
+- `pair_headset`：返回一次性 `pairing_id`、`pairing_code`、明确的 `wss_url` 和
+  公共 CA 证书 base64；不会返回 TLS 私钥或 session fence。
+- `revoke_headset`：撤销持久化头显凭据并安全释放当前 session。
+- `pause`、`release`、`emergency_stop`、生命周期 `stop`：均经过不可丢弃的最终
+  safe-stop 路径。
+
+`teleop_state` 是只读状态卡。实时 60Hz/90Hz Pose 永远不走 MCP。
+
+## 两个监听面
+
+| 监听面 | 默认地址 | 用途 |
+| --- | --- | --- |
+| MCP/health | `http://127.0.0.1:15711` | stock Core 的 `initialize`、`tools/list`、`tools/call`、`/health` |
+| Capture | `wss://<机器人地址>:15712/ws/teleop-capture` | 头显配对、凭据重连、presence、assignment 和 SDP |
+
+生产启动会在任何 Capture TLS 配置错误时 fail closed。Capture 证书必须：
+
+- 位于独立目录 `/opt/phanthy-motus/data/teleop-capture-tls`，不要复用或挂载
+  Core 私钥；
+- 证书 SAN 与 `MOTUS_CAPTURE_WSS_URL` 的 hostname/IP 完全匹配；
+- 证书和私钥能组成有效服务端证书对；
+- 返回头显的公开 PEM 链解码后不超过 32768 bytes（base64 最多 43692 字符）；
+- URL 必须是 `wss://.../ws/teleop-capture`。
+
+示例：为文档保留地址 `192.0.2.110` 创建独立实验室自签证书。请替换为实际
+Driver 地址；命令不会向终端输出私钥内容：
+
+```bash
+sudo install -d -o 10001 -g 10001 -m 700 \
+  /opt/phanthy-motus/data/teleop-capture-tls
+sudo openssl req -x509 -newkey rsa:3072 -sha256 -nodes -days 365 \
+  -keyout /opt/phanthy-motus/data/teleop-capture-tls/key.pem \
+  -out /opt/phanthy-motus/data/teleop-capture-tls/cert.pem \
+  -subj '/CN=motus-teleop-capture' \
+  -addext 'subjectAltName=IP:192.0.2.110'
+sudo chown 10001:10001 \
+  /opt/phanthy-motus/data/teleop-capture-tls/key.pem \
+  /opt/phanthy-motus/data/teleop-capture-tls/cert.pem
+sudo chmod 600 /opt/phanthy-motus/data/teleop-capture-tls/key.pem
+sudo chmod 644 /opt/phanthy-motus/data/teleop-capture-tls/cert.pem
+export MOTUS_CAPTURE_WSS_URL='wss://192.0.2.110:15712/ws/teleop-capture'
+```
+
+首次通过卡片 `pair_headset` 配对后，Driver 只将单设备凭据的 SHA-256 摘要、客户端
+类型和版本原子写入配置的 `MOTUS_CAPTURE_STATE_FILE`（0600），并 fsync 文件及父目录，
+不落盘原始凭据。
+原始凭据由头显保存。Driver 重启后头显可凭该凭据自动重连；它可先保持
+`xr_standby`，PC 之后点击卡片 `start` 时 Driver 会自动下发 assignment，无需用户
+在头显里再次点击或重新配对。
+
+宿主机状态目录需要预先创建并交给容器内 UID 10001，避免 Docker 自动创建一个
+不可写的 root 目录：
+
+```bash
+sudo install -d -o 10001 -g 10001 -m 700 \
+  /opt/phanthy-motus/data/teleop-shadow
+```
+
+多实例部署使用 `deploy/instances.example.yml` 的 schema v4 和
+`render_instances.py`。每个实例必须有全局唯一的 MCP/Capture 端口、WSS URL，
+并配置一个所有实例共享、只用于注册协调的 `registration_coordination_dir`。先创建
+这个独立持久目录并交给容器 UID 10001：
+
+```bash
+sudo install -d -o 10001 -g 10001 -m 700 \
+  /opt/phanthy-motus/data/teleop-registration
+```
+
+生成器要求 Core CA、每个 Capture TLS/状态目录和注册协调目录都已存在，宿主机输入
+必须是 canonical 真实绝对路径；叶节点或任一祖先为 symlink 都会被拒绝。它还按真实
+路径及文件系统 identity 拒绝同实例/跨实例 alias、相等或祖先/子孙重叠。最终 bind
+source 只使用校验后的 canonical 路径，注册协调目录不能包含 Capture 状态、TLS 或
+Core CA。
+
+所有多实例容器在该目录共享一个 0600 `flock` 和原子/fsync 的 barrier marker。锁覆盖
+完整 Core `POST /api/mcp` 和响应读取；上一请求收到响应，或在 timeout、transport
+error、取消边界结束后，下一实例必须等到新的 Unix 秒才发送。这样确定性规避 stock
+Core 以整秒生成 MCP id 的碰撞。单实例 manifest 不设置协调文件，因此注册不取锁也
+不增加启动等待。生成的 Compose 不包含 Driver Bearer 或共享 RTC ticket secret。
+
+## 本地验证
+
+```bash
+cd generic/teleop_shadow
+uv run --offline --python 3.14 --with-requirements requirements.txt \
+  python -m unittest discover -s tests -v
+```
+
+真实本地 Shadow E2E 覆盖：MCP start → 一次性配对 → 原生 wire-compatible
+assignment → Driver 内部 RTC ticket → WebRTC 双 DataChannel → Pose
+`would_apply` → pause/release，以及断开、focus loss、presence timeout 进入 HOLD。

--- a/generic/teleop_shadow/TELEOP.md
+++ b/generic/teleop_shadow/TELEOP.md
@@ -1,0 +1,53 @@
+# Driver-owned 遥操作协议
+
+## 控制权
+
+MCP `start` 只在 Driver 内部生成 `session_id`、递增 `epoch` 和私有 `fence`。
+这些字段不从 Core 接收。`session_id` 和 `epoch` 会作为非秘密关联标识出现在卡片
+状态和 Capture assignment；`fence` 始终只存在于 Driver 内部，不会出现在状态、
+health、assignment 或公开 RTC Frame。最终 adapter 在每次输出前仍校验 authority、
+session generation、deadline、deadman 和 tracking。
+
+会话只有一个已配对 Capture owner。Capture credential 只验证
+`/ws/teleop-capture` 的首条 in-band 消息，禁止放在 URL/query 中。
+
+## Stock Core 注册协调
+
+单实例沿用直接注册快速路径。schema v4 多实例部署为所有 Driver 挂载一个独立、
+持久且不与 TLS/凭据状态重叠的协调目录。Driver 用非阻塞 `flock` 串行化实际
+`POST /api/mcp`；锁保持到响应正文读取完成，并把响应、transport error、timeout 或
+已开始 POST 的取消所在 Unix 秒原子写入 0600 barrier marker、fsync 父目录后才释放。
+下一 Driver 只有进入更新后的 Unix 秒才能 POST，因此不依赖调度时隙或启动 sleep 的
+概率。等待锁和跨秒都通过 async sleep，不阻塞 MCP/Capture event loop。
+
+## Native Capture v1
+
+服务器保持现有客户端 wire 协议：
+
+1. `pair` 或 `credential`；
+2. `paired` 或 `connected`；
+3. `presence` / `presence_ack`；
+4. PC 卡片已启动且头显聚焦后，服务器发送 `assignment`；
+5. 头显对该 assignment 发送且只能发送一次 `signaling_offer`；
+6. Driver 基于当前私有 authority 为精确 SDP 创建并立即消费一次性 ticket，返回
+   `signaling_answer`；ticket 和 fence 从不发送给头显；
+7. `teleop-control` 必须 ordered/reliable；`teleop-pose` 必须 unordered 且
+   `maxRetransmits=0`。
+
+首次绑定以及合法的 `xr_standby`、`rtc_connecting`、`streaming` presence 才会建立或
+续 lease；Pose、SDP offer、`peer_ping`、DataChannel `heartbeat` 都不续 lease。ICE/
+DTLS 的 15 秒宽限固定锚定于最近一次合法 presence，重复 offer 不能滚动延长。
+`browser_ready`、`xr_ended` 或 `error` 会同步撤销 assignment、关闭 RTC、进入 HOLD
+并等待最终 stop ack。
+
+## 恢复与终止
+
+- Pose timeout 或 RTC channel 断开进入 HOLD；再次动作要求同 generation 双通道恢复
+  且 `clutch_sequence` 严格增加。
+- Capture WSS 断开立即进入 HOLD；持久凭据重连后可获得新 assignment。
+- `pause` 是锁存安全状态；必须 release 后重新 start。
+- `release`、`emergency_stop`、生命周期 stop 和 `revoke_headset` 均撤销 authority，
+  旧 Frame、旧 ticket 和旧 RTC callback 不能复活 session。
+- WSS presence timeout 会立即撤销 assignment 并进入 HOLD；若持久凭据在 Driver motion
+  lease 到期前重连，可获得新 assignment。motion lease 一旦到期则当前 authority
+  不可逆失效，需要 PC 再次 start。

--- a/generic/teleop_shadow/capture.py
+++ b/generic/teleop_shadow/capture.py
@@ -1,0 +1,766 @@
+"""Driver-owned Capture pairing, lease and signaling control plane.
+
+The wire messages intentionally match the existing Meta/PICO native Capture
+client.  Long-lived Capture credentials authenticate only this control plane;
+they are never accepted by the loopback MCP endpoint and never enter a Pose
+frame.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import stat
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from protocol import (
+    CAPABILITY_DIGEST,
+    RTC_FRAME_PROTOCOL,
+    ProtocolError,
+    TicketCodec,
+    make_ticket_claims,
+)
+from rtc import RtcManager, RtcRequestError
+from runtime import ShadowRuntime
+
+CAPTURE_PROTOCOL = "motus.teleop.capture.v1"
+MAX_CAPTURE_MESSAGE_BYTES = 128 * 1024
+MAX_SIGNALING_SDP_BYTES = 120 * 1024
+_UUID4_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+_APP_VERSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.+-]{0,31}$")
+
+
+class CaptureError(RuntimeError):
+    def __init__(self, code: str, *, status: int = 400):
+        super().__init__(code)
+        self.code = code
+        self.status = status
+
+
+class _CaptureStatePersistenceError(OSError):
+    """State persistence failed before or after the atomic commit point."""
+
+    def __init__(self, message: str, *, committed: bool):
+        super().__init__(message)
+        self.committed = committed
+
+
+@dataclass
+class _Pairing:
+    code_digest: bytes
+    expires_monotonic: float
+
+
+@dataclass
+class _Capture:
+    credential_digest: bytes
+    client_kind: str
+    app_version: str
+
+
+@dataclass
+class CaptureConnection:
+    capture_id: str
+    connection_id: str
+    generation: int = 0
+    assignment: dict | None = None
+    ready_for_assignment: bool = False
+    offer_consumed: bool = False
+    last_presence_monotonic: float = 0.0
+    events: asyncio.Queue[dict] = field(default_factory=asyncio.Queue)
+
+
+class CaptureManager:
+    """Own one exclusive Capture connection and its private RTC grants."""
+
+    def __init__(
+        self,
+        runtime: ShadowRuntime,
+        rtc: RtcManager,
+        ticket_codec: TicketCodec,
+        *,
+        pairing_ttl_seconds: int = 60,
+        ticket_ttl_seconds: int = 20,
+        presence_interval_ms: int = 1000,
+        presence_timeout_ms: int = 5000,
+        state_file: str | Path | None = None,
+        public_wss_url: str | None = None,
+        ca_certificate_base64: str | None = None,
+        clock=time.monotonic,
+        wall_clock=time.time,
+    ):
+        if pairing_ttl_seconds < 10 or pairing_ttl_seconds > 600:
+            raise ValueError("pairing_ttl_seconds must be in [10, 600]")
+        if ticket_ttl_seconds < 1 or ticket_ttl_seconds > 30:
+            raise ValueError("ticket_ttl_seconds must be in [1, 30]")
+        if presence_interval_ms < 250 or presence_interval_ms > 10_000:
+            raise ValueError("presence_interval_ms must be in [250, 10000]")
+        if presence_timeout_ms < 1000 or presence_timeout_ms > 30_000:
+            raise ValueError("presence_timeout_ms must be in [1000, 30000]")
+        if presence_timeout_ms <= presence_interval_ms:
+            raise ValueError("presence_timeout_ms must exceed presence_interval_ms")
+        self._runtime = runtime
+        self._rtc = rtc
+        self._ticket_codec = ticket_codec
+        self._pairing_ttl = int(pairing_ttl_seconds)
+        self._ticket_ttl = int(ticket_ttl_seconds)
+        self.presence_interval_ms = int(presence_interval_ms)
+        self.presence_timeout_ms = int(presence_timeout_ms)
+        self._clock = clock
+        self._wall_clock = wall_clock
+        self._state_file = Path(state_file) if state_file else None
+        self._public_wss_url = public_wss_url
+        self._ca_certificate_base64 = ca_certificate_base64
+        self._pairings: dict[str, _Pairing] = {}
+        self._captures: dict[str, _Capture] = {}
+        self._connection: CaptureConnection | None = None
+        self._assignment_generation = 0
+        self._assignment_session_id: str | None = None
+        self._lock = asyncio.Lock()
+        self._negotiating = False
+        self._load_state()
+
+    def _load_state(self) -> None:
+        path = self._state_file
+        if path is None or not path.exists():
+            return
+        metadata = path.stat()
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or stat.S_IMODE(metadata.st_mode) != 0o600
+        ):
+            raise ValueError("Capture state file must be a regular 0600 file")
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError("Capture state file is unreadable or invalid") from exc
+        if not isinstance(payload, dict) or set(payload) != {"schema_version", "capture"}:
+            raise ValueError("Capture state file schema is invalid")
+        if payload["schema_version"] != 1:
+            raise ValueError("Capture state file schema version is unsupported")
+        record = payload["capture"]
+        if record is None:
+            return
+        if not isinstance(record, dict) or set(record) != {
+            "capture_id", "credential_sha256", "client_kind", "app_version"
+        }:
+            raise ValueError("Capture state record is invalid")
+        capture_id = self._uuid4(record["capture_id"], "capture_id")
+        digest_hex = record["credential_sha256"]
+        if not isinstance(digest_hex, str) or not re.fullmatch(r"[0-9a-f]{64}", digest_hex):
+            raise ValueError("Capture state credential digest is invalid")
+        client_kind = record["client_kind"]
+        app_version = record["app_version"]
+        if client_kind != "native_openxr":
+            raise ValueError("Capture state client kind is invalid")
+        if not isinstance(app_version, str) or not _APP_VERSION_RE.fullmatch(app_version):
+            raise ValueError("Capture state app version is invalid")
+        self._captures[capture_id] = _Capture(
+            credential_digest=bytes.fromhex(digest_hex),
+            client_kind=client_kind,
+            app_version=app_version,
+        )
+
+    def _persist_state(self) -> None:
+        path = self._state_file
+        if path is None:
+            return
+        committed = False
+        temporary: Path | None = None
+        try:
+            if path.exists() and path.is_symlink():
+                raise OSError("Capture state file may not be a symlink")
+            path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            os.chmod(path.parent, 0o700)
+            record = None
+            if self._captures:
+                capture_id, capture = next(iter(self._captures.items()))
+                record = {
+                    "capture_id": capture_id,
+                    "credential_sha256": capture.credential_digest.hex(),
+                    "client_kind": capture.client_kind,
+                    "app_version": capture.app_version,
+                }
+            encoded = json.dumps(
+                {"schema_version": 1, "capture": record},
+                ensure_ascii=False,
+                allow_nan=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+            temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            descriptor = os.open(temporary, flags, 0o600)
+            try:
+                with os.fdopen(descriptor, "wb", closefd=True) as handle:
+                    handle.write(encoded)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(temporary, path)
+                committed = True
+                os.chmod(path, 0o600)
+                directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+                directory_flags |= getattr(os, "O_CLOEXEC", 0)
+                directory_descriptor = os.open(path.parent, directory_flags)
+                try:
+                    os.fsync(directory_descriptor)
+                finally:
+                    os.close(directory_descriptor)
+            finally:
+                if temporary is not None:
+                    try:
+                        temporary.unlink()
+                    except FileNotFoundError:
+                        pass
+        except _CaptureStatePersistenceError:
+            raise
+        except OSError as exc:
+            raise _CaptureStatePersistenceError(
+                "Capture state could not be persisted",
+                committed=committed,
+            ) from exc
+
+    @staticmethod
+    def _digest(secret: str) -> bytes:
+        return hashlib.sha256(secret.encode("utf-8")).digest()
+
+    @staticmethod
+    def _uuid4(
+        value: Any,
+        field_name: str,
+        *,
+        error_code: str | None = None,
+        status: int = 400,
+    ) -> str:
+        if not isinstance(value, str) or not _UUID4_RE.fullmatch(value):
+            raise CaptureError(error_code or f"invalid_{field_name}", status=status)
+        return value
+
+    @staticmethod
+    def _exact(value: Any, keys: set[str]) -> dict:
+        if not isinstance(value, dict) or set(value) != keys:
+            raise CaptureError("capture_message_invalid")
+        return value
+
+    @staticmethod
+    def _validate_client(message: dict) -> tuple[str, str]:
+        if message["capture_protocol"] != CAPTURE_PROTOCOL:
+            raise CaptureError("capture_protocol_unsupported")
+        if message["frame_protocol"] != RTC_FRAME_PROTOCOL:
+            raise CaptureError("frame_protocol_unsupported")
+        client_kind = message["client_kind"]
+        if client_kind != "native_openxr":
+            raise CaptureError("capture_client_unsupported")
+        app_version = message["app_version"]
+        if not isinstance(app_version, str) or not _APP_VERSION_RE.fullmatch(app_version):
+            raise CaptureError("capture_message_invalid")
+        return client_kind, app_version
+
+    async def create_pairing(self) -> dict:
+        pairing_id = str(uuid.uuid4())
+        pairing_code = secrets.token_urlsafe(32)
+        now = self._clock()
+        async with self._lock:
+            self._pairings = {
+                key: value
+                for key, value in self._pairings.items()
+                if value.expires_monotonic > now
+            }
+            self._pairings[pairing_id] = _Pairing(
+                code_digest=self._digest(pairing_code),
+                expires_monotonic=now + self._pairing_ttl,
+            )
+        return {
+            "pairing_id": pairing_id,
+            "pairing_code": pairing_code,
+            "expires_in_seconds": self._pairing_ttl,
+            "websocket_path": "/ws/teleop-capture",
+            "capture_protocol": CAPTURE_PROTOCOL,
+            "frame_protocol": RTC_FRAME_PROTOCOL,
+            "wss_url": self._public_wss_url,
+            "ca_certificate_base64": self._ca_certificate_base64,
+            "credential_persistence": (
+                "state_file" if self._state_file is not None else "process_memory"
+            ),
+        }
+
+    async def connect(self, raw: Any) -> tuple[CaptureConnection, dict, dict | None]:
+        if not isinstance(raw, dict):
+            raise CaptureError("capture_message_invalid")
+        message_type = raw.get("type")
+        now = self._clock()
+        fresh_credential: str | None = None
+
+        async with self._lock:
+            if self._connection is not None:
+                raise CaptureError("capture_busy", status=409)
+            if message_type == "pair":
+                message = self._exact(raw, {
+                    "type", "pairing_id", "pairing_code", "capture_protocol",
+                    "frame_protocol", "client_kind", "app_version",
+                })
+                pairing_id = self._uuid4(
+                    message["pairing_id"],
+                    "pairing_id",
+                    error_code="capture_pairing_invalid",
+                    status=401,
+                )
+                code = message["pairing_code"]
+                if not isinstance(code, str) or not 32 <= len(code) <= 128:
+                    raise CaptureError("capture_pairing_invalid", status=401)
+                pairing = self._pairings.pop(pairing_id, None)
+                if (
+                    pairing is None
+                    or pairing.expires_monotonic <= now
+                    or not hmac.compare_digest(pairing.code_digest, self._digest(code))
+                ):
+                    raise CaptureError("capture_pairing_invalid", status=401)
+                client_kind, app_version = self._validate_client(message)
+                capture_id = str(uuid.uuid4())
+                fresh_credential = secrets.token_urlsafe(32)
+                # A Driver instance intentionally owns one paired headset.
+                # Preserve the previous in-memory identity until the atomic
+                # state-file replacement succeeds, so an I/O error cannot
+                # make runtime and restart behavior disagree.
+                previous_captures = dict(self._captures)
+                self._captures.clear()
+                self._captures[capture_id] = _Capture(
+                    credential_digest=self._digest(fresh_credential),
+                    client_kind=client_kind,
+                    app_version=app_version,
+                )
+                try:
+                    self._persist_state()
+                except OSError as exc:
+                    if not bool(getattr(exc, "committed", False)):
+                        self._captures = previous_captures
+                    raise CaptureError("capture_state_unavailable", status=503) from exc
+            elif message_type == "credential":
+                message = self._exact(raw, {
+                    "type", "capture_id", "capture_credential", "capture_protocol",
+                    "frame_protocol", "client_kind", "app_version",
+                })
+                capture_id = self._uuid4(
+                    message["capture_id"],
+                    "capture_id",
+                    error_code="capture_credential_invalid",
+                    status=401,
+                )
+                credential = message["capture_credential"]
+                if not isinstance(credential, str) or not 32 <= len(credential) <= 128:
+                    raise CaptureError("capture_credential_invalid", status=401)
+                client_kind, app_version = self._validate_client(message)
+                capture = self._captures.get(capture_id)
+                if (
+                    capture is None
+                    or capture.client_kind != client_kind
+                    or not hmac.compare_digest(
+                        capture.credential_digest,
+                        self._digest(credential),
+                    )
+                ):
+                    raise CaptureError("capture_credential_invalid", status=401)
+                if capture.app_version != app_version:
+                    previous_app_version = capture.app_version
+                    capture.app_version = app_version
+                    try:
+                        self._persist_state()
+                    except OSError as exc:
+                        if not bool(getattr(exc, "committed", False)):
+                            capture.app_version = previous_app_version
+                        raise CaptureError("capture_state_unavailable", status=503) from exc
+            else:
+                raise CaptureError("capture_message_invalid")
+
+            connection = CaptureConnection(
+                capture_id=capture_id,
+                connection_id=str(uuid.uuid4()),
+                last_presence_monotonic=now,
+            )
+            self._connection = connection
+
+            try:
+                binding, generation = await asyncio.to_thread(
+                    self._runtime.bind_capture,
+                    capture_id,
+                )
+            except ProtocolError as exc:
+                if exc.code != "session_inactive":
+                    self._connection = None
+                    raise CaptureError(exc.code, status=409) from exc
+            else:
+                connection.generation = generation
+
+            if fresh_credential is not None:
+                acknowledgement = {
+                    "type": "paired",
+                    "capture_id": capture_id,
+                    "capture_credential": fresh_credential,
+                    "capture_protocol": CAPTURE_PROTOCOL,
+                    "frame_protocol": RTC_FRAME_PROTOCOL,
+                    "presence_interval_ms": self.presence_interval_ms,
+                    "presence_timeout_ms": self.presence_timeout_ms,
+                }
+            else:
+                acknowledgement = {
+                    "type": "connected",
+                    "capture_id": capture_id,
+                    "capture_protocol": CAPTURE_PROTOCOL,
+                    "frame_protocol": RTC_FRAME_PROTOCOL,
+                    "presence_interval_ms": self.presence_interval_ms,
+                    "presence_timeout_ms": self.presence_timeout_ms,
+                }
+            # The native client accepts an assignment only after it has
+            # announced XR focus with `xr_standby` presence.
+            return connection, acknowledgement, None
+
+    def _new_assignment(self, binding: dict) -> dict:
+        session_id = binding["session_id"]
+        if session_id != self._assignment_session_id:
+            self._assignment_session_id = session_id
+            self._assignment_generation = 0
+        self._assignment_generation += 1
+        now = float(self._wall_clock())
+        effectors = ["left_arm", "right_arm"]
+        return {
+            "id": str(uuid.uuid4()),
+            "generation": self._assignment_generation,
+            "session_id": session_id,
+            "mode": "shadow",
+            "profile_id": "generic_shadow_v1",
+            "capability_digest": CAPABILITY_DIGEST,
+            "capabilities": {
+                "profile_id": "generic_shadow_v1",
+                "input_bindings": {
+                    "head": {"required": True, "role": "reference"},
+                    "left_controller": {"required": True, "role": "left_hand"},
+                    "right_controller": {"required": True, "role": "right_hand"},
+                },
+                "outputs": {
+                    "left_arm": {"enabled": True},
+                    "right_arm": {"enabled": True},
+                },
+                "effectors": effectors,
+            },
+            "effectors": effectors,
+            "state": "issued",
+            "created_at": now,
+            "updated_at": now,
+            "failure_code": None,
+        }
+
+    async def issue_assignment_if_connected(self) -> None:
+        async with self._lock:
+            connection = self._connection
+            if (
+                connection is None
+                or connection.assignment is not None
+                or not connection.ready_for_assignment
+            ):
+                return
+            try:
+                binding, generation = await asyncio.to_thread(
+                    self._runtime.bind_capture,
+                    connection.capture_id,
+                )
+            except ProtocolError:
+                return
+            connection.generation = generation
+            connection.offer_consumed = False
+            connection.assignment = self._new_assignment(binding)
+            await connection.events.put({
+                "type": "assignment",
+                "assignment": connection.assignment,
+            })
+
+    async def revoke_assignment(self, reason: str) -> None:
+        async with self._lock:
+            connection = self._connection
+            if connection is None or connection.assignment is None:
+                return
+            assignment_id = connection.assignment["id"]
+            connection.assignment = None
+            connection.generation = 0
+            connection.offer_consumed = False
+            await connection.events.put({
+                "type": "assignment_revoked",
+                "assignment_id": assignment_id,
+                "reason": reason,
+            })
+
+    async def revoke_headset(self) -> dict:
+        async with self._lock:
+            connection = self._connection
+            capture_id = (
+                connection.capture_id
+                if connection
+                else next(iter(self._captures), None)
+            )
+            had_capture = bool(self._captures)
+            previous_captures = dict(self._captures)
+            self._captures.clear()
+            try:
+                self._persist_state()
+            except OSError as exc:
+                if not bool(getattr(exc, "committed", False)):
+                    self._captures = previous_captures
+                raise CaptureError("capture_state_unavailable", status=503) from exc
+            if connection is not None:
+                await connection.events.put({
+                    "type": "capture_revoked",
+                    "reason": "operator_revoked",
+                })
+            return {"revoked": had_capture, "capture_id": capture_id}
+
+    async def presence(self, connection: CaptureConnection, raw: Any) -> dict:
+        message = self._exact(raw, {"type", "state", "assignment_id"})
+        if message["type"] != "presence" or message["state"] not in {
+            "browser_ready", "error", "rtc_connecting", "streaming",
+            "xr_ended", "xr_standby",
+        }:
+            raise CaptureError("capture_message_invalid")
+        state = message["state"]
+        assignment_id = message["assignment_id"]
+        assignment_bound = state in {"error", "rtc_connecting", "streaming"}
+        focus_lost = state in {"browser_ready", "error", "xr_ended"}
+
+        if focus_lost:
+            # This handler and the aiortc callbacks share one event loop.
+            # Validate and revoke runtime authority synchronously before an
+            # async lock, socket response, or peer close can yield to Pose.
+            if self._connection is not connection:
+                raise CaptureError("capture_stale", status=409)
+            current_id = (
+                connection.assignment["id"]
+                if connection.assignment is not None
+                else None
+            )
+            if state == "error":
+                if current_id is None:
+                    if assignment_id is not None:
+                        raise CaptureError("capture_message_invalid")
+                else:
+                    self._uuid4(assignment_id, "assignment_id")
+                    if assignment_id != current_id:
+                        raise CaptureError("capture_assignment_mismatch", status=409)
+            elif assignment_id is not None:
+                raise CaptureError("capture_message_invalid")
+            hold_generation = connection.generation
+            connection.generation = 0
+            connection.offer_consumed = False
+            revoke_event = None
+            if connection.assignment is not None:
+                revoke_event = {
+                    "type": "assignment_revoked",
+                    "assignment_id": connection.assignment["id"],
+                    "reason": f"capture_{state}",
+                }
+                connection.assignment = None
+            connection.last_presence_monotonic = self._clock()
+            if hold_generation:
+                self._runtime.capture_hold(
+                    connection.capture_id,
+                    hold_generation,
+                    f"capture_{state}",
+                )
+            if revoke_event is not None:
+                await connection.events.put(revoke_event)
+            if hold_generation:
+                await self._rtc.close_all()
+            return {"type": "presence_ack", "state": state}
+
+        async with self._lock:
+            if self._connection is not connection:
+                raise CaptureError("capture_stale", status=409)
+            current_id = (
+                connection.assignment["id"]
+                if connection.assignment is not None
+                else None
+            )
+            if assignment_bound:
+                self._uuid4(assignment_id, "assignment_id")
+                if assignment_id != current_id:
+                    raise CaptureError("capture_assignment_mismatch", status=409)
+            elif assignment_id is not None:
+                raise CaptureError("capture_message_invalid")
+            if connection.generation and state in {
+                "xr_standby", "rtc_connecting", "streaming"
+            }:
+                try:
+                    await asyncio.to_thread(
+                        self._runtime.renew_capture_lease,
+                        connection.capture_id,
+                        connection.generation,
+                    )
+                except ProtocolError as exc:
+                    raise CaptureError(exc.code, status=409) from exc
+            if state == "xr_standby":
+                connection.ready_for_assignment = True
+                if connection.assignment is None:
+                    try:
+                        binding, generation = await asyncio.to_thread(
+                            self._runtime.bind_capture,
+                            connection.capture_id,
+                        )
+                    except ProtocolError as exc:
+                        if exc.code == "session_inactive":
+                            connection.last_presence_monotonic = self._clock()
+                            return {"type": "presence_ack", "state": message["state"]}
+                        raise CaptureError(exc.code, status=409) from exc
+                    connection.generation = generation
+                    connection.offer_consumed = False
+                    connection.assignment = self._new_assignment(binding)
+                    await connection.events.put({
+                        "type": "assignment",
+                        "assignment": connection.assignment,
+                    })
+            connection.last_presence_monotonic = self._clock()
+        return {"type": "presence_ack", "state": state}
+
+    async def signaling_offer(self, connection: CaptureConnection, raw: Any) -> dict:
+        message = self._exact(raw, {"type", "assignment_id", "offer"})
+        if message["type"] != "signaling_offer":
+            raise CaptureError("capture_message_invalid")
+        assignment_id = self._uuid4(message["assignment_id"], "assignment_id")
+        offer = self._exact(message["offer"], {"type", "sdp"})
+        sdp = offer["sdp"]
+        if (
+            offer["type"] != "offer"
+            or not isinstance(sdp, str)
+            or not sdp
+            or len(sdp.encode("utf-8")) > MAX_SIGNALING_SDP_BYTES
+            or "\0" in sdp
+        ):
+            raise CaptureError("invalid_signaling_offer")
+
+        async with self._lock:
+            if self._connection is not connection:
+                raise CaptureError("capture_stale", status=409)
+            if (
+                self._clock() - connection.last_presence_monotonic
+                > self.presence_timeout_ms / 1000.0
+            ):
+                raise CaptureError("capture_presence_timeout", status=408)
+            if (
+                connection.assignment is None
+                or connection.assignment["id"] != assignment_id
+                or connection.generation == 0
+            ):
+                raise CaptureError("capture_assignment_mismatch", status=409)
+            if connection.offer_consumed:
+                raise CaptureError("capture_offer_already_consumed", status=409)
+            connection.offer_consumed = True
+            try:
+                binding, generation = await asyncio.to_thread(
+                    self._runtime.rtc_authority_snapshot,
+                )
+            except ProtocolError as exc:
+                raise CaptureError(exc.code, status=409) from exc
+            if generation != connection.generation:
+                raise CaptureError("capture_assignment_stale", status=409)
+            try:
+                await asyncio.to_thread(
+                    self._runtime.begin_capture_negotiation,
+                    connection.capture_id,
+                    connection.generation,
+                    grace_ms=15_000,
+                )
+            except ProtocolError as exc:
+                raise CaptureError(exc.code, status=409) from exc
+            ticket = self._ticket_codec.sign(make_ticket_claims(
+                session=binding,
+                sdp=sdp,
+                ttl_seconds=self._ticket_ttl,
+                wall_clock=self._wall_clock,
+                jti=secrets.token_urlsafe(18),
+            ))
+            self._negotiating = True
+            try:
+                answer = await self._rtc.accept_offer({
+                    "type": "offer",
+                    "sdp": sdp,
+                    "ticket": ticket,
+                })
+            except RtcRequestError as exc:
+                raise CaptureError(exc.code, status=exc.status) from exc
+            finally:
+                self._negotiating = False
+            if (
+                self._connection is not connection
+                or connection.generation != generation
+            ):
+                await self._rtc.close_all()
+                raise CaptureError("capture_stale", status=409)
+            return {
+                "type": "signaling_answer",
+                "assignment_id": assignment_id,
+                "answer": {"type": answer["type"], "sdp": answer["sdp"]},
+            }
+
+    def disconnect_immediate(self, connection: CaptureConnection) -> bool:
+        """Synchronously fence Capture authority before any socket await."""
+
+        if self._connection is not connection:
+            return False
+        self._connection = None
+        generation = connection.generation
+        connection.generation = 0
+        connection.offer_consumed = False
+        if generation:
+            self._runtime.mark_capture_disconnected(
+                connection.capture_id,
+                generation,
+            )
+        return True
+
+    async def disconnect(self, connection: CaptureConnection) -> None:
+        self.disconnect_immediate(connection)
+        await self._rtc.close_all()
+
+    def presence_expired(self, connection: CaptureConnection) -> bool:
+        return (
+            not self._negotiating
+            and
+            self._clock() - connection.last_presence_monotonic
+            > self.presence_timeout_ms / 1000.0
+        )
+
+    async def status(self) -> dict:
+        async with self._lock:
+            now = self._clock()
+            self._pairings = {
+                key: value
+                for key, value in self._pairings.items()
+                if value.expires_monotonic > now
+            }
+            connection = self._connection
+            return {
+                "paired_devices": len(self._captures),
+                "pending_pairings": len(self._pairings),
+                "connected": connection is not None,
+                "capture_id": connection.capture_id if connection else None,
+                "assignment_id": (
+                    connection.assignment["id"]
+                    if connection and connection.assignment is not None
+                    else None
+                ),
+                "presence_interval_ms": self.presence_interval_ms,
+                "presence_timeout_ms": self.presence_timeout_ms,
+                "credential_persistence": (
+                    "state_file" if self._state_file is not None else "process_memory"
+                ),
+                "pairing_survives_restart": self._state_file is not None,
+            }

--- a/generic/teleop_shadow/config.yaml
+++ b/generic/teleop_shadow/config.yaml
@@ -1,0 +1,39 @@
+driver_id: "teleop-shadow-driver"
+driver_name: "Generic Teleop Shadow Diagnostics"
+robot_id: null
+mcp_port: 15711
+bind_host: "127.0.0.1"
+mcp_allow_non_loopback: false
+
+teleop:
+  lease_timeout_ms: 6000
+  pose_timeout_ms: 200
+  watchdog_interval_ms: 25
+  dispatch_io_timeout_ms: 100
+  dispatch_ack_timeout_ms: 200
+  ticket_ttl_max_seconds: 30
+  ticket_replay_cache_entries: 4096
+  ticket_ttl_seconds: 20
+
+capture:
+  bind_host: "0.0.0.0"
+  port: 15712
+  public_wss_url: null
+  tls_cert_file: "/etc/motus-capture-tls/cert.pem"
+  tls_key_file: "/etc/motus-capture-tls/key.pem"
+  state_file: "/var/lib/motus-teleop-shadow/capture.json"
+  pairing_ttl_seconds: 60
+  presence_interval_ms: 1000
+  presence_timeout_ms: 5000
+
+registration:
+  enabled: true
+  agent_core_url: "https://localhost:15678"
+  advertise_url: "http://localhost:15711/mcp"
+  interval_seconds: 30
+  verify_tls: true
+  ca_file: "/etc/motus-core-ca/core-ca.pem"
+  # Null preserves a no-lock/no-wait single-instance fast path. The strict
+  # multi-instance renderer mounts one shared coordination directory and
+  # overrides this with its durable lock/marker file.
+  coordination_file: null

--- a/generic/teleop_shadow/deploy/instances.example.yml
+++ b/generic/teleop_shadow/deploy/instances.example.yml
@@ -1,0 +1,24 @@
+schema_version: 4
+core_ca_file: /opt/phanthy-motus/data/certs/cert.pem
+registration_coordination_dir: /opt/phanthy-motus/data/teleop-registration
+instances:
+  - service: teleop-shadow-lab-a
+    container: motus-teleop-shadow-lab-a
+    driver_id: teleop-shadow-lab-a
+    driver_name: Lab A Quest Teleop Shadow
+    robot_id: teleop-shadow-lab-a
+    mcp_port: 15711
+    capture_port: 15811
+    capture_wss_url: wss://192.0.2.110:15811/ws/teleop-capture
+    capture_tls_dir: /opt/phanthy-motus/data/teleop-capture-tls/lab-a
+    capture_state_dir: /opt/phanthy-motus/data/teleop-shadow/lab-a
+  - service: teleop-shadow-lab-b
+    container: motus-teleop-shadow-lab-b
+    driver_id: teleop-shadow-lab-b
+    driver_name: Lab B PICO Teleop Shadow
+    robot_id: teleop-shadow-lab-b
+    mcp_port: 15712
+    capture_port: 15812
+    capture_wss_url: wss://192.0.2.111:15812/ws/teleop-capture
+    capture_tls_dir: /opt/phanthy-motus/data/teleop-capture-tls/lab-b
+    capture_state_dir: /opt/phanthy-motus/data/teleop-shadow/lab-b

--- a/generic/teleop_shadow/deploy/service.yml
+++ b/generic/teleop_shadow/deploy/service.yml
@@ -1,0 +1,31 @@
+generic-teleop-shadow:
+  image: __IMAGE__
+  container_name: embodied-generic-teleop-shadow
+  network_mode: host
+  volumes:
+    - /opt/phanthy-motus/data/certs/cert.pem:/etc/motus-core-ca/core-ca.pem:ro
+    - /opt/phanthy-motus/data/teleop-capture-tls:/etc/motus-capture-tls:ro
+    - /opt/phanthy-motus/data/teleop-shadow:/var/lib/motus-teleop-shadow
+  environment:
+    - MOTUS_BIND_HOST=127.0.0.1
+    - MOTUS_MCP_PORT=15711
+    - MOTUS_MCP_URL=http://localhost:15711/mcp
+    - MOTUS_DRIVER_ID
+    - MOTUS_DRIVER_NAME
+    - MOTUS_ROBOT_ID
+    - MOTUS_CAPTURE_BIND_HOST=0.0.0.0
+    - MOTUS_CAPTURE_PORT=15712
+    - MOTUS_CAPTURE_WSS_URL=${MOTUS_CAPTURE_WSS_URL:?set the headset-reachable wss URL}
+    - MOTUS_CAPTURE_TLS_CERT_FILE=/etc/motus-capture-tls/cert.pem
+    - MOTUS_CAPTURE_TLS_KEY_FILE=/etc/motus-capture-tls/key.pem
+    - MOTUS_CAPTURE_STATE_FILE=/var/lib/motus-teleop-shadow/capture.json
+    - AGENT_CORE_URL=https://localhost:15678
+    - MOTUS_AGENT_CORE_VERIFY_TLS=1
+    - MOTUS_AGENT_CORE_CA_FILE=/etc/motus-core-ca/core-ca.pem
+    - PYTHONUNBUFFERED=1
+  logging:
+    driver: local
+    options:
+      max-size: "10m"
+      max-file: "3"
+  restart: unless-stopped

--- a/generic/teleop_shadow/dispatch.py
+++ b/generic/teleop_shadow/dispatch.py
@@ -1,0 +1,826 @@
+"""Final-dispatch arbitration for the robot-free teleop Shadow Driver.
+
+The adapter in this package records what a live adapter *would* receive.  It
+never imports a robot SDK or publishes a hardware command.  The arbiter is the
+executable reference for the safety boundary that later live adapters must
+implement: a one-slot motion mailbox, a non-droppable stop path, generation
+fencing, final deadline checks, and acknowledged startup/shutdown safety.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import hmac
+import json
+import math
+import re
+import threading
+import time
+from collections import Counter, deque
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from protocol import MAX_SEQUENCE
+
+_TRACKING_KEYS = frozenset({"head", "left_controller", "right_controller"})
+_ACK_CODE_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+
+def _tracking_ready(value: Any) -> bool:
+    return (
+        isinstance(value, Mapping)
+        and set(value) == _TRACKING_KEYS
+        and all(item is True for item in value.values())
+    )
+
+
+def _normalized_ack(value: Any, invalid_code: str) -> AdapterAck:
+    if not isinstance(value, AdapterAck) or not isinstance(value.ok, bool):
+        return AdapterAck(False, invalid_code)
+    if not isinstance(value.code, str) or not _ACK_CODE_RE.fullmatch(value.code):
+        return AdapterAck(False, invalid_code)
+    return value
+
+
+@dataclass(frozen=True)
+class AdapterAck:
+    """Bounded adapter acknowledgement with a stable, non-secret code."""
+
+    ok: bool
+    code: str = "ok"
+
+
+@dataclass(frozen=True)
+class MotionIntent:
+    """Sanitized motion intent delivered to an output adapter.
+
+    ``frame`` deliberately omits the fence.  Session and dispatch generations
+    are internal monotonic fences and are safe to expose to a test adapter.
+    """
+
+    session_generation: int
+    dispatch_generation: int
+    sequence: int
+    clutch_sequence: int
+    admitted_monotonic: float
+    expires_monotonic: float
+    frame: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class StopRequest:
+    dispatch_generation: int
+    reason: str
+    requested_monotonic: float
+    deadline_monotonic: float
+
+
+class OutputAdapter(Protocol):
+    """Serial adapter contract used by the final-dispatch owner thread.
+
+    Implementations must enforce their deadline in the same critical section as
+    the real SDK write. ``apply`` may not leave an unbounded background output;
+    any asynchronous downstream work must carry the supplied generation and a
+    hardware-enforced TTL. A successful ``safe_stop`` ack means all older
+    generations are cancelled, drained, or made incapable of later output.
+    Adapter methods must also impose their own downstream I/O timeout: Python
+    can detect a stalled call and revoke authority, but cannot interrupt a
+    blocking vendor SDK call safely. Adapter methods must not re-enter the
+    arbiter; a defensive self-close rejection exists only to avoid deadlock.
+    """
+
+    def startup_safe(self, deadline_monotonic: float) -> AdapterAck: ...
+
+    def apply(self, intent: MotionIntent) -> AdapterAck: ...
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck: ...
+
+    def snapshot(self) -> dict: ...
+
+    def close(self) -> AdapterAck | None: ...
+
+
+class StopHandle:
+    """Waitable result for one non-droppable safety request."""
+
+    def __init__(self, request: StopRequest, *, safety_deadline: float):
+        self.request = request
+        self.safety_deadline = safety_deadline
+        self._event = threading.Event()
+        self._ack: AdapterAck | None = None
+
+    def _finish(self, ack: AdapterAck) -> None:
+        self._ack = ack
+        self._event.set()
+
+    def wait(self, timeout: float) -> AdapterAck:
+        if not self._event.wait(timeout):
+            return AdapterAck(False, "stop_ack_timeout")
+        return self._ack or AdapterAck(False, "stop_ack_missing")
+
+    @property
+    def done(self) -> bool:
+        return self._event.is_set()
+
+
+@dataclass(frozen=True)
+class _PendingMotion:
+    intent: MotionIntent
+    authority_digest: str
+
+
+def _binding_digest(value: Mapping[str, Any]) -> str:
+    required = ("boot_id", "session_id", "epoch", "fence")
+    if any(key not in value for key in required):
+        raise ValueError("authority binding is incomplete")
+    encoded = json.dumps(
+        {key: value[key] for key in required},
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class RecordingAdapter:
+    """Bounded, thread-safe zero-actuation adapter for visible verification."""
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        max_records: int = 64,
+    ):
+        if max_records < 8 or max_records > 4096:
+            raise ValueError("max_records must be in [8, 4096]")
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._records: deque[dict] = deque(maxlen=max_records)
+        self._current = {"kind": "safe", "reason": "not_started"}
+        self._closed = False
+
+    def _record(self, value: dict) -> None:
+        record = {"recorded_monotonic": self._clock(), **copy.deepcopy(value)}
+        self._records.append(record)
+        self._current = copy.deepcopy(value)
+
+    def startup_safe(self, deadline_monotonic: float) -> AdapterAck:
+        with self._lock:
+            if self._closed:
+                return AdapterAck(False, "adapter_closed")
+            self._record({
+                "kind": "would_stop",
+                "reason": "startup_safe",
+                "dispatch_generation": 0,
+                "deadline_monotonic": deadline_monotonic,
+            })
+            if self._clock() >= deadline_monotonic:
+                return AdapterAck(False, "startup_safe_deadline_missed")
+            return AdapterAck(True)
+
+    def apply(self, intent: MotionIntent) -> AdapterAck:
+        with self._lock:
+            if self._closed:
+                return AdapterAck(False, "adapter_closed")
+            if self._clock() >= intent.expires_monotonic:
+                return AdapterAck(False, "intent_expired_at_adapter")
+            # The adapter contract itself refuses unsafe content even if a
+            # caller accidentally bypasses the runtime admission layer.
+            if intent.frame.get("deadman") is not True:
+                return AdapterAck(False, "unsafe_deadman")
+            if not _tracking_ready(intent.frame.get("tracking")):
+                return AdapterAck(False, "unsafe_tracking")
+            self._record({
+                "kind": "would_apply",
+                "sequence": intent.sequence,
+                "clutch_sequence": intent.clutch_sequence,
+                "session_generation": intent.session_generation,
+                "dispatch_generation": intent.dispatch_generation,
+                "base_twist": copy.deepcopy(intent.frame.get("base_twist")),
+            })
+            return AdapterAck(True)
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck:
+        with self._lock:
+            if self._closed:
+                return AdapterAck(False, "adapter_closed")
+            self._record({
+                "kind": "would_stop",
+                "reason": request.reason,
+                "dispatch_generation": request.dispatch_generation,
+                "deadline_monotonic": request.deadline_monotonic,
+            })
+            if self._clock() >= request.deadline_monotonic:
+                return AdapterAck(False, "adapter_stop_deadline_missed")
+            return AdapterAck(True)
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            return {
+                "kind": "recording",
+                "closed": self._closed,
+                "current": copy.deepcopy(self._current),
+                "records": copy.deepcopy(list(self._records)),
+            }
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+
+
+class FinalDispatchArbiter:
+    """Own all adapter I/O and enforce the last command authority check."""
+
+    _MOTION_STATES = frozenset({"safe_waiting_frame", "motion_eligible"})
+
+    def __init__(
+        self,
+        adapter: OutputAdapter,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        safety_clock: Callable[[], float] = time.monotonic,
+        io_timeout_ms: int = 250,
+    ):
+        if io_timeout_ms < 20 or io_timeout_ms > 5000:
+            raise ValueError("io_timeout_ms must be in [20, 5000]")
+        self._adapter = adapter
+        self._clock = clock
+        self._safety_clock = safety_clock
+        self._io_timeout = io_timeout_ms / 1000.0
+        self._condition = threading.Condition(threading.RLock())
+        self._stop_queue: deque[StopHandle] = deque()
+        self._mailbox: _PendingMotion | None = None
+        self._generation = 0
+        self._authority_digest: str | None = None
+        self._session_generation: int | None = None
+        self._state = "starting"
+        self._fault_code: str | None = None
+        self._stop_acknowledged = False
+        self._last_admitted_sequence: int | None = None
+        self._last_applied_sequence: int | None = None
+        self._last_decision = "starting"
+        self._counters: Counter[str] = Counter()
+        self._shutdown = False
+        self._closed = False
+        self._close_lock = threading.Lock()
+        self._adapter_snapshot_lock = threading.Lock()
+        self._close_result: AdapterAck | None = None
+        self._adapter_close_ack: AdapterAck | None = None
+        self._adapter_snapshot: dict = {
+            "kind": "unavailable",
+            "reason": "startup_in_progress",
+        }
+        self._io_inflight_kind: str | None = None
+        self._io_deadline_safety: float | None = None
+        self._startup_done = threading.Event()
+        self._startup_decision = threading.Event()
+        self._startup_owner_done = threading.Event()
+        # Fail-safe default: unless the constructor explicitly hands the
+        # adapter to the final-dispatch worker, the startup owner closes it
+        # after startup_safe eventually returns.
+        self._startup_should_close = True
+
+        started_at = self._clock()
+        started_safety = self._safety_clock()
+        startup_result: list[AdapterAck] = []
+
+        def run_startup_safe() -> None:
+            try:
+                startup_result.append(_normalized_ack(
+                    adapter.startup_safe(started_at + self._io_timeout),
+                    "invalid_startup_ack",
+                ))
+            except Exception:  # noqa: BLE001 -- normalize adapter faults
+                startup_result.append(AdapterAck(False, "startup_safe_exception"))
+            finally:
+                self._capture_adapter_snapshot_owned()
+                self._startup_done.set()
+            # The startup call may outlive the constructor timeout.  It keeps
+            # exclusive adapter ownership until the constructor chooses either
+            # a worker hand-off or cleanup; close/snapshot never race it.
+            self._startup_decision.wait()
+            try:
+                if self._startup_should_close:
+                    self._close_adapter_owned()
+            finally:
+                self._startup_owner_done.set()
+
+        self._startup_thread = threading.Thread(
+            target=run_startup_safe,
+            daemon=True,
+            name="teleop-shadow-startup-safe",
+        )
+        self._startup_thread.start()
+        completed = self._startup_done.wait(self._io_timeout)
+        elapsed_safety = self._safety_clock() - started_safety
+        ack = (
+            startup_result[0]
+            if completed and startup_result
+            else AdapterAck(False, "startup_safe_timeout")
+        )
+        if ack.ok and elapsed_safety <= self._io_timeout:
+            self._state = "safe_unarmed"
+            self._stop_acknowledged = True
+            self._last_decision = "startup_safe_ack"
+            self._counters["startup_safe_acks"] += 1
+        else:
+            self._state = "fault_latched"
+            self._fault_code = "startup_safe_timeout" if ack.ok else ack.code
+            self._last_decision = "startup_safe_failed"
+            self._counters["adapter_faults"] += 1
+
+        self._worker: threading.Thread | None = None
+        if self._fault_code is None:
+            self._startup_should_close = False
+        self._startup_decision.set()
+        if self._fault_code is None:
+            # The startup owner performs no adapter calls after hand-off.  This
+            # short wait also prevents successful starts from leaving a
+            # transient daemon behind in short-lived tests.
+            self._startup_owner_done.wait(self._io_timeout)
+            self._worker = threading.Thread(
+                target=self._worker_loop,
+                daemon=True,
+                name="teleop-shadow-final-dispatch",
+            )
+            self._worker.start()
+
+    @property
+    def ready(self) -> bool:
+        with self._condition:
+            self._refresh_io_stall_locked()
+            return self._fault_code is None and not self._closed
+
+    def begin_prepare(self) -> StopHandle:
+        return self.trip(
+            "prepare_shadow",
+            target_state="transitioning",
+            retain_authority=False,
+        )
+
+    def complete_prepare(
+        self,
+        handle: StopHandle,
+        binding: Mapping[str, Any],
+        session_generation: int,
+    ) -> AdapterAck:
+        digest = _binding_digest(binding)
+        with self._condition:
+            if self._closed:
+                return AdapterAck(False, "dispatch_closed")
+            if self._fault_code is not None:
+                return AdapterAck(False, self._fault_code)
+            if (
+                handle.request.dispatch_generation != self._generation
+                or not handle.done
+                or self._state != "transitioning"
+            ):
+                return AdapterAck(False, "prepare_superseded")
+            ack = handle.wait(0)
+            if not ack.ok:
+                return ack
+            self._authority_digest = digest
+            self._session_generation = session_generation
+            self._state = "safe_waiting_frame"
+            self._stop_acknowledged = True
+            self._last_admitted_sequence = None
+            self._last_applied_sequence = None
+            self._last_decision = "prepared_after_stop_ack"
+            self._counters["sessions_armed"] += 1
+            return AdapterAck(True)
+
+    def publish_latest(
+        self,
+        frame: Mapping[str, Any],
+        *,
+        session_generation: int,
+        expires_monotonic: float,
+        allow_reclutch: bool = False,
+    ) -> AdapterAck:
+        if frame.get("deadman") is not True:
+            return AdapterAck(False, "unsafe_deadman")
+        if not _tracking_ready(frame.get("tracking")):
+            return AdapterAck(False, "unsafe_tracking")
+        try:
+            digest = _binding_digest(frame)
+            sequence = frame["sequence"]
+            clutch_sequence = frame["clutch_sequence"]
+            if (
+                isinstance(sequence, bool)
+                or not isinstance(sequence, int)
+                or sequence < 0
+                or sequence > MAX_SEQUENCE
+            ):
+                raise ValueError("invalid sequence")
+            if (
+                isinstance(clutch_sequence, bool)
+                or not isinstance(clutch_sequence, int)
+                or clutch_sequence < 0
+                or clutch_sequence > MAX_SEQUENCE
+            ):
+                raise ValueError("invalid clutch sequence")
+            expiry = float(expires_monotonic)
+            if not math.isfinite(expiry):
+                raise ValueError("invalid expiry")
+        except (KeyError, TypeError, ValueError, OverflowError):
+            return AdapterAck(False, "invalid_intent")
+
+        admitted = self._clock()
+        sanitized = copy.deepcopy(dict(frame))
+        sanitized.pop("fence", None)
+        with self._condition:
+            if self._closed:
+                return AdapterAck(False, "dispatch_closed")
+            if self._fault_code is not None:
+                return AdapterAck(False, self._fault_code)
+            if self._session_generation != session_generation:
+                return AdapterAck(False, "stale_session_generation")
+            if self._authority_digest is None or not hmac.compare_digest(
+                digest, self._authority_digest
+            ):
+                return AdapterAck(False, "authority_mismatch")
+            if self._state == "safe_reclutch_required" and allow_reclutch:
+                self._state = "motion_eligible"
+                self._counters["dispatch_reclutches"] += 1
+            elif self._state not in self._MOTION_STATES:
+                return AdapterAck(False, "motion_inhibited")
+            if expiry <= admitted:
+                return AdapterAck(False, "intent_expired")
+            if (
+                self._last_admitted_sequence is not None
+                and sequence <= self._last_admitted_sequence
+            ):
+                return AdapterAck(False, "sequence_not_increasing")
+            if self._mailbox is not None:
+                self._counters["mailbox_replacements"] += 1
+            intent = MotionIntent(
+                session_generation=session_generation,
+                dispatch_generation=self._generation,
+                sequence=sequence,
+                clutch_sequence=clutch_sequence,
+                admitted_monotonic=admitted,
+                expires_monotonic=expiry,
+                frame=sanitized,
+            )
+            self._mailbox = _PendingMotion(intent, digest)
+            self._state = "motion_eligible"
+            self._last_admitted_sequence = sequence
+            self._last_decision = "admitted"
+            self._counters["motion_admitted"] += 1
+            self._condition.notify_all()
+            return AdapterAck(True)
+
+    def trip(
+        self,
+        reason: str,
+        *,
+        target_state: str,
+        retain_authority: bool,
+    ) -> StopHandle:
+        if not isinstance(reason, str) or not reason:
+            raise ValueError("stop reason is required")
+        with self._condition:
+            self._generation += 1
+            now = self._clock()
+            request = StopRequest(
+                dispatch_generation=self._generation,
+                reason=reason,
+                requested_monotonic=now,
+                deadline_monotonic=now + self._io_timeout,
+            )
+            handle = StopHandle(
+                request,
+                safety_deadline=self._safety_clock() + self._io_timeout,
+            )
+            if self._mailbox is not None:
+                self._mailbox = None
+                self._counters["mailbox_cleared_by_stop"] += 1
+            self._state = target_state
+            self._stop_acknowledged = False
+            self._last_decision = f"stop_requested:{reason}"
+            if not retain_authority:
+                self._authority_digest = None
+                self._session_generation = None
+            if self._closed or self._shutdown:
+                handle._finish(AdapterAck(False, "dispatch_closed"))
+            elif self._worker is None:
+                handle._finish(AdapterAck(False, "dispatch_unavailable"))
+            else:
+                self._stop_queue.append(handle)
+                self._counters["stop_requests"] += 1
+                self._condition.notify_all()
+            return handle
+
+    @staticmethod
+    def wait_safe(handle: StopHandle, timeout: float = 0.5) -> AdapterAck:
+        return handle.wait(timeout)
+
+    def wait_applied(self, sequence: int, timeout: float = 1.0) -> bool:
+        deadline = time.monotonic() + timeout
+        with self._condition:
+            while self._last_applied_sequence != sequence:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or self._fault_code is not None or self._closed:
+                    return False
+                self._condition.wait(remaining)
+            return True
+
+    def snapshot(self) -> dict:
+        with self._condition:
+            self._refresh_io_stall_locked()
+            state = {
+                "kind": "recording",
+                "state": self._state,
+                "ready": self._fault_code is None and not self._closed,
+                "generation": self._generation,
+                "mailbox_depth": int(self._mailbox is not None),
+                "stop_queue_depth": len(self._stop_queue),
+                "last_admitted_sequence": self._last_admitted_sequence,
+                "last_would_apply_sequence": self._last_applied_sequence,
+                "last_decision": self._last_decision,
+                "stop_acknowledged": self._stop_acknowledged,
+                "fault_code": self._fault_code,
+                "io_inflight": self._io_inflight_kind,
+                "counters": dict(sorted(self._counters.items())),
+            }
+        with self._adapter_snapshot_lock:
+            cached_adapter = self._adapter_snapshot
+        # Cache entries are replaced, never mutated.  Copying outside both
+        # arbiter locks prevents high-rate status reads from starving the I/O
+        # owner while still returning an isolated public value.
+        state["adapter"] = copy.deepcopy(cached_adapter)
+        return state
+
+    def _refresh_io_stall_locked(self) -> None:
+        if (
+            self._io_inflight_kind is None
+            or self._io_deadline_safety is None
+            or self._fault_code is not None
+            or self._safety_clock() < self._io_deadline_safety
+        ):
+            return
+        self._fault_code = "adapter_io_stalled"
+        self._state = "fault_latched"
+        self._authority_digest = None
+        self._session_generation = None
+        self._mailbox = None
+        self._stop_acknowledged = False
+        self._last_decision = f"io_stalled:{self._io_inflight_kind}"
+        self._counters["adapter_faults"] += 1
+        self._counters["adapter_io_stalls"] += 1
+        # The owner may currently be blocked, but the stop remains queued and
+        # will be its first operation if the vendor call ever returns.
+        self.trip(
+            "adapter_io_stalled",
+            target_state="fault_latched",
+            retain_authority=False,
+        )
+
+    def close(self, timeout: float = 0.5) -> AdapterAck:
+        if self._worker is threading.current_thread():
+            return AdapterAck(False, "owner_cannot_self_close")
+        with self._close_lock:
+            unavailable_result: AdapterAck | None = None
+            with self._condition:
+                if self._close_result is not None:
+                    return self._close_result
+                worker = self._worker
+                if worker is None:
+                    code = self._fault_code or "dispatch_unavailable"
+                    self._closed = True
+                    self._shutdown = True
+                    self._state = "fault_latched"
+                    self._stop_acknowledged = False
+                    self._close_result = AdapterAck(False, code)
+                    unavailable_result = self._close_result
+            if unavailable_result is not None:
+                # A timed-out startup call still owns the adapter.  It will
+                # close it serially if it ever returns; wait only within the
+                # caller's shutdown budget.
+                if self._startup_thread is not threading.current_thread():
+                    self._startup_owner_done.wait(timeout)
+                return unavailable_result
+
+            handle = self.trip(
+                "service_close",
+                target_state="closing",
+                retain_authority=False,
+            )
+            stop_ack = self.wait_safe(handle, timeout)
+            with self._condition:
+                self._closed = True
+                self._shutdown = True
+                self._mailbox = None
+                self._state = "closing" if stop_ack.ok else "fault_latched"
+                if not stop_ack.ok:
+                    self._fault_code = self._fault_code or stop_ack.code
+                self._condition.notify_all()
+            worker.join(timeout=max(timeout, self._io_timeout * 2))
+            with self._condition:
+                if worker.is_alive():
+                    result = AdapterAck(False, stop_ack.code if not stop_ack.ok else "owner_close_timeout")
+                elif not stop_ack.ok:
+                    result = stop_ack
+                elif self._adapter_close_ack is None:
+                    result = AdapterAck(False, "adapter_close_ack_missing")
+                else:
+                    result = self._adapter_close_ack
+                self._close_result = result
+                self._state = "closed" if result.ok else "fault_latched"
+                if not result.ok:
+                    self._fault_code = self._fault_code or result.code
+                    self._stop_acknowledged = False
+                return result
+
+    def _worker_loop(self) -> None:
+        try:
+            while True:
+                with self._condition:
+                    while not self._stop_queue and self._mailbox is None and not self._shutdown:
+                        self._condition.wait()
+                    if self._shutdown and not self._stop_queue:
+                        break
+                    if self._stop_queue:
+                        item: StopHandle | _PendingMotion = self._stop_queue.popleft()
+                        is_stop = True
+                    else:
+                        assert self._mailbox is not None
+                        item = self._mailbox
+                        self._mailbox = None
+                        is_stop = False
+                if is_stop:
+                    assert isinstance(item, StopHandle)
+                    self._perform_stop(item)
+                else:
+                    assert isinstance(item, _PendingMotion)
+                    self._perform_motion(item)
+        finally:
+            self._close_adapter_owned()
+
+    def _close_adapter_owned(self) -> None:
+        """Close the adapter from its sole current owner thread."""
+
+        try:
+            raw_ack = self._adapter.close()
+            close_ack = _normalized_ack(
+                AdapterAck(True) if raw_ack is None else raw_ack,
+                "invalid_close_ack",
+            )
+        except Exception:  # noqa: BLE001 -- normalize adapter close faults
+            close_ack = AdapterAck(False, "adapter_close_exception")
+        self._capture_adapter_snapshot_owned()
+        with self._condition:
+            self._adapter_close_ack = close_ack
+            self._condition.notify_all()
+
+    def _capture_adapter_snapshot_owned(self) -> None:
+        """Refresh public adapter evidence without crossing the owner boundary."""
+
+        try:
+            snapshot = self._adapter.snapshot()
+            if not isinstance(snapshot, dict):
+                snapshot = {
+                    "kind": "unavailable",
+                    "reason": "invalid_adapter_snapshot",
+                }
+            else:
+                snapshot = copy.deepcopy(snapshot)
+        except Exception:  # noqa: BLE001 -- status must survive adapter diagnostics
+            snapshot = {
+                "kind": "unavailable",
+                "reason": "adapter_snapshot_exception",
+            }
+        with self._adapter_snapshot_lock:
+            self._adapter_snapshot = snapshot
+
+    def _perform_stop(self, handle: StopHandle) -> None:
+        request = handle.request
+        started_safety = self._safety_clock()
+        with self._condition:
+            self._io_inflight_kind = "safe_stop"
+            self._io_deadline_safety = handle.safety_deadline
+        try:
+            ack = _normalized_ack(
+                self._adapter.safe_stop(request),
+                "invalid_stop_ack",
+            )
+            self._capture_adapter_snapshot_owned()
+        except Exception:  # noqa: BLE001 -- normalize adapter faults
+            ack = AdapterAck(False, "adapter_stop_exception")
+        finished_safety = self._safety_clock()
+        elapsed_safety = finished_safety - started_safety
+        if ack.ok:
+            if finished_safety >= handle.safety_deadline:
+                ack = AdapterAck(False, "adapter_stop_deadline_missed")
+            elif elapsed_safety > self._io_timeout:
+                ack = AdapterAck(False, "adapter_stop_timeout")
+        with self._condition:
+            self._io_inflight_kind = None
+            self._io_deadline_safety = None
+            handle._finish(ack)
+            if ack.ok:
+                self._counters["stop_acks"] += 1
+                if request.dispatch_generation == self._generation:
+                    self._stop_acknowledged = True
+                    self._last_decision = f"would_stop:{request.reason}"
+            else:
+                self._fault_code = self._fault_code or ack.code
+                self._state = "fault_latched"
+                self._authority_digest = None
+                self._session_generation = None
+                self._mailbox = None
+                self._stop_acknowledged = False
+                self._last_decision = f"stop_failed:{ack.code}"
+                self._counters["adapter_faults"] += 1
+            self._condition.notify_all()
+
+    def _perform_motion(self, pending: _PendingMotion) -> None:
+        intent = pending.intent
+        with self._condition:
+            now = self._clock()
+            valid = (
+                self._fault_code is None
+                and not self._closed
+                and self._state == "motion_eligible"
+                and intent.dispatch_generation == self._generation
+                and intent.session_generation == self._session_generation
+                and self._authority_digest is not None
+                and hmac.compare_digest(pending.authority_digest, self._authority_digest)
+            )
+            if not valid:
+                self._last_decision = "motion_dropped_stale"
+                self._counters["motion_dropped_stale"] += 1
+                self._condition.notify_all()
+                return
+            if now >= intent.expires_monotonic:
+                self._last_decision = "motion_dropped_expired"
+                self._counters["motion_dropped_expired"] += 1
+                self.trip(
+                    "dispatch_deadline",
+                    target_state="safe_reclutch_required",
+                    retain_authority=True,
+                )
+                self._condition.notify_all()
+                return
+            # This is the linearization point.  A concurrent trip after this
+            # commit is queued behind the bounded apply and cannot acknowledge
+            # until its safe-stop has executed.
+            self._last_decision = "motion_committed"
+            remaining = max(0.0, intent.expires_monotonic - now)
+            started_safety = self._safety_clock()
+            self._io_inflight_kind = "apply"
+            self._io_deadline_safety = started_safety + min(self._io_timeout, remaining)
+
+        try:
+            ack = _normalized_ack(
+                self._adapter.apply(intent),
+                "invalid_apply_ack",
+            )
+            self._capture_adapter_snapshot_owned()
+        except Exception:  # noqa: BLE001 -- normalize adapter faults
+            ack = AdapterAck(False, "adapter_apply_exception")
+        finished = self._clock()
+        finished_safety = self._safety_clock()
+        elapsed_safety = finished_safety - started_safety
+        if ack.ok:
+            if finished >= intent.expires_monotonic:
+                ack = AdapterAck(False, "adapter_apply_deadline_missed")
+            elif elapsed_safety > self._io_timeout:
+                ack = AdapterAck(False, "adapter_apply_timeout")
+        with self._condition:
+            self._io_inflight_kind = None
+            self._io_deadline_safety = None
+            if (
+                ack.ok
+                and self._fault_code is None
+                and not self._closed
+                and intent.dispatch_generation == self._generation
+            ):
+                self._last_applied_sequence = intent.sequence
+                self._last_decision = "would_apply"
+                self._counters["motion_applied"] += 1
+            elif ack.ok:
+                self._counters["late_adapter_returns"] += 1
+            else:
+                already_faulted = self._fault_code is not None
+                self._fault_code = self._fault_code or ack.code
+                self._state = "fault_latched"
+                self._authority_digest = None
+                self._session_generation = None
+                self._mailbox = None
+                self._stop_acknowledged = False
+                self._last_decision = f"apply_failed:{self._fault_code}"
+                if not already_faulted:
+                    self._counters["adapter_faults"] += 1
+                # A failed motion write still schedules the independent safety
+                # path.  Its acknowledgement cannot clear the fault latch.
+                if not already_faulted:
+                    self.trip(
+                        "adapter_fault",
+                        target_state="fault_latched",
+                        retain_authority=False,
+                    )
+            self._condition.notify_all()

--- a/generic/teleop_shadow/driver.yaml
+++ b/generic/teleop_shadow/driver.yaml
@@ -1,0 +1,9 @@
+id: teleop-shadow-driver
+name: Generic Teleop Shadow Diagnostics
+category: driver
+hardware_provider: generic
+hardware_model: "teleop-shadow"
+image_name: teleop-shadow
+port: 15711
+mcp_url: "http://localhost:15711/mcp"
+description: "Robot-free Quest/WebRTC protocol, fencing and recording final-dispatch diagnostics; permanently zero hardware actuation"

--- a/generic/teleop_shadow/main.py
+++ b/generic/teleop_shadow/main.py
@@ -1,0 +1,1392 @@
+"""Deployable MCP + WebRTC server for the generic teleop shadow Driver."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import fcntl
+import ipaddress
+import json
+import logging
+import os
+import re
+import secrets
+import ssl
+import stat
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+import aiohttp
+import yaml
+from aiohttp import web
+from cryptography import x509
+from capture import (
+    MAX_CAPTURE_MESSAGE_BYTES,
+    CaptureConnection,
+    CaptureError,
+    CaptureManager,
+)
+from protocol import (
+    CAPABILITY_DIGEST,
+    DISPATCH_CONTRACT,
+    PROTOCOL,
+    ProtocolError,
+    TicketCodec,
+    TicketVerifier,
+)
+from rtc import RtcManager
+from runtime import ShadowRuntime
+
+LOGGER = logging.getLogger("teleop-shadow")
+DEFAULT_DRIVER_ID = "teleop-shadow-driver"
+DEFAULT_DRIVER_NAME = "Generic Teleop Shadow Diagnostics"
+DEFAULT_CONFIG_PATH = Path(__file__).with_name("config.yaml")
+_INSTANCE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+MAX_CAPTURE_CA_PEM_BYTES = 32 * 1024
+MAX_CAPTURE_CA_BASE64_CHARS = 43_692
+REGISTRATION_COORDINATION_SCHEMA_VERSION = 1
+MAX_REGISTRATION_MARKER_BYTES = 1024
+
+
+class RegistrationTlsError(RuntimeError):
+    """Agent Core registration cannot establish the required pinned TLS trust."""
+
+
+class RegistrationCoordinationError(RuntimeError):
+    """Shared stock-Core registration ordering cannot be guaranteed."""
+
+
+class CaptureTlsError(RuntimeError):
+    """The network Capture listener cannot start with authenticated TLS."""
+
+
+def _is_loopback_bind(host: object) -> bool:
+    if not isinstance(host, str):
+        return False
+    try:
+        address = ipaddress.ip_address(host)
+        if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped:
+            return address.ipv4_mapped.is_loopback
+        return address.is_loopback
+    except ValueError:
+        return host.lower() == "localhost"
+
+
+def tool_definitions(
+    *,
+    driver_id: str = DEFAULT_DRIVER_ID,
+    driver_name: str = DEFAULT_DRIVER_NAME,
+    robot_id: str | None = None,
+    signaling_enabled: bool = True,
+) -> list[dict]:
+    actions = {
+        "start": {"params": [], "description": "启动 Driver 本地独占 Shadow 会话"},
+        "stop": {"params": [], "description": "停止卡片并安全释放会话"},
+        "info": {"params": [], "description": "返回卡片状态和数据主题信息"},
+        "pair_headset": {"params": [], "description": "生成一次性头显配对码"},
+        "revoke_headset": {"params": [], "description": "撤销已配对头显及其持久凭据"},
+        "pause": {"params": [], "description": "暂停并进入安全保持状态"},
+        "release": {"params": [], "description": "释放当前本地会话"},
+        "emergency_stop": {"params": [], "description": "立即撤销会话并触发最终安全停止"},
+        "status": {"params": [], "description": "读取会话、Capture、RTC 与安全状态"},
+    }
+    signaling = ({
+        "signaling": {
+            "protocol": "motus.teleop.capture.v1",
+            "path": "/ws/teleop-capture",
+            "access": "paired-capture-credential-only",
+        },
+    } if signaling_enabled else {})
+    return [
+        {
+            "name": "teleop_session",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": (
+                "无需修改 Core 的 Quest/PICO WebRTC Shadow 遥操作卡；Driver 本地管理配对、"
+                "独占会话、租约和一次性 RTC 授权，并仅记录 would-apply/would-stop。"
+            ),
+            "annotations": {"destructiveHint": False, "idempotentHint": False},
+            "inputSchema": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "action": {"type": "string", "enum": list(actions)},
+                    "instance_id": {
+                        "type": "string",
+                        "description": "由 PhanthyMotus Core 自动注入的卡片实例 ID",
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": actions,
+            },
+            "x-teleop": {
+                "protocol": PROTOCOL,
+                "driver_id": driver_id,
+                "driver_name": driver_name,
+                "robot_id": robot_id,
+                "mode": "shadow",
+                "actuation_enabled": False,
+                "capability_digest": CAPABILITY_DIGEST,
+                "dispatch_contract": DISPATCH_CONTRACT,
+                **signaling,
+            },
+        },
+        {
+            "name": "teleop_state",
+            "type": "resource",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": "Shadow 会话、Capture 租约、Pose、RTC 和拒绝计数的只读快照",
+            "annotations": {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+            "inputSchema": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["start", "stop", "info", "status"],
+                    },
+                    "instance_id": {"type": "string"},
+                },
+                "x-action-params": {
+                    action: {"params": []}
+                    for action in ("start", "stop", "info", "status")
+                },
+            },
+            "x-teleop": {
+                "protocol": PROTOCOL,
+                "driver_id": driver_id,
+                "driver_name": driver_name,
+                "robot_id": robot_id,
+                "mode": "shadow",
+                "actuation_enabled": False,
+                "capability_digest": CAPABILITY_DIGEST,
+                "dispatch_contract": DISPATCH_CONTRACT,
+                **signaling,
+            },
+        },
+    ]
+
+
+def load_config(path: str | Path | None = None) -> dict:
+    config_path = Path(path or os.environ.get("CONFIG_PATH", DEFAULT_CONFIG_PATH))
+    with config_path.open(encoding="utf-8") as handle:
+        config = yaml.safe_load(handle) or {}
+    config["driver_id"] = os.environ.get(
+        "MOTUS_DRIVER_ID", config.get("driver_id", DEFAULT_DRIVER_ID)
+    )
+    config["driver_name"] = os.environ.get(
+        "MOTUS_DRIVER_NAME", config.get("driver_name", DEFAULT_DRIVER_NAME)
+    )
+    if "MOTUS_ROBOT_ID" in os.environ:
+        config["robot_id"] = os.environ["MOTUS_ROBOT_ID"] or None
+    config["bind_host"] = os.environ.get("MOTUS_BIND_HOST", config.get("bind_host", "127.0.0.1"))
+    config["mcp_port"] = int(os.environ.get("MOTUS_MCP_PORT", config.get("mcp_port", 15711)))
+    registration = config.setdefault("registration", {})
+    registration["agent_core_url"] = os.environ.get(
+        "AGENT_CORE_URL", registration.get("agent_core_url", "https://localhost:15678")
+    )
+    registration["advertise_url"] = os.environ.get(
+        "MOTUS_MCP_URL", registration.get("advertise_url", f"http://localhost:{config['mcp_port']}/mcp")
+    )
+    # Production always verifies the mounted Core certificate.  Disabling it
+    # requires the explicit, conspicuous local-development environment value.
+    registration["verify_tls"] = True
+    if "MOTUS_AGENT_CORE_VERIFY_TLS" in os.environ:
+        verify_value = os.environ["MOTUS_AGENT_CORE_VERIFY_TLS"].strip()
+        if verify_value not in ("0", "1"):
+            raise ValueError("MOTUS_AGENT_CORE_VERIFY_TLS must be 1, or 0 for explicit local development")
+        registration["verify_tls"] = verify_value == "1"
+    registration["ca_file"] = os.environ.get(
+        "MOTUS_AGENT_CORE_CA_FILE",
+        registration.get("ca_file", "/etc/motus-core-ca/core-ca.pem"),
+    )
+    coordination_file = os.environ.get(
+        "MOTUS_REGISTRATION_COORDINATION_FILE",
+        registration.get("coordination_file"),
+    )
+    if coordination_file in (None, ""):
+        registration["coordination_file"] = None
+    else:
+        coordination_path = Path(str(coordination_file))
+        if (
+            not coordination_path.is_absolute()
+            or str(coordination_path) != str(coordination_file)
+            or ".." in coordination_path.parts
+            or len(str(coordination_path)) > 1024
+        ):
+            raise ValueError(
+                "registration coordination_file must be a normalized absolute path"
+            )
+        registration["coordination_file"] = str(coordination_path)
+    capture = config.setdefault("capture", {})
+    capture["bind_host"] = os.environ.get(
+        "MOTUS_CAPTURE_BIND_HOST", capture.get("bind_host", "0.0.0.0")
+    )
+    capture["port"] = int(os.environ.get(
+        "MOTUS_CAPTURE_PORT", capture.get("port", 15712)
+    ))
+    capture["public_wss_url"] = os.environ.get(
+        "MOTUS_CAPTURE_WSS_URL",
+        capture.get("public_wss_url"),
+    )
+    capture["tls_cert_file"] = os.environ.get(
+        "MOTUS_CAPTURE_TLS_CERT_FILE",
+        capture.get("tls_cert_file", "/etc/motus-capture-tls/cert.pem"),
+    )
+    capture["tls_key_file"] = os.environ.get(
+        "MOTUS_CAPTURE_TLS_KEY_FILE",
+        capture.get("tls_key_file", "/etc/motus-capture-tls/key.pem"),
+    )
+    capture["state_file"] = os.environ.get(
+        "MOTUS_CAPTURE_STATE_FILE",
+        capture.get("state_file", "/var/lib/motus-teleop-shadow/capture.json"),
+    )
+    return config
+
+
+def _validated_instance_id(
+    value: Any,
+    name: str,
+    *,
+    optional: bool = False,
+    max_length: int = 128,
+) -> str | None:
+    if optional and value is None:
+        return None
+    if (
+        not isinstance(value, str)
+        or len(value) > max_length
+        or not _INSTANCE_ID_RE.fullmatch(value)
+    ):
+        suffix = " or null" if optional else ""
+        raise ValueError(
+            f"{name} must be a stable 1-{max_length} character instance identifier{suffix}"
+        )
+    return value
+
+
+def build_registration_ssl_context(registration: dict) -> ssl.SSLContext | bool:
+    """Build an Agent Core client context pinned to the deployed Core certificate."""
+
+    if not bool(registration.get("verify_tls", True)):
+        return False
+
+    ca_file = Path(str(registration.get("ca_file", "/etc/motus-core-ca/core-ca.pem")))
+    if not ca_file.is_file():
+        raise RegistrationTlsError(f"Agent Core pinned CA file is missing: {ca_file}")
+    try:
+        context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH, cafile=str(ca_file))
+    except (OSError, ssl.SSLError) as exc:
+        raise RegistrationTlsError(f"Agent Core pinned CA file is invalid: {ca_file}: {exc}") from exc
+
+    # The current self-signed Core certificate is issued to `phanthy-motus`, while
+    # host-network registration intentionally targets https://localhost:15678.
+    # Chain verification remains mandatory; only the DNS-name check is disabled.
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_REQUIRED
+    return context
+
+
+def _validated_capture_wss_url(
+    value: Any,
+    *,
+    expected_port: int | None = None,
+) -> str:
+    if not isinstance(value, str) or len(value) > 2048:
+        raise CaptureTlsError("Capture public URL must be a bounded wss:// URL")
+    parsed = urlsplit(value)
+    try:
+        url_port = parsed.port
+    except ValueError as exc:
+        raise CaptureTlsError("Capture public URL contains an invalid port") from exc
+    if (
+        parsed.scheme != "wss"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path != "/ws/teleop-capture"
+        or (expected_port is not None and url_port != expected_port)
+    ):
+        raise CaptureTlsError(
+            "Capture public URL must be wss://<host>:<port>/ws/teleop-capture"
+        )
+    return value
+
+
+def _capture_certificate_base64(capture: dict) -> str:
+    certificate_path = Path(str(capture.get(
+        "tls_cert_file", "/etc/motus-capture-tls/cert.pem"
+    )))
+    if not certificate_path.is_file() or certificate_path.is_symlink():
+        raise CaptureTlsError(f"Capture TLS certificate is missing: {certificate_path}")
+    certificate = certificate_path.read_bytes()
+    if (
+        not certificate
+        or len(certificate) > MAX_CAPTURE_CA_PEM_BYTES
+        or b"-----BEGIN CERTIFICATE-----" not in certificate
+        or b"PRIVATE KEY" in certificate
+    ):
+        raise CaptureTlsError("Capture TLS certificate must contain only a bounded public PEM chain")
+    return base64.b64encode(certificate).decode("ascii")
+
+
+def _validated_capture_ca_base64(value: object) -> str:
+    """Match the native client's exact public-CA bootstrap limits."""
+
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > MAX_CAPTURE_CA_BASE64_CHARS
+    ):
+        raise ValueError(
+            "capture.ca_certificate_base64 must be at most 43692 base64 characters"
+        )
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise ValueError("capture.ca_certificate_base64 must be valid base64") from exc
+    if not decoded or len(decoded) > MAX_CAPTURE_CA_PEM_BYTES:
+        raise ValueError(
+            "capture.ca_certificate_base64 must decode to 1-32768 bytes"
+        )
+    if base64.b64encode(decoded).decode("ascii") != value:
+        raise ValueError("capture.ca_certificate_base64 must use canonical base64")
+    return value
+
+
+def build_capture_ssl_context(capture: dict) -> ssl.SSLContext:
+    """Load the dedicated network Capture listener's server certificate."""
+
+    public_wss_url = _validated_capture_wss_url(
+        capture.get("public_wss_url"),
+        expected_port=int(capture.get("port", 15712)),
+    )
+    # Validate the exact public bootstrap material before loading its private
+    # counterpart.  Pairing returns only this base64-encoded public chain.
+    _capture_certificate_base64(capture)
+    certificate_path = Path(str(capture.get(
+        "tls_cert_file", "/etc/motus-capture-tls/cert.pem"
+    )))
+    key_path = Path(str(capture.get(
+        "tls_key_file", "/etc/motus-capture-tls/key.pem"
+    )))
+    if not key_path.is_file() or key_path.is_symlink():
+        raise CaptureTlsError(f"Capture TLS private key is missing: {key_path}")
+    try:
+        certificate = x509.load_pem_x509_certificate(certificate_path.read_bytes())
+        alternatives = certificate.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
+        ).value
+    except (OSError, ValueError, x509.ExtensionNotFound) as exc:
+        raise CaptureTlsError("Capture TLS certificate must contain a valid SAN extension") from exc
+    hostname = urlsplit(public_wss_url).hostname
+    assert hostname is not None
+    try:
+        requested_ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        requested_ip = None
+    if requested_ip is not None:
+        matches_host = requested_ip in alternatives.get_values_for_type(x509.IPAddress)
+    else:
+        normalized_host = hostname.rstrip(".").lower()
+        matches_host = any(
+            normalized_host == candidate.rstrip(".").lower()
+            or (
+                candidate.startswith("*.")
+                and normalized_host.endswith(candidate[1:].lower())
+                and normalized_host.count(".") == candidate.count(".")
+            )
+            for candidate in alternatives.get_values_for_type(x509.DNSName)
+        )
+    if not matches_host:
+        raise CaptureTlsError(
+            "Capture TLS certificate SAN does not match MOTUS_CAPTURE_WSS_URL host"
+        )
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
+    try:
+        context.load_cert_chain(str(certificate_path), str(key_path))
+    except (OSError, ssl.SSLError) as exc:
+        raise CaptureTlsError(f"Capture TLS certificate/key pair is invalid: {exc}") from exc
+    return context
+
+
+class ShadowDriverService:
+    def __init__(self, config: dict):
+        self.driver_id = str(_validated_instance_id(
+            config.get("driver_id", DEFAULT_DRIVER_ID), "driver_id", max_length=64
+        ))
+        driver_name = config.get("driver_name", DEFAULT_DRIVER_NAME)
+        if not isinstance(driver_name, str) or not driver_name.strip() or len(driver_name) > 200:
+            raise ValueError("driver_name must be a non-empty string of at most 200 characters")
+        self.driver_name = driver_name.strip()
+        self.robot_id = _validated_instance_id(
+            config.get("robot_id"),
+            "robot_id",
+            optional=True,
+            # Agent Core uses the same 64-character authority-domain boundary.
+            max_length=64,
+        )
+        registration = config.get("registration", {})
+        registration_enabled = bool(registration.get("enabled", True))
+        teleop = config.get("teleop", {})
+        # This secret protects only the in-process, one-use handoff from the
+        # authenticated Capture socket to the RTC verifier.  It is deliberately
+        # regenerated per process and is never configurable, persisted, or
+        # shared with Core.
+        ticket_codec = TicketCodec(secrets.token_bytes(32))
+        self.runtime = ShadowRuntime(
+            lease_timeout_ms=int(teleop.get("lease_timeout_ms", 1000)),
+            pose_timeout_ms=int(teleop.get("pose_timeout_ms", 200)),
+            watchdog_interval_ms=int(teleop.get("watchdog_interval_ms", 25)),
+            driver_id=self.driver_id,
+            driver_name=self.driver_name,
+            robot_id=self.robot_id,
+            dispatch_io_timeout_ms=int(teleop.get("dispatch_io_timeout_ms", 100)),
+            dispatch_ack_timeout_ms=int(teleop.get("dispatch_ack_timeout_ms", 200)),
+        )
+        verifier = TicketVerifier(
+            ticket_codec,
+            max_ttl_seconds=int(teleop.get("ticket_ttl_max_seconds", 30)),
+            max_replay_entries=int(teleop.get("ticket_replay_cache_entries", 4096)),
+        )
+        self.rtc = RtcManager(self.runtime, verifier)
+        capture_config = config.get("capture", {})
+        public_wss_url = capture_config.get("public_wss_url")
+        if public_wss_url is not None:
+            public_wss_url = _validated_capture_wss_url(
+                public_wss_url,
+                expected_port=int(capture_config.get("port", 15712)),
+            )
+        ca_certificate_base64 = capture_config.get("ca_certificate_base64")
+        if ca_certificate_base64 is None and capture_config.get("tls_cert_file"):
+            certificate_path = Path(str(capture_config["tls_cert_file"]))
+            if certificate_path.is_file() and not certificate_path.is_symlink():
+                ca_certificate_base64 = _capture_certificate_base64(capture_config)
+        if ca_certificate_base64 is not None:
+            ca_certificate_base64 = _validated_capture_ca_base64(
+                ca_certificate_base64
+            )
+        self.capture = CaptureManager(
+            self.runtime,
+            self.rtc,
+            ticket_codec,
+            pairing_ttl_seconds=int(capture_config.get("pairing_ttl_seconds", 60)),
+            ticket_ttl_seconds=int(teleop.get("ticket_ttl_seconds", 20)),
+            presence_interval_ms=int(capture_config.get("presence_interval_ms", 1000)),
+            presence_timeout_ms=int(capture_config.get("presence_timeout_ms", 5000)),
+            state_file=capture_config.get("state_file") or None,
+            public_wss_url=public_wss_url,
+            ca_certificate_base64=ca_certificate_base64,
+        )
+        self.config = config
+        self._instance_id: str | None = None
+        if bool(config.get("mcp_allow_non_loopback", False)):
+            raise ValueError("MCP is permanently loopback-only for stock Core compatibility")
+        self.registration_task: asyncio.Task | None = None
+        self.registration_status = {
+            "state": "starting" if registration_enabled else "disabled",
+            "attempts": 0,
+            "successes": 0,
+            "last_http_status": None,
+            "last_error": None,
+            "coordination": (
+                "shared_file_lock"
+                if registration.get("coordination_file")
+                else "single_instance_fast_path"
+            ),
+            "tls_verification": (
+                "pinned_certificate"
+                if bool(registration.get("verify_tls", True))
+                else "disabled_local_development"
+            ),
+        }
+
+    async def dispatch_tool(self, name: str, arguments: Any) -> dict:
+        if not isinstance(arguments, dict):
+            raise ProtocolError("invalid_arguments", "tool arguments must be an object")
+        args = dict(arguments)
+        if name == "teleop_state":
+            instance_id = args.pop("instance_id", None)
+            action = args.pop("action", "status")
+            if args or action not in {"start", "stop", "info", "status"}:
+                raise ProtocolError("invalid_arguments", "teleop_state accepts only lifecycle/status actions")
+            result = self.runtime.status()
+            result["capture_control"] = await self.capture.status()
+            result["instance_id"] = instance_id
+            result["topic_out"] = []
+            return result
+        if name != "teleop_session":
+            raise ProtocolError("unknown_tool", f"unknown tool: {name}")
+        action = args.pop("action", None)
+        if not isinstance(action, str):
+            raise ProtocolError("missing_action", "teleop_session requires an action")
+        instance_id = args.pop("instance_id", None)
+        if instance_id is not None:
+            try:
+                instance_id = _validated_instance_id(instance_id, "instance_id")
+            except ValueError as exc:
+                raise ProtocolError("invalid_instance_id", str(exc)) from exc
+        if args:
+            raise ProtocolError("invalid_arguments", f"{action} accepts no additional arguments")
+        if action == "start":
+            if (
+                self._instance_id is not None
+                and instance_id is not None
+                and self._instance_id != instance_id
+                and self.runtime.status()["authority_valid"]
+            ):
+                raise ProtocolError("instance_conflict", "another card instance owns the session")
+            result = await asyncio.to_thread(self.runtime.prepare_local_session)
+            self._instance_id = instance_id or self._instance_id
+            await self.capture.issue_assignment_if_connected()
+            result["lifecycle_state"] = (
+                "ready" if result["dispatch"]["ready"] else "fault"
+            )
+            result["instance_id"] = self._instance_id
+            result["capture_control"] = await self.capture.status()
+            return result
+        if action == "stop":
+            result = await asyncio.to_thread(
+                self.runtime.release_local,
+                reason="lifecycle_stop",
+            )
+            await self.rtc.close_all()
+            await self.capture.revoke_assignment("lifecycle_stop")
+            self._instance_id = None
+            return result
+        if action == "info":
+            result = self.runtime.status()
+            result["instance_id"] = self._instance_id or instance_id
+            result["topic_out"] = []
+            result["capture_control"] = await self.capture.status()
+            return result
+        if action == "pair_headset":
+            if not self.runtime.status()["authority_valid"]:
+                raise ProtocolError("session_inactive", "start the teleop_session card before pairing")
+            result = await self.capture.create_pairing()
+            if not result["wss_url"] or not result["ca_certificate_base64"]:
+                raise ProtocolError(
+                    "capture_tls_unavailable",
+                    "Capture WSS URL or public CA bootstrap is not configured",
+                )
+            result["state"] = "pairing_ready"
+            return result
+        if action == "revoke_headset":
+            result = await asyncio.to_thread(
+                self.runtime.release_local,
+                reason="capture_revoked",
+            )
+            await self.rtc.close_all()
+            try:
+                revoked = await self.capture.revoke_headset()
+            except CaptureError as exc:
+                raise ProtocolError(exc.code, str(exc)) from exc
+            result["headset"] = revoked
+            return result
+        if action == "pause":
+            result = await asyncio.to_thread(self.runtime.pause_local)
+            await self.rtc.close_all()
+            await self.capture.revoke_assignment("operator_pause")
+            return result
+        if action == "release":
+            result = await asyncio.to_thread(self.runtime.release_local)
+            await self.rtc.close_all()
+            await self.capture.revoke_assignment("operator_release")
+            return result
+        if action == "emergency_stop":
+            result = await asyncio.to_thread(
+                self.runtime.release_local,
+                reason="emergency_stop",
+            )
+            await self.rtc.close_all()
+            await self.capture.revoke_assignment("emergency_stop")
+            return result
+        if action == "status":
+            result = self.runtime.status()
+            result["instance_id"] = self._instance_id or instance_id
+            result["capture_control"] = await self.capture.status()
+            return result
+        raise ProtocolError("unknown_action", f"unknown teleop_session action: {action}")
+
+    async def close(self) -> None:
+        if self.registration_task:
+            self.registration_task.cancel()
+            try:
+                await self.registration_task
+            except asyncio.CancelledError:
+                pass
+        await self.rtc.close_all()
+        await asyncio.to_thread(self.runtime.close)
+
+
+SERVICE_KEY = web.AppKey("teleop_shadow_service", ShadowDriverService)
+
+
+def _rpc_success(request_id: Any, result: Any) -> web.Response:
+    return web.json_response({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+
+def _rpc_error(request_id: Any, code: int, message: str, *, data: dict | None = None) -> web.Response:
+    error = {"code": code, "message": message}
+    if data:
+        error["data"] = data
+    return web.json_response({"jsonrpc": "2.0", "id": request_id, "error": error})
+
+
+async def mcp_handler(request: web.Request) -> web.Response:
+    service = request.app[SERVICE_KEY]
+    if not _is_loopback_bind(request.remote):
+        return web.json_response({"error": "mcp_loopback_only"}, status=403)
+    try:
+        rpc = await request.json()
+    except (json.JSONDecodeError, ValueError, RecursionError):
+        return _rpc_error(None, -32700, "Parse error")
+    if not isinstance(rpc, dict) or rpc.get("jsonrpc") != "2.0":
+        return _rpc_error(rpc.get("id") if isinstance(rpc, dict) else None, -32600, "Invalid Request")
+    request_id = rpc.get("id")
+    if request_id is None:
+        return web.Response(status=202)
+    method = rpc.get("method")
+    params = rpc.get("params") or {}
+    try:
+        if method == "initialize":
+            return _rpc_success(request_id, {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "teleop-shadow-driver", "version": "2.0.0"},
+            })
+        if method == "tools/list":
+            return _rpc_success(request_id, {"tools": tool_definitions(
+                driver_id=service.driver_id,
+                driver_name=service.driver_name,
+                robot_id=service.robot_id,
+                signaling_enabled=service.rtc.enabled,
+            )})
+        if method == "tools/call":
+            if not isinstance(params, dict):
+                raise ProtocolError("invalid_params", "params must be an object")
+            result = await service.dispatch_tool(params.get("name", ""), params.get("arguments") or {})
+            return _rpc_success(request_id, {
+                "content": [{"type": "text", "text": json.dumps(result, ensure_ascii=False, allow_nan=False)}]
+            })
+        return _rpc_error(request_id, -32601, f"Method not found: {method}")
+    except ProtocolError as exc:
+        if exc.code in ("unknown_tool", "unknown_action"):
+            return _rpc_error(request_id, -32601, str(exc), data={"code": exc.code})
+        return _rpc_error(request_id, -32602, str(exc), data={"code": exc.code})
+    except Exception:
+        LOGGER.exception("unhandled MCP request failure")
+        return _rpc_error(request_id, -32603, "Internal error")
+
+
+async def offer_handler(request: web.Request) -> web.Response:
+    return web.json_response(
+        {
+            "error": {
+                "code": "capture_control_required",
+                "message": "RTC offers must use an authenticated /ws/teleop-capture connection",
+            }
+        },
+        status=401,
+    )
+
+
+class _DuplicateJsonField(ValueError):
+    pass
+
+
+def _capture_json(raw: str) -> dict:
+    if not isinstance(raw, str) or len(raw.encode("utf-8")) > MAX_CAPTURE_MESSAGE_BYTES:
+        raise CaptureError("capture_message_invalid")
+
+    def reject_duplicates(pairs):
+        result = {}
+        for key, value in pairs:
+            if key in result:
+                raise _DuplicateJsonField(key)
+            result[key] = value
+        return result
+
+    try:
+        value = json.loads(
+            raw,
+            object_pairs_hook=reject_duplicates,
+            parse_constant=lambda _value: (_ for _ in ()).throw(ValueError()),
+        )
+    except (
+        UnicodeEncodeError,
+        json.JSONDecodeError,
+        _DuplicateJsonField,
+        TypeError,
+        ValueError,
+        RecursionError,
+    ) as exc:
+        raise CaptureError("capture_message_invalid") from exc
+    if not isinstance(value, dict):
+        raise CaptureError("capture_message_invalid")
+    return value
+
+
+async def _capture_ws_text(
+    websocket: web.WebSocketResponse,
+    *,
+    timeout: float | None = None,
+) -> str:
+    try:
+        message = await websocket.receive(timeout=timeout)
+    except asyncio.TimeoutError as exc:
+        raise CaptureError("capture_auth_timeout", status=408) from exc
+    if message.type != web.WSMsgType.TEXT or not isinstance(message.data, str):
+        if message.type in {web.WSMsgType.CLOSE, web.WSMsgType.CLOSING, web.WSMsgType.CLOSED}:
+            raise EOFError
+        raise CaptureError("capture_message_invalid")
+    return message.data
+
+
+async def capture_websocket_handler(request: web.Request) -> web.StreamResponse:
+    service = request.app[SERVICE_KEY]
+    websocket = web.WebSocketResponse(max_msg_size=MAX_CAPTURE_MESSAGE_BYTES)
+    await websocket.prepare(request)
+    if request.query_string:
+        await websocket.send_json({"type": "error", "code": "capture_query_forbidden"})
+        await websocket.close(code=4400, message=b"capture_query_forbidden")
+        return websocket
+
+    connection: CaptureConnection | None = None
+    receive_task: asyncio.Task | None = None
+    event_task: asyncio.Task | None = None
+    try:
+        first = _capture_json(await _capture_ws_text(websocket, timeout=5.0))
+        connection, acknowledgement, assignment = await service.capture.connect(first)
+        await websocket.send_json(acknowledgement)
+        if assignment is not None:
+            await websocket.send_json(assignment)
+
+        receive_task = asyncio.create_task(_capture_ws_text(websocket))
+        event_task = asyncio.create_task(connection.events.get())
+        while True:
+            done, _ = await asyncio.wait(
+                {receive_task, event_task},
+                timeout=0.25,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if not done:
+                if service.capture.presence_expired(connection):
+                    await service.capture.disconnect(connection)
+                    connection = None
+                    await websocket.send_json({
+                        "type": "error",
+                        "code": "capture_presence_timeout",
+                    })
+                    await websocket.close(code=4408, message=b"capture_presence_timeout")
+                    break
+                continue
+            if event_task in done:
+                event = event_task.result()
+                await websocket.send_json(event)
+                if event.get("type") in {"capture_revoked", "capture_stale"}:
+                    await websocket.close(code=4403, message=b"capture_revoked")
+                    break
+                event_task = asyncio.create_task(connection.events.get())
+            if receive_task in done:
+                incoming = _capture_json(receive_task.result())
+                message_type = incoming.get("type")
+                if message_type == "presence":
+                    response = await service.capture.presence(connection, incoming)
+                elif message_type == "signaling_offer":
+                    response = await service.capture.signaling_offer(connection, incoming)
+                else:
+                    raise CaptureError("capture_message_invalid")
+                await websocket.send_json(response)
+                receive_task = asyncio.create_task(_capture_ws_text(websocket))
+    except EOFError:
+        pass
+    except asyncio.CancelledError:
+        raise
+    except CaptureError as exc:
+        if connection is not None:
+            # A protocol/signaling failure is itself a Capture control-plane
+            # loss.  HOLD before awaiting the error response or close frame.
+            await service.capture.disconnect(connection)
+            connection = None
+        if not websocket.closed:
+            await websocket.send_json({"type": "error", "code": exc.code})
+            await websocket.close(
+                code=4403 if exc.status in {401, 403} else 4400,
+                message=exc.code.encode("ascii", errors="ignore")[:120],
+            )
+    finally:
+        tasks = [
+            task
+            for task in (receive_task, event_task)
+            if task is not None
+        ]
+        for task in tasks:
+            if task is not None:
+                task.cancel()
+        if tasks:
+            # Consume both pending and already-completed task outcomes.  A
+            # terminal Capture event and a peer disconnect can become ready in
+            # the same loop turn; leaving the completed receive task unread
+            # would otherwise emit ``Task exception was never retrieved``.
+            await asyncio.gather(*tasks, return_exceptions=True)
+        if connection is not None:
+            await service.capture.disconnect(connection)
+    return websocket
+
+
+async def health_handler(request: web.Request) -> web.Response:
+    service = request.app[SERVICE_KEY]
+    state = service.runtime.status()
+    dispatch_ready = bool(state["dispatch"]["ready"])
+    ready = dispatch_ready and service.rtc.enabled
+    return web.json_response({
+        "state": "running" if ready else "diagnostic" if dispatch_ready else "fault",
+        "ready": ready,
+        "driver": service.driver_id,
+        "driver_id": service.driver_id,
+        "driver_name": service.driver_name,
+        "robot_id": service.robot_id,
+        "mode": "shadow",
+        "actuation_enabled": False,
+        "boot_id": state["boot_id"],
+        "dispatch": {
+            "kind": state["dispatch"]["kind"],
+            "state": state["dispatch"]["state"],
+            "stop_acknowledged": state["dispatch"]["stop_acknowledged"],
+            "fault_code": state["dispatch"]["fault_code"],
+        },
+        "rtc_enabled": service.rtc.enabled,
+        "mcp_access": "loopback-only",
+        "capture_control": await service.capture.status(),
+        "registration": dict(service.registration_status),
+    })
+
+
+def registration_payload(service: ShadowDriverService, registration: dict | None = None) -> dict:
+    registration = registration or service.config.get("registration", {})
+    return {
+        "name": service.driver_name,
+        "url": registration.get("advertise_url", "http://localhost:15711/mcp"),
+        "transport": "http",
+        "category": "driver",
+        "render_hint": "teleop",
+    }
+
+
+def registration_headers(service: ShadowDriverService) -> dict[str, str]:
+    # Stock Core's registration and Driver calls do not use a Core-issued
+    # Bearer credential.  The MCP route is protected by its loopback boundary.
+    return {"Content-Type": "application/json"}
+
+
+class RegistrationCoordinator:
+    """Serialize stock-Core POSTs across Driver containers with a durable barrier."""
+
+    def __init__(
+        self,
+        marker_file: str | Path,
+        *,
+        wall_clock=time.time,
+        barrier_sleep=asyncio.sleep,
+        lock_poll_sleep=asyncio.sleep,
+        lock_poll_seconds: float = 0.02,
+    ):
+        marker = Path(marker_file)
+        if (
+            not marker.is_absolute()
+            or marker.parent == Path(marker.anchor)
+            or ".." in marker.parts
+            or len(str(marker)) > 1024
+        ):
+            raise RegistrationCoordinationError(
+                "registration coordination marker must be a bounded absolute file path"
+            )
+        self.marker_file = marker
+        self.lock_file = marker.with_name(f".{marker.name}.lock")
+        self._wall_clock = wall_clock
+        self._barrier_sleep = barrier_sleep
+        self._lock_poll_sleep = lock_poll_sleep
+        self._lock_poll_seconds = max(0.001, float(lock_poll_seconds))
+        self._descriptor: int | None = None
+        self._barrier_second: int | None = None
+        self._validate_real_parent()
+
+    def _validate_real_parent(self) -> None:
+        parent = self.marker_file.parent
+        current = Path(parent.anchor)
+        try:
+            for part in parent.parts[1:]:
+                current /= part
+                metadata = current.lstat()
+                if stat.S_ISLNK(metadata.st_mode):
+                    raise RegistrationCoordinationError(
+                        "registration coordination directory must not use symlink ancestors"
+                    )
+            if parent.resolve(strict=True) != parent or not parent.is_dir():
+                raise RegistrationCoordinationError(
+                    "registration coordination directory must be an existing canonical directory"
+                )
+        except RegistrationCoordinationError:
+            raise
+        except (OSError, RuntimeError) as exc:
+            raise RegistrationCoordinationError(
+                "registration coordination directory must be an existing canonical directory"
+            ) from exc
+
+    @staticmethod
+    def _directory_fsync(directory: Path) -> None:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        descriptor = os.open(directory, flags)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+    @staticmethod
+    def _validate_private_regular_file(descriptor: int, field: str) -> os.stat_result:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or stat.S_IMODE(metadata.st_mode) != 0o600
+            or metadata.st_nlink != 1
+        ):
+            raise RegistrationCoordinationError(
+                f"{field} must be a private 0600 regular file with one link"
+            )
+        return metadata
+
+    def _open_lock_file(self) -> int:
+        flags = os.O_RDWR | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        created = False
+        try:
+            descriptor = os.open(self.lock_file, flags | os.O_CREAT | os.O_EXCL, 0o600)
+            created = True
+        except FileExistsError:
+            try:
+                descriptor = os.open(self.lock_file, flags)
+            except OSError as exc:
+                raise RegistrationCoordinationError(
+                    "registration coordination lock is not a safe regular file"
+                ) from exc
+        except OSError as exc:
+            raise RegistrationCoordinationError(
+                "registration coordination lock could not be created"
+            ) from exc
+        try:
+            if created:
+                os.fchmod(descriptor, 0o600)
+            self._validate_private_regular_file(
+                descriptor,
+                "registration coordination lock",
+            )
+            if created:
+                self._directory_fsync(self.lock_file.parent)
+            return descriptor
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+    async def __aenter__(self) -> RegistrationCoordinator:
+        if self._descriptor is not None:
+            raise RegistrationCoordinationError(
+                "registration coordinator cannot be entered twice"
+            )
+        descriptor = self._open_lock_file()
+        try:
+            while True:
+                try:
+                    fcntl.flock(
+                        descriptor,
+                        fcntl.LOCK_EX | fcntl.LOCK_NB,
+                    )
+                    break
+                except BlockingIOError:
+                    await self._lock_poll_sleep(self._lock_poll_seconds)
+            self._descriptor = descriptor
+            descriptor = -1
+            return self
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+
+    async def __aexit__(self, _exc_type, _exc, _traceback) -> None:
+        descriptor = self._descriptor
+        self._descriptor = None
+        self._barrier_second = None
+        if descriptor is None:
+            return
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
+
+    def _read_barrier_sync(self) -> int | None:
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        flags |= getattr(os, "O_NONBLOCK", 0)
+        try:
+            descriptor = os.open(self.marker_file, flags)
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            raise RegistrationCoordinationError(
+                "registration coordination marker is not a safe regular file"
+            ) from exc
+        try:
+            metadata = self._validate_private_regular_file(
+                descriptor,
+                "registration coordination marker",
+            )
+            if not 1 <= metadata.st_size <= MAX_REGISTRATION_MARKER_BYTES:
+                raise RegistrationCoordinationError(
+                    "registration coordination marker has an invalid size"
+                )
+            encoded = os.read(descriptor, MAX_REGISTRATION_MARKER_BYTES + 1)
+        finally:
+            os.close(descriptor)
+        try:
+            value = json.loads(encoded.decode("ascii"))
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise RegistrationCoordinationError(
+                "registration coordination marker is invalid"
+            ) from exc
+        if (
+            type(value) is not dict
+            or set(value) != {
+                "schema_version",
+                "last_attempt_barrier_unix_second",
+            }
+            or value["schema_version"] != REGISTRATION_COORDINATION_SCHEMA_VERSION
+            or type(value["last_attempt_barrier_unix_second"]) is not int
+            or not 0 <= value["last_attempt_barrier_unix_second"] <= (2**63 - 1)
+        ):
+            raise RegistrationCoordinationError(
+                "registration coordination marker schema is invalid"
+            )
+        return value["last_attempt_barrier_unix_second"]
+
+    def _write_barrier_sync(self, second: int) -> None:
+        if self.marker_file.exists() or self.marker_file.is_symlink():
+            try:
+                metadata = self.marker_file.lstat()
+            except OSError as exc:
+                raise RegistrationCoordinationError(
+                    "registration coordination marker could not be inspected"
+                ) from exc
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or stat.S_IMODE(metadata.st_mode) != 0o600
+                or metadata.st_nlink != 1
+            ):
+                raise RegistrationCoordinationError(
+                    "registration coordination marker must remain a private 0600 regular file"
+                )
+        encoded = json.dumps(
+            {
+                "schema_version": REGISTRATION_COORDINATION_SCHEMA_VERSION,
+                "last_attempt_barrier_unix_second": second,
+            },
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("ascii")
+        temporary = self.marker_file.with_name(
+            f".{self.marker_file.name}.{secrets.token_hex(8)}.tmp"
+        )
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = -1
+        try:
+            descriptor = os.open(temporary, flags, 0o600)
+            with os.fdopen(descriptor, "wb") as handle:
+                descriptor = -1
+                os.fchmod(handle.fileno(), 0o600)
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.marker_file)
+            self._directory_fsync(self.marker_file.parent)
+        except RegistrationCoordinationError:
+            raise
+        except OSError as exc:
+            raise RegistrationCoordinationError(
+                "registration coordination marker could not be persisted"
+            ) from exc
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
+
+    async def wait_for_turn(self) -> None:
+        if self._descriptor is None:
+            raise RegistrationCoordinationError(
+                "registration coordination lock is not held"
+            )
+        barrier = await asyncio.to_thread(self._read_barrier_sync)
+        self._barrier_second = barrier
+        while barrier is not None and int(self._wall_clock()) <= barrier:
+            remaining = (barrier + 1) - float(self._wall_clock())
+            await self._barrier_sleep(max(0.001, min(remaining, 0.25)))
+
+    async def _persist_barrier(self, second: int) -> None:
+        barrier = max(second, self._barrier_second or 0)
+        write_task = asyncio.create_task(
+            asyncio.to_thread(self._write_barrier_sync, barrier)
+        )
+        try:
+            await asyncio.shield(write_task)
+        except asyncio.CancelledError:
+            # The flock must not be released until the durable barrier exists.
+            await write_task
+            raise
+        self._barrier_second = barrier
+
+    async def reserve_attempt_second(self) -> None:
+        """Persist a conservative same-second barrier before starting POST."""
+
+        if self._descriptor is None:
+            raise RegistrationCoordinationError(
+                "registration coordination lock is not held"
+            )
+        await self._persist_barrier(int(self._wall_clock()))
+
+    async def record_attempt_finished(self) -> None:
+        """Advance the barrier at the actual response/error/cancel boundary."""
+
+        if self._descriptor is None:
+            raise RegistrationCoordinationError(
+                "registration coordination lock is not held"
+            )
+        await self._persist_barrier(int(self._wall_clock()))
+
+
+async def _post_registration_attempt(
+    session: aiohttp.ClientSession,
+    endpoint: str,
+    *,
+    payload: dict,
+    headers: dict[str, str],
+    ssl_context: ssl.SSLContext | bool,
+    coordinator: RegistrationCoordinator | None,
+) -> int:
+    async def post_and_consume() -> int:
+        async with session.post(
+            endpoint,
+            json=payload,
+            headers=headers,
+            ssl=ssl_context,
+        ) as response:
+            await response.read()
+            return response.status
+
+    if coordinator is None:
+        return await post_and_consume()
+
+    async with coordinator:
+        await coordinator.wait_for_turn()
+        await coordinator.reserve_attempt_second()
+        post_started = False
+        try:
+            post_started = True
+            return await post_and_consume()
+        finally:
+            if post_started:
+                await coordinator.record_attempt_finished()
+
+
+async def _registration_loop(service: ShadowDriverService) -> None:
+    registration = service.config.get("registration", {})
+    interval = max(5.0, float(registration.get("interval_seconds", 30)))
+    endpoint = registration.get("agent_core_url", "https://localhost:15678").rstrip("/") + "/api/mcp"
+    payload = registration_payload(service, registration)
+    headers = registration_headers(service)
+    timeout = aiohttp.ClientTimeout(total=5)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        while True:
+            if not service.rtc.enabled:
+                service.registration_status["state"] = "rtc_unavailable"
+                service.registration_status["last_error"] = (
+                    "ticket verification is not ready; registration inhibited"
+                )
+                await asyncio.sleep(interval)
+                continue
+            if not service.runtime.status()["dispatch"]["ready"]:
+                service.registration_status["state"] = "dispatch_fault"
+                service.registration_status["last_error"] = (
+                    "final dispatch is not ready; registration inhibited"
+                )
+                await asyncio.sleep(interval)
+                continue
+            service.registration_status["attempts"] += 1
+            try:
+                ssl_context = build_registration_ssl_context(registration)
+                coordination_file = registration.get("coordination_file")
+                coordinator = (
+                    RegistrationCoordinator(coordination_file)
+                    if coordination_file
+                    else None
+                )
+                status = await _post_registration_attempt(
+                    session,
+                    endpoint,
+                    payload=payload,
+                    headers=headers,
+                    ssl_context=ssl_context,
+                    coordinator=coordinator,
+                )
+                service.registration_status["last_http_status"] = status
+                if status >= 400:
+                    service.registration_status["state"] = "http_error"
+                    service.registration_status["last_error"] = f"Agent Core returned HTTP {status}"
+                    LOGGER.warning("registration failed with HTTP %s", status)
+                else:
+                    service.registration_status["state"] = "registered"
+                    service.registration_status["successes"] += 1
+                    service.registration_status["last_error"] = None
+            except asyncio.CancelledError:
+                raise
+            except RegistrationCoordinationError as exc:
+                service.registration_status["state"] = "coordination_error"
+                service.registration_status["last_error"] = str(exc)
+                LOGGER.warning(
+                    "registration coordination failed closed; will retry: %s",
+                    exc,
+                )
+            except RegistrationTlsError as exc:
+                service.registration_status["state"] = "tls_error"
+                service.registration_status["last_error"] = str(exc)
+                LOGGER.warning("registration TLS setup failed; will retry: %s", exc)
+            except (aiohttp.ClientError, OSError) as exc:
+                service.registration_status["state"] = "connection_error"
+                service.registration_status["last_error"] = f"{type(exc).__name__}: {exc}"
+                LOGGER.warning("registration failed: %s", exc)
+            await asyncio.sleep(interval)
+
+
+def create_app(
+    config: dict | None = None,
+    *,
+    allow_insecure_test_transport: bool = False,
+) -> web.Application:
+    """Create a loopback-only combined app for deterministic local tests.
+
+    Production uses :func:`_serve` so the stock-Core MCP and TLS Capture
+    listeners can never share a network socket.
+    """
+
+    if not allow_insecure_test_transport:
+        raise CaptureTlsError(
+            "the combined HTTP Capture app is test-only; production must use dedicated WSS"
+        )
+    effective = config or load_config()
+    service = ShadowDriverService(effective)
+    app = web.Application(client_max_size=2 * 1024 * 1024)
+    app[SERVICE_KEY] = service
+    app.router.add_post("/mcp", mcp_handler)
+    app.router.add_post("/offer", offer_handler)
+    app.router.add_get("/ws/teleop-capture", capture_websocket_handler)
+    app.router.add_get("/health", health_handler)
+
+    async def startup(_app: web.Application) -> None:
+        if (
+            effective.get("registration", {}).get("enabled", True)
+            and service.runtime.status()["dispatch"]["ready"]
+        ):
+            service.registration_task = asyncio.create_task(
+                _registration_loop(service), name="teleop-shadow-registration"
+            )
+        elif effective.get("registration", {}).get("enabled", True):
+            service.registration_status["state"] = "dispatch_fault"
+            service.registration_status["last_error"] = (
+                "startup safe-stop was not acknowledged; registration inhibited"
+            )
+
+    async def cleanup(_app: web.Application) -> None:
+        await service.close()
+
+    app.on_startup.append(startup)
+    app.on_cleanup.append(cleanup)
+    return app
+
+
+def create_mcp_app(service: ShadowDriverService) -> web.Application:
+    app = web.Application(client_max_size=2 * 1024 * 1024)
+    app[SERVICE_KEY] = service
+    app.router.add_post("/mcp", mcp_handler)
+    app.router.add_post("/offer", offer_handler)
+    app.router.add_get("/health", health_handler)
+    return app
+
+
+def create_capture_app(service: ShadowDriverService) -> web.Application:
+    app = web.Application(client_max_size=MAX_CAPTURE_MESSAGE_BYTES)
+    app[SERVICE_KEY] = service
+    app.router.add_get("/ws/teleop-capture", capture_websocket_handler)
+    return app
+
+
+async def _serve(config: dict) -> None:
+    mcp_host = config.get("bind_host", "127.0.0.1")
+    if not _is_loopback_bind(mcp_host):
+        raise RuntimeError("MCP listener must bind a loopback address")
+    capture_config = config.get("capture", {})
+    capture_host = capture_config.get("bind_host", "0.0.0.0")
+    capture_port = int(capture_config.get("port", 15712))
+    mcp_port = int(config["mcp_port"])
+    if capture_port == mcp_port:
+        raise RuntimeError("Capture WSS and MCP HTTP must use different ports")
+    capture_ssl = build_capture_ssl_context(capture_config)
+    service = ShadowDriverService(config)
+    mcp_runner = web.AppRunner(create_mcp_app(service))
+    capture_runner = web.AppRunner(create_capture_app(service))
+    try:
+        await mcp_runner.setup()
+        await capture_runner.setup()
+        await web.TCPSite(mcp_runner, mcp_host, mcp_port).start()
+        await web.TCPSite(
+            capture_runner,
+            capture_host,
+            capture_port,
+            ssl_context=capture_ssl,
+        ).start()
+        if (
+            config.get("registration", {}).get("enabled", True)
+            and service.runtime.status()["dispatch"]["ready"]
+        ):
+            service.registration_task = asyncio.create_task(
+                _registration_loop(service),
+                name="teleop-shadow-registration",
+            )
+        await asyncio.Event().wait()
+    finally:
+        await capture_runner.cleanup()
+        await mcp_runner.cleanup()
+        await service.close()
+
+
+def main() -> None:
+    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
+    config = load_config()
+    try:
+        asyncio.run(_serve(config))
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/generic/teleop_shadow/protocol.py
+++ b/generic/teleop_shadow/protocol.py
@@ -1,0 +1,542 @@
+"""Pure protocol validation and HMAC ticket helpers for teleop-shadow.
+
+This module deliberately has no aiohttp or aiortc dependency.  It is shared by
+the HTTP/RTC adapters and the offline protocol tests.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import math
+import re
+import threading
+import time
+import uuid
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+FRAME_SCHEMA_VERSION = 1
+MODE = "shadow"
+PROTOCOL = "motus.teleop.shadow.v1"
+RTC_FRAME_PROTOCOL = "motus.teleop.rtc-frame.v1"
+RTC_CONTROL_PROTOCOL = "motus.teleop.rtc-control.v1"
+SIGNALING_PROTOCOL = "motus.teleop.webrtc-offer-answer.v1"
+DISPATCH_CONTRACT = "motus.teleop.dispatch.recording.v1"
+MAX_FRAME_BYTES = 64 * 1024
+MAX_SEQUENCE = (1 << 63) - 1
+_TOKEN_ID_RE = re.compile(r"^[A-Za-z0-9_-]{16,128}$")
+_FENCE_RE = re.compile(r"^[A-Za-z0-9_-]{24,128}$")
+
+
+class ProtocolError(ValueError):
+    """A stable, user-visible protocol validation failure."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+class TicketError(ProtocolError):
+    """A ticket authentication or replay failure."""
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+FRAME_V1_DESCRIPTION = {
+    "schema_version": FRAME_SCHEMA_VERSION,
+    "mode": MODE,
+    "required": [
+        "schema_version",
+        "boot_id",
+        "session_id",
+        "epoch",
+        "fence",
+        "sequence",
+        "client_monotonic_ns",
+        "mode",
+        "deadman",
+        "clutch_sequence",
+        "tracking",
+        "head",
+        "left_controller",
+        "right_controller",
+        "controllers",
+    ],
+    "optional": ["base_twist"],
+    "integer_bounds": {
+        "sequence": {"minimum": 0, "maximum": MAX_SEQUENCE},
+        "clutch_sequence": {"minimum": 0, "maximum": MAX_SEQUENCE},
+    },
+    "pose": {
+        "position": "[x,y,z] metres, finite, abs <= 100",
+        "orientation": "[x,y,z,w] unit quaternion",
+    },
+    "transport": {
+        "control": {"label": "teleop-control", "ordered": True, "reliable": True},
+        "pose": {"label": "teleop-pose", "ordered": False, "maxRetransmits": 0},
+    },
+}
+
+RTC_FRAME_V1_DESCRIPTION = {
+    "protocol": RTC_FRAME_PROTOCOL,
+    "schema_version": FRAME_SCHEMA_VERSION,
+    "mode": MODE,
+    "required": [
+        field
+        for field in FRAME_V1_DESCRIPTION["required"]
+        if field not in {"boot_id", "session_id", "epoch", "fence"}
+    ],
+    "optional": list(FRAME_V1_DESCRIPTION["optional"]),
+    "authority_binding": "verified-offer-ticket",
+    "forbidden_private_fields": ["boot_id", "session_id", "epoch", "fence"],
+    "integer_bounds": dict(FRAME_V1_DESCRIPTION["integer_bounds"]),
+    "pose": dict(FRAME_V1_DESCRIPTION["pose"]),
+}
+
+CAPABILITIES = {
+    "driver": "teleop-shadow",
+    "protocol": PROTOCOL,
+    "mode": MODE,
+    "actuation_enabled": False,
+    "frame": FRAME_V1_DESCRIPTION,
+    "rtc_frame": RTC_FRAME_V1_DESCRIPTION,
+    "rtc_control": {
+        "protocol": RTC_CONTROL_PROTOCOL,
+        "allowed": ["peer_ping", "status"],
+        "lease_renewal": False,
+        "session_actions": "loopback-mcp-card-only",
+        "private_authority_fields_allowed": False,
+    },
+    "signaling": {
+        "protocol": "motus.teleop.capture.v1",
+        "path": "/ws/teleop-capture",
+        "access": "paired-capture-credential-only",
+        "rtc_ticket": "driver-issued-internal-one-time",
+    },
+    "lease": {
+        "authority": "paired-capture-control-only",
+        "pose_renews_lease": False,
+        "rtc_ping_renews_lease": False,
+    },
+    "dispatch": {
+        "contract": DISPATCH_CONTRACT,
+        "kind": "recording",
+        "hardware_output": False,
+        "motion_mailbox_depth": 1,
+        "stop_path": "non-droppable-acknowledged",
+        "final_checks": [
+            "authority",
+            "session_generation",
+            "dispatch_generation",
+            "deadline",
+            "deadman",
+            "tracking",
+        ],
+    },
+}
+CAPABILITY_DIGEST = hashlib.sha256(canonical_json(CAPABILITIES)).hexdigest()
+
+
+def _strict_object(value: Any, name: str, required: set[str], optional: set[str] | None = None) -> dict:
+    if not isinstance(value, dict):
+        raise ProtocolError("invalid_type", f"{name} must be an object")
+    optional = optional or set()
+    keys = set(value)
+    missing = required - keys
+    unknown = keys - required - optional
+    if missing:
+        raise ProtocolError("missing_field", f"{name} missing fields: {sorted(missing)}")
+    if unknown:
+        raise ProtocolError("unknown_field", f"{name} contains unknown fields: {sorted(unknown)}")
+    return value
+
+
+def _strict_int(
+    value: Any,
+    name: str,
+    *,
+    minimum: int = 0,
+    maximum: int | None = None,
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ProtocolError("invalid_type", f"{name} must be an integer")
+    if value < minimum:
+        raise ProtocolError("out_of_range", f"{name} must be >= {minimum}")
+    if maximum is not None and value > maximum:
+        raise ProtocolError("out_of_range", f"{name} must be <= {maximum}")
+    return value
+
+
+def _strict_bool(value: Any, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ProtocolError("invalid_type", f"{name} must be a boolean")
+    return value
+
+
+def _finite_number(value: Any, name: str, *, lower: float, upper: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ProtocolError("invalid_type", f"{name} must be a number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ProtocolError("non_finite", f"{name} must be finite")
+    if number < lower or number > upper:
+        raise ProtocolError("out_of_range", f"{name} must be in [{lower}, {upper}]")
+    return number
+
+
+def _float_array(value: Any, name: str, *, size: int | None, maximum_size: int | None,
+                 lower: float, upper: float) -> list[float]:
+    if not isinstance(value, list):
+        raise ProtocolError("invalid_type", f"{name} must be an array")
+    if size is not None and len(value) != size:
+        raise ProtocolError("invalid_length", f"{name} must contain exactly {size} values")
+    if maximum_size is not None and len(value) > maximum_size:
+        raise ProtocolError("invalid_length", f"{name} may contain at most {maximum_size} values")
+    return [
+        _finite_number(item, f"{name}[{index}]", lower=lower, upper=upper)
+        for index, item in enumerate(value)
+    ]
+
+
+def _validate_uuid(value: Any, name: str) -> str:
+    if not isinstance(value, str):
+        raise ProtocolError("invalid_type", f"{name} must be a UUID string")
+    try:
+        parsed = uuid.UUID(value)
+    except (ValueError, AttributeError) as exc:
+        raise ProtocolError("invalid_value", f"{name} must be a valid UUID") from exc
+    if str(parsed) != value.lower():
+        raise ProtocolError("invalid_value", f"{name} must use canonical UUID form")
+    return str(parsed)
+
+
+def _validate_fence(value: Any) -> str:
+    if not isinstance(value, str) or not _FENCE_RE.fullmatch(value):
+        raise ProtocolError("invalid_value", "fence must be a URL-safe token of 24-128 characters")
+    return value
+
+
+def _validate_pose(value: Any, name: str, tracking_valid: bool) -> dict | None:
+    if value is None:
+        if tracking_valid:
+            raise ProtocolError("tracking_mismatch", f"{name} is required while tracking is valid")
+        return None
+    if not tracking_valid:
+        raise ProtocolError("tracking_mismatch", f"{name} must be null while tracking is invalid")
+    pose = _strict_object(value, name, {"position", "orientation"})
+    position = _float_array(
+        pose["position"], f"{name}.position", size=3, maximum_size=None, lower=-100.0, upper=100.0
+    )
+    orientation = _float_array(
+        pose["orientation"], f"{name}.orientation", size=4, maximum_size=None, lower=-1.0, upper=1.0
+    )
+    norm = math.sqrt(sum(item * item for item in orientation))
+    if abs(norm - 1.0) > 0.02:
+        raise ProtocolError("invalid_quaternion", f"{name}.orientation must be normalized")
+    return {"position": position, "orientation": orientation}
+
+
+def _validate_controller(value: Any, name: str) -> dict:
+    controller = _strict_object(value, name, {"axes", "buttons"})
+    return {
+        "axes": _float_array(
+            controller["axes"], f"{name}.axes", size=None, maximum_size=8, lower=-1.0, upper=1.0
+        ),
+        "buttons": _float_array(
+            controller["buttons"], f"{name}.buttons", size=None, maximum_size=16, lower=0.0, upper=1.0
+        ),
+    }
+
+
+def _normalize_frame_v1(value: Any) -> dict:
+    required = set(FRAME_V1_DESCRIPTION["required"])
+    frame = _strict_object(value, "frame", required, {"base_twist"})
+    version = _strict_int(frame["schema_version"], "schema_version", minimum=1)
+    if version != FRAME_SCHEMA_VERSION:
+        raise ProtocolError("unsupported_version", f"schema_version must be {FRAME_SCHEMA_VERSION}")
+    if frame["mode"] != MODE:
+        raise ProtocolError("unsupported_mode", f"mode must be {MODE!r}")
+
+    tracking = _strict_object(
+        frame["tracking"], "tracking", {"head", "left_controller", "right_controller"}
+    )
+    normalized_tracking = {
+        key: _strict_bool(tracking[key], f"tracking.{key}")
+        for key in ("head", "left_controller", "right_controller")
+    }
+    controllers = _strict_object(frame["controllers"], "controllers", {"left", "right"})
+
+    normalized = {
+        "schema_version": version,
+        "boot_id": _validate_uuid(frame["boot_id"], "boot_id"),
+        "session_id": _validate_uuid(frame["session_id"], "session_id"),
+        "epoch": _strict_int(frame["epoch"], "epoch", minimum=1),
+        "fence": _validate_fence(frame["fence"]),
+        "sequence": _strict_int(
+            frame["sequence"], "sequence", minimum=0, maximum=MAX_SEQUENCE
+        ),
+        "client_monotonic_ns": _strict_int(
+            frame["client_monotonic_ns"], "client_monotonic_ns", minimum=0
+        ),
+        "mode": MODE,
+        "deadman": _strict_bool(frame["deadman"], "deadman"),
+        "clutch_sequence": _strict_int(
+            frame["clutch_sequence"],
+            "clutch_sequence",
+            minimum=0,
+            maximum=MAX_SEQUENCE,
+        ),
+        "tracking": normalized_tracking,
+        "head": _validate_pose(frame["head"], "head", normalized_tracking["head"]),
+        "left_controller": _validate_pose(
+            frame["left_controller"], "left_controller", normalized_tracking["left_controller"]
+        ),
+        "right_controller": _validate_pose(
+            frame["right_controller"], "right_controller", normalized_tracking["right_controller"]
+        ),
+        "controllers": {
+            "left": _validate_controller(controllers["left"], "controllers.left"),
+            "right": _validate_controller(controllers["right"], "controllers.right"),
+        },
+    }
+    if "base_twist" in frame:
+        twist = _strict_object(frame["base_twist"], "base_twist", {"linear", "angular"})
+        normalized["base_twist"] = {
+            "linear": _float_array(
+                twist["linear"], "base_twist.linear", size=3, maximum_size=None, lower=-20.0, upper=20.0
+            ),
+            "angular": _float_array(
+                twist["angular"], "base_twist.angular", size=3, maximum_size=None,
+                lower=-20.0, upper=20.0
+            ),
+        }
+    return normalized
+
+
+def validate_frame_v1(value: Any, *, max_bytes: int = MAX_FRAME_BYTES) -> dict:
+    """Validate and normalize one authority-bearing Teleop Frame v1 object."""
+
+    try:
+        encoded_size = len(canonical_json(value))
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise ProtocolError("invalid_json", "frame must contain JSON-compatible finite values") from exc
+    if encoded_size > max_bytes:
+        raise ProtocolError("frame_too_large", f"frame exceeds {max_bytes} bytes")
+    return _normalize_frame_v1(value)
+
+
+def bind_rtc_frame_v1(
+    value: Any,
+    *,
+    authority: Mapping[str, Any],
+    max_bytes: int = MAX_FRAME_BYTES,
+) -> dict:
+    """Bind a public RTC wire Frame to its ticket-authorized private identity.
+
+    The browser is deliberately forbidden from supplying any authority field.
+    The returned internal Frame can therefore use the same runtime and final
+    dispatch validation as authenticated MCP diagnostics without disclosing the
+    session fence to JavaScript.
+    """
+
+    try:
+        encoded_size = len(canonical_json(value))
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise ProtocolError("invalid_json", "RTC frame must contain JSON-compatible finite values") from exc
+    if encoded_size > max_bytes:
+        raise ProtocolError("frame_too_large", f"RTC frame exceeds {max_bytes} bytes")
+    wire = _strict_object(
+        value,
+        "RTC frame",
+        set(RTC_FRAME_V1_DESCRIPTION["required"]),
+        set(RTC_FRAME_V1_DESCRIPTION["optional"]),
+    )
+    if not isinstance(authority, Mapping):
+        raise ProtocolError("invalid_rtc_binding", "RTC authority binding is invalid")
+    try:
+        internal = {
+            "boot_id": authority["boot_id"],
+            "session_id": authority["session_id"],
+            "epoch": authority["epoch"],
+            "fence": authority["fence"],
+            **wire,
+        }
+    except KeyError as exc:
+        raise ProtocolError("invalid_rtc_binding", "RTC authority binding is incomplete") from exc
+    return _normalize_frame_v1(internal)
+
+
+def sdp_digest(sdp: str) -> str:
+    if not isinstance(sdp, str) or not sdp:
+        raise TicketError("invalid_sdp", "sdp must be a non-empty string")
+    return hashlib.sha256(sdp.encode("utf-8")).hexdigest()
+
+
+def _b64encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(value: str) -> bytes:
+    if not isinstance(value, str) or not value:
+        raise TicketError("malformed_ticket", "ticket segment is empty")
+    try:
+        return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+    except Exception as exc:
+        raise TicketError("malformed_ticket", "ticket is not valid base64url") from exc
+
+
+@dataclass(frozen=True)
+class TicketClaims:
+    boot_id: str
+    session_id: str
+    epoch: int
+    fence: str
+    capability_digest: str
+    sdp_sha256: str
+    iat: int
+    exp: int
+    jti: str
+
+    def as_dict(self) -> dict:
+        return {
+            "v": 1,
+            "aud": "teleop-shadow-rtc",
+            "boot_id": self.boot_id,
+            "session_id": self.session_id,
+            "epoch": self.epoch,
+            "fence": self.fence,
+            "capability_digest": self.capability_digest,
+            "sdp_sha256": self.sdp_sha256,
+            "iat": self.iat,
+            "exp": self.exp,
+            "jti": self.jti,
+        }
+
+
+class TicketCodec:
+    """Small HMAC-SHA256 token codec shared with Core-side integration tests."""
+
+    def __init__(self, secret: str | bytes):
+        if isinstance(secret, str):
+            try:
+                secret_bytes = secret.encode("utf-8")
+            except UnicodeEncodeError:
+                raise ValueError(
+                    "teleop ticket secret must be valid UTF-8"
+                ) from None
+        else:
+            secret_bytes = bytes(secret)
+        if len(secret_bytes) < 32:
+            raise ValueError("teleop ticket secret must contain at least 32 bytes")
+        self._secret = secret_bytes
+
+    def sign(self, claims: TicketClaims) -> str:
+        payload = _b64encode(canonical_json(claims.as_dict()))
+        signature = _b64encode(hmac.new(self._secret, payload.encode("ascii"), hashlib.sha256).digest())
+        return f"{payload}.{signature}"
+
+    def decode_and_verify_signature(self, token: str) -> dict:
+        if not isinstance(token, str) or token.count(".") != 1:
+            raise TicketError("malformed_ticket", "ticket must contain payload and signature")
+        payload, signature = token.split(".", 1)
+        expected = _b64encode(hmac.new(self._secret, payload.encode("ascii"), hashlib.sha256).digest())
+        if not hmac.compare_digest(signature, expected):
+            raise TicketError("invalid_signature", "ticket signature is invalid")
+        try:
+            decoded = json.loads(_b64decode(payload))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise TicketError("malformed_ticket", "ticket payload is not valid JSON") from exc
+        return _strict_object(
+            decoded,
+            "ticket",
+            {
+                "v", "aud", "boot_id", "session_id", "epoch", "fence",
+                "capability_digest", "sdp_sha256", "iat", "exp", "jti",
+            },
+        )
+
+
+class TicketVerifier:
+    """Verify binding, expiry and one-time use for RTC offers."""
+
+    def __init__(
+        self,
+        codec: TicketCodec,
+        *,
+        max_ttl_seconds: int = 30,
+        max_replay_entries: int = 4096,
+        wall_clock: Callable[[], float] = time.time,
+    ):
+        self._codec = codec
+        self._max_ttl = int(max_ttl_seconds)
+        self._max_replay_entries = int(max_replay_entries)
+        self._wall_clock = wall_clock
+        self._used: dict[str, int] = {}
+        self._lock = threading.Lock()
+
+    def verify_and_consume(self, token: str, *, expected: Mapping[str, Any], sdp: str) -> dict:
+        claims = self._codec.decode_and_verify_signature(token)
+        now = int(self._wall_clock())
+        if claims["v"] != 1 or claims["aud"] != "teleop-shadow-rtc":
+            raise TicketError("invalid_audience", "ticket version or audience is invalid")
+        iat = _strict_int(claims["iat"], "ticket.iat", minimum=0)
+        exp = _strict_int(claims["exp"], "ticket.exp", minimum=1)
+        if iat > now + 5:
+            raise TicketError("ticket_not_yet_valid", "ticket issue time is in the future")
+        if exp <= now:
+            raise TicketError("ticket_expired", "ticket has expired")
+        if exp - iat <= 0 or exp - iat > self._max_ttl:
+            raise TicketError("invalid_ticket_ttl", f"ticket TTL must be <= {self._max_ttl} seconds")
+        jti = claims["jti"]
+        if not isinstance(jti, str) or not _TOKEN_ID_RE.fullmatch(jti):
+            raise TicketError("invalid_jti", "ticket jti is invalid")
+        if claims["sdp_sha256"] != sdp_digest(sdp):
+            raise TicketError("sdp_mismatch", "ticket is not bound to this SDP offer")
+        for key, value in expected.items():
+            if claims.get(key) != value:
+                raise TicketError("binding_mismatch", f"ticket {key} does not match the active session")
+
+        with self._lock:
+            self._used = {key: expiry for key, expiry in self._used.items() if expiry > now}
+            if jti in self._used:
+                raise TicketError("ticket_replayed", "ticket has already been used")
+            if len(self._used) >= self._max_replay_entries:
+                raise TicketError("replay_cache_full", "ticket replay cache is full")
+            self._used[jti] = exp
+        return claims
+
+
+def make_ticket_claims(
+    *,
+    session: Mapping[str, Any],
+    sdp: str,
+    ttl_seconds: int = 20,
+    wall_clock: Callable[[], float] = time.time,
+    jti: str | None = None,
+) -> TicketClaims:
+    """Reference claim builder for Core integration and local tests."""
+
+    now = int(wall_clock())
+    return TicketClaims(
+        boot_id=str(session["boot_id"]),
+        session_id=str(session["session_id"]),
+        epoch=int(session["epoch"]),
+        fence=str(session["fence"]),
+        capability_digest=str(session["capability_digest"]),
+        sdp_sha256=sdp_digest(sdp),
+        iat=now,
+        exp=now + int(ttl_seconds),
+        jti=jti or _b64encode(uuid.uuid4().bytes),
+    )

--- a/generic/teleop_shadow/render_instances.py
+++ b/generic/teleop_shadow/render_instances.py
@@ -1,0 +1,775 @@
+"""Render validated teleop-shadow instances into deterministic Docker Compose."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import re
+import ssl
+import stat
+import sys
+import tempfile
+from urllib.parse import urlsplit
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+from yaml.constructor import ConstructorError
+from yaml.nodes import MappingNode
+
+SCHEMA_VERSION = 4
+MIN_MCP_PORT = 15700
+MAX_MCP_PORT = 15799
+MIN_CAPTURE_PORT = 1024
+MAX_CAPTURE_PORT = 65535
+MAX_INPUT_BYTES = 256 * 1024
+MAX_INSTANCES = 64
+MAX_CORE_CA_BYTES = 4 * 1024 * 1024
+CORE_CA_TARGET = "/etc/motus-core-ca/core-ca.pem"
+CORE_CA_SOURCE_ROOT = pathlib.Path("/opt/phanthy-motus")
+REGISTRATION_COORDINATION_TARGET = "/var/lib/motus-registration-coordination"
+REGISTRATION_COORDINATION_FILE = (
+    f"{REGISTRATION_COORDINATION_TARGET}/registration.json"
+)
+AGENT_CORE_URL = "https://localhost:15678"
+_ROOT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "core_ca_file",
+        "registration_coordination_dir",
+        "instances",
+    }
+)
+_INSTANCE_FIELDS = frozenset(
+    {
+        "service",
+        "container",
+        "driver_id",
+        "driver_name",
+        "robot_id",
+        "mcp_port",
+        "capture_port",
+        "capture_wss_url",
+        "capture_tls_dir",
+        "capture_state_dir",
+    }
+)
+_COMPOSE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+_INSTANCE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_IMAGE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/@:+-]{0,254}$")
+_SAFE_ABSOLUTE_PATH_RE = re.compile(r"^/[A-Za-z0-9._/-]+$")
+_PRIVATE_KEY_PEM_RE = re.compile(br"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----")
+_PEM_BLOCK_RE = re.compile(
+    br"-----BEGIN ([A-Z0-9][A-Z0-9 ]*)-----\r?\n.*?-----END \1-----",
+    re.DOTALL,
+)
+_PUBLIC_CERTIFICATE_LABELS = frozenset({b"CERTIFICATE", b"TRUSTED CERTIFICATE"})
+
+
+class RenderError(ValueError):
+    """The instances document cannot safely produce a Compose deployment."""
+
+
+class _StrictSafeLoader(yaml.SafeLoader):
+    """SafeLoader variant that rejects duplicate mapping keys."""
+
+    def construct_mapping(self, node: MappingNode, deep: bool = False) -> dict:
+        if not isinstance(node, MappingNode):
+            raise ConstructorError(
+                None,
+                None,
+                f"expected a mapping node, got {node.id}",
+                node.start_mark,
+            )
+        self.flatten_mapping(node)
+        mapping: dict[Any, Any] = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            try:
+                duplicate = key in mapping
+            except TypeError as exc:
+                raise ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "found an unhashable key",
+                    key_node.start_mark,
+                ) from exc
+            if duplicate:
+                raise ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    f"found duplicate key {key!r}",
+                    key_node.start_mark,
+                )
+            mapping[key] = self.construct_object(value_node, deep=deep)
+        return mapping
+
+
+@dataclass(frozen=True, slots=True)
+class InstanceSpec:
+    service: str
+    container: str
+    driver_id: str
+    driver_name: str
+    robot_id: str
+    mcp_port: int
+    capture_port: int
+    capture_wss_url: str
+    capture_tls_dir: str
+    capture_state_dir: str
+
+
+@dataclass(frozen=True, slots=True)
+class DeploymentSpec:
+    core_ca_file: str
+    registration_coordination_dir: str | None
+    instances: tuple[InstanceSpec, ...]
+
+
+def _mapping(value: object, location: str) -> dict:
+    if type(value) is not dict:
+        raise RenderError(f"{location} must be a mapping")
+    if any(not isinstance(key, str) for key in value):
+        raise RenderError(f"{location} field names must be strings")
+    return value
+
+
+def _reject_unknown_and_missing(
+    value: dict,
+    allowed: frozenset[str],
+    location: str,
+) -> None:
+    unknown = sorted(set(value) - allowed)
+    missing = sorted(allowed - set(value))
+    if unknown:
+        raise RenderError(f"{location} has unknown fields: {', '.join(unknown)}")
+    if missing:
+        raise RenderError(f"{location} is missing fields: {', '.join(missing)}")
+
+
+def _compose_name(value: object, field: str) -> str:
+    if not isinstance(value, str) or not _COMPOSE_NAME_RE.fullmatch(value):
+        raise RenderError(
+            f"{field} must match {_COMPOSE_NAME_RE.pattern!r} and be at most 63 characters"
+        )
+    return value
+
+
+def _instance_id(value: object, field: str, max_length: int) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) > max_length
+        or not _INSTANCE_ID_RE.fullmatch(value)
+    ):
+        raise RenderError(
+            f"{field} must be a stable 1-{max_length} character instance identifier"
+        )
+    return value
+
+
+def _driver_name(value: object, field: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > 200
+        or value != value.strip()
+        or not value.isprintable()
+        or "$" in value
+    ):
+        raise RenderError(
+            f"{field} must be a trimmed printable string of 1-200 characters without '$'"
+        )
+    return value
+
+
+def _mcp_port(value: object, field: str) -> int:
+    if type(value) is not int or not MIN_MCP_PORT <= value <= MAX_MCP_PORT:
+        raise RenderError(
+            f"{field} must be an integer in the Driver range {MIN_MCP_PORT}-{MAX_MCP_PORT}"
+        )
+    return value
+
+
+def _capture_port(value: object, field: str) -> int:
+    if type(value) is not int or not MIN_CAPTURE_PORT <= value <= MAX_CAPTURE_PORT:
+        raise RenderError(
+            f"{field} must be an integer in {MIN_CAPTURE_PORT}-{MAX_CAPTURE_PORT}"
+        )
+    return value
+
+
+def _managed_directory(value: object, field: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) > 1024
+        or not _SAFE_ABSOLUTE_PATH_RE.fullmatch(value)
+    ):
+        raise RenderError(f"{field} must be a safe absolute POSIX directory path")
+    path = pathlib.PurePosixPath(value)
+    root = pathlib.PurePosixPath(CORE_CA_SOURCE_ROOT.as_posix())
+    if root not in path.parents or ".." in path.parts or str(path) != value:
+        raise RenderError(
+            f"{field} must be normalized below {CORE_CA_SOURCE_ROOT.as_posix()}"
+        )
+    return _validate_managed_directory_on_host(pathlib.Path(value), field)
+
+
+def _registration_coordination_directory(value: object) -> str | None:
+    if value is None:
+        return None
+    return _managed_directory(value, "registration_coordination_dir")
+
+
+def _capture_wss_url(value: object, field: str, capture_port: int) -> str:
+    if not isinstance(value, str) or len(value) > 2048:
+        raise RenderError(f"{field} must be a bounded wss URL")
+    parsed = urlsplit(value)
+    try:
+        url_port = parsed.port
+    except ValueError as exc:
+        raise RenderError(f"{field} contains an invalid port") from exc
+    if (
+        parsed.scheme != "wss"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path != "/ws/teleop-capture"
+        or url_port != capture_port
+    ):
+        raise RenderError(
+            f"{field} must be wss://<host>:{capture_port}/ws/teleop-capture"
+        )
+    return value
+
+
+def _core_ca_file(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) > 1024
+        or not _SAFE_ABSOLUTE_PATH_RE.fullmatch(value)
+    ):
+        raise RenderError(
+            "core_ca_file must be a safe absolute POSIX file path without interpolation"
+        )
+    path = pathlib.PurePosixPath(value)
+    if path == pathlib.PurePosixPath("/") or ".." in path.parts or str(path) != value:
+        raise RenderError("core_ca_file must be normalized and must not contain '..'")
+    lexical_root = pathlib.PurePosixPath(CORE_CA_SOURCE_ROOT.as_posix())
+    if lexical_root not in path.parents or path.suffix.lower() not in {".pem", ".crt"}:
+        raise RenderError(
+            "core_ca_file must be a .pem or .crt file below /opt/phanthy-motus"
+        )
+    return _validate_core_ca_file_on_host(pathlib.Path(value))
+
+
+def _assert_no_symlink_components(path: pathlib.Path, field: str) -> None:
+    """Reject a symlink at the leaf or in any existing absolute ancestor."""
+
+    if not path.is_absolute():
+        raise RenderError(f"{field} must be an absolute host path")
+    current = pathlib.Path(path.anchor)
+    for part in path.parts[1:]:
+        current /= part
+        try:
+            metadata = current.lstat()
+        except OSError as exc:
+            raise RenderError(
+                f"{field} must be an existing host path with no symlink components"
+            ) from exc
+        if stat.S_ISLNK(metadata.st_mode):
+            raise RenderError(
+                f"{field} must not use a symlink or symlink ancestor: {current}"
+            )
+
+
+def _canonical_host_path(
+    path: pathlib.Path,
+    field: str,
+    *,
+    require_directory: bool,
+) -> pathlib.Path:
+    """Return an existing canonical path below the canonical deployment root."""
+
+    root = CORE_CA_SOURCE_ROOT
+    _assert_no_symlink_components(root, "host deployment root")
+    _assert_no_symlink_components(path, field)
+    try:
+        resolved_root = root.resolve(strict=True)
+        resolved = path.resolve(strict=True)
+        resolved.relative_to(resolved_root)
+        metadata = path.stat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise RenderError(
+            f"{field} must resolve to an existing path inside "
+            f"{CORE_CA_SOURCE_ROOT.as_posix()}"
+        ) from exc
+    if resolved_root != root or resolved != path:
+        raise RenderError(
+            f"{field} and the host deployment root must use canonical real paths"
+        )
+    expected_type = stat.S_ISDIR if require_directory else stat.S_ISREG
+    if not expected_type(metadata.st_mode):
+        kind = "directory" if require_directory else "regular file"
+        raise RenderError(f"{field} must resolve to a {kind}")
+    return resolved
+
+
+def _validate_managed_directory_on_host(path: pathlib.Path, field: str) -> str:
+    """Validate and canonicalize one host bind-source directory."""
+
+    return str(
+        _canonical_host_path(path, field, require_directory=True)
+    )
+
+
+def _validate_core_ca_file_on_host(path: pathlib.Path) -> str:
+    """Return a canonical, public X.509-only CA path inside the deployment root."""
+
+    resolved = _canonical_host_path(
+        path,
+        "core_ca_file",
+        require_directory=False,
+    )
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    flags |= getattr(os, "O_NONBLOCK", 0)
+    descriptor = -1
+    try:
+        descriptor = os.open(resolved, flags)
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise RenderError("core_ca_file must resolve to a regular file")
+        if not 1 <= metadata.st_size <= MAX_CORE_CA_BYTES:
+            raise RenderError(
+                f"core_ca_file must contain 1-{MAX_CORE_CA_BYTES} bytes"
+            )
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = -1
+            encoded = handle.read(MAX_CORE_CA_BYTES + 1)
+    except OSError as exc:
+        raise RenderError("core_ca_file must be a readable regular file") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if not 1 <= len(encoded) <= MAX_CORE_CA_BYTES:
+        raise RenderError(f"core_ca_file must contain 1-{MAX_CORE_CA_BYTES} bytes")
+    if _PRIVATE_KEY_PEM_RE.search(encoded):
+        raise RenderError("core_ca_file must never contain a private-key PEM block")
+    position = 0
+    block_count = 0
+    for match in _PEM_BLOCK_RE.finditer(encoded):
+        if encoded[position:match.start()].strip():
+            raise RenderError("core_ca_file must contain only public X.509 PEM blocks")
+        if match.group(1) not in _PUBLIC_CERTIFICATE_LABELS:
+            raise RenderError("core_ca_file must contain only public X.509 PEM blocks")
+        block_count += 1
+        position = match.end()
+    if block_count == 0 or encoded[position:].strip():
+        raise RenderError("core_ca_file must contain only public X.509 PEM blocks")
+    try:
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.load_verify_locations(cadata=encoded.decode("ascii"))
+    except (OSError, UnicodeError, ssl.SSLError) as exc:
+        raise RenderError(
+            "core_ca_file must contain a parseable X.509 certificate or CA bundle"
+        ) from exc
+    return str(resolved)
+
+
+def _parse_instance(raw: object, index: int) -> InstanceSpec:
+    location = f"instances[{index}]"
+    value = _mapping(raw, location)
+    _reject_unknown_and_missing(value, _INSTANCE_FIELDS, location)
+    capture_port = _capture_port(value["capture_port"], f"{location}.capture_port")
+    return InstanceSpec(
+        service=_compose_name(value["service"], f"{location}.service"),
+        container=_compose_name(value["container"], f"{location}.container"),
+        driver_id=_instance_id(
+            value["driver_id"], f"{location}.driver_id", max_length=64
+        ),
+        driver_name=_driver_name(value["driver_name"], f"{location}.driver_name"),
+        robot_id=_instance_id(
+            value["robot_id"], f"{location}.robot_id", max_length=64
+        ),
+        mcp_port=_mcp_port(value["mcp_port"], f"{location}.mcp_port"),
+        capture_port=capture_port,
+        capture_wss_url=_capture_wss_url(
+            value["capture_wss_url"],
+            f"{location}.capture_wss_url",
+            capture_port,
+        ),
+        capture_tls_dir=_managed_directory(
+            value["capture_tls_dir"], f"{location}.capture_tls_dir"
+        ),
+        capture_state_dir=_managed_directory(
+            value["capture_state_dir"], f"{location}.capture_state_dir"
+        ),
+    )
+
+
+def _require_unique(instances: Sequence[InstanceSpec], field: str) -> None:
+    seen: dict[object, int] = {}
+    for index, instance in enumerate(instances):
+        value = getattr(instance, field)
+        if value in seen:
+            raise RenderError(
+                f"instances[{index}].{field} duplicates instances[{seen[value]}].{field}"
+            )
+        seen[value] = index
+
+
+def _paths_overlap(left: str, right: str) -> bool:
+    """Return whether two normalized POSIX paths share an ownership tree."""
+
+    left_path = pathlib.PurePosixPath(left)
+    right_path = pathlib.PurePosixPath(right)
+    return (
+        left_path == right_path
+        or left_path in right_path.parents
+        or right_path in left_path.parents
+    )
+
+
+def _path_and_parents(path: pathlib.Path) -> tuple[pathlib.Path, ...]:
+    return (path, *path.parents)
+
+
+def _host_paths_overlap(left: str, right: str) -> bool:
+    """Compare canonical ownership trees, including same-file host aliases."""
+
+    if _paths_overlap(left, right):
+        return True
+    left_path = pathlib.Path(left)
+    right_path = pathlib.Path(right)
+    try:
+        return any(
+            left_path.samefile(candidate)
+            for candidate in _path_and_parents(right_path)
+        ) or any(
+            right_path.samefile(candidate)
+            for candidate in _path_and_parents(left_path)
+        )
+    except OSError as exc:
+        raise RenderError(
+            "canonical host deployment paths could not be compared safely"
+        ) from exc
+
+
+def _require_isolated_storage(
+    instances: Sequence[InstanceSpec],
+    core_ca_file: str,
+    registration_coordination_dir: str | None,
+) -> None:
+    managed = [
+        (index, field, getattr(instance, field))
+        for index, instance in enumerate(instances)
+        for field in ("capture_tls_dir", "capture_state_dir")
+    ]
+    for position, (left_index, left_field, left_path) in enumerate(managed):
+        for right_index, right_field, right_path in managed[position + 1:]:
+            if _host_paths_overlap(left_path, right_path):
+                raise RenderError(
+                    f"instances[{left_index}].{left_field} overlaps "
+                    f"instances[{right_index}].{right_field}"
+                )
+        if _host_paths_overlap(left_path, core_ca_file):
+            raise RenderError(
+                f"instances[{left_index}].{left_field} overlaps core_ca_file"
+            )
+        if (
+            registration_coordination_dir is not None
+            and _host_paths_overlap(left_path, registration_coordination_dir)
+        ):
+            raise RenderError(
+                f"instances[{left_index}].{left_field} overlaps "
+                "registration_coordination_dir"
+            )
+    if (
+        registration_coordination_dir is not None
+        and _host_paths_overlap(registration_coordination_dir, core_ca_file)
+    ):
+        raise RenderError(
+            "registration_coordination_dir overlaps core_ca_file"
+        )
+
+
+def parse_instances_document(document: object) -> DeploymentSpec:
+    """Validate a loaded instances document and return its typed form."""
+
+    root = _mapping(document, "document")
+    _reject_unknown_and_missing(root, _ROOT_FIELDS, "document")
+    if type(root["schema_version"]) is not int or root["schema_version"] != SCHEMA_VERSION:
+        raise RenderError(f"schema_version must be exactly {SCHEMA_VERSION}")
+    raw_instances = root["instances"]
+    if type(raw_instances) is not list:
+        raise RenderError("instances must be a list")
+    if not 1 <= len(raw_instances) <= MAX_INSTANCES:
+        raise RenderError(f"instances must contain 1-{MAX_INSTANCES} entries")
+
+    instances = tuple(
+        _parse_instance(raw_instance, index)
+        for index, raw_instance in enumerate(raw_instances)
+    )
+    for field in (
+        "service", "container", "driver_id", "robot_id", "mcp_port",
+        "capture_port", "capture_wss_url", "capture_tls_dir", "capture_state_dir",
+    ):
+        _require_unique(instances, field)
+    all_ports = [
+        port
+        for instance in instances
+        for port in (instance.mcp_port, instance.capture_port)
+    ]
+    if len(all_ports) != len(set(all_ports)):
+        raise RenderError("all MCP and Capture listener ports must be globally unique")
+    core_ca_file = _core_ca_file(root["core_ca_file"])
+    registration_coordination_dir = _registration_coordination_directory(
+        root["registration_coordination_dir"]
+    )
+    if len(instances) > 1 and registration_coordination_dir is None:
+        raise RenderError(
+            "registration_coordination_dir is required for multi-instance deployment"
+        )
+    _require_isolated_storage(
+        instances,
+        core_ca_file,
+        registration_coordination_dir,
+    )
+    return DeploymentSpec(
+        core_ca_file=core_ca_file,
+        registration_coordination_dir=registration_coordination_dir,
+        instances=instances,
+    )
+
+
+def load_instances(path: str | pathlib.Path) -> DeploymentSpec:
+    """Load a bounded UTF-8 YAML file with duplicate-key rejection."""
+
+    input_path = pathlib.Path(path)
+    if not input_path.is_file():
+        raise RenderError(f"instances input is not a regular file: {input_path}")
+    try:
+        with input_path.open("rb") as handle:
+            encoded = handle.read(MAX_INPUT_BYTES + 1)
+        if len(encoded) > MAX_INPUT_BYTES:
+            raise RenderError(f"instances input exceeds {MAX_INPUT_BYTES} bytes")
+        text = encoded.decode("utf-8")
+        document = yaml.load(text, Loader=_StrictSafeLoader)
+    except UnicodeError as exc:
+        raise RenderError("instances input must be valid UTF-8") from exc
+    except RecursionError as exc:
+        raise RenderError("instances input YAML nesting is too deep") from exc
+    except yaml.YAMLError as exc:
+        raise RenderError(f"instances input is invalid YAML: {exc}") from exc
+    return parse_instances_document(document)
+
+
+def validate_image(image: object) -> str:
+    """Accept a conservative Compose-safe image reference."""
+
+    if not isinstance(image, str) or not _IMAGE_RE.fullmatch(image) or ".." in image:
+        raise RenderError(
+            "image must be a 1-255 character container reference without whitespace or interpolation"
+        )
+    return image
+
+
+def _service(
+    instance: InstanceSpec,
+    deployment: DeploymentSpec,
+    image: str,
+) -> dict:
+    port = instance.mcp_port
+    volumes = [
+        {
+            "type": "bind",
+            "source": deployment.core_ca_file,
+            "target": CORE_CA_TARGET,
+            "read_only": True,
+            "bind": {"create_host_path": False},
+        },
+        {
+            "type": "bind",
+            "source": instance.capture_tls_dir,
+            "target": "/etc/motus-capture-tls",
+            "read_only": True,
+            "bind": {"create_host_path": False},
+        },
+        {
+            "type": "bind",
+            "source": instance.capture_state_dir,
+            "target": "/var/lib/motus-teleop-shadow",
+            "read_only": False,
+            "bind": {"create_host_path": False},
+        },
+    ]
+    environment = [
+        "MOTUS_BIND_HOST=127.0.0.1",
+        f"MOTUS_MCP_PORT={port}",
+        f"MOTUS_MCP_URL=http://localhost:{port}/mcp",
+        f"MOTUS_DRIVER_ID={instance.driver_id}",
+        f"MOTUS_DRIVER_NAME={instance.driver_name}",
+        f"MOTUS_ROBOT_ID={instance.robot_id}",
+        "MOTUS_CAPTURE_BIND_HOST=0.0.0.0",
+        f"MOTUS_CAPTURE_PORT={instance.capture_port}",
+        f"MOTUS_CAPTURE_WSS_URL={instance.capture_wss_url}",
+        "MOTUS_CAPTURE_TLS_CERT_FILE=/etc/motus-capture-tls/cert.pem",
+        "MOTUS_CAPTURE_TLS_KEY_FILE=/etc/motus-capture-tls/key.pem",
+        "MOTUS_CAPTURE_STATE_FILE=/var/lib/motus-teleop-shadow/capture.json",
+        f"AGENT_CORE_URL={AGENT_CORE_URL}",
+        "MOTUS_AGENT_CORE_VERIFY_TLS=1",
+        f"MOTUS_AGENT_CORE_CA_FILE={CORE_CA_TARGET}",
+        "PYTHONUNBUFFERED=1",
+    ]
+    if deployment.registration_coordination_dir is not None:
+        volumes.append(
+            {
+                "type": "bind",
+                "source": deployment.registration_coordination_dir,
+                "target": REGISTRATION_COORDINATION_TARGET,
+                "read_only": False,
+                "bind": {"create_host_path": False},
+            }
+        )
+        environment.insert(
+            -1,
+            f"MOTUS_REGISTRATION_COORDINATION_FILE={REGISTRATION_COORDINATION_FILE}",
+        )
+    return {
+        "image": image,
+        "container_name": instance.container,
+        "network_mode": "host",
+        "volumes": volumes,
+        "environment": environment,
+        "logging": {
+            "driver": "local",
+            "options": {"max-size": "10m", "max-file": "3"},
+        },
+        "restart": "unless-stopped",
+    }
+
+
+def render_compose(deployment: DeploymentSpec, image: str) -> str:
+    """Render canonical Compose YAML without consulting process secrets."""
+
+    safe_image = validate_image(image)
+    ordered_instances = sorted(deployment.instances, key=lambda item: item.service)
+    services = {
+        instance.service: _service(instance, deployment, safe_image)
+        for instance in ordered_instances
+    }
+    rendered = yaml.safe_dump(
+        {"services": services},
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=False,
+        width=1000,
+    )
+    return "# Generated by render_instances.py; contains no secret values.\n" + rendered
+
+
+def atomic_write(path: str | pathlib.Path, content: str) -> None:
+    """Atomically replace a regular output file in an existing directory."""
+
+    output_path = pathlib.Path(path)
+    parent = output_path.parent
+    if not parent.is_dir():
+        raise RenderError(f"output parent is not a directory: {parent}")
+    if output_path.is_symlink() or (output_path.exists() and not output_path.is_file()):
+        raise RenderError(f"output must be a regular file path: {output_path}")
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{output_path.name}.",
+        suffix=".tmp",
+        dir=parent,
+        text=True,
+    )
+    temporary_path = pathlib.Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            os.fchmod(handle.fileno(), 0o644)
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, output_path)
+        directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        directory_flags |= getattr(os, "O_CLOEXEC", 0)
+        directory_fd = os.open(parent, directory_flags)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        if temporary_path.exists() or temporary_path.is_symlink():
+            temporary_path.unlink()
+
+
+def require_distinct_input_output(
+    input_path: str | pathlib.Path,
+    output_path: str | pathlib.Path,
+) -> None:
+    """Refuse to replace the source YAML through a direct path or hard link."""
+
+    source = pathlib.Path(input_path)
+    destination = pathlib.Path(output_path)
+    try:
+        source_resolved = source.resolve(strict=True)
+        destination_resolved = destination.resolve(strict=False)
+        aliases = source_resolved == destination_resolved
+        if destination.exists() and source.samefile(destination):
+            aliases = True
+    except OSError as exc:
+        raise RenderError("instances input and output paths could not be compared safely") from exc
+    if aliases:
+        raise RenderError("output must not replace or alias the instances input file")
+
+
+def _argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Render strict teleop-shadow instances into Docker Compose."
+    )
+    parser.add_argument("--instances", required=True, help="strict instances YAML input")
+    parser.add_argument("--image", required=True, help="one image reference for all instances")
+    parser.add_argument(
+        "--output",
+        default="teleop-shadow.compose.yml",
+        help="atomic output path (default: teleop-shadow.compose.yml)",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--stdout", action="store_true", help="render to stdout; write no file")
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="validate and render to stdout; write no file",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _argument_parser()
+    arguments = parser.parse_args(argv)
+    try:
+        deployment = load_instances(arguments.instances)
+        rendered = render_compose(deployment, arguments.image)
+        if arguments.stdout or arguments.dry_run:
+            sys.stdout.write(rendered)
+        else:
+            require_distinct_input_output(arguments.instances, arguments.output)
+            atomic_write(arguments.output, rendered)
+            print(
+                f"rendered {len(deployment.instances)} teleop-shadow instances to "
+                f"{arguments.output}",
+                file=sys.stderr,
+            )
+    except (OSError, RenderError) as exc:
+        print(f"render error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/generic/teleop_shadow/requirements.txt
+++ b/generic/teleop_shadow/requirements.txt
@@ -1,0 +1,8 @@
+# aiohttp: MCP, registration and WebRTC signaling HTTP service (Apache-2.0/MIT).
+aiohttp>=3.13,<3.15
+# aiortc: standards-based ICE/DTLS/SCTP/DataChannel implementation (BSD-3-Clause).
+# The Driver does not implement or fork WebRTC itself.
+aiortc>=1.14,<1.16
+# Keep aiortc's crypto backend on a wheel-backed, reproducible range (Apache-2.0/BSD-3-Clause).
+cryptography>=44,<47
+PyYAML>=6.0,<7

--- a/generic/teleop_shadow/rtc.py
+++ b/generic/teleop_shadow/rtc.py
@@ -1,0 +1,262 @@
+"""aiortc transport for the teleop-shadow diagnostic Driver."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from aiortc import RTCDataChannel, RTCPeerConnection, RTCSessionDescription
+from protocol import ProtocolError, TicketError, TicketVerifier
+from runtime import ShadowRuntime
+
+
+class RtcRequestError(RuntimeError):
+    def __init__(self, status: int, code: str, message: str):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+
+
+class RtcManager:
+    def __init__(self, runtime: ShadowRuntime, verifier: TicketVerifier | None):
+        self._runtime = runtime
+        self._verifier = verifier
+        self._peers: set[RTCPeerConnection] = set()
+        self._lock = asyncio.Lock()
+
+    @property
+    def enabled(self) -> bool:
+        return self._verifier is not None
+
+    async def accept_offer(self, payload: Any) -> dict:
+        if self._verifier is None:
+            raise RtcRequestError(
+                503,
+                "rtc_ticket_secret_missing",
+                "RTC is disabled until its internal one-time ticket verifier is configured",
+            )
+        if not isinstance(payload, dict):
+            raise RtcRequestError(400, "invalid_offer", "offer body must be an object")
+        unknown = set(payload) - {"sdp", "type", "ticket"}
+        missing = {"sdp", "type", "ticket"} - set(payload)
+        if missing or unknown:
+            raise RtcRequestError(
+                400,
+                "invalid_offer",
+                f"offer fields invalid; missing={sorted(missing)}, unknown={sorted(unknown)}",
+            )
+        if payload["type"] != "offer" or not isinstance(payload["sdp"], str):
+            raise RtcRequestError(400, "invalid_offer", "type must be 'offer' and sdp must be a string")
+
+        try:
+            binding, generation = self._runtime.rtc_authority_snapshot()
+            self._verifier.verify_and_consume(
+                payload["ticket"],
+                expected=binding,
+                sdp=payload["sdp"],
+            )
+        except TicketError as exc:
+            self._runtime.record_protocol_error(exc.code)
+            raise RtcRequestError(401, exc.code, str(exc)) from exc
+        except ProtocolError as exc:
+            raise RtcRequestError(409, exc.code, str(exc)) from exc
+
+        async with self._lock:
+            # MCP may prepare a newer session while an offer is being verified.
+            # Never let a ticket for the old authority create a peer whose
+            # callbacks are accidentally bound to the new runtime generation.
+            try:
+                current_binding, current_generation = (
+                    self._runtime.rtc_authority_snapshot()
+                )
+                if current_binding != binding or current_generation != generation:
+                    raise RtcRequestError(
+                        409,
+                        "session_changed",
+                        "session changed while the RTC offer was being authorized",
+                    )
+            except ProtocolError as exc:
+                raise RtcRequestError(409, exc.code, str(exc)) from exc
+            await self._close_all_locked()
+            peer = RTCPeerConnection()
+            self._peers.add(peer)
+            self._install_peer_handlers(peer, generation, binding)
+            try:
+                await peer.setRemoteDescription(
+                    RTCSessionDescription(sdp=payload["sdp"], type=payload["type"])
+                )
+                answer = await peer.createAnswer()
+                await peer.setLocalDescription(answer)
+            except Exception as exc:
+                self._peers.discard(peer)
+                await peer.close()
+                self._runtime.record_protocol_error("invalid_sdp")
+                raise RtcRequestError(400, "invalid_sdp", f"failed to negotiate offer: {exc}") from exc
+
+        local = peer.localDescription
+        return {
+            "sdp": local.sdp,
+            "type": local.type,
+            "boot_id": binding["boot_id"],
+            "session_id": binding["session_id"],
+            "epoch": binding["epoch"],
+            "capability_digest": binding["capability_digest"],
+            "mode": "shadow",
+            "actuation_enabled": False,
+        }
+
+    async def close_all(self) -> None:
+        async with self._lock:
+            await self._close_all_locked()
+
+    async def _close_all_locked(self) -> None:
+        peers = list(self._peers)
+        self._peers.clear()
+        if peers:
+            await asyncio.gather(*(peer.close() for peer in peers), return_exceptions=True)
+
+    def _install_peer_handlers(
+        self,
+        peer: RTCPeerConnection,
+        generation: int,
+        authority: dict,
+    ) -> None:
+        accepted_labels: set[str] = set()
+
+        @peer.on("datachannel")
+        def on_datachannel(channel: RTCDataChannel) -> None:
+            label = channel.label
+            if label in accepted_labels or not self._channel_contract_valid(channel):
+                self._runtime.record_protocol_error("invalid_data_channel")
+                channel.close()
+                return
+            accepted_labels.add(label)
+
+            @channel.on("open")
+            def on_open() -> None:
+                self._runtime.mark_channel(generation, label, True)
+
+            @channel.on("close")
+            def on_close() -> None:
+                self._runtime.mark_channel(generation, label, False)
+
+            @channel.on("message")
+            def on_message(message: str | bytes) -> None:
+                if label == "teleop-pose":
+                    self._handle_pose_message(message, generation, authority)
+                else:
+                    if not self._runtime.generation_matches(generation):
+                        self._runtime.record_protocol_error("stale_rtc_message")
+                        return
+                    self._handle_control_message(channel, message)
+
+            # aiortc emits the remote `datachannel` event after moving the
+            # channel to open, so its earlier `open` event is not observable
+            # from this callback.  Record that already-open state explicitly.
+            if channel.readyState == "open":
+                self._runtime.mark_channel(generation, label, True)
+
+        @peer.on("connectionstatechange")
+        async def on_connectionstatechange() -> None:
+            if peer.connectionState in ("failed", "closed", "disconnected"):
+                self._runtime.mark_rtc_disconnected(generation, f"rtc_{peer.connectionState}")
+                self._peers.discard(peer)
+                if peer.connectionState != "closed":
+                    await peer.close()
+
+    @staticmethod
+    def _channel_contract_valid(channel: RTCDataChannel) -> bool:
+        if channel.label == "teleop-control":
+            return (
+                channel.ordered is True
+                and channel.maxRetransmits is None
+                and channel.maxPacketLifeTime is None
+            )
+        if channel.label == "teleop-pose":
+            return (
+                channel.ordered is False
+                and channel.maxRetransmits == 0
+                and channel.maxPacketLifeTime is None
+            )
+        return False
+
+    def _decode_message(self, message: str | bytes, *, maximum: int) -> Any:
+        if isinstance(message, bytes):
+            if len(message) > maximum:
+                raise ProtocolError("message_too_large", f"RTC message exceeds {maximum} bytes")
+            try:
+                message = message.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ProtocolError("invalid_encoding", "RTC message must be UTF-8 JSON") from exc
+        if not isinstance(message, str):
+            raise ProtocolError("invalid_encoding", "RTC message must be UTF-8 JSON")
+        try:
+            encoded_size = len(message.encode("utf-8"))
+        except UnicodeEncodeError as exc:
+            raise ProtocolError("invalid_encoding", "RTC message must be UTF-8 JSON") from exc
+        if encoded_size > maximum:
+            raise ProtocolError("message_too_large", f"RTC message exceeds {maximum} bytes")
+        try:
+            return json.loads(message)
+        except (json.JSONDecodeError, ValueError, RecursionError) as exc:
+            raise ProtocolError("invalid_json", "RTC message must be valid JSON") from exc
+
+    def _handle_pose_message(
+        self,
+        message: str | bytes,
+        generation: int,
+        authority: dict,
+    ) -> None:
+        try:
+            self._runtime.submit_rtc_frame(
+                self._decode_message(message, maximum=64 * 1024),
+                authority=authority,
+                rtc_generation=generation,
+            )
+        except ProtocolError as exc:
+            self._runtime.record_protocol_error(exc.code)
+
+    def _handle_control_message(
+        self,
+        channel: RTCDataChannel,
+        message: str | bytes,
+    ) -> None:
+        try:
+            payload = self._decode_message(message, maximum=8 * 1024)
+            if not isinstance(payload, dict) or set(payload) - {"type", "request_id"}:
+                raise ProtocolError(
+                    "invalid_control",
+                    "control message contains invalid or private authority fields",
+                )
+            message_type = payload.get("type")
+            if message_type in ("peer_ping", "status"):
+                result = self._runtime.status()
+            elif message_type == "heartbeat":
+                raise ProtocolError(
+                    "rtc_cannot_renew_lease",
+                    "RTC DataChannel messages never renew the Capture control lease",
+                )
+            elif message_type in ("pause", "soft_stop", "release"):
+                raise ProtocolError(
+                    "rtc_control_requires_mcp_card",
+                    "session mutations must use the loopback MCP card actions",
+                )
+            else:
+                raise ProtocolError("invalid_control", f"unsupported control message type: {message_type}")
+            channel.send(json.dumps({
+                "type": "response",
+                "request_id": payload.get("request_id"),
+                "ok": True,
+                "state": result["state"],
+                "lease_renewed": False,
+            }, separators=(",", ":")))
+        except ProtocolError as exc:
+            self._runtime.record_protocol_error(exc.code)
+            if channel.readyState == "open":
+                channel.send(json.dumps({
+                    "type": "response",
+                    "ok": False,
+                    "error": {"code": exc.code, "message": str(exc)},
+                    "lease_renewed": False,
+                }, separators=(",", ":")))

--- a/generic/teleop_shadow/runtime.py
+++ b/generic/teleop_shadow/runtime.py
@@ -1,0 +1,938 @@
+"""Thread-safe, robot-free teleoperation shadow session runtime."""
+
+from __future__ import annotations
+
+import copy
+import re
+import secrets
+import threading
+import time
+import uuid
+from collections import Counter
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from dispatch import FinalDispatchArbiter, RecordingAdapter, StopHandle
+from protocol import (
+    CAPABILITIES,
+    CAPABILITY_DIGEST,
+    MODE,
+    ProtocolError,
+    bind_rtc_frame_v1,
+    validate_frame_v1,
+)
+
+SESSION_STATES = {
+    "idle",
+    "prepared_shadow",
+    "active_shadow",
+    "hold",
+    "paused",
+    "released",
+    "fault",
+}
+
+
+class ShadowRuntime:
+    """Own fencing, watchdogs and a recording-only final dispatch boundary."""
+
+    def __init__(
+        self,
+        *,
+        lease_timeout_ms: int = 1000,
+        pose_timeout_ms: int = 200,
+        watchdog_interval_ms: int = 25,
+        driver_id: str = "teleop-shadow-driver",
+        driver_name: str = "Generic Teleop Shadow Diagnostics",
+        robot_id: str | None = None,
+        clock: Callable[[], float] = time.monotonic,
+        auto_watchdog: bool = True,
+        dispatch_io_timeout_ms: int = 100,
+        dispatch_ack_timeout_ms: int = 200,
+        dispatcher: FinalDispatchArbiter | None = None,
+    ):
+        if lease_timeout_ms < 100:
+            raise ValueError("lease_timeout_ms must be >= 100")
+        if pose_timeout_ms < 20:
+            raise ValueError("pose_timeout_ms must be >= 20")
+        if watchdog_interval_ms < 5:
+            raise ValueError("watchdog_interval_ms must be >= 5")
+        if dispatch_io_timeout_ms < 20 or dispatch_io_timeout_ms > 150:
+            raise ValueError("dispatch_io_timeout_ms must be in [20, 150]")
+        if (
+            dispatch_ack_timeout_ms < dispatch_io_timeout_ms
+            or dispatch_ack_timeout_ms > 200
+        ):
+            raise ValueError(
+                "dispatch_ack_timeout_ms must be >= dispatch_io_timeout_ms and <= 200"
+            )
+        self.boot_id = str(uuid.uuid4())
+        self.driver_id = driver_id
+        self.driver_name = driver_name
+        self.robot_id = robot_id
+        self.capability_digest = CAPABILITY_DIGEST
+        self._lease_timeout = lease_timeout_ms / 1000.0
+        self._pose_timeout = pose_timeout_ms / 1000.0
+        self._watchdog_interval = watchdog_interval_ms / 1000.0
+        self._clock = clock
+        self._lock = threading.RLock()
+        self._transition_lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._watchdog_thread: threading.Thread | None = None
+        self._dispatch_ack_timeout = dispatch_ack_timeout_ms / 1000.0
+        self._dispatcher = dispatcher or FinalDispatchArbiter(
+            RecordingAdapter(clock=clock),
+            clock=clock,
+            io_timeout_ms=dispatch_io_timeout_ms,
+        )
+        self._closed = False
+
+        self._epoch = 0
+        self._generation = 0
+        self._state = "idle"
+        self._reason: str | None = None
+        self._session_id: str | None = None
+        self._fence: str | None = None
+        self._prepared_at: float | None = None
+        self._last_lease_at: float | None = None
+        self._lease_armed = False
+        self._lease_grace_until: float | None = None
+        self._capture_id: str | None = None
+        self._authority_valid = False
+        self._authority_invalid_reason: str | None = "not_prepared"
+        self._last_pose_at: float | None = None
+        self._latest_frame: dict | None = None
+        self._last_sequence: int | None = None
+        self._hold_clutch_sequence = -1
+        self._rtc_connected = False
+        self._channels = {"teleop-control": False, "teleop-pose": False}
+        self._counters: Counter[str] = Counter()
+        if auto_watchdog:
+            self.start()
+
+    def start(self) -> None:
+        """Start one long-lived watchdog thread; calling twice is harmless."""
+
+        with self._lock:
+            if self._closed:
+                return
+            if self._watchdog_thread and self._watchdog_thread.is_alive():
+                return
+            self._stop_event.clear()
+            self._watchdog_thread = threading.Thread(
+                target=self._watchdog_loop,
+                daemon=True,
+                name="teleop-shadow-watchdog",
+            )
+            self._watchdog_thread.start()
+
+    def close(self) -> None:
+        self._stop_event.set()
+        thread = self._watchdog_thread
+        if thread and thread is not threading.current_thread():
+            thread.join(timeout=max(1.0, self._watchdog_interval * 4))
+        with self._transition_lock:
+            with self._lock:
+                if self._closed:
+                    return
+                self._closed = True
+                if self._authority_valid:
+                    self._generation += 1
+                self._authority_valid = False
+                self._authority_invalid_reason = "service_close"
+                self._state = "released"
+                self._reason = "service_close"
+                self._clear_session_locked()
+            ack = self._dispatcher.close(self._dispatch_ack_timeout)
+            if not ack.ok:
+                with self._lock:
+                    self._latch_dispatch_fault_locked(ack.code)
+
+    def prepare_shadow(self, args: dict, *, lease_armed: bool = True) -> dict:
+        """Install a fenced session.
+
+        ``prepare_shadow`` remains the low-level adapter boundary used by the
+        robot-specific Driver.  The public MCP card no longer accepts these
+        authority fields from Core; :meth:`prepare_local_session` generates
+        them inside the Driver instead.
+        """
+
+        session_id = self._canonical_uuid(args.get("session_id"), "session_id")
+        epoch = args.get("epoch")
+        if isinstance(epoch, bool) or not isinstance(epoch, int) or epoch < 1:
+            raise ProtocolError("invalid_epoch", "epoch must be an integer >= 1")
+        fence = args.get("fence")
+        if not isinstance(fence, str) or not re.fullmatch(r"[A-Za-z0-9_-]{24,128}", fence):
+            raise ProtocolError("invalid_fence", "fence must be a URL-safe token of 24-128 characters")
+        binding = {
+            "boot_id": self.boot_id,
+            "session_id": session_id,
+            "epoch": epoch,
+            "fence": fence,
+        }
+        with self._transition_lock:
+            with self._lock:
+                self._require_open_locked()
+                if epoch <= self._epoch:
+                    raise ProtocolError("stale_epoch", f"epoch must be greater than {self._epoch}")
+                # Fence RTC and Frame callbacks before the safe-stop leaves the
+                # runtime lock.  The new authority is installed only after the
+                # final adapter has acknowledged that stop.
+                self._generation += 1
+                generation = self._generation
+                self._authority_valid = False
+                self._authority_invalid_reason = "prepare_shadow"
+                self._state = "hold"
+                self._reason = "prepare_shadow"
+                self._clear_session_locked()
+                handle = self._dispatcher.begin_prepare()
+            ack = self._dispatcher.wait_safe(handle, self._dispatch_ack_timeout)
+            if not ack.ok:
+                with self._lock:
+                    self._latch_dispatch_fault_locked(ack.code)
+                raise ProtocolError(
+                    "dispatch_stop_unconfirmed",
+                    "final output adapter did not acknowledge prepare safe-stop",
+                )
+            with self._lock:
+                self._require_open_locked()
+                dispatch_ack = self._dispatcher.complete_prepare(handle, binding, generation)
+                if not dispatch_ack.ok:
+                    self._latch_dispatch_fault_locked(dispatch_ack.code)
+                    raise ProtocolError(
+                        "dispatch_prepare_failed",
+                        "final output adapter could not arm the Shadow recording session",
+                    )
+                now = self._clock()
+                self._epoch = epoch
+                self._state = "prepared_shadow"
+                self._reason = None
+                self._session_id = session_id
+                self._fence = fence
+                self._prepared_at = now
+                self._last_lease_at = now if lease_armed else None
+                self._lease_armed = lease_armed
+                self._lease_grace_until = None
+                self._capture_id = None
+                self._authority_valid = True
+                self._authority_invalid_reason = None
+                self._last_pose_at = None
+                self._latest_frame = None
+                self._last_sequence = None
+                self._hold_clutch_sequence = -1
+                self._rtc_connected = False
+                self._channels = {"teleop-control": False, "teleop-pose": False}
+                self._counters["sessions_prepared"] += 1
+                return self._public_snapshot_locked(now)
+
+    def prepare_local_session(self) -> dict:
+        """Create a Driver-owned exclusive session with private authority."""
+
+        with self._lock:
+            self._require_open_locked()
+            if self._authority_valid:
+                if self._state == "paused":
+                    raise ProtocolError(
+                        "session_paused",
+                        "release the paused session before starting a new one",
+                    )
+                return self._public_snapshot_locked(self._clock())
+            epoch = self._epoch + 1
+        return self.prepare_shadow(
+            {
+                "session_id": str(uuid.uuid4()),
+                "epoch": epoch,
+                "fence": secrets.token_urlsafe(32),
+            },
+            # Pairing can legitimately take longer than the motion lease.  The
+            # lease begins only after one authenticated Capture is bound.
+            lease_armed=False,
+        )
+
+    def bind_capture(self, capture_id: str) -> tuple[dict, int]:
+        """Bind the sole authenticated Capture and start/renew its lease."""
+
+        capture_id = self._canonical_uuid(capture_id, "capture_id")
+        now = self._clock()
+        with self._lock:
+            self._require_open_locked()
+            self._require_session_live_locked()
+            if self._state == "paused":
+                raise ProtocolError(
+                    "session_paused",
+                    "release the paused session before starting a new one",
+                )
+            if self._capture_id is not None and self._capture_id != capture_id:
+                raise ProtocolError(
+                    "capture_conflict",
+                    "another paired Capture already owns the local session",
+                )
+            if self._lease_armed and self._lease_deadline_passed_locked(now):
+                self._invalidate_authority_locked("lease_timeout", target_state="hold")
+                raise ProtocolError(
+                    "session_expired",
+                    "the Capture control lease expired; start a new local session",
+                )
+            self._capture_id = capture_id
+            self._lease_armed = True
+            self._last_lease_at = now
+            self._counters["capture_bindings"] += 1
+            self._counters["lease_heartbeats"] += 1
+            return self._ticket_binding_locked(), self._generation
+
+    def renew_capture_lease(self, capture_id: str, generation: int) -> dict:
+        """Renew authority only from the paired Capture control connection."""
+
+        capture_id = self._canonical_uuid(capture_id, "capture_id")
+        now = self._clock()
+        with self._lock:
+            self._require_open_locked()
+            self._require_session_live_locked()
+            if generation != self._generation:
+                raise ProtocolError("stale_capture_generation", "Capture belongs to a stale session")
+            if self._capture_id != capture_id:
+                raise ProtocolError("capture_mismatch", "Capture does not own the local session")
+            self._require_authority_valid_locked(now)
+            self._last_lease_at = now
+            self._lease_grace_until = None
+            self._counters["lease_heartbeats"] += 1
+            return self._public_snapshot_locked(now)
+
+    def begin_capture_negotiation(
+        self,
+        capture_id: str,
+        generation: int,
+        *,
+        grace_ms: int = 15_000,
+    ) -> dict:
+        """Grant ICE/DTLS time anchored to the last real Capture presence.
+
+        Signaling offers are not lease heartbeats. Repeated offers therefore
+        cannot move this deadline forward.
+        """
+
+        if grace_ms < 1000 or grace_ms > 30_000:
+            raise ProtocolError("invalid_negotiation_grace", "negotiation grace must be in [1000, 30000] ms")
+        capture_id = self._canonical_uuid(capture_id, "capture_id")
+        now = self._clock()
+        with self._lock:
+            self._require_open_locked()
+            self._require_session_live_locked()
+            if generation != self._generation or self._capture_id != capture_id:
+                raise ProtocolError("capture_mismatch", "Capture does not own the local session")
+            self._require_authority_valid_locked(now)
+            if self._last_lease_at is None:
+                raise ProtocolError(
+                    "capture_lease_missing",
+                    "Capture negotiation requires a real presence lease",
+                )
+            grace_until = self._last_lease_at + grace_ms / 1000.0
+            if now > grace_until:
+                self._invalidate_authority_locked(
+                    "lease_timeout",
+                    target_state="hold",
+                )
+                raise ProtocolError(
+                    "session_expired",
+                    "Capture control lease expired; start a new local session",
+                )
+            self._lease_grace_until = grace_until
+            self._counters["capture_negotiations"] += 1
+            return self._public_snapshot_locked(now)
+
+    def mark_capture_disconnected(self, capture_id: str, generation: int) -> dict:
+        """Enter HOLD without allowing a stale socket to mutate a new session."""
+
+        capture_id = self._canonical_uuid(capture_id, "capture_id")
+        now = self._clock()
+        with self._lock:
+            if generation != self._generation or self._capture_id != capture_id:
+                self._counters["stale_capture_callbacks"] += 1
+                return self._public_snapshot_locked(now)
+            if not self._authority_valid:
+                return self._public_snapshot_locked(now)
+            handle = None
+            if self._state in ("prepared_shadow", "active_shadow"):
+                handle = self._enter_hold_locked("capture_disconnected")
+            self._counters["capture_disconnects"] += 1
+        self._wait_for_transition_stop(handle, "capture disconnect")
+        with self._lock:
+            return self._public_snapshot_locked(self._clock())
+
+    def capture_hold(self, capture_id: str, generation: int, reason: str) -> dict:
+        """Immediately inhibit motion when the authenticated Capture loses focus."""
+
+        capture_id = self._canonical_uuid(capture_id, "capture_id")
+        now = self._clock()
+        with self._lock:
+            if generation != self._generation or self._capture_id != capture_id:
+                self._counters["stale_capture_callbacks"] += 1
+                return self._public_snapshot_locked(now)
+            if not self._authority_valid:
+                return self._public_snapshot_locked(now)
+            handle = None
+            if self._state in ("prepared_shadow", "active_shadow"):
+                handle = self._enter_hold_locked(reason)
+                self._counters["capture_focus_losses"] += 1
+        self._wait_for_transition_stop(handle, reason)
+        with self._lock:
+            return self._public_snapshot_locked(self._clock())
+
+    def pause_local(self) -> dict:
+        with self._transition_lock:
+            now = self._clock()
+            with self._lock:
+                self._require_open_locked()
+                self._require_session_live_locked()
+                self._require_authority_valid_locked(now)
+                handle = self._enter_hold_locked("operator_pause", target_state="paused")
+            self._wait_for_transition_stop(handle, "pause")
+            with self._lock:
+                return self._public_snapshot_locked(self._clock())
+
+    def release_local(self, *, reason: str = "operator_release") -> dict:
+        with self._transition_lock:
+            with self._lock:
+                self._require_open_locked()
+                if not self._authority_valid:
+                    return self._public_snapshot_locked(self._clock())
+                handle = self._invalidate_authority_locked(reason, target_state="released")
+                self._counters["sessions_released"] += 1
+                if reason == "emergency_stop":
+                    self._counters["emergency_stops"] += 1
+            self._wait_for_transition_stop(handle, reason)
+            with self._lock:
+                return self._public_snapshot_locked(self._clock())
+
+    def heartbeat(self, args: dict) -> dict:
+        now = self._clock()
+        with self._lock:
+            self._require_open_locked()
+            self._require_session_live_locked()
+            self._require_identity_locked(args)
+            self._require_authority_valid_locked(now)
+            self._last_lease_at = now
+            self._counters["lease_heartbeats"] += 1
+            return self._public_snapshot_locked(now)
+
+    def pause(self, args: dict) -> dict:
+        with self._transition_lock:
+            now = self._clock()
+            with self._lock:
+                self._require_open_locked()
+                self._require_session_live_locked()
+                self._require_identity_locked(args)
+                self._require_authority_valid_locked(now)
+                handle = self._enter_hold_locked("operator_pause", target_state="paused")
+            self._wait_for_transition_stop(handle, "pause")
+            with self._lock:
+                return self._public_snapshot_locked(self._clock())
+
+    def soft_stop(self, args: dict) -> dict:
+        with self._transition_lock:
+            now = self._clock()
+            with self._lock:
+                self._require_open_locked()
+                self._require_session_live_locked()
+                self._require_identity_locked(args)
+                self._require_authority_valid_locked(now)
+                if self._state == "paused":
+                    raise ProtocolError("session_paused", "a paused session requires a new prepare_shadow")
+                handle = self._enter_hold_locked("soft_stop")
+                self._counters["soft_stops"] += 1
+            self._wait_for_transition_stop(handle, "soft_stop")
+            with self._lock:
+                return self._public_snapshot_locked(self._clock())
+
+    def release(self, args: dict | None = None, *, lifecycle: bool = False) -> dict:
+        with self._transition_lock:
+            with self._lock:
+                self._require_open_locked()
+                if not lifecycle:
+                    self._require_session_live_locked()
+                    self._require_identity_locked(args or {})
+                reason = "lifecycle_stop" if lifecycle else "operator_release"
+                handle = self._invalidate_authority_locked(reason, target_state="released")
+                self._counters["sessions_released"] += 1
+            self._wait_for_transition_stop(handle, "release")
+            with self._lock:
+                return self._public_snapshot_locked(self._clock())
+
+    def submit_shadow_frame(
+        self,
+        raw_frame: Any,
+        *,
+        source: str,
+        rtc_generation: int | None = None,
+    ) -> dict:
+        try:
+            frame = validate_frame_v1(raw_frame)
+        except ProtocolError as exc:
+            with self._lock:
+                self._counters["frames_rejected"] += 1
+                self._counters[f"reject_{exc.code}"] += 1
+            raise
+
+        now = self._clock()
+        with self._lock:
+            try:
+                self._require_open_locked()
+                self._require_session_live_locked()
+                self._require_identity_locked(frame)
+                self._require_authority_valid_locked(now)
+                if source == "rtc":
+                    if rtc_generation != self._generation:
+                        raise ProtocolError(
+                            "stale_rtc_generation",
+                            "RTC Pose belongs to a stale session generation",
+                        )
+                    if not self._rtc_connected or not all(self._channels.values()):
+                        if self._state in ("prepared_shadow", "active_shadow"):
+                            self._enter_hold_locked("rtc_not_ready")
+                        raise ProtocolError(
+                            "rtc_not_ready",
+                            "both teleop-control and teleop-pose must be open for RTC Pose",
+                        )
+                if self._state == "paused":
+                    raise ProtocolError("session_inactive", f"cannot accept frames in state {self._state}")
+                sequence = frame["sequence"]
+                if self._last_sequence is not None and sequence <= self._last_sequence:
+                    raise ProtocolError(
+                        "sequence_not_increasing",
+                        f"sequence must be greater than {self._last_sequence}",
+                    )
+            except ProtocolError as exc:
+                self._counters["frames_rejected"] += 1
+                self._counters[f"reject_{exc.code}"] += 1
+                raise
+
+            self._latest_frame = frame
+            self._last_sequence = sequence
+            self._last_pose_at = now
+            self._counters["frames_accepted"] += 1
+            self._counters[f"frames_from_{source}"] += 1
+
+            tracking_ok = all(frame["tracking"].values())
+            dispatch_frame = False
+            allow_reclutch = False
+            if self._state == "hold" and self._reason == "soft_stop":
+                # Core has no resume/rearm action.  An operator soft-stop is a
+                # latch: only release followed by a newer prepare can re-arm.
+                self._counters["frames_held_after_soft_stop"] += 1
+            elif not frame["deadman"]:
+                self._enter_hold_locked("deadman_released")
+            elif not tracking_ok:
+                self._enter_hold_locked("tracking_lost")
+            elif self._state == "prepared_shadow":
+                self._state = "active_shadow"
+                self._reason = None
+                dispatch_frame = True
+            elif self._state == "hold":
+                if frame["clutch_sequence"] > self._hold_clutch_sequence:
+                    self._state = "active_shadow"
+                    self._reason = None
+                    self._counters["explicit_reclutches"] += 1
+                    dispatch_frame = True
+                    allow_reclutch = True
+                else:
+                    self._counters["frames_held_without_reclutch"] += 1
+            elif self._state == "active_shadow":
+                dispatch_frame = True
+
+            if dispatch_frame:
+                lease_started = (
+                    self._last_lease_at if self._last_lease_at is not None else now
+                )
+                dispatch_ack = self._dispatcher.publish_latest(
+                    frame,
+                    session_generation=self._generation,
+                    expires_monotonic=min(
+                        now + self._pose_timeout,
+                        lease_started + self._lease_timeout,
+                    ),
+                    allow_reclutch=allow_reclutch,
+                )
+                if not dispatch_ack.ok:
+                    self._counters["dispatch_rejections"] += 1
+                    self._counters[f"dispatch_reject_{dispatch_ack.code}"] += 1
+                    dispatch_state = self._dispatcher.snapshot()["state"]
+                    if dispatch_ack.code == "intent_expired" or (
+                        dispatch_ack.code == "motion_inhibited"
+                        and dispatch_state == "safe_reclutch_required"
+                    ):
+                        self._enter_hold_locked("pose_timeout")
+                    else:
+                        self._dispatcher.trip(
+                            "dispatch_fault",
+                            target_state="fault_latched",
+                            retain_authority=False,
+                        )
+                        self._latch_dispatch_fault_locked(dispatch_ack.code)
+                        raise ProtocolError(
+                            "dispatch_fault",
+                            "final output authority check failed; a new Driver process is required",
+                        )
+
+            result = self._public_snapshot_locked(now)
+            result["accepted_sequence"] = sequence
+            return result
+
+    def mark_channel(self, generation: int, label: str, opened: bool) -> dict:
+        now = self._clock()
+        with self._lock:
+            if generation != self._generation:
+                self._counters["stale_rtc_callbacks"] += 1
+                return self._public_snapshot_locked(now)
+            if self._state in ("idle", "released"):
+                self._counters["terminal_rtc_callbacks_ignored"] += 1
+                return self._public_snapshot_locked(now)
+            if not self._authority_valid or self._lease_deadline_passed_locked(now):
+                if self._authority_valid:
+                    self._invalidate_authority_locked("lease_timeout", target_state="hold")
+                self._counters["expired_rtc_callbacks_ignored"] += 1
+                return self._public_snapshot_locked(now)
+            if label in self._channels:
+                self._channels[label] = bool(opened)
+            self._rtc_connected = all(self._channels.values())
+            if not opened and self._state in ("prepared_shadow", "active_shadow"):
+                self._enter_hold_locked("rtc_disconnected")
+            return self._public_snapshot_locked(now)
+
+    def submit_rtc_frame(
+        self,
+        raw_frame: Any,
+        *,
+        authority: Mapping[str, Any],
+        rtc_generation: int,
+    ) -> dict:
+        """Bind one public RTC frame before entering the common safety path."""
+
+        try:
+            frame = bind_rtc_frame_v1(raw_frame, authority=authority)
+        except ProtocolError as exc:
+            with self._lock:
+                self._counters["frames_rejected"] += 1
+                self._counters[f"reject_{exc.code}"] += 1
+            raise
+        return self.submit_shadow_frame(
+            frame,
+            source="rtc",
+            rtc_generation=rtc_generation,
+        )
+
+    def mark_rtc_disconnected(self, generation: int, reason: str = "rtc_disconnected") -> dict:
+        now = self._clock()
+        with self._lock:
+            if generation != self._generation:
+                self._counters["stale_rtc_callbacks"] += 1
+                return self._public_snapshot_locked(now)
+            if self._state in ("idle", "released"):
+                self._counters["terminal_rtc_callbacks_ignored"] += 1
+                return self._public_snapshot_locked(now)
+            if not self._authority_valid or self._lease_deadline_passed_locked(now):
+                if self._authority_valid:
+                    self._invalidate_authority_locked("lease_timeout", target_state="hold")
+                self._counters["expired_rtc_callbacks_ignored"] += 1
+                return self._public_snapshot_locked(now)
+            self._rtc_connected = False
+            self._channels = {"teleop-control": False, "teleop-pose": False}
+            if self._state in ("prepared_shadow", "active_shadow"):
+                self._enter_hold_locked(reason)
+            self._counters["rtc_disconnects"] += 1
+            return self._public_snapshot_locked(now)
+
+    def record_protocol_error(self, code: str) -> None:
+        with self._lock:
+            self._counters["protocol_errors"] += 1
+            self._counters[f"protocol_{code}"] += 1
+
+    def status(self) -> dict:
+        with self._lock:
+            now = self._clock()
+            if self._authority_valid and self._lease_deadline_passed_locked(now):
+                self._invalidate_authority_locked("lease_timeout", target_state="hold")
+            return self._public_snapshot_locked(now)
+
+    def ticket_binding(self) -> dict:
+        with self._lock:
+            self._require_open_locked()
+            self._require_session_live_locked()
+            self._require_authority_valid_locked(self._clock())
+            return self._ticket_binding_locked()
+
+    def rtc_authority_snapshot(self) -> tuple[dict, int]:
+        """Capture one immutable RTC authority tuple under the runtime lock."""
+
+        with self._lock:
+            self._require_open_locked()
+            self._require_session_live_locked()
+            self._require_authority_valid_locked(self._clock())
+            return self._ticket_binding_locked(), self._generation
+
+    def session_generation(self) -> int:
+        """Return the opaque internal generation used only to fence RTC callbacks."""
+
+        with self._lock:
+            return self._generation
+
+    def generation_matches(self, generation: int) -> bool:
+        with self._lock:
+            self._sync_dispatch_fault_locked()
+            if generation != self._generation:
+                return False
+            if not self._authority_valid:
+                return False
+            if self._lease_deadline_passed_locked(self._clock()):
+                self._invalidate_authority_locked("lease_timeout", target_state="hold")
+                return False
+            return True
+
+    def watchdog_tick(self) -> dict:
+        now = self._clock()
+        with self._lock:
+            if self._authority_valid and self._state in (
+                "prepared_shadow", "active_shadow", "hold", "paused"
+            ):
+                if self._lease_deadline_passed_locked(now):
+                    self._invalidate_authority_locked("lease_timeout", target_state="hold")
+                elif (
+                    self._state == "active_shadow"
+                    and self._last_pose_at is not None
+                    and now - self._last_pose_at > self._pose_timeout
+                ):
+                    self._enter_hold_locked("pose_timeout")
+                    self._counters["pose_timeouts"] += 1
+            return self._public_snapshot_locked(now)
+
+    def _watchdog_loop(self) -> None:
+        while not self._stop_event.wait(self._watchdog_interval):
+            self.watchdog_tick()
+
+    def _enter_hold_locked(
+        self,
+        reason: str,
+        *,
+        target_state: str = "hold",
+    ) -> StopHandle | None:
+        changed = self._state != target_state or self._reason != reason
+        self._state = target_state
+        self._reason = reason
+        if self._latest_frame is not None:
+            self._hold_clutch_sequence = max(
+                self._hold_clutch_sequence,
+                int(self._latest_frame["clutch_sequence"]),
+            )
+        if not changed:
+            return None
+        dispatch_state = (
+            "safe_latched"
+            if target_state == "paused" or reason == "soft_stop"
+            else "safe_reclutch_required"
+        )
+        return self._dispatcher.trip(
+            reason,
+            target_state=dispatch_state,
+            retain_authority=True,
+        )
+
+    def _lease_deadline_passed_locked(self, now: float) -> bool:
+        if self._lease_grace_until is not None and now <= self._lease_grace_until:
+            return False
+        return (
+            self._lease_armed
+            and (self._last_lease_at is None or now - self._last_lease_at > self._lease_timeout)
+        )
+
+    def _invalidate_authority_locked(
+        self,
+        reason: str,
+        *,
+        target_state: str,
+    ) -> StopHandle:
+        was_valid = self._authority_valid
+        self._authority_valid = False
+        self._authority_invalid_reason = reason
+        if was_valid:
+            self._generation += 1
+        self._state = target_state
+        self._reason = reason
+        self._clear_session_locked()
+        handle = self._dispatcher.trip(
+            reason,
+            target_state="safe_revoked",
+            retain_authority=False,
+        )
+        if was_valid and reason == "lease_timeout":
+            self._counters["lease_timeouts"] += 1
+        return handle
+
+    def _clear_session_locked(self) -> None:
+        self._session_id = None
+        self._fence = None
+        self._prepared_at = None
+        self._last_lease_at = None
+        self._lease_armed = False
+        self._lease_grace_until = None
+        self._capture_id = None
+        self._last_pose_at = None
+        self._latest_frame = None
+        self._last_sequence = None
+        self._hold_clutch_sequence = -1
+        self._rtc_connected = False
+        self._channels = {"teleop-control": False, "teleop-pose": False}
+
+    def _wait_for_transition_stop(
+        self,
+        handle: StopHandle | None,
+        operation: str,
+    ) -> None:
+        if handle is None:
+            return
+        ack = self._dispatcher.wait_safe(handle, self._dispatch_ack_timeout)
+        if ack.ok:
+            return
+        with self._lock:
+            self._latch_dispatch_fault_locked(ack.code)
+        raise ProtocolError(
+            "dispatch_stop_unconfirmed",
+            f"final output adapter did not acknowledge {operation} safe-stop",
+        )
+
+    def _latch_dispatch_fault_locked(self, code: str) -> None:
+        if self._authority_valid:
+            self._generation += 1
+        self._authority_valid = False
+        self._authority_invalid_reason = "dispatch_fault"
+        self._state = "fault"
+        self._reason = "dispatch_fault"
+        self._clear_session_locked()
+        self._counters["dispatch_faults"] += 1
+        self._counters[f"dispatch_fault_{code}"] += 1
+
+    def _sync_dispatch_fault_locked(self) -> None:
+        dispatch = self._dispatcher.snapshot()
+        code = dispatch.get("fault_code")
+        if code is not None and self._authority_invalid_reason != "dispatch_fault":
+            self._latch_dispatch_fault_locked(str(code))
+
+    def _require_open_locked(self) -> None:
+        if self._closed:
+            raise ProtocolError("service_closed", "the Driver process is closing")
+        self._sync_dispatch_fault_locked()
+
+    def _require_authority_valid_locked(self, now: float) -> None:
+        if not self._authority_valid:
+            self._raise_invalid_authority_locked()
+        if self._lease_deadline_passed_locked(now):
+            self._invalidate_authority_locked("lease_timeout", target_state="hold")
+            raise ProtocolError(
+                "session_expired",
+                "Capture control lease expired; a new prepare_shadow is required",
+            )
+
+    def _require_session_live_locked(self) -> None:
+        if not self._authority_valid:
+            self._raise_invalid_authority_locked()
+
+    def _raise_invalid_authority_locked(self) -> None:
+        if self._authority_invalid_reason == "lease_timeout":
+            raise ProtocolError(
+                "session_expired",
+                "Capture control lease expired; a new prepare_shadow is required",
+            )
+        raise ProtocolError("session_inactive", "a new prepare_shadow session is required")
+
+    def _require_identity_locked(self, value: dict) -> None:
+        required = ("boot_id", "session_id", "epoch", "fence")
+        missing = [key for key in required if key not in value]
+        if missing:
+            raise ProtocolError("missing_identity", f"missing session identity fields: {missing}")
+        if value["boot_id"] != self.boot_id:
+            raise ProtocolError("boot_mismatch", "boot_id does not match this Driver process")
+        if value["session_id"] != self._session_id:
+            raise ProtocolError("session_mismatch", "session_id does not match the active session")
+        if isinstance(value["epoch"], bool) or value["epoch"] != self._epoch:
+            raise ProtocolError("epoch_mismatch", "epoch does not match the active session")
+        if not isinstance(value["fence"], str) or not secrets.compare_digest(value["fence"], self._fence or ""):
+            raise ProtocolError("fence_mismatch", "fence does not match the active session")
+
+    def _ticket_binding_locked(self) -> dict:
+        assert self._session_id is not None and self._fence is not None
+        return {
+            "boot_id": self.boot_id,
+            "session_id": self._session_id,
+            "epoch": self._epoch,
+            "fence": self._fence,
+            "capability_digest": self.capability_digest,
+        }
+
+    @staticmethod
+    def _canonical_uuid(value: Any, name: str) -> str:
+        if not isinstance(value, str):
+            raise ProtocolError("invalid_session_id", f"{name} must be a canonical UUID")
+        try:
+            parsed = uuid.UUID(value)
+        except ValueError as exc:
+            raise ProtocolError("invalid_session_id", f"{name} must be a canonical UUID") from exc
+        if str(parsed) != value.lower():
+            raise ProtocolError("invalid_session_id", f"{name} must be a canonical UUID")
+        return str(parsed)
+
+    def _public_snapshot_locked(self, now: float) -> dict:
+        self._sync_dispatch_fault_locked()
+        lease_age = None if self._last_lease_at is None else max(0.0, now - self._last_lease_at)
+        pose_age = None if self._last_pose_at is None else max(0.0, now - self._last_pose_at)
+        latest = copy.deepcopy(self._latest_frame)
+        if latest is not None:
+            latest.pop("fence", None)
+        return {
+            "driver": self.driver_id,
+            "driver_id": self.driver_id,
+            "driver_name": self.driver_name,
+            "driver_type": "teleop-shadow",
+            "robot_id": self.robot_id,
+            "mode": MODE,
+            "actuation_enabled": False,
+            "boot_id": self.boot_id,
+            "session_id": self._session_id,
+            "epoch": self._epoch,
+            "state": self._state,
+            "reason": self._reason,
+            "authority_valid": self._authority_valid,
+            "capability_digest": self.capability_digest,
+            "capabilities": copy.deepcopy(CAPABILITIES),
+            "lease": {
+                "source": "paired-capture-control-only",
+                "timeout_ms": round(self._lease_timeout * 1000),
+                "age_ms": None if lease_age is None else round(lease_age * 1000, 3),
+                "armed": self._lease_armed,
+                "fresh": (
+                    not self._lease_armed
+                    or (lease_age is not None and lease_age <= self._lease_timeout)
+                ),
+                "authority_valid": self._authority_valid,
+                "expired_latched": self._authority_invalid_reason == "lease_timeout",
+                "negotiation_grace": (
+                    self._lease_grace_until is not None and now <= self._lease_grace_until
+                ),
+            },
+            "capture": {
+                "paired": self._capture_id is not None,
+                "capture_id": self._capture_id,
+                "renews_lease": True,
+            },
+            "pose": {
+                "timeout_ms": round(self._pose_timeout * 1000),
+                "age_ms": None if pose_age is None else round(pose_age * 1000, 3),
+                "fresh": pose_age is not None and pose_age <= self._pose_timeout,
+                "latest_sequence": self._last_sequence,
+                "latest": latest,
+            },
+            "rtc": {
+                "connected": self._rtc_connected,
+                "channels": dict(self._channels),
+                "renews_lease": False,
+            },
+            "dispatch": self._dispatcher.snapshot(),
+            "counters": dict(sorted(self._counters.items())),
+        }

--- a/generic/teleop_shadow/smoke_recording.py
+++ b/generic/teleop_shadow/smoke_recording.py
@@ -1,0 +1,125 @@
+"""Run a visible, robot-free final-dispatch smoke scenario."""
+
+from __future__ import annotations
+
+import json
+import secrets
+import time
+import uuid
+
+from runtime import ShadowRuntime
+
+
+def _frame(runtime: ShadowRuntime, session: dict) -> dict:
+    pose = {
+        "position": [0.0, 1.0, 0.0],
+        "orientation": [0.0, 0.0, 0.0, 1.0],
+    }
+    return {
+        "schema_version": 1,
+        "mode": "shadow",
+        "boot_id": runtime.boot_id,
+        **session,
+        "sequence": 1,
+        "client_monotonic_ns": 1,
+        "deadman": True,
+        "clutch_sequence": 1,
+        "tracking": {
+            "head": True,
+            "left_controller": True,
+            "right_controller": True,
+        },
+        "head": dict(pose),
+        "left_controller": dict(pose),
+        "right_controller": dict(pose),
+        "controllers": {
+            "left": {"axes": [0.0, 0.0], "buttons": [1.0]},
+            "right": {"axes": [0.0, 0.0], "buttons": [1.0]},
+        },
+        "base_twist": {
+            "linear": [0.1, 0.0, 0.0],
+            "angular": [0.0, 0.0, 0.1],
+        },
+    }
+
+
+def _wait_for_apply(runtime: ShadowRuntime, sequence: int) -> dict:
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        dispatch = runtime.status()["dispatch"]
+        if dispatch["last_would_apply_sequence"] == sequence:
+            return dispatch
+        time.sleep(0.005)
+    raise RuntimeError("recording adapter did not acknowledge the motion intent")
+
+
+def run_smoke() -> dict:
+    runtime = ShadowRuntime(auto_watchdog=False)
+    session = {
+        "session_id": str(uuid.uuid4()),
+        "epoch": 1,
+        "fence": secrets.token_urlsafe(32),
+    }
+    identity = {"boot_id": runtime.boot_id, **session}
+    try:
+        prepared = runtime.prepare_shadow(session)
+        submitted = runtime.submit_shadow_frame(
+            _frame(runtime, session),
+            source="mcp_diagnostic",
+        )
+        applied = _wait_for_apply(runtime, 1)
+        held = runtime.soft_stop(identity)
+        released = runtime.release(identity)
+        decisions = []
+        for record in released["dispatch"]["adapter"]["records"]:
+            if record["kind"] == "would_apply":
+                decisions.append(
+                    {"kind": "would_apply", "sequence": record["sequence"]}
+                )
+            elif record["kind"] == "would_stop":
+                decisions.append(
+                    {"kind": "would_stop", "reason": record["reason"]}
+                )
+        proof = {
+            "mode": prepared["mode"],
+            "actuation_enabled": prepared["actuation_enabled"],
+            "prepared_state": prepared["state"],
+            "motion_state": submitted["state"],
+            "last_would_apply_sequence": applied["last_would_apply_sequence"],
+            "soft_stop": {
+                "state": held["state"],
+                "reason": held["reason"],
+                "acknowledged": held["dispatch"]["stop_acknowledged"],
+            },
+            "release": {
+                "state": released["state"],
+                "authority_valid": released["authority_valid"],
+                "stop_acknowledged": released["dispatch"]["stop_acknowledged"],
+            },
+            "recorded_decisions": decisions,
+        }
+        if proof["actuation_enabled"] is not False:
+            raise RuntimeError("Shadow smoke unexpectedly enabled actuation")
+        if proof["last_would_apply_sequence"] != 1:
+            raise RuntimeError("motion intent did not reach recording dispatch")
+        if not proof["soft_stop"]["acknowledged"]:
+            raise RuntimeError("soft-stop was not acknowledged")
+        if proof["release"] != {
+            "state": "released",
+            "authority_valid": False,
+            "stop_acknowledged": True,
+        }:
+            raise RuntimeError("release did not revoke and stop the session")
+        if session["fence"] in json.dumps(proof, sort_keys=True):
+            raise RuntimeError("public proof disclosed the session fence")
+        return proof
+    finally:
+        runtime.close()
+
+
+def main() -> None:
+    print(json.dumps(run_smoke(), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/generic/teleop_shadow/tests/__init__.py
+++ b/generic/teleop_shadow/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the teleop-shadow Driver."""

--- a/generic/teleop_shadow/tests/helpers.py
+++ b/generic/teleop_shadow/tests/helpers.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import uuid
+
+TEST_SECRET = "test-only-teleop-ticket-secret-32-bytes-minimum"
+TEST_DRIVER_TOKEN = "test-driver-token-private-0001"
+
+
+class FakeClock:
+    def __init__(self, value: float = 100.0):
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def new_session(*, epoch: int = 1, fence: str | None = None) -> dict:
+    return {
+        "session_id": str(uuid.uuid4()),
+        "epoch": epoch,
+        "fence": fence or ("f" * 32),
+    }
+
+
+def identity(runtime, session: dict) -> dict:
+    return {
+        "boot_id": runtime.boot_id,
+        "session_id": session["session_id"],
+        "epoch": session["epoch"],
+        "fence": session["fence"],
+    }
+
+
+def valid_frame(runtime, session: dict, *, sequence: int = 1, clutch_sequence: int = 1,
+                deadman: bool = True, tracking: bool = True) -> dict:
+    pose = {"position": [0.0, 1.0, 0.0], "orientation": [0.0, 0.0, 0.0, 1.0]}
+    return {
+        "schema_version": 1,
+        **identity(runtime, session),
+        "sequence": sequence,
+        "client_monotonic_ns": sequence * 1_000_000,
+        "mode": "shadow",
+        "deadman": deadman,
+        "clutch_sequence": clutch_sequence,
+        "tracking": {
+            "head": tracking,
+            "left_controller": tracking,
+            "right_controller": tracking,
+        },
+        "head": dict(pose) if tracking else None,
+        "left_controller": dict(pose) if tracking else None,
+        "right_controller": dict(pose) if tracking else None,
+        "controllers": {
+            "left": {"axes": [0.0, 0.0], "buttons": [0.0, 1.0]},
+            "right": {"axes": [0.0, 0.0], "buttons": [0.0, 1.0]},
+        },
+        "base_twist": {"linear": [0.0, 0.0, 0.0], "angular": [0.0, 0.0, 0.0]},
+    }
+
+
+def rtc_wire_frame(runtime, session: dict, **kwargs) -> dict:
+    frame = valid_frame(runtime, session, **kwargs)
+    for field in ("boot_id", "session_id", "epoch", "fence"):
+        frame.pop(field)
+    return frame
+
+
+def contains_value(value, needle: str) -> bool:
+    if isinstance(value, dict):
+        return any(key == needle or contains_value(item, needle) for key, item in value.items())
+    if isinstance(value, list):
+        return any(contains_value(item, needle) for item in value)
+    return value == needle

--- a/generic/teleop_shadow/tests/test_dispatch.py
+++ b/generic/teleop_shadow/tests/test_dispatch.py
@@ -1,0 +1,539 @@
+from __future__ import annotations
+
+import copy
+import sys
+import threading
+import time
+import unittest
+import uuid
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from dispatch import (
+    AdapterAck,
+    FinalDispatchArbiter,
+    MotionIntent,
+    RecordingAdapter,
+    StopRequest,
+)
+from protocol import MAX_SEQUENCE
+
+
+def binding(*, epoch: int = 1, fence: str = "f" * 32) -> dict:
+    return {
+        "boot_id": str(uuid.uuid4()),
+        "session_id": str(uuid.uuid4()),
+        "epoch": epoch,
+        "fence": fence,
+    }
+
+
+def frame(authority: dict, sequence: int, *, deadman: bool = True) -> dict:
+    pose = {"position": [0.0, 1.0, 0.0], "orientation": [0.0, 0.0, 0.0, 1.0]}
+    return {
+        **authority,
+        "sequence": sequence,
+        "clutch_sequence": 1,
+        "deadman": deadman,
+        "tracking": {"head": True, "left_controller": True, "right_controller": True},
+        "head": dict(pose),
+        "left_controller": dict(pose),
+        "right_controller": dict(pose),
+        "controllers": {
+            "left": {"axes": [0.0, 0.0], "buttons": [1.0]},
+            "right": {"axes": [0.0, 0.0], "buttons": [1.0]},
+        },
+        "base_twist": {"linear": [0.1, 0.0, 0.0], "angular": [0.0, 0.0, 0.1]},
+    }
+
+
+class ControllableAdapter:
+    def __init__(self, *, startup_ack: AdapterAck | None = None, fail_apply: bool = False):
+        self.startup_ack = startup_ack or AdapterAck(True)
+        self.fail_apply = fail_apply
+        self.first_apply_started = threading.Event()
+        self.allow_first_apply = threading.Event()
+        self.block_first_apply = False
+        self.events: list[tuple] = []
+        self.snapshot_threads: list[str] = []
+        self.closed = False
+        self._lock = threading.Lock()
+
+    def startup_safe(self, deadline_monotonic: float) -> AdapterAck:
+        with self._lock:
+            self.events.append(("stop", "startup_safe", 0))
+        return self.startup_ack
+
+    def apply(self, intent: MotionIntent) -> AdapterAck:
+        if self.block_first_apply and not self.first_apply_started.is_set():
+            self.first_apply_started.set()
+            self.allow_first_apply.wait(1.0)
+        with self._lock:
+            self.events.append(("apply", intent.sequence, intent.dispatch_generation))
+        if self.fail_apply:
+            return AdapterAck(False, "injected_apply_failure")
+        return AdapterAck(True)
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck:
+        with self._lock:
+            self.events.append(("stop", request.reason, request.dispatch_generation))
+        return AdapterAck(True)
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            self.snapshot_threads.append(threading.current_thread().name)
+            return {"kind": "test", "events": copy.deepcopy(self.events), "closed": self.closed}
+
+    def close(self) -> None:
+        with self._lock:
+            self.events.append(("close",))
+            self.closed = True
+
+
+class HangingStartupAdapter(ControllableAdapter):
+    def __init__(self):
+        super().__init__()
+        self.startup_entered = threading.Event()
+        self.release_startup = threading.Event()
+        self.concurrent_calls: list[str] = []
+
+    def startup_safe(self, deadline_monotonic: float) -> AdapterAck:
+        self.startup_entered.set()
+        self.release_startup.wait(1.0)
+        return AdapterAck(True)
+
+    def snapshot(self) -> dict:
+        if not self.release_startup.is_set():
+            self.concurrent_calls.append("snapshot")
+        return super().snapshot()
+
+    def close(self) -> None:
+        if not self.release_startup.is_set():
+            self.concurrent_calls.append("close")
+        super().close()
+
+
+class DelayedStopAdapter(ControllableAdapter):
+    def __init__(self):
+        super().__init__()
+        self.stop_delay = 0.0
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck:
+        if self.stop_delay:
+            time.sleep(self.stop_delay)
+        return super().safe_stop(request)
+
+
+class AdvancingStopAdapter(ControllableAdapter):
+    def __init__(self, safety_time: list[float], *, advance: float):
+        super().__init__()
+        self.safety_time = safety_time
+        self.advance = advance
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck:
+        self.safety_time[0] += self.advance
+        return super().safe_stop(request)
+
+
+class GatedRecordingAdapter(RecordingAdapter):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.apply_entered = threading.Event()
+        self.release_apply = threading.Event()
+
+    def apply(self, intent: MotionIntent) -> AdapterAck:
+        self.apply_entered.set()
+        self.release_apply.wait(1.0)
+        return super().apply(intent)
+
+
+class FalseCloseAdapter(ControllableAdapter):
+    def close(self):
+        super().close()
+        return False
+
+
+class ReentrantCloseAdapter(ControllableAdapter):
+    def __init__(self):
+        super().__init__()
+        self.arbiter: FinalDispatchArbiter | None = None
+        self.reentrant_ack: AdapterAck | None = None
+
+    def safe_stop(self, request: StopRequest) -> AdapterAck:
+        if request.reason == "service_close":
+            assert self.arbiter is not None
+            self.reentrant_ack = self.arbiter.close()
+        return super().safe_stop(request)
+
+
+class FinalDispatchArbiterTests(unittest.TestCase):
+    def setUp(self):
+        self.adapter = ControllableAdapter()
+        self.arbiter = FinalDispatchArbiter(self.adapter, io_timeout_ms=250)
+        self.authority = binding()
+        handle = self.arbiter.begin_prepare()
+        self.assertTrue(self.arbiter.wait_safe(handle).ok)
+        self.assertTrue(self.arbiter.complete_prepare(handle, self.authority, 7).ok)
+
+    def tearDown(self):
+        self.adapter.allow_first_apply.set()
+        self.arbiter.close()
+
+    def publish(self, sequence: int, *, expiry: float = 1.0, deadman: bool = True) -> AdapterAck:
+        return self.arbiter.publish_latest(
+            frame(self.authority, sequence, deadman=deadman),
+            session_generation=7,
+            expires_monotonic=time.monotonic() + expiry,
+        )
+
+    def wait_until(self, predicate, timeout: float = 1.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            value = predicate()
+            if value:
+                return value
+            time.sleep(0.005)
+        self.fail("condition not reached")
+
+    def test_latest_only_mailbox_keeps_one_inflight_and_newest_pending(self):
+        self.adapter.block_first_apply = True
+        self.assertTrue(self.publish(1).ok)
+        self.assertTrue(self.adapter.first_apply_started.wait(1.0))
+        for sequence in range(2, 101):
+            self.assertTrue(self.publish(sequence).ok)
+            self.assertLessEqual(self.arbiter.snapshot()["mailbox_depth"], 1)
+        self.adapter.allow_first_apply.set()
+        self.assertTrue(self.arbiter.wait_applied(100))
+        applies = [event[1] for event in self.adapter.events if event[0] == "apply"]
+        self.assertEqual([1, 100], applies)
+        self.assertEqual(98, self.arbiter.snapshot()["counters"]["mailbox_replacements"])
+
+    def test_stop_clears_admitted_motion_and_ack_fences_old_generation(self):
+        self.adapter.block_first_apply = True
+        self.assertTrue(self.publish(1).ok)
+        self.assertTrue(self.adapter.first_apply_started.wait(1.0))
+        self.assertTrue(self.publish(2).ok)
+        handle = self.arbiter.trip(
+            "operator_release",
+            target_state="safe_revoked",
+            retain_authority=False,
+        )
+        self.adapter.allow_first_apply.set()
+        self.assertTrue(self.arbiter.wait_safe(handle).ok)
+        time.sleep(0.02)
+        applies = [event[1] for event in self.adapter.events if event[0] == "apply"]
+        self.assertEqual([1], applies)
+        self.assertEqual(("stop", "operator_release"), self.adapter.events[-1][:2])
+        self.assertFalse(self.publish(3).ok)
+        self.assertTrue(self.arbiter.snapshot()["stop_acknowledged"])
+
+    def test_final_deadline_check_drops_queued_motion_and_stops(self):
+        self.adapter.block_first_apply = True
+        self.assertTrue(self.publish(1).ok)
+        self.assertTrue(self.adapter.first_apply_started.wait(1.0))
+        self.assertTrue(self.publish(2, expiry=0.02).ok)
+        time.sleep(0.03)
+        self.adapter.allow_first_apply.set()
+        self.wait_until(
+            lambda: any(
+                event[:2] == ("stop", "dispatch_deadline") for event in self.adapter.events
+            )
+        )
+        applies = [event[1] for event in self.adapter.events if event[0] == "apply"]
+        self.assertEqual([1], applies)
+        self.assertEqual("safe_reclutch_required", self.arbiter.snapshot()["state"])
+
+    def test_adapter_never_receives_unsafe_or_wrong_authority(self):
+        self.assertEqual("unsafe_deadman", self.publish(1, deadman=False).code)
+        missing_tracking = frame(self.authority, 1)
+        missing_tracking["tracking"].pop("head")
+        self.assertEqual(
+            "unsafe_tracking",
+            self.arbiter.publish_latest(
+                missing_tracking,
+                session_generation=7,
+                expires_monotonic=time.monotonic() + 1,
+            ).code,
+        )
+        wrong = binding(epoch=2, fence="x" * 32)
+        ack = self.arbiter.publish_latest(
+            frame(wrong, 2),
+            session_generation=7,
+            expires_monotonic=time.monotonic() + 1,
+        )
+        self.assertEqual("authority_mismatch", ack.code)
+        self.assertFalse(any(event[0] == "apply" for event in self.adapter.events))
+
+    def test_final_boundary_rejects_non_increasing_sequence(self):
+        self.adapter.block_first_apply = True
+        self.assertTrue(self.publish(5).ok)
+        self.assertTrue(self.adapter.first_apply_started.wait(1.0))
+        self.assertEqual("sequence_not_increasing", self.publish(5).code)
+        self.assertEqual("sequence_not_increasing", self.publish(4).code)
+        self.adapter.allow_first_apply.set()
+        self.assertTrue(self.arbiter.wait_applied(5))
+
+    def test_final_boundary_enforces_sequence_wire_limits(self):
+        at_limit = frame(self.authority, MAX_SEQUENCE)
+        at_limit["clutch_sequence"] = MAX_SEQUENCE
+        self.assertTrue(
+            self.arbiter.publish_latest(
+                at_limit,
+                session_generation=7,
+                expires_monotonic=time.monotonic() + 1,
+            ).ok
+        )
+
+        above_sequence = frame(self.authority, MAX_SEQUENCE + 1)
+        self.assertEqual(
+            "invalid_intent",
+            self.arbiter.publish_latest(
+                above_sequence,
+                session_generation=7,
+                expires_monotonic=time.monotonic() + 1,
+            ).code,
+        )
+
+        above_clutch = frame(self.authority, MAX_SEQUENCE)
+        above_clutch["clutch_sequence"] = MAX_SEQUENCE + 1
+        self.assertEqual(
+            "invalid_intent",
+            self.arbiter.publish_latest(
+                above_clutch,
+                session_generation=7,
+                expires_monotonic=time.monotonic() + 1,
+            ).code,
+        )
+
+    def test_adapter_apply_failure_latches_fault_and_runs_safety_path(self):
+        self.adapter.fail_apply = True
+        self.assertTrue(self.publish(1).ok)
+        self.wait_until(lambda: self.arbiter.snapshot()["fault_code"] is not None)
+        self.wait_until(
+            lambda: any(event[:2] == ("stop", "adapter_fault") for event in self.adapter.events)
+        )
+        state = self.arbiter.snapshot()
+        self.assertEqual("fault_latched", state["state"])
+        self.assertEqual("injected_apply_failure", state["fault_code"])
+        self.assertFalse(self.publish(2).ok)
+
+    def test_public_snapshot_contains_no_fence(self):
+        self.assertNotIn(self.authority["fence"], repr(self.arbiter.snapshot()))
+
+    def test_public_snapshot_uses_owner_cache_only(self):
+        before = len(self.adapter.snapshot_threads)
+        for _ in range(100):
+            self.arbiter.snapshot()
+        self.assertEqual(before, len(self.adapter.snapshot_threads))
+        self.assertNotIn("MainThread", self.adapter.snapshot_threads)
+        self.assertTrue(
+            set(self.adapter.snapshot_threads)
+            <= {"teleop-shadow-startup-safe", "teleop-shadow-final-dispatch"}
+        )
+
+
+class StartupAndRestartTests(unittest.TestCase):
+    def test_failed_startup_safe_is_not_ready_or_armable(self):
+        adapter = ControllableAdapter(startup_ack=AdapterAck(False, "no_stop_ack"))
+        arbiter = FinalDispatchArbiter(adapter)
+        try:
+            self.assertFalse(arbiter.ready)
+            handle = arbiter.begin_prepare()
+            self.assertEqual("dispatch_unavailable", arbiter.wait_safe(handle).code)
+            self.assertFalse(arbiter.complete_prepare(handle, binding(), 1).ok)
+            self.assertFalse(arbiter.snapshot()["ready"])
+        finally:
+            first_close = arbiter.close()
+            self.assertFalse(first_close.ok)
+            self.assertEqual(first_close, arbiter.close())
+            self.assertTrue(adapter.closed)
+
+    def test_new_arbiter_starts_with_safe_stop_before_any_motion(self):
+        adapter = ControllableAdapter()
+        arbiter = FinalDispatchArbiter(adapter)
+        try:
+            self.assertEqual(("stop", "startup_safe", 0), adapter.events[0])
+            self.assertIsNone(arbiter.snapshot()["last_would_apply_sequence"])
+        finally:
+            arbiter.close()
+
+    def test_hung_startup_fails_closed_without_concurrent_adapter_calls(self):
+        adapter = HangingStartupAdapter()
+        started = time.monotonic()
+        arbiter = FinalDispatchArbiter(adapter, io_timeout_ms=20)
+        self.assertLess(time.monotonic() - started, 0.2)
+        try:
+            self.assertTrue(adapter.startup_entered.is_set())
+            state = arbiter.snapshot()
+            self.assertEqual("startup_safe_timeout", state["fault_code"])
+            self.assertEqual("unavailable", state["adapter"]["kind"])
+            close_ack = arbiter.close()
+            self.assertFalse(close_ack.ok)
+            self.assertEqual([], adapter.concurrent_calls)
+        finally:
+            adapter.release_startup.set()
+            deadline = time.monotonic() + 1.0
+            while not adapter.closed and time.monotonic() < deadline:
+                time.sleep(0.005)
+            self.assertTrue(adapter.closed)
+            self.assertEqual([], adapter.concurrent_calls)
+
+
+class DeadlineAndShutdownTests(unittest.TestCase):
+    def test_frozen_protocol_clock_does_not_hide_real_io_stall(self):
+        adapter = ControllableAdapter()
+        adapter.block_first_apply = True
+        arbiter = FinalDispatchArbiter(adapter, clock=lambda: 100.0, io_timeout_ms=20)
+        authority = binding()
+        prepare = arbiter.begin_prepare()
+        self.assertTrue(arbiter.wait_safe(prepare).ok)
+        self.assertTrue(arbiter.complete_prepare(prepare, authority, 1).ok)
+        try:
+            self.assertTrue(arbiter.publish_latest(
+                frame(authority, 1),
+                session_generation=1,
+                expires_monotonic=101.0,
+            ).ok)
+            self.assertTrue(adapter.first_apply_started.wait(1.0))
+            time.sleep(0.03)
+            state = arbiter.snapshot()
+            self.assertEqual("adapter_io_stalled", state["fault_code"])
+            self.assertFalse(state["ready"])
+            self.assertEqual("apply", state["io_inflight"])
+        finally:
+            adapter.allow_first_apply.set()
+            arbiter.close()
+
+    def test_stop_completion_after_total_deadline_is_not_acknowledged(self):
+        adapter = DelayedStopAdapter()
+        arbiter = FinalDispatchArbiter(adapter, clock=lambda: 100.0, io_timeout_ms=20)
+        authority = binding()
+        prepare = arbiter.begin_prepare()
+        self.assertTrue(arbiter.wait_safe(prepare).ok)
+        self.assertTrue(arbiter.complete_prepare(prepare, authority, 1).ok)
+        adapter.stop_delay = 0.03
+        try:
+            handle = arbiter.trip(
+                "deadline_test",
+                target_state="safe_revoked",
+                retain_authority=False,
+            )
+            ack = arbiter.wait_safe(handle, 0.2)
+            self.assertFalse(ack.ok)
+            self.assertEqual("adapter_stop_deadline_missed", ack.code)
+            self.assertEqual("fault_latched", arbiter.snapshot()["state"])
+        finally:
+            arbiter.close()
+
+    def test_queued_stops_each_keep_their_original_total_deadline(self):
+        safety_time = [10.0]
+        adapter = AdvancingStopAdapter(safety_time, advance=0.015)
+        arbiter = FinalDispatchArbiter(
+            adapter,
+            safety_clock=lambda: safety_time[0],
+            io_timeout_ms=20,
+        )
+        try:
+            first = arbiter.trip(
+                "first_stop",
+                target_state="safe_revoked",
+                retain_authority=False,
+            )
+            second = arbiter.trip(
+                "second_stop",
+                target_state="safe_revoked",
+                retain_authority=False,
+            )
+            self.assertTrue(arbiter.wait_safe(first, 0.2).ok)
+            second_ack = arbiter.wait_safe(second, 0.2)
+            self.assertFalse(second_ack.ok)
+            self.assertEqual("adapter_stop_deadline_missed", second_ack.code)
+        finally:
+            arbiter.close()
+
+    def test_close_never_overtakes_blocked_apply_and_caches_failure(self):
+        adapter = ControllableAdapter()
+        adapter.block_first_apply = True
+        arbiter = FinalDispatchArbiter(adapter, io_timeout_ms=200)
+        authority = binding()
+        prepare = arbiter.begin_prepare()
+        self.assertTrue(arbiter.wait_safe(prepare).ok)
+        self.assertTrue(arbiter.complete_prepare(prepare, authority, 1).ok)
+        self.assertTrue(arbiter.publish_latest(
+            frame(authority, 1),
+            session_generation=1,
+            expires_monotonic=time.monotonic() + 1,
+        ).ok)
+        self.assertTrue(adapter.first_apply_started.wait(1.0))
+
+        results: list[AdapterAck] = []
+        close_thread = threading.Thread(target=lambda: results.append(arbiter.close(0.03)))
+        close_thread.start()
+        time.sleep(0.05)
+        self.assertFalse(adapter.closed)
+        self.assertTrue(close_thread.is_alive())
+        adapter.allow_first_apply.set()
+        close_thread.join(1.0)
+        self.assertFalse(close_thread.is_alive())
+        self.assertFalse(results[0].ok)
+        self.assertEqual(results[0], arbiter.close())
+        kinds = [event[0] for event in adapter.events]
+        self.assertLess(kinds.index("apply"), kinds.index("close"))
+        self.assertLess(
+            max(index for index, kind in enumerate(kinds) if kind == "stop"),
+            kinds.index("close"),
+        )
+
+    def test_false_close_result_is_not_treated_as_success(self):
+        adapter = FalseCloseAdapter()
+        arbiter = FinalDispatchArbiter(adapter)
+        ack = arbiter.close()
+        self.assertFalse(ack.ok)
+        self.assertEqual("invalid_close_ack", ack.code)
+        self.assertEqual("fault_latched", arbiter.snapshot()["state"])
+
+    def test_reentrant_owner_close_does_not_poison_external_close(self):
+        adapter = ReentrantCloseAdapter()
+        arbiter = FinalDispatchArbiter(adapter)
+        adapter.arbiter = arbiter
+        ack = arbiter.close()
+        self.assertTrue(ack.ok)
+        self.assertEqual(AdapterAck(False, "owner_cannot_self_close"), adapter.reentrant_ack)
+        self.assertTrue(adapter.closed)
+        self.assertEqual(ack, arbiter.close())
+
+    def test_recording_adapter_rechecks_expiry_inside_final_output_lock(self):
+        now = [100.0]
+        adapter = GatedRecordingAdapter(clock=lambda: now[0])
+        arbiter = FinalDispatchArbiter(adapter, clock=lambda: now[0], io_timeout_ms=100)
+        authority = binding()
+        prepare = arbiter.begin_prepare()
+        self.assertTrue(arbiter.wait_safe(prepare).ok)
+        self.assertTrue(arbiter.complete_prepare(prepare, authority, 1).ok)
+        try:
+            self.assertTrue(arbiter.publish_latest(
+                frame(authority, 1),
+                session_generation=1,
+                expires_monotonic=100.05,
+            ).ok)
+            self.assertTrue(adapter.apply_entered.wait(1.0))
+            now[0] = 100.06
+            adapter.release_apply.set()
+            deadline = time.monotonic() + 1
+            while arbiter.snapshot()["fault_code"] is None and time.monotonic() < deadline:
+                time.sleep(0.005)
+            records = adapter.snapshot()["records"]
+            self.assertFalse(any(record["kind"] == "would_apply" for record in records))
+            self.assertEqual(
+                "intent_expired_at_adapter",
+                arbiter.snapshot()["fault_code"],
+            )
+        finally:
+            adapter.release_apply.set()
+            arbiter.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_http_mcp.py
+++ b/generic/teleop_shadow/tests/test_http_mcp.py
@@ -1,0 +1,657 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+from unittest.mock import AsyncMock
+
+from aiohttp.test_utils import TestClient, TestServer
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from capture import CaptureError
+
+from main import (
+    CaptureTlsError,
+    SERVICE_KEY,
+    ShadowDriverService,
+    create_app,
+    load_config,
+    registration_headers,
+    registration_payload,
+    tool_definitions,
+)
+
+from tests.helpers import TEST_SECRET, contains_value
+
+TEST_CONFIG = {
+    "mcp_port": 15711,
+    "bind_host": "127.0.0.1",
+    "teleop": {
+        "lease_timeout_ms": 5000,
+        "pose_timeout_ms": 500,
+        "watchdog_interval_ms": 25,
+        "ticket_ttl_max_seconds": 30,
+        "ticket_replay_cache_entries": 128,
+    },
+    "capture": {
+        "pairing_ttl_seconds": 60,
+        "presence_interval_ms": 1000,
+        "presence_timeout_ms": 5000,
+        "public_wss_url": "wss://robot.test:15712/ws/teleop-capture",
+        "ca_certificate_base64": "dGVzdC1jYQ==",
+    },
+    "registration": {"enabled": False},
+}
+
+
+class McpHttpTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.env = mock.patch.dict(os.environ, {
+            # A legacy Core token must not change the stock-Core MCP contract.
+            "MOTUS_DRIVER_TOKEN": "legacy-token-that-stock-core-will-not-send",
+        })
+        self.env.start()
+        self.client = TestClient(TestServer(create_app(
+            copy.deepcopy(TEST_CONFIG),
+            allow_insecure_test_transport=True,
+        )))
+        await self.client.start_server()
+        self.request_id = 0
+
+    async def asyncTearDown(self):
+        await self.client.close()
+        self.env.stop()
+
+    async def rpc(self, method: str, params: dict | None = None, *, headers: dict | None = None):
+        self.request_id += 1
+        response = await self.client.post("/mcp", json={
+            "jsonrpc": "2.0",
+            "id": self.request_id,
+            "method": method,
+            "params": params or {},
+        }, headers=headers or {})
+        return response.status, await response.json()
+
+    async def call(self, name: str, arguments: dict) -> dict:
+        status, payload = await self.rpc(
+            "tools/call",
+            {"name": name, "arguments": arguments},
+        )
+        self.assertEqual(200, status)
+        self.assertNotIn("error", payload, payload)
+        return json.loads(payload["result"]["content"][0]["text"])
+
+    async def test_stock_core_can_initialize_list_and_call_without_authorization(self):
+        status, initialized = await self.rpc("initialize")
+        self.assertEqual(200, status)
+        self.assertEqual(
+            "teleop-shadow-driver",
+            initialized["result"]["serverInfo"]["name"],
+        )
+        status, listed = await self.rpc("tools/list")
+        self.assertEqual(200, status)
+        self.assertEqual(
+            {"teleop_session", "teleop_state"},
+            {tool["name"] for tool in listed["result"]["tools"]},
+        )
+        self.assertNotIn("Authorization", registration_headers(
+            self.client.server.app[SERVICE_KEY]
+        ))
+
+    async def test_non_loopback_mcp_request_is_rejected_even_with_legacy_token(self):
+        with mock.patch("main._is_loopback_bind", return_value=False):
+            status, payload = await self.rpc(
+                "tools/list",
+                headers={"Authorization": "Bearer legacy-token-that-stock-core-will-not-send"},
+            )
+        self.assertEqual(403, status)
+        self.assertEqual("mcp_loopback_only", payload["error"])
+
+    async def test_session_card_has_only_driver_owned_visible_actions(self):
+        _, payload = await self.rpc("tools/list")
+        tools = {tool["name"]: tool for tool in payload["result"]["tools"]}
+        actions = tools["teleop_session"]["inputSchema"]["x-action-params"]
+        self.assertEqual({
+            "start", "stop", "info", "pair_headset", "revoke_headset", "pause", "release",
+            "emergency_stop", "status",
+        }, set(actions))
+        self.assertTrue({"prepare_shadow", "heartbeat", "soft_stop"}.isdisjoint(actions))
+        signaling = tools["teleop_session"]["x-teleop"]["signaling"]
+        self.assertEqual("/ws/teleop-capture", signaling["path"])
+        self.assertEqual("paired-capture-credential-only", signaling["access"])
+
+    async def test_start_info_stop_tolerate_core_instance_id(self):
+        started = await self.call("teleop_session", {
+            "action": "start",
+            "instance_id": "canvas-card-1",
+        })
+        self.assertEqual("prepared_shadow", started["state"])
+        self.assertTrue(started["authority_valid"])
+        self.assertFalse(started["lease"]["armed"])
+        self.assertEqual("canvas-card-1", started["instance_id"])
+        self.assertIsNotNone(started["session_id"])
+
+        info = await self.call("teleop_session", {
+            "action": "info",
+            "instance_id": "canvas-card-1",
+        })
+        self.assertEqual(started["session_id"], info["session_id"])
+        self.assertEqual([], info["topic_out"])
+
+        stopped = await self.call("teleop_session", {
+            "action": "stop",
+            "instance_id": "canvas-card-1",
+        })
+        self.assertEqual("released", stopped["state"])
+        self.assertFalse(stopped["authority_valid"])
+
+    async def test_pairing_is_created_only_for_started_session(self):
+        _, failed = await self.rpc("tools/call", {
+            "name": "teleop_session",
+            "arguments": {"action": "pair_headset", "instance_id": "card"},
+        })
+        self.assertEqual("session_inactive", failed["error"]["data"]["code"])
+        await self.call("teleop_session", {"action": "start", "instance_id": "card"})
+        pairing = await self.call("teleop_session", {
+            "action": "pair_headset",
+            "instance_id": "card",
+        })
+        self.assertEqual("pairing_ready", pairing["state"])
+        self.assertEqual("/ws/teleop-capture", pairing["websocket_path"])
+        self.assertEqual(36, len(pairing["pairing_id"]))
+        self.assertGreaterEqual(len(pairing["pairing_code"]), 32)
+
+    async def test_pause_release_and_emergency_stop_need_no_private_authority(self):
+        await self.call("teleop_session", {"action": "start", "instance_id": "card"})
+        paused = await self.call("teleop_session", {"action": "pause", "instance_id": "card"})
+        self.assertEqual("paused", paused["state"])
+        released = await self.call("teleop_session", {"action": "release", "instance_id": "card"})
+        self.assertEqual("released", released["state"])
+
+        await self.call("teleop_session", {"action": "start", "instance_id": "card"})
+        stopped = await self.call("teleop_session", {
+            "action": "emergency_stop",
+            "instance_id": "card",
+        })
+        self.assertEqual("released", stopped["state"])
+        self.assertEqual("emergency_stop", stopped["reason"])
+        self.assertEqual(1, stopped["counters"]["emergency_stops"])
+
+    async def test_core_issued_authority_and_pose_submission_are_not_public_actions(self):
+        for action, extra in (
+            ("prepare_shadow", {"session_id": "private", "epoch": 1, "fence": "x" * 32}),
+            ("heartbeat", {}),
+            ("submit_shadow_frame", {"frame": {}}),
+        ):
+            with self.subTest(action=action):
+                _, payload = await self.rpc("tools/call", {
+                    "name": "teleop_session",
+                    "arguments": {"action": action, **extra},
+                })
+                self.assertIn("error", payload)
+
+    async def test_direct_offer_is_fail_closed_and_health_discloses_no_secret(self):
+        offer = await self.client.post("/offer", json={"type": "offer", "sdp": "x"})
+        self.assertEqual(401, offer.status)
+        self.assertEqual(
+            "capture_control_required",
+            (await offer.json())["error"]["code"],
+        )
+        health = await (await self.client.get("/health")).json()
+        self.assertTrue(health["ready"])
+        self.assertTrue(health["rtc_enabled"])
+        self.assertEqual("loopback-only", health["mcp_access"])
+        self.assertFalse(contains_value(health, TEST_SECRET))
+        self.assertNotIn("legacy-token-that-stock-core-will-not-send", json.dumps(health))
+
+
+class DriverOwnedCredentialTests(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def _pair_message(pairing: dict, *, app_version: str = "1.2.0") -> dict:
+        return {
+            "type": "pair",
+            "pairing_id": pairing["pairing_id"],
+            "pairing_code": pairing["pairing_code"],
+            "capture_protocol": "motus.teleop.capture.v1",
+            "frame_protocol": "motus.teleop.rtc-frame.v1",
+            "client_kind": "native_openxr",
+            "app_version": app_version,
+        }
+
+    @staticmethod
+    def _credential_message(identity: dict, *, app_version: str) -> dict:
+        return {
+            "type": "credential",
+            "capture_id": identity["capture_id"],
+            "capture_credential": identity["capture_credential"],
+            "capture_protocol": "motus.teleop.capture.v1",
+            "frame_protocol": "motus.teleop.rtc-frame.v1",
+            "client_kind": "native_openxr",
+            "app_version": app_version,
+        }
+
+    @staticmethod
+    def _post_commit_fsync_failure():
+        real_fsync = os.fsync
+
+        def fail_directory_fsync(descriptor: int) -> None:
+            if stat.S_ISDIR(os.fstat(descriptor).st_mode):
+                raise OSError("directory fsync unavailable")
+            real_fsync(descriptor)
+
+        return mock.patch("capture.os.fsync", side_effect=fail_directory_fsync)
+
+    async def test_signaling_offer_is_single_use_and_never_renews_capture_lease(self):
+        service = ShadowDriverService(copy.deepcopy(TEST_CONFIG))
+        try:
+            await asyncio.to_thread(service.runtime.prepare_local_session)
+            pairing = await service.capture.create_pairing()
+            connection, _ack, _assignment = await service.capture.connect({
+                "type": "pair",
+                "pairing_id": pairing["pairing_id"],
+                "pairing_code": pairing["pairing_code"],
+                "capture_protocol": "motus.teleop.capture.v1",
+                "frame_protocol": "motus.teleop.rtc-frame.v1",
+                "client_kind": "native_openxr",
+                "app_version": "1.2.0",
+            })
+            await service.capture.presence(connection, {
+                "type": "presence",
+                "state": "xr_standby",
+                "assignment_id": None,
+            })
+            assignment = (await connection.events.get())["assignment"]
+            before = service.runtime.status()["counters"]["lease_heartbeats"]
+            service.capture._rtc.accept_offer = AsyncMock(return_value={
+                "type": "answer",
+                "sdp": "answer-sdp",
+            })
+            offer = {
+                "type": "signaling_offer",
+                "assignment_id": assignment["id"],
+                "offer": {"type": "offer", "sdp": "offer-sdp"},
+            }
+            answer = await service.capture.signaling_offer(connection, offer)
+            self.assertEqual("signaling_answer", answer["type"])
+            self.assertEqual(
+                before,
+                service.runtime.status()["counters"]["lease_heartbeats"],
+            )
+            with self.assertRaisesRegex(CaptureError, "capture_offer_already_consumed"):
+                await service.capture.signaling_offer(connection, offer)
+        finally:
+            await service.close()
+
+    async def test_combined_plain_http_capture_app_is_test_only(self):
+        with self.assertRaisesRegex(CaptureTlsError, "test-only"):
+            create_app(copy.deepcopy(TEST_CONFIG))
+
+    async def test_missing_ticket_secret_uses_ephemeral_internal_secret(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            service = ShadowDriverService(copy.deepcopy(TEST_CONFIG))
+        try:
+            self.assertTrue(service.rtc.enabled)
+            self.assertEqual({"Content-Type": "application/json"}, registration_headers(service))
+        finally:
+            await service.close()
+
+    async def test_registration_and_network_bind_do_not_require_core_bearer(self):
+        config = copy.deepcopy(TEST_CONFIG)
+        config["bind_host"] = "0.0.0.0"
+        config["registration"]["enabled"] = True
+        with mock.patch.dict(os.environ, {}, clear=True):
+            service = ShadowDriverService(config)
+        try:
+            self.assertTrue(service.rtc.enabled)
+            self.assertNotIn("Authorization", registration_headers(service))
+        finally:
+            await service.close()
+
+    async def test_paired_capture_credential_survives_driver_restart_and_can_be_revoked(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = copy.deepcopy(TEST_CONFIG)
+            state_file = Path(directory) / "capture.json"
+            config["capture"]["state_file"] = str(state_file)
+            with mock.patch.dict(os.environ, {}, clear=True):
+                service = ShadowDriverService(config)
+            started = await service.dispatch_tool(
+                "teleop_session",
+                {"action": "start", "instance_id": "card"},
+            )
+            self.assertTrue(started["authority_valid"])
+            pairing = await service.dispatch_tool(
+                "teleop_session",
+                {"action": "pair_headset", "instance_id": "card"},
+            )
+            connection, paired, _ = await service.capture.connect({
+                "type": "pair",
+                "pairing_id": pairing["pairing_id"],
+                "pairing_code": pairing["pairing_code"],
+                "capture_protocol": "motus.teleop.capture.v1",
+                "frame_protocol": "motus.teleop.rtc-frame.v1",
+                "client_kind": "native_openxr",
+                "app_version": "1.2.0",
+            })
+            await service.capture.presence(connection, {
+                "type": "presence",
+                "state": "xr_standby",
+                "assignment_id": None,
+            })
+            first_assignment = await connection.events.get()
+            self.assertEqual("assignment", first_assignment["type"])
+            await service.capture.disconnect(connection)
+            await service.close()
+            self.assertEqual(0o600, stat.S_IMODE(state_file.stat().st_mode))
+
+            with mock.patch.dict(os.environ, {}, clear=True):
+                restarted = ShadowDriverService(config)
+            try:
+                await restarted.dispatch_tool(
+                    "teleop_session",
+                    {"action": "start", "instance_id": "card"},
+                )
+                reconnected, acknowledgement, _ = await restarted.capture.connect({
+                    "type": "credential",
+                    "capture_id": paired["capture_id"],
+                    "capture_credential": paired["capture_credential"],
+                    "capture_protocol": "motus.teleop.capture.v1",
+                    "frame_protocol": "motus.teleop.rtc-frame.v1",
+                    "client_kind": "native_openxr",
+                    "app_version": "1.2.1",
+                })
+                self.assertEqual("connected", acknowledgement["type"])
+                await restarted.capture.presence(reconnected, {
+                    "type": "presence",
+                    "state": "xr_standby",
+                    "assignment_id": None,
+                })
+                second_assignment = await reconnected.events.get()
+                self.assertEqual("assignment", second_assignment["type"])
+                self.assertEqual(
+                    1,
+                    first_assignment["assignment"]["generation"],
+                )
+                self.assertEqual(
+                    1,
+                    second_assignment["assignment"]["generation"],
+                )
+                self.assertNotEqual(
+                    first_assignment["assignment"]["session_id"],
+                    second_assignment["assignment"]["session_id"],
+                )
+                await restarted.capture.disconnect(reconnected)
+                revoked = await restarted.dispatch_tool(
+                    "teleop_session",
+                    {"action": "revoke_headset", "instance_id": "card"},
+                )
+                self.assertEqual("capture_revoked", revoked["reason"])
+                persisted = json.loads(state_file.read_text(encoding="utf-8"))
+                self.assertIsNone(persisted["capture"])
+            finally:
+                await restarted.close()
+
+    async def test_capture_state_failure_rolls_back_identity_changes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = copy.deepcopy(TEST_CONFIG)
+            config["capture"]["state_file"] = str(Path(directory) / "capture.json")
+            service = ShadowDriverService(config)
+            try:
+                await service.dispatch_tool(
+                    "teleop_session",
+                    {"action": "start", "instance_id": "card"},
+                )
+                first_pairing = await service.dispatch_tool(
+                    "teleop_session",
+                    {"action": "pair_headset", "instance_id": "card"},
+                )
+                first_connection, first_identity, _ = await service.capture.connect({
+                    "type": "pair",
+                    "pairing_id": first_pairing["pairing_id"],
+                    "pairing_code": first_pairing["pairing_code"],
+                    "capture_protocol": "motus.teleop.capture.v1",
+                    "frame_protocol": "motus.teleop.rtc-frame.v1",
+                    "client_kind": "native_openxr",
+                    "app_version": "1.2.0",
+                })
+                await service.capture.disconnect(first_connection)
+
+                replacement = await service.dispatch_tool(
+                    "teleop_session",
+                    {"action": "pair_headset", "instance_id": "card"},
+                )
+                with (
+                    mock.patch.object(
+                        service.capture,
+                        "_persist_state",
+                        side_effect=OSError("disk unavailable"),
+                    ),
+                    self.assertRaisesRegex(CaptureError, "capture_state_unavailable"),
+                ):
+                    await service.capture.connect({
+                        "type": "pair",
+                        "pairing_id": replacement["pairing_id"],
+                        "pairing_code": replacement["pairing_code"],
+                        "capture_protocol": "motus.teleop.capture.v1",
+                        "frame_protocol": "motus.teleop.rtc-frame.v1",
+                        "client_kind": "native_openxr",
+                        "app_version": "1.2.0",
+                    })
+
+                restored, acknowledgement, _ = await service.capture.connect({
+                    "type": "credential",
+                    "capture_id": first_identity["capture_id"],
+                    "capture_credential": first_identity["capture_credential"],
+                    "capture_protocol": "motus.teleop.capture.v1",
+                    "frame_protocol": "motus.teleop.rtc-frame.v1",
+                    "client_kind": "native_openxr",
+                    "app_version": "1.2.0",
+                })
+                self.assertEqual("connected", acknowledgement["type"])
+                await service.capture.disconnect(restored)
+
+                with (
+                    mock.patch.object(
+                        service.capture,
+                        "_persist_state",
+                        side_effect=OSError("disk unavailable"),
+                    ),
+                    self.assertRaisesRegex(CaptureError, "capture_state_unavailable"),
+                ):
+                    await service.capture.revoke_headset()
+                self.assertEqual(1, (await service.capture.status())["paired_devices"])
+            finally:
+                await service.close()
+
+    async def test_post_commit_pair_failure_keeps_memory_equal_to_replaced_state(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = copy.deepcopy(TEST_CONFIG)
+            state_file = Path(directory) / "capture.json"
+            config["capture"]["state_file"] = str(state_file)
+            service = ShadowDriverService(config)
+            try:
+                pairing = await service.capture.create_pairing()
+                with (
+                    self._post_commit_fsync_failure(),
+                    self.assertRaisesRegex(CaptureError, "capture_state_unavailable"),
+                ):
+                    await service.capture.connect(self._pair_message(pairing))
+                persisted = json.loads(state_file.read_text(encoding="utf-8"))
+                self.assertIsNotNone(persisted["capture"])
+                self.assertEqual(1, (await service.capture.status())["paired_devices"])
+            finally:
+                await service.close()
+
+    async def test_post_commit_version_failure_keeps_new_version_in_memory_and_state(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = copy.deepcopy(TEST_CONFIG)
+            state_file = Path(directory) / "capture.json"
+            config["capture"]["state_file"] = str(state_file)
+            service = ShadowDriverService(config)
+            try:
+                pairing = await service.capture.create_pairing()
+                connection, identity, _ = await service.capture.connect(
+                    self._pair_message(pairing)
+                )
+                await service.capture.disconnect(connection)
+                updated = self._credential_message(identity, app_version="1.2.1")
+                with (
+                    self._post_commit_fsync_failure(),
+                    self.assertRaisesRegex(CaptureError, "capture_state_unavailable"),
+                ):
+                    await service.capture.connect(updated)
+                self.assertEqual(
+                    "1.2.1",
+                    json.loads(state_file.read_text(encoding="utf-8"))["capture"]["app_version"],
+                )
+                with mock.patch.object(service.capture, "_persist_state") as persist:
+                    reconnected, acknowledgement, _ = await service.capture.connect(updated)
+                persist.assert_not_called()
+                self.assertEqual("connected", acknowledgement["type"])
+                await service.capture.disconnect(reconnected)
+            finally:
+                await service.close()
+
+    async def test_post_commit_revoke_failure_keeps_memory_equal_to_tombstone(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = copy.deepcopy(TEST_CONFIG)
+            state_file = Path(directory) / "capture.json"
+            config["capture"]["state_file"] = str(state_file)
+            service = ShadowDriverService(config)
+            try:
+                pairing = await service.capture.create_pairing()
+                connection, _identity, _ = await service.capture.connect(
+                    self._pair_message(pairing)
+                )
+                await service.capture.disconnect(connection)
+                with (
+                    self._post_commit_fsync_failure(),
+                    self.assertRaisesRegex(CaptureError, "capture_state_unavailable"),
+                ):
+                    await service.capture.revoke_headset()
+                self.assertIsNone(
+                    json.loads(state_file.read_text(encoding="utf-8"))["capture"]
+                )
+                self.assertEqual(0, (await service.capture.status())["paired_devices"])
+                self.assertFalse((await service.capture.revoke_headset())["revoked"])
+            finally:
+                await service.close()
+
+    async def test_malformed_auth_ids_use_native_terminal_error_codes(self):
+        service = ShadowDriverService(copy.deepcopy(TEST_CONFIG))
+        try:
+            pairing = await service.capture.create_pairing()
+            malformed_pair = self._pair_message(pairing)
+            malformed_pair["pairing_id"] = "not-a-uuid"
+            with self.assertRaises(CaptureError) as pairing_error:
+                await service.capture.connect(malformed_pair)
+            self.assertEqual("capture_pairing_invalid", pairing_error.exception.code)
+            self.assertEqual(401, pairing_error.exception.status)
+
+            malformed_credential = {
+                "type": "credential",
+                "capture_id": "not-a-uuid",
+                "capture_credential": "x" * 32,
+                "capture_protocol": "motus.teleop.capture.v1",
+                "frame_protocol": "motus.teleop.rtc-frame.v1",
+                "client_kind": "native_openxr",
+                "app_version": "1.2.0",
+            }
+            with self.assertRaises(CaptureError) as credential_error:
+                await service.capture.connect(malformed_credential)
+            self.assertEqual(
+                "capture_credential_invalid",
+                credential_error.exception.code,
+            )
+            self.assertEqual(401, credential_error.exception.status)
+        finally:
+            await service.close()
+
+    async def test_browser_capture_client_is_not_an_implicit_fallback(self):
+        service = ShadowDriverService(copy.deepcopy(TEST_CONFIG))
+        try:
+            await service.dispatch_tool(
+                "teleop_session",
+                {"action": "start", "instance_id": "card"},
+            )
+            pairing = await service.dispatch_tool(
+                "teleop_session",
+                {"action": "pair_headset", "instance_id": "card"},
+            )
+            with self.assertRaisesRegex(CaptureError, "capture_client_unsupported"):
+                await service.capture.connect({
+                    "type": "pair",
+                    "pairing_id": pairing["pairing_id"],
+                    "pairing_code": pairing["pairing_code"],
+                    "capture_protocol": "motus.teleop.capture.v1",
+                    "frame_protocol": "motus.teleop.rtc-frame.v1",
+                    "client_kind": "browser_webxr",
+                    "app_version": "1.2.0",
+                })
+        finally:
+            await service.close()
+
+
+class IdentityAndRegistrationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_environment_overrides_and_tls_development_flag(self):
+        with mock.patch.dict(os.environ, {
+            "MOTUS_DRIVER_ID": "teleop-shadow-env-instance",
+            "MOTUS_DRIVER_NAME": "Environment Instance",
+            "MOTUS_ROBOT_ID": "robot-env-1",
+            "MOTUS_AGENT_CORE_VERIFY_TLS": "0",
+        }):
+            config = load_config(ROOT / "config.yaml")
+        self.assertEqual("teleop-shadow-env-instance", config["driver_id"])
+        self.assertEqual("Environment Instance", config["driver_name"])
+        self.assertEqual("robot-env-1", config["robot_id"])
+        self.assertFalse(config["registration"]["verify_tls"])
+
+    async def test_driver_and_robot_ids_keep_stock_core_boundaries(self):
+        for field in ("driver_id", "robot_id"):
+            accepted = copy.deepcopy(TEST_CONFIG)
+            accepted[field] = "x" * 64
+            rejected = copy.deepcopy(TEST_CONFIG)
+            rejected[field] = "x" * 65
+            with mock.patch.dict(os.environ, {}, clear=True):
+                service = ShadowDriverService(accepted)
+                await service.close()
+                with self.assertRaisesRegex(ValueError, "1-64"):
+                    ShadowDriverService(rejected)
+
+    async def test_two_services_have_distinct_authority_domains(self):
+        config_a = copy.deepcopy(TEST_CONFIG)
+        config_a.update({"driver_id": "shadow-a", "robot_id": "robot-a"})
+        config_b = copy.deepcopy(TEST_CONFIG)
+        config_b.update({"driver_id": "shadow-b", "robot_id": "robot-b"})
+        with mock.patch.dict(os.environ, {}, clear=True):
+            service_a = ShadowDriverService(config_a)
+            service_b = ShadowDriverService(config_b)
+        try:
+            self.assertNotEqual(service_a.runtime.boot_id, service_b.runtime.boot_id)
+            self.assertEqual({
+                "name": service_a.driver_name,
+                "url": "http://localhost:15711/mcp",
+                "transport": "http",
+                "category": "driver",
+                "render_hint": "teleop",
+            }, registration_payload(service_a))
+            self.assertEqual(service_b.driver_name, registration_payload(service_b)["name"])
+            self.assertEqual(
+                "shadow-a",
+                tool_definitions(driver_id="shadow-a")[0]["x-teleop"]["driver_id"],
+            )
+        finally:
+            await service_a.close()
+            await service_b.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_manifest.py
+++ b/generic/teleop_shadow/tests/test_manifest.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class DeploymentManifestTests(unittest.TestCase):
+    def test_mcp_is_loopback_and_capture_uses_separate_tls_state_mounts(self):
+        manifest = yaml.safe_load((ROOT / "deploy/service.yml").read_text(encoding="utf-8"))
+        service = manifest["generic-teleop-shadow"]
+        self.assertEqual("host", service["network_mode"])
+        environment = service["environment"]
+        self.assertIn("MOTUS_BIND_HOST=127.0.0.1", environment)
+        self.assertIn("MOTUS_MCP_URL=http://localhost:15711/mcp", environment)
+        self.assertIn("MOTUS_CAPTURE_BIND_HOST=0.0.0.0", environment)
+        self.assertIn("MOTUS_CAPTURE_PORT=15712", environment)
+        self.assertIn(
+            "MOTUS_CAPTURE_WSS_URL=${MOTUS_CAPTURE_WSS_URL:?set the headset-reachable wss URL}",
+            environment,
+        )
+        self.assertFalse(any(entry.startswith("MOTUS_DRIVER_TOKEN=") for entry in environment))
+        self.assertFalse(any(entry.startswith("MOTUS_TELEOP_TICKET_SECRET=") for entry in environment))
+        self.assertFalse(
+            any(
+                entry.startswith("MOTUS_REGISTRATION_COORDINATION_FILE=")
+                for entry in environment
+            )
+        )
+        self.assertIn(
+            "/opt/phanthy-motus/data/certs/cert.pem:/etc/motus-core-ca/core-ca.pem:ro",
+            service["volumes"],
+        )
+        self.assertNotIn(
+            "/opt/phanthy-motus/data/certs:/etc/motus-core-certs:ro",
+            service["volumes"],
+        )
+        self.assertIn(
+            "/opt/phanthy-motus/data/teleop-capture-tls:/etc/motus-capture-tls:ro",
+            service["volumes"],
+        )
+        self.assertNotIn(
+            "/opt/phanthy-motus/data/certs:/etc/motus-capture-tls:ro",
+            service["volumes"],
+        )
+        self.assertIn(
+            "/opt/phanthy-motus/data/teleop-shadow:/var/lib/motus-teleop-shadow",
+            service["volumes"],
+        )
+
+    def test_driver_and_runtime_ports_match_and_capture_port_is_distinct(self):
+        driver = yaml.safe_load((ROOT / "driver.yaml").read_text(encoding="utf-8"))
+        config = yaml.safe_load((ROOT / "config.yaml").read_text(encoding="utf-8"))
+        self.assertEqual(driver["port"], config["mcp_port"])
+        self.assertEqual("127.0.0.1", config["bind_host"])
+        self.assertFalse(config["mcp_allow_non_loopback"])
+        self.assertNotEqual(config["mcp_port"], config["capture"]["port"])
+        self.assertEqual("0.0.0.0", config["capture"]["bind_host"])
+        self.assertIsNone(config["registration"]["coordination_file"])
+
+    def test_image_contains_capture_runtime_and_declares_both_ports(self):
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+        self.assertIn("capture.py", dockerfile)
+        self.assertIn("dispatch.py", dockerfile)
+        self.assertIn("EXPOSE 15711", dockerfile)
+        self.assertIn("EXPOSE 15712", dockerfile)
+        command_line = next(
+            line.strip() for line in dockerfile.splitlines() if line.strip().startswith("CMD [")
+        )
+        command = json.loads(command_line.removeprefix("CMD "))
+        self.assertEqual(["python", "-c"], command[:2])
+        compile(command[2], "<docker-healthcheck>", "exec")
+
+    def test_docs_state_stock_core_tls_and_persistent_pairing_boundaries(self):
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        for statement in (
+            "未修改 Core",
+            "stock Core",
+            "MOTUS_CAPTURE_WSS_URL",
+            "SAN",
+            "不要复用或挂载\n  Core 私钥",
+            "10001:10001",
+            "0600",
+            "自动重连",
+            "无需用户\n在头显里再次点击",
+            "revoke_headset",
+            "schema v4",
+            "registration_coordination_dir",
+            "新的 Unix 秒",
+            "32768 bytes",
+        ):
+            self.assertIn(statement, readme)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_protocol.py
+++ b/generic/teleop_shadow/tests/test_protocol.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import math
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from protocol import (
+    CAPABILITIES,
+    CAPABILITY_DIGEST,
+    FRAME_V1_DESCRIPTION,
+    MAX_SEQUENCE,
+    RTC_FRAME_V1_DESCRIPTION,
+    ProtocolError,
+    TicketCodec,
+    TicketError,
+    TicketVerifier,
+    bind_rtc_frame_v1,
+    make_ticket_claims,
+    validate_frame_v1,
+)
+from rtc import RtcManager
+from runtime import ShadowRuntime
+
+from tests.helpers import (
+    TEST_SECRET,
+    FakeClock,
+    new_session,
+    rtc_wire_frame,
+    valid_frame,
+)
+
+
+class FrameV1Tests(unittest.TestCase):
+    def setUp(self):
+        self.clock = FakeClock()
+        self.runtime = ShadowRuntime(clock=self.clock, auto_watchdog=False)
+        self.addCleanup(self.runtime.close)
+        self.session = new_session()
+        self.runtime.prepare_shadow(self.session)
+
+    def test_valid_frame_is_normalized(self):
+        frame = validate_frame_v1(valid_frame(self.runtime, self.session))
+        self.assertEqual(1, frame["schema_version"])
+        self.assertEqual("shadow", frame["mode"])
+        self.assertEqual([0.0, 0.0], frame["controllers"]["left"]["axes"])
+
+    def test_unknown_fields_are_rejected(self):
+        frame = valid_frame(self.runtime, self.session)
+        frame["vendor_extension"] = True
+        with self.assertRaisesRegex(ProtocolError, "unknown fields"):
+            validate_frame_v1(frame)
+
+    def test_nan_and_bad_quaternion_are_rejected(self):
+        frame = valid_frame(self.runtime, self.session)
+        frame["base_twist"]["linear"][0] = math.nan
+        with self.assertRaisesRegex(ProtocolError, "finite"):
+            validate_frame_v1(frame)
+        frame = valid_frame(self.runtime, self.session)
+        frame["head"]["orientation"] = [0.0, 0.0, 0.0, 0.2]
+        with self.assertRaisesRegex(ProtocolError, "normalized"):
+            validate_frame_v1(frame)
+
+    def test_tracking_false_requires_null_pose(self):
+        frame = valid_frame(self.runtime, self.session, tracking=False)
+        frame["head"] = {"position": [0, 0, 0], "orientation": [0, 0, 0, 1]}
+        with self.assertRaisesRegex(ProtocolError, "tracking is invalid"):
+            validate_frame_v1(frame)
+        frame = valid_frame(self.runtime, self.session, tracking=True)
+        frame["head"] = None
+        with self.assertRaisesRegex(ProtocolError, "tracking is valid"):
+            validate_frame_v1(frame)
+
+    def test_sequence_fields_accept_signed_64_bit_maximum(self):
+        frame = valid_frame(self.runtime, self.session)
+        frame["sequence"] = MAX_SEQUENCE
+        frame["clutch_sequence"] = MAX_SEQUENCE
+
+        normalized = validate_frame_v1(frame)
+
+        self.assertEqual(MAX_SEQUENCE, normalized["sequence"])
+        self.assertEqual(MAX_SEQUENCE, normalized["clutch_sequence"])
+
+    def test_sequence_fields_reject_values_above_signed_64_bit_maximum(self):
+        for field in ("sequence", "clutch_sequence"):
+            with self.subTest(field=field):
+                frame = valid_frame(self.runtime, self.session)
+                frame[field] = MAX_SEQUENCE + 1
+
+                with self.assertRaises(ProtocolError) as raised:
+                    validate_frame_v1(frame)
+
+                self.assertEqual("out_of_range", raised.exception.code)
+
+    def test_capability_schema_advertises_sequence_bounds(self):
+        expected = {"minimum": 0, "maximum": MAX_SEQUENCE}
+        bounds = FRAME_V1_DESCRIPTION["integer_bounds"]
+        self.assertEqual(expected, bounds["sequence"])
+        self.assertEqual(expected, bounds["clutch_sequence"])
+        self.assertEqual(bounds, CAPABILITIES["frame"]["integer_bounds"])
+
+    def test_rtc_wire_frame_is_bound_server_side_without_private_identity(self):
+        wire = rtc_wire_frame(self.runtime, self.session, sequence=7)
+        authority, _generation = self.runtime.rtc_authority_snapshot()
+
+        normalized = bind_rtc_frame_v1(wire, authority=authority)
+
+        self.assertEqual(7, normalized["sequence"])
+        self.assertEqual(self.runtime.boot_id, normalized["boot_id"])
+        self.assertEqual(self.session["session_id"], normalized["session_id"])
+        self.assertEqual(self.session["fence"], normalized["fence"])
+
+    def test_rtc_wire_frame_rejects_client_supplied_private_identity(self):
+        wire = rtc_wire_frame(self.runtime, self.session)
+        wire["fence"] = self.session["fence"]
+        authority, _generation = self.runtime.rtc_authority_snapshot()
+
+        with self.assertRaises(ProtocolError) as raised:
+            bind_rtc_frame_v1(wire, authority=authority)
+
+        self.assertEqual("unknown_field", raised.exception.code)
+
+    def test_rtc_capability_contract_has_no_private_identity_fields(self):
+        private = {"boot_id", "session_id", "epoch", "fence"}
+        self.assertTrue(private.isdisjoint(RTC_FRAME_V1_DESCRIPTION["required"]))
+        self.assertEqual(
+            sorted(private),
+            sorted(RTC_FRAME_V1_DESCRIPTION["forbidden_private_fields"]),
+        )
+        self.assertEqual(
+            RTC_FRAME_V1_DESCRIPTION,
+            CAPABILITIES["rtc_frame"],
+        )
+        self.assertEqual(
+            "motus.teleop.rtc-frame.v1",
+            CAPABILITIES["rtc_frame"]["protocol"],
+        )
+        self.assertEqual(
+            ["peer_ping", "status"],
+            CAPABILITIES["rtc_control"]["allowed"],
+        )
+        self.assertFalse(
+            CAPABILITIES["rtc_control"]["private_authority_fields_allowed"]
+        )
+
+
+class RtcMessageDecodingTests(unittest.TestCase):
+    def setUp(self):
+        self.runtime = ShadowRuntime(auto_watchdog=False)
+        self.addCleanup(self.runtime.close)
+        self.rtc = RtcManager(self.runtime, None)
+
+    def test_pose_huge_integer_is_stable_invalid_json(self):
+        message = '{"sequence":' + ('9' * 5000) + '}'
+
+        with self.assertRaises(ProtocolError) as raised:
+            self.rtc._decode_message(message, maximum=64 * 1024)
+
+        self.assertEqual("invalid_json", raised.exception.code)
+
+    def test_control_deep_json_is_stable_invalid_json(self):
+        with (
+            mock.patch("rtc.json.loads", side_effect=RecursionError),
+            self.assertRaises(ProtocolError) as raised,
+        ):
+            self.rtc._decode_message("[]", maximum=8 * 1024)
+
+        self.assertEqual("invalid_json", raised.exception.code)
+
+    def test_unencodable_text_is_stable_invalid_encoding(self):
+        message = '"' + chr(0xD800) + '"'
+
+        with self.assertRaises(ProtocolError) as raised:
+            self.rtc._decode_message(message, maximum=8 * 1024)
+
+        self.assertEqual("invalid_encoding", raised.exception.code)
+
+
+class TicketTests(unittest.TestCase):
+    def setUp(self):
+        self.wall = FakeClock(1_000)
+        self.codec = TicketCodec(TEST_SECRET)
+        self.verifier = TicketVerifier(self.codec, wall_clock=self.wall)
+        self.session = {
+            "boot_id": "11111111-1111-1111-1111-111111111111",
+            "session_id": "22222222-2222-2222-2222-222222222222",
+            "epoch": 7,
+            "fence": "f" * 32,
+            "capability_digest": CAPABILITY_DIGEST,
+        }
+        self.sdp = "v=0\r\nt=test-offer\r\n"
+
+    def ticket(self, *, jti: str = "ticket_identifier_1234", sdp: str | None = None) -> str:
+        claims = make_ticket_claims(
+            session=self.session,
+            sdp=sdp or self.sdp,
+            wall_clock=self.wall,
+            jti=jti,
+        )
+        return self.codec.sign(claims)
+
+    def test_ticket_is_bound_and_one_time(self):
+        ticket = self.ticket()
+        claims = self.verifier.verify_and_consume(ticket, expected=self.session, sdp=self.sdp)
+        self.assertEqual(self.session["fence"], claims["fence"])
+        with self.assertRaisesRegex(TicketError, "already been used"):
+            self.verifier.verify_and_consume(ticket, expected=self.session, sdp=self.sdp)
+
+    def test_wrong_sdp_and_expired_ticket_are_rejected(self):
+        with self.assertRaisesRegex(TicketError, "SDP"):
+            self.verifier.verify_and_consume(self.ticket(), expected=self.session, sdp="other")
+        ticket = self.ticket(jti="ticket_identifier_5678")
+        self.wall.advance(31)
+        with self.assertRaisesRegex(TicketError, "expired"):
+            self.verifier.verify_and_consume(ticket, expected=self.session, sdp=self.sdp)
+
+    def test_short_secret_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "32 bytes"):
+            TicketCodec("too-short")
+
+    def test_ticket_secret_must_be_valid_utf8_without_disclosure(self):
+        secret = "private-prefix-" + ("\ud800" * 32)
+        with self.assertRaisesRegex(ValueError, "valid UTF-8") as raised:
+            TicketCodec(secret)
+        self.assertNotIn("private-prefix", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_registration_tls.py
+++ b/generic/teleop_shadow/tests/test_registration_tls.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import datetime
+import ipaddress
+import json
+import os
+import ssl
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import aiohttp
+from aiohttp import web
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from main import (
+    CaptureTlsError,
+    MAX_CAPTURE_CA_BASE64_CHARS,
+    MAX_CAPTURE_CA_PEM_BYTES,
+    RegistrationCoordinationError,
+    RegistrationCoordinator,
+    RegistrationTlsError,
+    ShadowDriverService,
+    _capture_certificate_base64,
+    _post_registration_attempt,
+    _registration_loop,
+    _validated_capture_ca_base64,
+    build_registration_ssl_context,
+    build_capture_ssl_context,
+)
+
+from tests.helpers import TEST_SECRET
+
+
+class _ControlledWallClock:
+    def __init__(self, value: float):
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+    async def sleep(self, delay: float) -> None:
+        self.value += max(0.0, delay)
+        await asyncio.sleep(0)
+
+
+def _write_self_signed_certificate(directory: Path, stem: str) -> tuple[Path, Path]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "phanthy-motus")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.DNSName("phanthy-motus"),
+                x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
+            ]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    certificate_path = directory / f"{stem}.pem"
+    key_path = directory / f"{stem}-key.pem"
+    certificate_path.write_bytes(certificate.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ))
+    return certificate_path, key_path
+
+
+async def _registration_ok(_request: web.Request) -> web.Response:
+    return web.json_response({"registered": True})
+
+
+class RegistrationTlsTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        directory = Path(self.temporary_directory.name)
+        self.core_certificate, core_key = _write_self_signed_certificate(directory, "core")
+        self.wrong_certificate, _ = _write_self_signed_certificate(directory, "wrong")
+
+        self.server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        self.server_context.load_cert_chain(self.core_certificate, core_key)
+
+    async def asyncSetUp(self):
+        app = web.Application()
+        app.router.add_post("/api/mcp", _registration_ok)
+        self.runner = web.AppRunner(app)
+        await self.runner.setup()
+        self.site = web.TCPSite(self.runner, "127.0.0.1", 0, ssl_context=self.server_context)
+        await self.site.start()
+        sockets = self.site._server.sockets  # type: ignore[union-attr]
+        self.endpoint = f"https://127.0.0.1:{sockets[0].getsockname()[1]}/api/mcp"
+
+    async def asyncTearDown(self):
+        await self.runner.cleanup()
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    async def test_pinned_core_certificate_succeeds(self):
+        context = build_registration_ssl_context({
+            "verify_tls": True,
+            "ca_file": str(self.core_certificate),
+        })
+        self.assertIsInstance(context, ssl.SSLContext)
+        self.assertEqual(ssl.CERT_REQUIRED, context.verify_mode)
+        self.assertFalse(context.check_hostname)
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(self.endpoint, ssl=context) as response,
+        ):
+            self.assertEqual(200, response.status)
+            self.assertTrue((await response.json())["registered"])
+
+    async def test_wrong_pinned_certificate_fails_handshake(self):
+        context = build_registration_ssl_context({
+            "verify_tls": True,
+            "ca_file": str(self.wrong_certificate),
+        })
+        loop = asyncio.get_running_loop()
+        previous_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, _context: None)
+        try:
+            with self.assertRaises(aiohttp.ClientError):
+                async with aiohttp.ClientSession() as session:
+                    await session.post(self.endpoint, ssl=context)
+            await asyncio.sleep(0.05)
+        finally:
+            loop.set_exception_handler(previous_handler)
+
+    async def test_missing_certificate_fails_before_connection(self):
+        missing = Path(self.temporary_directory.name) / "missing.pem"
+        with self.assertRaisesRegex(RegistrationTlsError, "pinned CA file is missing"):
+            build_registration_ssl_context({"verify_tls": True, "ca_file": str(missing)})
+
+    async def test_explicit_local_development_override_disables_verification(self):
+        self.assertIs(False, build_registration_ssl_context({"verify_tls": False}))
+
+    async def test_registration_reports_missing_pin_and_keeps_retrying(self):
+        missing = Path(self.temporary_directory.name) / "never-created.pem"
+        config = {
+            "driver_id": "teleop-shadow-tls-retry",
+            "driver_name": "TLS retry test",
+            "mcp_port": 15711,
+            "teleop": {},
+            "registration": {
+                "enabled": True,
+                "agent_core_url": "https://127.0.0.1:1",
+                "interval_seconds": 30,
+                "verify_tls": True,
+                "ca_file": str(missing),
+            },
+        }
+        real_sleep = asyncio.sleep
+
+        async def yield_immediately(_delay: float) -> None:
+            await real_sleep(0)
+
+        with mock.patch.dict(os.environ, {
+            "MOTUS_DRIVER_TOKEN": "registration-tls-test-driver-token",
+            "MOTUS_TELEOP_TICKET_SECRET": TEST_SECRET,
+        }):
+            service = ShadowDriverService(config)
+        with (
+            self.assertLogs("teleop-shadow", level="WARNING"),
+            mock.patch("main.asyncio.sleep", new=yield_immediately),
+        ):
+            task = asyncio.create_task(_registration_loop(service))
+            try:
+                for _ in range(100):
+                    if service.registration_status["attempts"] >= 2:
+                        break
+                    await real_sleep(0)
+                self.assertGreaterEqual(service.registration_status["attempts"], 2)
+                self.assertEqual("tls_error", service.registration_status["state"])
+                self.assertIn("pinned CA file is missing", service.registration_status["last_error"])
+            finally:
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+                await service.close()
+
+    async def test_capture_wss_tls_requires_matching_public_url_san(self):
+        context = build_capture_ssl_context({
+            "public_wss_url": "wss://127.0.0.1:15712/ws/teleop-capture",
+            "tls_cert_file": str(self.core_certificate),
+            "tls_key_file": str(Path(self.temporary_directory.name) / "core-key.pem"),
+        })
+        self.assertIsInstance(context, ssl.SSLContext)
+        self.assertEqual(ssl.TLSVersion.TLSv1_2, context.minimum_version)
+
+        with self.assertRaisesRegex(CaptureTlsError, "SAN does not match"):
+            build_capture_ssl_context({
+                "public_wss_url": "wss://192.0.2.110:15712/ws/teleop-capture",
+                "tls_cert_file": str(self.core_certificate),
+                "tls_key_file": str(Path(self.temporary_directory.name) / "core-key.pem"),
+            })
+
+    async def test_capture_wss_tls_missing_material_fails_closed(self):
+        with self.assertRaisesRegex(CaptureTlsError, "certificate is missing"):
+            build_capture_ssl_context({
+                "public_wss_url": "wss://127.0.0.1:15712/ws/teleop-capture",
+                "tls_cert_file": str(Path(self.temporary_directory.name) / "capture-missing.pem"),
+                "tls_key_file": str(Path(self.temporary_directory.name) / "capture-key-missing.pem"),
+            })
+
+    async def test_capture_listener_rejects_non_wss_bootstrap_url(self):
+        with self.assertRaisesRegex(CaptureTlsError, "must be wss"):
+            build_capture_ssl_context({
+                "public_wss_url": "ws://127.0.0.1:15712/ws/teleop-capture",
+                "tls_cert_file": str(self.core_certificate),
+                "tls_key_file": str(Path(self.temporary_directory.name) / "core-key.pem"),
+            })
+
+        with self.assertRaisesRegex(CaptureTlsError, "must be wss"):
+            build_capture_ssl_context({
+                "port": 15712,
+                "public_wss_url": "wss://127.0.0.1:15713/ws/teleop-capture",
+                "tls_cert_file": str(self.core_certificate),
+                "tls_key_file": str(Path(self.temporary_directory.name) / "core-key.pem"),
+            })
+
+    async def test_capture_ca_bootstrap_matches_native_32_kib_boundary(self):
+        exact = base64.b64encode(b"x" * MAX_CAPTURE_CA_PEM_BYTES).decode("ascii")
+        self.assertEqual(MAX_CAPTURE_CA_BASE64_CHARS, len(exact))
+        self.assertEqual(exact, _validated_capture_ca_base64(exact))
+        oversized = base64.b64encode(
+            b"x" * (MAX_CAPTURE_CA_PEM_BYTES + 1)
+        ).decode("ascii")
+        with self.assertRaisesRegex(ValueError, "decode to 1-32768"):
+            _validated_capture_ca_base64(oversized)
+        with self.assertRaisesRegex(ValueError, "at most 43692"):
+            _validated_capture_ca_base64("A" * (MAX_CAPTURE_CA_BASE64_CHARS + 1))
+        with self.assertRaisesRegex(ValueError, "valid base64"):
+            _validated_capture_ca_base64("!not-base64!")
+
+        oversized_certificate = Path(self.temporary_directory.name) / "large.pem"
+        oversized_certificate.write_bytes(
+            b"-----BEGIN CERTIFICATE-----\n"
+            + b"A" * MAX_CAPTURE_CA_PEM_BYTES
+            + b"\n-----END CERTIFICATE-----\n"
+        )
+        with self.assertRaisesRegex(CaptureTlsError, "bounded public PEM"):
+            _capture_certificate_base64({
+                "tls_cert_file": str(oversized_certificate),
+            })
+
+
+class RegistrationCoordinationTests(unittest.IsolatedAsyncioTestCase):
+    async def _serve(self, handler):
+        app = web.Application()
+        app.router.add_post("/api/mcp", handler)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, "127.0.0.1", 0)
+        await site.start()
+        sockets = site._server.sockets  # type: ignore[union-attr]
+        endpoint = f"http://127.0.0.1:{sockets[0].getsockname()[1]}/api/mcp"
+        return runner, endpoint
+
+    def _coordinator(self, directory: Path, clock: _ControlledWallClock):
+        return RegistrationCoordinator(
+            directory / "registration.json",
+            wall_clock=clock,
+            barrier_sleep=clock.sleep,
+            lock_poll_seconds=0.001,
+        )
+
+    async def _post(self, session, endpoint, coordinator):
+        return await _post_registration_attempt(
+            session,
+            endpoint,
+            payload={"name": "test", "url": "http://localhost:15711/mcp"},
+            headers={"Content-Type": "application/json"},
+            ssl_context=False,
+            coordinator=coordinator,
+        )
+
+    async def test_two_drivers_post_serially_after_previous_response_in_new_second(self):
+        clock = _ControlledWallClock(1_000.20)
+        first_received = asyncio.Event()
+        release_first = asyncio.Event()
+        starts: list[float] = []
+        finishes: list[float] = []
+        active = 0
+        maximum_active = 0
+
+        async def fake_core(_request: web.Request) -> web.Response:
+            nonlocal active, maximum_active
+            index = len(starts)
+            starts.append(clock())
+            active += 1
+            maximum_active = max(maximum_active, active)
+            try:
+                if index == 0:
+                    first_received.set()
+                    await release_first.wait()
+                finishes.append(clock())
+                return web.json_response({"registered": True})
+            finally:
+                active -= 1
+
+        runner, endpoint = await self._serve(fake_core)
+        try:
+            with tempfile.TemporaryDirectory() as temporary:
+                directory = Path(temporary).resolve() / "coordination"
+                directory.mkdir()
+                first = self._coordinator(directory, clock)
+                second = self._coordinator(directory, clock)
+                async with aiohttp.ClientSession() as session:
+                    first_task = asyncio.create_task(self._post(session, endpoint, first))
+                    await asyncio.wait_for(first_received.wait(), timeout=2)
+                    second_task = asyncio.create_task(self._post(session, endpoint, second))
+                    await asyncio.sleep(0.02)
+                    self.assertFalse(second_task.done())
+                    clock.value = 1_000.75
+                    release_first.set()
+                    self.assertEqual([200, 200], await asyncio.gather(first_task, second_task))
+
+                self.assertEqual(1, maximum_active)
+                self.assertEqual(2, len(starts))
+                self.assertGreater(int(starts[1]), int(finishes[0]))
+                marker = json.loads(
+                    (directory / "registration.json").read_text(encoding="ascii")
+                )
+                self.assertEqual(1_001, marker["last_attempt_barrier_unix_second"])
+                self.assertEqual(
+                    0o600,
+                    stat.S_IMODE((directory / "registration.json").stat().st_mode),
+                )
+        finally:
+            await runner.cleanup()
+
+    async def test_lost_response_records_attempt_boundary_and_releases_lock(self):
+        clock = _ControlledWallClock(2_000.20)
+        starts: list[float] = []
+
+        async def fake_core(request: web.Request) -> web.Response:
+            starts.append(clock())
+            if len(starts) == 1:
+                clock.value = 2_000.80
+                assert request.transport is not None
+                request.transport.close()
+                return web.Response(status=200)
+            return web.json_response({"registered": True})
+
+        runner, endpoint = await self._serve(fake_core)
+        try:
+            with tempfile.TemporaryDirectory() as temporary:
+                directory = Path(temporary).resolve() / "coordination"
+                directory.mkdir()
+                async with aiohttp.ClientSession() as session:
+                    with self.assertRaises(aiohttp.ClientError):
+                        await self._post(
+                            session,
+                            endpoint,
+                            self._coordinator(directory, clock),
+                        )
+                    marker_after_loss = json.loads(
+                        (directory / "registration.json").read_text(encoding="ascii")
+                    )
+                    self.assertEqual(
+                        2_000,
+                        marker_after_loss["last_attempt_barrier_unix_second"],
+                    )
+                    clock.value = 2_000.90
+                    status = await asyncio.wait_for(
+                        self._post(
+                            session,
+                            endpoint,
+                            self._coordinator(directory, clock),
+                        ),
+                        timeout=2,
+                    )
+                    self.assertEqual(200, status)
+                self.assertEqual(2, len(starts))
+                self.assertGreater(int(starts[1]), 2_000)
+        finally:
+            await runner.cleanup()
+
+    async def test_cancellation_before_post_releases_descriptor_without_marker(self):
+        clock = _ControlledWallClock(3_000.25)
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary).resolve() / "coordination"
+            directory.mkdir()
+            holder = self._coordinator(directory, clock)
+            waiter = self._coordinator(directory, clock)
+            await holder.__aenter__()
+
+            async def wait_for_lock() -> None:
+                async with waiter:
+                    await waiter.wait_for_turn()
+
+            task = asyncio.create_task(wait_for_lock())
+            await asyncio.sleep(0.02)
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+            await holder.__aexit__(None, None, None)
+            self.assertFalse((directory / "registration.json").exists())
+
+            successor = self._coordinator(directory, clock)
+            await asyncio.wait_for(successor.__aenter__(), timeout=1)
+            await successor.__aexit__(None, None, None)
+
+    async def test_cancellation_after_post_persists_barrier_then_unlocks(self):
+        clock = _ControlledWallClock(3_500.20)
+        received = asyncio.Event()
+        finish_handler = asyncio.Event()
+
+        async def fake_core(_request: web.Request) -> web.Response:
+            received.set()
+            await finish_handler.wait()
+            return web.json_response({"registered": True})
+
+        runner, endpoint = await self._serve(fake_core)
+        try:
+            with tempfile.TemporaryDirectory() as temporary:
+                directory = Path(temporary).resolve() / "coordination"
+                directory.mkdir()
+                async with aiohttp.ClientSession() as session:
+                    task = asyncio.create_task(
+                        self._post(
+                            session,
+                            endpoint,
+                            self._coordinator(directory, clock),
+                        )
+                    )
+                    await asyncio.wait_for(received.wait(), timeout=2)
+                    clock.value = 3_500.80
+                    task.cancel()
+                    with self.assertRaises(asyncio.CancelledError):
+                        await task
+
+                marker = json.loads(
+                    (directory / "registration.json").read_text(encoding="ascii")
+                )
+                self.assertEqual(
+                    3_500,
+                    marker["last_attempt_barrier_unix_second"],
+                )
+                clock.value = 3_500.90
+                successor = self._coordinator(directory, clock)
+                async with successor:
+                    await successor.wait_for_turn()
+                    self.assertGreater(int(clock()), 3_500)
+        finally:
+            finish_handler.set()
+            await runner.cleanup()
+
+    async def test_symlink_marker_fails_closed_and_unlocks(self):
+        clock = _ControlledWallClock(4_000.25)
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary).resolve()
+            directory = root / "coordination"
+            directory.mkdir()
+            outside = root / "outside.json"
+            outside.write_text("do-not-touch", encoding="ascii")
+            (directory / "registration.json").symlink_to(outside)
+            coordinator = self._coordinator(directory, clock)
+            with self.assertRaisesRegex(
+                RegistrationCoordinationError,
+                "safe regular file",
+            ):
+                async with coordinator:
+                    await coordinator.wait_for_turn()
+            self.assertEqual("do-not-touch", outside.read_text(encoding="ascii"))
+
+            (directory / "registration.json").unlink()
+            successor = self._coordinator(directory, clock)
+            async with successor:
+                await successor.wait_for_turn()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_render_instances.py
+++ b/generic/teleop_shadow/tests/test_render_instances.py
@@ -1,0 +1,528 @@
+from __future__ import annotations
+
+import contextlib
+import copy
+import io
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import render_instances as renderer
+import yaml
+from render_instances import (
+    CORE_CA_TARGET,
+    REGISTRATION_COORDINATION_FILE,
+    REGISTRATION_COORDINATION_TARGET,
+    RenderError,
+    _validate_core_ca_file_on_host,
+    atomic_write,
+    load_instances,
+    main,
+    parse_instances_document,
+    render_compose,
+    require_distinct_input_output,
+    validate_image,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _instances_document() -> dict:
+    return {
+        "schema_version": 4,
+        "core_ca_file": "/opt/phanthy-motus/data/certs/cert.pem",
+        "registration_coordination_dir": "/opt/phanthy-motus/data/teleop-registration",
+        "instances": [
+            {
+                "service": "teleop-shadow-lab-b",
+                "container": "motus-teleop-shadow-lab-b",
+                "driver_id": "teleop-shadow-lab-b",
+                "driver_name": "Lab B PICO Teleop Shadow",
+                "robot_id": "teleop-shadow-lab-b",
+                "mcp_port": 15712,
+                "capture_port": 15812,
+                "capture_wss_url": "wss://192.0.2.111:15812/ws/teleop-capture",
+                "capture_tls_dir": "/opt/phanthy-motus/data/teleop-capture-tls/lab-b",
+                "capture_state_dir": "/opt/phanthy-motus/data/teleop-shadow/lab-b",
+            },
+            {
+                "service": "teleop-shadow-lab-a",
+                "container": "motus-teleop-shadow-lab-a",
+                "driver_id": "teleop-shadow-lab-a",
+                "driver_name": "Lab A Quest Teleop Shadow",
+                "robot_id": "teleop-shadow-lab-a",
+                "mcp_port": 15711,
+                "capture_port": 15811,
+                "capture_wss_url": "wss://192.0.2.110:15811/ws/teleop-capture",
+                "capture_tls_dir": "/opt/phanthy-motus/data/teleop-capture-tls/lab-a",
+                "capture_state_dir": "/opt/phanthy-motus/data/teleop-shadow/lab-a",
+            },
+        ],
+    }
+
+
+class RenderInstancesTests(unittest.TestCase):
+    def setUp(self):
+        ca_validation = mock.patch(
+            "render_instances._validate_core_ca_file_on_host",
+            side_effect=lambda path: str(path),
+        )
+        directory_validation = mock.patch(
+            "render_instances._validate_managed_directory_on_host",
+            side_effect=lambda path, _field: str(path),
+        )
+        overlap_validation = mock.patch(
+            "render_instances._host_paths_overlap",
+            side_effect=renderer._paths_overlap,
+        )
+        ca_validation.start()
+        directory_validation.start()
+        overlap_validation.start()
+        self.addCleanup(ca_validation.stop)
+        self.addCleanup(directory_validation.stop)
+        self.addCleanup(overlap_validation.stop)
+
+    def test_two_instances_render_driver_owned_dual_listener_compose(self):
+        deployment = parse_instances_document(_instances_document())
+        rendered = render_compose(deployment, "registry.example/motus/teleop-shadow:2.0")
+        compose = yaml.safe_load(rendered)
+        self.assertEqual(
+            ["teleop-shadow-lab-a", "teleop-shadow-lab-b"],
+            list(compose["services"]),
+        )
+        for instance in deployment.instances:
+            service = compose["services"][instance.service]
+            environment = service["environment"]
+            self.assertEqual("host", service["network_mode"])
+            self.assertIn("MOTUS_BIND_HOST=127.0.0.1", environment)
+            self.assertIn(f"MOTUS_MCP_PORT={instance.mcp_port}", environment)
+            self.assertIn("MOTUS_CAPTURE_BIND_HOST=0.0.0.0", environment)
+            self.assertIn(f"MOTUS_CAPTURE_PORT={instance.capture_port}", environment)
+            self.assertIn(f"MOTUS_CAPTURE_WSS_URL={instance.capture_wss_url}", environment)
+            self.assertIn(
+                f"MOTUS_REGISTRATION_COORDINATION_FILE={REGISTRATION_COORDINATION_FILE}",
+                environment,
+            )
+            self.assertFalse(
+                any(entry.startswith("MOTUS_REGISTRATION_SLOT=") for entry in environment)
+            )
+            self.assertFalse(any(entry.startswith("MOTUS_DRIVER_TOKEN=") for entry in environment))
+            self.assertFalse(any(entry.startswith("MOTUS_TELEOP_TICKET_SECRET=") for entry in environment))
+            self.assertEqual(4, len(service["volumes"]))
+            core_ca, capture_tls, capture_state, registration_coordination = service["volumes"]
+            self.assertEqual(deployment.core_ca_file, core_ca["source"])
+            self.assertEqual(CORE_CA_TARGET, core_ca["target"])
+            self.assertTrue(core_ca["read_only"])
+            self.assertEqual(instance.capture_tls_dir, capture_tls["source"])
+            self.assertEqual("/etc/motus-capture-tls", capture_tls["target"])
+            self.assertTrue(capture_tls["read_only"])
+            self.assertEqual(instance.capture_state_dir, capture_state["source"])
+            self.assertEqual("/var/lib/motus-teleop-shadow", capture_state["target"])
+            self.assertFalse(capture_state["read_only"])
+            self.assertEqual(
+                deployment.registration_coordination_dir,
+                registration_coordination["source"],
+            )
+            self.assertEqual(
+                REGISTRATION_COORDINATION_TARGET,
+                registration_coordination["target"],
+            )
+            self.assertFalse(registration_coordination["read_only"])
+            for volume in service["volumes"]:
+                self.assertFalse(volume["bind"]["create_host_path"])
+
+    def test_rendering_is_deterministic_and_never_reads_process_secrets(self):
+        first = _instances_document()
+        second = copy.deepcopy(first)
+        second["instances"].reverse()
+        secret_environment = {
+            "MOTUS_DRIVER_TOKEN": "driver-secret-sentinel",
+            "MOTUS_TELEOP_TICKET_SECRET": "ticket-secret-sentinel-at-least-32-bytes",
+        }
+        with mock.patch.dict(os.environ, secret_environment):
+            first_render = render_compose(parse_instances_document(first), "teleop-shadow:local")
+            second_render = render_compose(parse_instances_document(second), "teleop-shadow:local")
+        self.assertEqual(first_render, second_render)
+        for name, secret in secret_environment.items():
+            self.assertNotIn(name, first_render)
+            self.assertNotIn(secret, first_render)
+
+    def test_every_identity_port_url_and_storage_domain_is_unique(self):
+        for field in (
+            "service", "container", "driver_id", "robot_id", "mcp_port",
+            "capture_port", "capture_wss_url", "capture_tls_dir", "capture_state_dir",
+        ):
+            with self.subTest(field=field):
+                document = _instances_document()
+                document["instances"][1][field] = document["instances"][0][field]
+                if field == "capture_port":
+                    document["instances"][1]["capture_wss_url"] = (
+                        "wss://192.0.2.110:15812/ws/teleop-capture"
+                    )
+                with self.assertRaisesRegex(RenderError, field):
+                    parse_instances_document(document)
+
+        document = _instances_document()
+        document["instances"][1]["capture_port"] = document["instances"][0]["mcp_port"]
+        document["instances"][1]["capture_wss_url"] = (
+            "wss://192.0.2.110:15712/ws/teleop-capture"
+        )
+        with self.assertRaisesRegex(RenderError, "globally unique"):
+            parse_instances_document(document)
+
+    def test_tls_state_and_core_ca_ownership_trees_never_overlap(self):
+        mutations = (
+            # Same instance: writable state cannot be the TLS directory or
+            # one of its ancestors/children.
+            (1, "capture_state_dir", "/opt/phanthy-motus/data/teleop-capture-tls/lab-a"),
+            (1, "capture_state_dir", "/opt/phanthy-motus/data/teleop-capture-tls"),
+            (1, "capture_state_dir", "/opt/phanthy-motus/data/teleop-capture-tls/lab-a/state"),
+            # Cross instance: a writable state tree cannot contain another
+            # instance's TLS key material.
+            (1, "capture_state_dir", "/opt/phanthy-motus/data/teleop-capture-tls/lab-b"),
+            # No managed directory may contain the mounted Core CA file.
+            (1, "capture_state_dir", "/opt/phanthy-motus/data"),
+            (1, "capture_tls_dir", "/opt/phanthy-motus/data/certs"),
+            # The shared registration directory owns only its lock/marker.
+            (1, "capture_state_dir", "/opt/phanthy-motus/data/teleop-registration"),
+            (1, "capture_tls_dir", "/opt/phanthy-motus/data/teleop-registration/tls"),
+        )
+        for index, field, value in mutations:
+            with self.subTest(index=index, field=field, value=value):
+                document = _instances_document()
+                document["instances"][index][field] = value
+                with self.assertRaisesRegex(RenderError, "overlaps"):
+                    parse_instances_document(document)
+
+        document = _instances_document()
+        document["registration_coordination_dir"] = "/opt/phanthy-motus/data"
+        with self.assertRaisesRegex(RenderError, "registration_coordination_dir"):
+            parse_instances_document(document)
+
+    def test_multi_instance_requires_coordination_but_single_instance_is_fast_path(self):
+        document = _instances_document()
+        document["registration_coordination_dir"] = None
+        with self.assertRaisesRegex(RenderError, "required for multi-instance"):
+            parse_instances_document(document)
+
+        document["instances"] = document["instances"][:1]
+        deployment = parse_instances_document(document)
+        rendered = yaml.safe_load(render_compose(deployment, "teleop-shadow:local"))
+        service = next(iter(rendered["services"].values()))
+        self.assertFalse(
+            any(
+                entry.startswith("MOTUS_REGISTRATION_COORDINATION_FILE=")
+                for entry in service["environment"]
+            )
+        )
+        self.assertEqual(3, len(service["volumes"]))
+
+    def test_old_secret_schema_and_unknown_fields_fail_with_migration_signal(self):
+        document = _instances_document()
+        document["schema_version"] = 3
+        with self.assertRaisesRegex(RenderError, "schema_version must be exactly 4"):
+            parse_instances_document(document)
+        document = _instances_document()
+        document["instances"][0]["driver_token_env"] = "MOTUS_DRIVER_TOKEN"
+        with self.assertRaisesRegex(RenderError, "driver_token_env"):
+            parse_instances_document(document)
+        document = _instances_document()
+        document["instances"][0].pop("capture_wss_url")
+        with self.assertRaisesRegex(RenderError, "capture_wss_url"):
+            parse_instances_document(document)
+
+    def test_identifiers_urls_ports_paths_and_images_reject_injection(self):
+        mutations = (
+            ("service", "Bad/Service"),
+            ("container", "../container"),
+            ("driver_id", "driver\nINJECTED=1"),
+            ("robot_id", "r" * 65),
+            ("driver_name", "${SECRET}"),
+            ("mcp_port", 15699),
+            ("mcp_port", "15711"),
+            ("capture_port", 80),
+            ("capture_port", True),
+            ("capture_wss_url", "ws://10.0.0.1:15812/ws/teleop-capture"),
+            ("capture_wss_url", "wss://user:pass@10.0.0.1:15812/ws/teleop-capture"),
+            ("capture_wss_url", "wss://10.0.0.1:15813/ws/teleop-capture"),
+            ("capture_wss_url", "wss://10.0.0.1:15812/other"),
+            ("capture_tls_dir", "/opt/phanthy-motus/../private"),
+            ("capture_tls_dir", "/etc/shadow"),
+            ("capture_state_dir", "relative/state"),
+            ("capture_state_dir", "/opt/phanthy-motus/${SECRET}"),
+        )
+        for field, value in mutations:
+            with self.subTest(field=field, value=value):
+                document = _instances_document()
+                document["instances"][0][field] = value
+                with self.assertRaises(RenderError):
+                    parse_instances_document(document)
+        for image in ("", "../image", "image\nservices:", "${SECRET_IMAGE}"):
+            with self.subTest(image=image), self.assertRaises(RenderError):
+                validate_image(image)
+
+    def test_core_ca_path_and_duplicate_yaml_keys_are_rejected(self):
+        for path in (
+            "relative/cert.pem", "/opt/phanthy-motus/../secret.pem",
+            "/opt/phanthy-motus/${CORE_CA}", "/etc/shadow",
+        ):
+            document = _instances_document()
+            document["core_ca_file"] = path
+            with self.subTest(path=path), self.assertRaises(RenderError):
+                parse_instances_document(document)
+        text = """schema_version: 4
+core_ca_file: /opt/phanthy-motus/data/certs/cert.pem
+core_ca_file: /tmp/overridden.pem
+registration_coordination_dir: /opt/phanthy-motus/data/teleop-registration
+instances: []
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "instances.yml"
+            path.write_text(text, encoding="utf-8")
+            with self.assertRaisesRegex(RenderError, "duplicate key"):
+                load_instances(path)
+
+    def test_atomic_output_alias_and_cli_modes(self):
+        deployment = parse_instances_document(_instances_document())
+        rendered = render_compose(deployment, "teleop-shadow:local")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "teleop-shadow.compose.yml"
+            output.write_text("partial", encoding="utf-8")
+            atomic_write(output, rendered)
+            self.assertEqual(rendered, output.read_text(encoding="utf-8"))
+            self.assertEqual(0o644, output.stat().st_mode & 0o777)
+            self.assertEqual([], list(root.glob(f".{output.name}.*.tmp")))
+
+            source = root / "instances.yml"
+            source.write_text(yaml.safe_dump(_instances_document(), sort_keys=False), encoding="utf-8")
+            with self.assertRaisesRegex(RenderError, "must not replace"):
+                require_distinct_input_output(source, source)
+            hard_link = root / "hard-link.yml"
+            os.link(source, hard_link)
+            with self.assertRaisesRegex(RenderError, "must not replace"):
+                require_distinct_input_output(source, hard_link)
+
+            for flag in ("--stdout", "--dry-run"):
+                destination = root / f"{flag[2:]}.yml"
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                    code = main([
+                        "--instances", str(source), "--image", "teleop-shadow:local",
+                        "--output", str(destination), flag,
+                    ])
+                self.assertEqual(0, code, stderr.getvalue())
+                self.assertFalse(destination.exists())
+                self.assertEqual(2, len(yaml.safe_load(stdout.getvalue())["services"]))
+
+    def test_atomic_output_rejects_broken_symlink_and_cli_refuses_source_overwrite(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "compose.yml"
+            missing = root / "missing"
+            output.symlink_to(missing)
+            with self.assertRaisesRegex(RenderError, "regular file path"):
+                atomic_write(output, "services: {}\n")
+            source = root / "instances.yml"
+            original = yaml.safe_dump(_instances_document(), sort_keys=False)
+            source.write_text(original, encoding="utf-8")
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                code = main([
+                    "--instances", str(source), "--image", "teleop-shadow:local",
+                    "--output", str(source),
+                ])
+            self.assertEqual(2, code)
+            self.assertEqual(original, source.read_text(encoding="utf-8"))
+
+    def test_bundled_example_is_directly_renderable(self):
+        deployment = load_instances(ROOT / "deploy/instances.example.yml")
+        rendered = render_compose(deployment, "teleop-shadow:local")
+        self.assertEqual(2, len(yaml.safe_load(rendered)["services"]))
+        self.assertNotIn("MOTUS_DRIVER_TOKEN", rendered)
+        self.assertNotIn("MOTUS_TELEOP_TICKET_SECRET", rendered)
+
+    @unittest.skipUnless(shutil.which("docker"), "Docker Compose is unavailable")
+    def test_rendered_document_passes_real_docker_compose_preflight(self):
+        version = subprocess.run(
+            ["docker", "compose", "version"], capture_output=True, text=True, check=False
+        )
+        if version.returncode != 0:
+            self.skipTest("Docker Compose plugin is unavailable")
+        rendered = render_compose(
+            parse_instances_document(_instances_document()), "teleop-shadow:local"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            compose = Path(directory) / "compose.yml"
+            compose.write_text(rendered, encoding="utf-8")
+            result = subprocess.run(
+                ["docker", "compose", "-f", str(compose), "config", "--quiet"],
+                capture_output=True, text=True, check=False,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+
+
+class CoreCaValidationTests(unittest.TestCase):
+    @unittest.skipUnless(shutil.which("openssl"), "OpenSSL is unavailable")
+    def test_ca_must_be_public_x509_inside_the_real_deployment_root(self):
+        with tempfile.TemporaryDirectory() as directory:
+            temporary = Path(directory).resolve()
+            root = temporary / "opt" / "phanthy-motus"
+            tls_dir = root / "tls"
+            tls_dir.mkdir(parents=True)
+            certificate = tls_dir / "core-ca.pem"
+            private_key = temporary / "private-key.pem"
+            subprocess.run([
+                "openssl", "req", "-x509", "-newkey", "rsa:2048",
+                "-keyout", str(private_key), "-out", str(certificate),
+                "-days", "1", "-nodes", "-subj", "/CN=motus-renderer-test",
+            ], check=True, capture_output=True)
+            with mock.patch.object(renderer, "CORE_CA_SOURCE_ROOT", root):
+                self.assertEqual(str(certificate.resolve()), _validate_core_ca_file_on_host(certificate))
+                private_inside = tls_dir / "private.pem"
+                shutil.copyfile(private_key, private_inside)
+                with self.assertRaisesRegex(RenderError, "private-key PEM"):
+                    _validate_core_ca_file_on_host(private_inside)
+                combined = tls_dir / "combined.pem"
+                combined.write_bytes(certificate.read_bytes() + private_key.read_bytes())
+                with self.assertRaisesRegex(RenderError, "private-key PEM"):
+                    _validate_core_ca_file_on_host(combined)
+                outside = temporary / "outside.pem"
+                shutil.copyfile(certificate, outside)
+                escaped = tls_dir / "escaped.pem"
+                escaped.symlink_to(outside)
+                with self.assertRaisesRegex(RenderError, "symlink"):
+                    _validate_core_ca_file_on_host(escaped)
+
+                in_tree_link = tls_dir / "linked.pem"
+                in_tree_link.symlink_to(certificate)
+                with self.assertRaisesRegex(RenderError, "symlink"):
+                    _validate_core_ca_file_on_host(in_tree_link)
+
+                real_parent = root / "real-ca-parent"
+                real_parent.mkdir()
+                ancestor_link = root / "linked-ca-parent"
+                ancestor_link.symlink_to(real_parent, target_is_directory=True)
+                linked_certificate = ancestor_link / "core-ca.pem"
+                shutil.copyfile(certificate, real_parent / linked_certificate.name)
+                with self.assertRaisesRegex(RenderError, "symlink ancestor"):
+                    _validate_core_ca_file_on_host(linked_certificate)
+
+
+class CanonicalManagedPathTests(unittest.TestCase):
+    def _document(self, root: Path) -> dict:
+        return {
+            "schema_version": 4,
+            "core_ca_file": str(root / "core" / "core-ca.pem"),
+            "registration_coordination_dir": str(root / "registration"),
+            "instances": [
+                {
+                    "service": "teleop-a",
+                    "container": "teleop-a",
+                    "driver_id": "teleop-a",
+                    "driver_name": "Teleop A",
+                    "robot_id": "robot-a",
+                    "mcp_port": 15711,
+                    "capture_port": 15811,
+                    "capture_wss_url": "wss://192.0.2.11:15811/ws/teleop-capture",
+                    "capture_tls_dir": str(root / "tls-a"),
+                    "capture_state_dir": str(root / "state-a"),
+                },
+                {
+                    "service": "teleop-b",
+                    "container": "teleop-b",
+                    "driver_id": "teleop-b",
+                    "driver_name": "Teleop B",
+                    "robot_id": "robot-b",
+                    "mcp_port": 15712,
+                    "capture_port": 15812,
+                    "capture_wss_url": "wss://192.0.2.12:15812/ws/teleop-capture",
+                    "capture_tls_dir": str(root / "tls-b"),
+                    "capture_state_dir": str(root / "state-b"),
+                },
+            ],
+        }
+
+    def _tree(self, temporary: str) -> tuple[Path, dict]:
+        root = Path(temporary).resolve() / "opt" / "phanthy-motus"
+        for name in (
+            "core",
+            "registration",
+            "tls-a",
+            "state-a",
+            "tls-b",
+            "state-b",
+        ):
+            (root / name).mkdir(parents=True, exist_ok=True)
+        (root / "core" / "core-ca.pem").write_text("test", encoding="ascii")
+        return root, self._document(root)
+
+    def _parse_without_ca_contents(self, root: Path, document: dict):
+        with (
+            mock.patch.object(renderer, "CORE_CA_SOURCE_ROOT", root),
+            mock.patch(
+                "render_instances._validate_core_ca_file_on_host",
+                side_effect=lambda path: str(path.resolve(strict=True)),
+            ),
+        ):
+            return parse_instances_document(document)
+
+    def test_bind_sources_are_host_canonical_and_isolated(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root, document = self._tree(directory)
+            deployment = self._parse_without_ca_contents(root, document)
+            self.assertEqual(str((root / "registration").resolve()), deployment.registration_coordination_dir)
+            for instance in deployment.instances:
+                self.assertEqual(str(Path(instance.capture_tls_dir).resolve()), instance.capture_tls_dir)
+                self.assertEqual(str(Path(instance.capture_state_dir).resolve()), instance.capture_state_dir)
+            compose = yaml.safe_load(render_compose(deployment, "teleop-shadow:local"))
+            for service in compose["services"].values():
+                for volume in service["volumes"]:
+                    self.assertEqual(str(Path(volume["source"]).resolve()), volume["source"])
+
+    def test_same_instance_symlink_alias_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root, document = self._tree(directory)
+            (root / "state-a").rmdir()
+            (root / "state-a").symlink_to(root / "tls-a", target_is_directory=True)
+            with self.assertRaisesRegex(RenderError, "symlink"):
+                self._parse_without_ca_contents(root, document)
+
+    def test_cross_instance_symlink_alias_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root, document = self._tree(directory)
+            (root / "state-b").rmdir()
+            (root / "state-b").symlink_to(root / "state-a", target_is_directory=True)
+            with self.assertRaisesRegex(RenderError, "symlink"):
+                self._parse_without_ca_contents(root, document)
+
+    def test_ancestor_symlink_is_rejected_for_managed_and_coordination_paths(self):
+        for field, instance_index in (
+            ("capture_tls_dir", 0),
+            ("capture_state_dir", 0),
+            ("registration_coordination_dir", None),
+        ):
+            with self.subTest(field=field), tempfile.TemporaryDirectory() as directory:
+                root, document = self._tree(directory)
+                real_parent = root / "real-parent"
+                real_parent.mkdir()
+                leaf = real_parent / "leaf"
+                leaf.mkdir()
+                linked_parent = root / "linked-parent"
+                linked_parent.symlink_to(real_parent, target_is_directory=True)
+                value = str(linked_parent / "leaf")
+                if instance_index is None:
+                    document[field] = value
+                else:
+                    document["instances"][instance_index][field] = value
+                with self.assertRaisesRegex(RenderError, "symlink ancestor"):
+                    self._parse_without_ca_contents(root, document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_rtc_scenario.py
+++ b/generic/teleop_shadow/tests/test_rtc_scenario.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from aiohttp import WSMsgType
+from aiohttp.test_utils import TestClient, TestServer
+from aiortc import RTCPeerConnection, RTCSessionDescription
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from main import SERVICE_KEY, create_app
+
+from tests.helpers import new_session, rtc_wire_frame
+
+RTC_CONFIG = {
+    "mcp_port": 15711,
+    "bind_host": "127.0.0.1",
+    "teleop": {
+        "lease_timeout_ms": 5000,
+        "pose_timeout_ms": 1000,
+        "watchdog_interval_ms": 25,
+        "ticket_ttl_max_seconds": 30,
+        "ticket_replay_cache_entries": 128,
+    },
+    "capture": {
+        "pairing_ttl_seconds": 60,
+        "presence_interval_ms": 250,
+        "presence_timeout_ms": 1500,
+        "public_wss_url": "wss://robot.test:15712/ws/teleop-capture",
+        "ca_certificate_base64": "dGVzdC1jYQ==",
+    },
+    "registration": {"enabled": False},
+}
+
+
+class DriverOwnedCaptureE2ETests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.env = mock.patch.dict(os.environ, {})
+        self.env.start()
+        self.http = TestClient(TestServer(create_app(
+            RTC_CONFIG,
+            allow_insecure_test_transport=True,
+        )))
+        await self.http.start_server()
+        self.peer = RTCPeerConnection()
+        self.request_id = 0
+
+    async def asyncTearDown(self):
+        await self.peer.close()
+        await self.http.close()
+        self.env.stop()
+
+    async def rpc_call(self, name: str, arguments: dict) -> dict:
+        self.request_id += 1
+        response = await self.http.post("/mcp", json={
+            "jsonrpc": "2.0",
+            "id": self.request_id,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        })
+        payload = await response.json()
+        self.assertNotIn("error", payload, payload)
+        return json.loads(payload["result"]["content"][0]["text"])
+
+    async def receive_type(self, websocket, expected: str, *, timeout: float = 5.0) -> dict:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while asyncio.get_running_loop().time() < deadline:
+            message = await websocket.receive(timeout=deadline - asyncio.get_running_loop().time())
+            self.assertEqual(WSMsgType.TEXT, message.type, message)
+            payload = json.loads(message.data)
+            if payload.get("type") == expected:
+                return payload
+        self.fail(f"timed out waiting for Capture message {expected}")
+
+    async def wait_until(self, predicate, *, timeout: float = 8.0):
+        deadline = asyncio.get_running_loop().time() + timeout
+        while asyncio.get_running_loop().time() < deadline:
+            result = predicate()
+            if result:
+                return result
+            await asyncio.sleep(0.02)
+        self.fail("timed out waiting for condition")
+
+    async def wait_counter_stable(self, getter, *, timeout: float = 2.0):
+        deadline = asyncio.get_running_loop().time() + timeout
+        previous = getter()
+        unchanged = 0
+        while asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.05)
+            current = getter()
+            if current == previous:
+                unchanged += 1
+                if unchanged >= 4:
+                    return current
+            else:
+                previous = current
+                unchanged = 0
+        self.fail("timed out waiting for counter to become stable")
+
+    async def pair_and_focus(self):
+        pairing = await self.rpc_call("teleop_session", {
+            "action": "pair_headset",
+            "instance_id": "canvas-teleop",
+        })
+        websocket = await self.http.ws_connect("/ws/teleop-capture")
+        await websocket.send_json({
+            "type": "pair",
+            "pairing_id": pairing["pairing_id"],
+            "pairing_code": pairing["pairing_code"],
+            "capture_protocol": "motus.teleop.capture.v1",
+            "frame_protocol": "motus.teleop.rtc-frame.v1",
+            "client_kind": "native_openxr",
+            "app_version": "1.2.0",
+        })
+        paired = await self.receive_type(websocket, "paired")
+        await websocket.send_json({
+            "type": "presence",
+            "state": "xr_standby",
+            "assignment_id": None,
+        })
+        await self.receive_type(websocket, "presence_ack")
+        assignment_message = await self.receive_type(websocket, "assignment")
+        return websocket, paired, assignment_message["assignment"]
+
+    async def test_stock_core_start_pair_assignment_rtc_pose_pause_release(self):
+        started = await self.rpc_call("teleop_session", {
+            "action": "start",
+            "instance_id": "canvas-teleop",
+        })
+        self.assertEqual("prepared_shadow", started["state"])
+        self.assertFalse(started["lease"]["armed"])
+
+        websocket, paired, assignment = await self.pair_and_focus()
+        self.assertEqual(started["session_id"], assignment["session_id"])
+        self.assertEqual("shadow", assignment["mode"])
+        self.assertEqual("generic_shadow_v1", assignment["profile_id"])
+        self.assertEqual(["left_arm", "right_arm"], assignment["effectors"])
+        self.assertNotIn("fence", json.dumps(assignment))
+
+        control_open = asyncio.Event()
+        pose_open = asyncio.Event()
+        control_responses: list[dict] = []
+        control_response = asyncio.Event()
+        control = self.peer.createDataChannel("teleop-control", ordered=True)
+        pose = self.peer.createDataChannel(
+            "teleop-pose",
+            ordered=False,
+            maxRetransmits=0,
+        )
+
+        @control.on("open")
+        def on_control_open():
+            control_open.set()
+
+        @pose.on("open")
+        def on_pose_open():
+            pose_open.set()
+
+        @control.on("message")
+        def on_control_message(message):
+            control_responses.append(json.loads(message))
+            control_response.set()
+
+        async def keep_capture_lease_during_local_ice():
+            while True:
+                await websocket.send_json({
+                    "type": "presence",
+                    "state": "rtc_connecting",
+                    "assignment_id": assignment["id"],
+                })
+                await asyncio.sleep(0.2)
+
+        presence_task = asyncio.create_task(keep_capture_lease_during_local_ice())
+        try:
+            await self.peer.setLocalDescription(await self.peer.createOffer())
+            await websocket.send_json({
+                "type": "signaling_offer",
+                "assignment_id": assignment["id"],
+                "offer": {
+                    "type": "offer",
+                    "sdp": self.peer.localDescription.sdp,
+                },
+            })
+            answer_message = await self.receive_type(
+                websocket,
+                "signaling_answer",
+                timeout=12,
+            )
+            self.assertEqual(assignment["id"], answer_message["assignment_id"])
+            self.assertEqual({"type", "sdp"}, set(answer_message["answer"]))
+            await self.peer.setRemoteDescription(RTCSessionDescription(
+                sdp=answer_message["answer"]["sdp"],
+                type=answer_message["answer"]["type"],
+            ))
+            await asyncio.wait_for(
+                asyncio.gather(control_open.wait(), pose_open.wait()),
+                timeout=8,
+            )
+        finally:
+            presence_task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await presence_task
+
+        service = self.http.server.app[SERVICE_KEY]
+        await self.wait_until(lambda: service.runtime.status()["rtc"]["connected"])
+        # Let already-sent Capture presence messages drain before proving the
+        # RTC control/pose paths themselves cannot extend the lease.
+        before_pose_lease_count = await self.wait_counter_stable(
+            lambda: service.runtime.status()["counters"]["lease_heartbeats"]
+        )
+
+        # DataChannel heartbeat is not the Capture control connection and may
+        # never extend the lease.
+        control.send(json.dumps({"type": "heartbeat", "request_id": "rtc-heartbeat"}))
+        await asyncio.wait_for(control_response.wait(), timeout=2)
+        self.assertFalse(control_responses[-1]["ok"])
+        self.assertEqual(
+            "rtc_cannot_renew_lease",
+            control_responses[-1]["error"]["code"],
+        )
+
+        wire_frame = rtc_wire_frame(service.runtime, new_session(), sequence=1)
+        self.assertTrue({"boot_id", "session_id", "epoch", "fence"}.isdisjoint(wire_frame))
+        pose.send(json.dumps(wire_frame))
+        await self.wait_until(
+            lambda: service.runtime.status()["dispatch"]["last_would_apply_sequence"] == 1
+        )
+        state = await self.rpc_call("teleop_state", {})
+        self.assertEqual("active_shadow", state["state"])
+        self.assertEqual(1, state["pose"]["latest_sequence"])
+        self.assertEqual(before_pose_lease_count, state["counters"]["lease_heartbeats"])
+        self.assertTrue(state["capture_control"]["connected"])
+        self.assertEqual(paired["capture_id"], state["capture_control"]["capture_id"])
+
+        paused = await self.rpc_call("teleop_session", {
+            "action": "pause",
+            "instance_id": "canvas-teleop",
+        })
+        self.assertEqual("paused", paused["state"])
+        revoked = await self.receive_type(websocket, "assignment_revoked")
+        self.assertEqual(assignment["id"], revoked["assignment_id"])
+        await websocket.send_json({
+            "type": "presence",
+            "state": "xr_standby",
+            "assignment_id": None,
+        })
+        paused_error = await self.receive_type(websocket, "error")
+        self.assertEqual("session_paused", paused_error["code"])
+
+        released = await self.rpc_call("teleop_session", {
+            "action": "release",
+            "instance_id": "canvas-teleop",
+        })
+        self.assertEqual("released", released["state"])
+        self.assertIsNone(released["session_id"])
+        await websocket.close()
+
+    async def test_capture_disconnect_enters_hold_and_credential_can_reconnect(self):
+        await self.rpc_call("teleop_session", {
+            "action": "start",
+            "instance_id": "canvas-teleop",
+        })
+        websocket, paired, _assignment = await self.pair_and_focus()
+        service = self.http.server.app[SERVICE_KEY]
+        await websocket.close()
+        await self.wait_until(
+            lambda: service.runtime.status()["state"] == "hold"
+            and service.runtime.status()["reason"] == "capture_disconnected"
+        )
+
+        reconnect = await self.http.ws_connect("/ws/teleop-capture")
+        await reconnect.send_json({
+            "type": "credential",
+            "capture_id": paired["capture_id"],
+            "capture_credential": paired["capture_credential"],
+            "capture_protocol": "motus.teleop.capture.v1",
+            "frame_protocol": "motus.teleop.rtc-frame.v1",
+            "client_kind": "native_openxr",
+            "app_version": "1.2.0",
+        })
+        connected = await self.receive_type(reconnect, "connected")
+        self.assertEqual(paired["capture_id"], connected["capture_id"])
+        await reconnect.send_json({
+            "type": "presence",
+            "state": "xr_standby",
+            "assignment_id": None,
+        })
+        await self.receive_type(reconnect, "presence_ack")
+        replacement = await self.receive_type(reconnect, "assignment")
+        self.assertGreater(
+            replacement["assignment"]["generation"],
+            _assignment["generation"],
+        )
+        await reconnect.close()
+
+    async def test_presence_timeout_fails_closed_to_hold(self):
+        await self.rpc_call("teleop_session", {
+            "action": "start",
+            "instance_id": "canvas-teleop",
+        })
+        websocket, _paired, _assignment = await self.pair_and_focus()
+        timeout_error = await self.receive_type(
+            websocket,
+            "error",
+            timeout=3,
+        )
+        self.assertEqual("capture_presence_timeout", timeout_error["code"])
+        service = self.http.server.app[SERVICE_KEY]
+        await self.wait_until(lambda: service.runtime.status()["state"] == "hold")
+        self.assertIn(
+            service.runtime.status()["reason"],
+            {"capture_disconnected", "rtc_disconnected", "rtc_closed"},
+        )
+
+    async def test_headset_can_wait_in_standby_before_pc_starts_session(self):
+        service = self.http.server.app[SERVICE_KEY]
+        # Pairing is intentionally an operator card action, but after the
+        # credential exists a subsequent boot may connect before the PC starts.
+        await self.rpc_call("teleop_session", {
+            "action": "start", "instance_id": "canvas-teleop",
+        })
+        pairing = await self.rpc_call("teleop_session", {
+            "action": "pair_headset", "instance_id": "canvas-teleop",
+        })
+        await self.rpc_call("teleop_session", {
+            "action": "stop", "instance_id": "canvas-teleop",
+        })
+        websocket = await self.http.ws_connect("/ws/teleop-capture")
+        await websocket.send_json({
+            "type": "pair",
+            "pairing_id": pairing["pairing_id"],
+            "pairing_code": pairing["pairing_code"],
+            "capture_protocol": "motus.teleop.capture.v1",
+            "frame_protocol": "motus.teleop.rtc-frame.v1",
+            "client_kind": "native_openxr",
+            "app_version": "1.2.0",
+        })
+        await self.receive_type(websocket, "paired")
+        await websocket.send_json({
+            "type": "presence", "state": "xr_standby", "assignment_id": None,
+        })
+        await self.receive_type(websocket, "presence_ack")
+        self.assertFalse(service.runtime.status()["authority_valid"])
+        self.assertIsNone((await service.capture.status())["assignment_id"])
+
+        started = await self.rpc_call("teleop_session", {
+            "action": "start", "instance_id": "canvas-teleop",
+        })
+        assignment = await self.receive_type(websocket, "assignment")
+        self.assertEqual(started["session_id"], assignment["assignment"]["session_id"])
+        await websocket.close()
+
+    async def test_focus_loss_holds_immediately_while_wss_remains_connected(self):
+        await self.rpc_call("teleop_session", {
+            "action": "start", "instance_id": "canvas-teleop",
+        })
+        websocket, _paired, assignment = await self.pair_and_focus()
+        service = self.http.server.app[SERVICE_KEY]
+        await websocket.send_json({
+            "type": "presence", "state": "xr_ended", "assignment_id": None,
+        })
+        acknowledged = await self.receive_type(websocket, "presence_ack")
+        self.assertEqual("xr_ended", acknowledged["state"])
+        revoked = await self.receive_type(websocket, "assignment_revoked")
+        self.assertEqual(assignment["id"], revoked["assignment_id"])
+        state = service.runtime.status()
+        self.assertEqual("hold", state["state"])
+        self.assertEqual("capture_xr_ended", state["reason"])
+        self.assertTrue(state["dispatch"]["stop_acknowledged"])
+        focus_loss_count = state["counters"]["capture_focus_losses"]
+        await websocket.send_json({
+            "type": "presence", "state": "browser_ready", "assignment_id": None,
+        })
+        await self.receive_type(websocket, "presence_ack")
+        self.assertEqual(
+            focus_loss_count,
+            service.runtime.status()["counters"]["capture_focus_losses"],
+        )
+        self.assertFalse(websocket.closed)
+        await websocket.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_runtime.py
+++ b/generic/teleop_shadow/tests/test_runtime.py
@@ -1,0 +1,627 @@
+from __future__ import annotations
+
+import sys
+import threading
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from dispatch import FinalDispatchArbiter, RecordingAdapter, StopRequest
+from protocol import ProtocolError
+from runtime import ShadowRuntime
+
+from tests.helpers import (
+    FakeClock,
+    contains_value,
+    identity,
+    new_session,
+    rtc_wire_frame,
+    valid_frame,
+)
+
+
+class GatedStopRecordingAdapter(RecordingAdapter):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.block_reason: str | None = None
+        self.stop_entered = threading.Event()
+        self.release_stop = threading.Event()
+
+    def safe_stop(self, request: StopRequest):
+        if request.reason == self.block_reason:
+            self.stop_entered.set()
+            self.release_stop.wait(1.0)
+        return super().safe_stop(request)
+
+
+class ShadowRuntimeTests(unittest.TestCase):
+    def setUp(self):
+        self.clock = FakeClock()
+        # Keep synthetic mailbox tests on one deterministic clock. Real
+        # monotonic adapter-stall behavior is covered by DeadlineAndShutdownTests.
+        dispatcher = FinalDispatchArbiter(
+            RecordingAdapter(clock=self.clock),
+            clock=self.clock,
+            safety_clock=self.clock,
+            io_timeout_ms=100,
+        )
+        self.runtime = ShadowRuntime(
+            lease_timeout_ms=1000,
+            pose_timeout_ms=200,
+            clock=self.clock,
+            auto_watchdog=False,
+            dispatch_io_timeout_ms=100,
+            dispatcher=dispatcher,
+        )
+        self.addCleanup(self.runtime.close)
+        self.session = new_session()
+        self.prepared = self.runtime.prepare_shadow(self.session)
+
+    def wait_until(self, predicate, timeout: float = 1.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            value = predicate()
+            if value:
+                return value
+            time.sleep(0.005)
+        self.fail("condition not reached")
+
+    def gated_runtime(self):
+        clock = FakeClock()
+        adapter = GatedStopRecordingAdapter(clock=clock)
+        dispatcher = FinalDispatchArbiter(
+            adapter,
+            clock=clock,
+            io_timeout_ms=150,
+        )
+        runtime = ShadowRuntime(
+            clock=clock,
+            auto_watchdog=False,
+            dispatch_io_timeout_ms=150,
+            dispatch_ack_timeout_ms=200,
+            dispatcher=dispatcher,
+        )
+        self.addCleanup(runtime.close)
+        self.addCleanup(adapter.release_stop.set)
+        return clock, adapter, runtime
+
+    def test_prepare_and_public_status_never_disclose_fence(self):
+        self.assertNotIn("fence", self.prepared)
+        status = self.runtime.status()
+        self.assertNotIn("fence", status)
+        self.assertFalse(contains_value(status, self.session["fence"]))
+        self.assertFalse(status["actuation_enabled"])
+        self.assertEqual("shadow", status["mode"])
+
+    def test_latest_only_and_public_frame_is_sanitized(self):
+        for sequence in range(1, 1001):
+            self.runtime.submit_shadow_frame(
+                valid_frame(self.runtime, self.session, sequence=sequence), source="test"
+            )
+            # This synthetic producer is much faster than a headset. Yield the
+            # GIL periodically so it tests mailbox replacement without
+            # manufacturing an adapter-owner scheduling stall (>100 ms).
+            if sequence % 32 == 0:
+                time.sleep(0.001)
+        status = self.runtime.status()
+        self.assertEqual(1000, status["pose"]["latest_sequence"])
+        self.assertEqual(1000, status["counters"]["frames_accepted"])
+        self.assertNotIn("fence", status["pose"]["latest"])
+        self.assertFalse(contains_value(status, self.session["fence"]))
+
+    def test_valid_frame_reaches_visible_recording_dispatch(self):
+        self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=7), source="test"
+        )
+        dispatch = self.wait_until(
+            lambda: (
+                state
+                if (state := self.runtime.status()["dispatch"])["last_would_apply_sequence"] == 7
+                else None
+            )
+        )
+        self.assertEqual("would_apply", dispatch["last_decision"])
+        self.assertEqual("recording", dispatch["kind"])
+        self.assertEqual(0, dispatch["mailbox_depth"])
+        self.assertNotIn(self.session["fence"], repr(dispatch))
+
+    def test_unsafe_frame_stops_without_reaching_recording_apply(self):
+        held = self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1, deadman=False), source="test"
+        )
+        self.assertEqual(("hold", "deadman_released"), (held["state"], held["reason"]))
+        dispatch = self.wait_until(
+            lambda: (
+                state
+                if (state := self.runtime.status()["dispatch"])["stop_acknowledged"]
+                else None
+            )
+        )
+        self.assertIsNone(dispatch["last_would_apply_sequence"])
+        records = dispatch["adapter"]["records"]
+        self.assertEqual("deadman_released", records[-1]["reason"])
+        self.assertFalse(any(record["kind"] == "would_apply" for record in records))
+
+    def test_soft_stop_is_latched_until_new_prepare(self):
+        self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1, clutch_sequence=1), source="test"
+        )
+        self.wait_until(
+            lambda: self.runtime.status()["dispatch"]["last_would_apply_sequence"] == 1
+        )
+        stopped = self.runtime.soft_stop(identity(self.runtime, self.session))
+        self.assertEqual(("hold", "soft_stop"), (stopped["state"], stopped["reason"]))
+        held = self.runtime.submit_shadow_frame(
+            valid_frame(
+                self.runtime,
+                self.session,
+                sequence=2,
+                clutch_sequence=999,
+            ),
+            source="test",
+        )
+        self.assertEqual(("hold", "soft_stop"), (held["state"], held["reason"]))
+        time.sleep(0.02)
+        self.assertEqual(1, self.runtime.status()["dispatch"]["last_would_apply_sequence"])
+
+    def test_prepare_over_active_waits_for_visible_stop_ack(self):
+        self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1), source="test"
+        )
+        self.wait_until(
+            lambda: self.runtime.status()["dispatch"]["last_would_apply_sequence"] == 1
+        )
+        newer = new_session(epoch=2, fence="n" * 32)
+        prepared = self.runtime.prepare_shadow(newer)
+        self.assertEqual("prepared_shadow", prepared["state"])
+        self.assertTrue(prepared["dispatch"]["stop_acknowledged"])
+        self.assertEqual("safe_waiting_frame", prepared["dispatch"]["state"])
+        self.assertEqual(
+            "prepare_shadow",
+            prepared["dispatch"]["adapter"]["records"][-1]["reason"],
+        )
+
+    def test_prepare_stop_fences_old_rtc_callbacks_while_ack_is_pending(self):
+        _, adapter, runtime = self.gated_runtime()
+        first = new_session()
+        runtime.prepare_shadow(first)
+        old_generation = runtime.session_generation()
+        adapter.block_reason = "prepare_shadow"
+        adapter.stop_entered.clear()
+        adapter.release_stop.clear()
+        second = new_session(epoch=2, fence="n" * 32)
+        results: list[dict] = []
+        errors: list[Exception] = []
+        worker = threading.Thread(
+            target=lambda: self._capture_call(
+                lambda: runtime.prepare_shadow(second), results, errors
+            )
+        )
+        worker.start()
+        self.assertTrue(adapter.stop_entered.wait(1.0))
+        runtime.mark_channel(old_generation, "teleop-control", True)
+        runtime.mark_rtc_disconnected(old_generation, "rtc_closed")
+        adapter.release_stop.set()
+        worker.join(1.0)
+        self.assertFalse(worker.is_alive())
+        self.assertEqual([], errors)
+        self.assertEqual("prepared_shadow", results[0]["state"])
+        self.assertEqual(second["session_id"], results[0]["session_id"])
+        self.assertEqual(2, results[0]["counters"]["stale_rtc_callbacks"])
+
+    def test_release_cannot_be_revived_while_stop_ack_is_pending(self):
+        _, adapter, runtime = self.gated_runtime()
+        session = new_session()
+        runtime.prepare_shadow(session)
+        old_generation = runtime.session_generation()
+        adapter.block_reason = "operator_release"
+        adapter.stop_entered.clear()
+        adapter.release_stop.clear()
+        results: list[dict] = []
+        errors: list[Exception] = []
+        worker = threading.Thread(
+            target=lambda: self._capture_call(
+                lambda: runtime.release(identity(runtime, session)), results, errors
+            )
+        )
+        worker.start()
+        self.assertTrue(adapter.stop_entered.wait(1.0))
+        runtime.mark_channel(old_generation, "teleop-control", True)
+        runtime.mark_rtc_disconnected(old_generation, "rtc_closed")
+        pending = runtime.status()
+        self.assertEqual("released", pending["state"])
+        self.assertFalse(pending["authority_valid"])
+        self.assertFalse(pending["dispatch"]["stop_acknowledged"])
+        adapter.release_stop.set()
+        worker.join(1.0)
+        self.assertFalse(worker.is_alive())
+        self.assertEqual([], errors)
+        self.assertEqual("released", results[0]["state"])
+        self.assertFalse(results[0]["authority_valid"])
+        self.assertTrue(results[0]["dispatch"]["stop_acknowledged"])
+
+    def test_watchdog_revocation_supersedes_pause_while_stop_is_pending(self):
+        clock = FakeClock()
+        adapter = GatedStopRecordingAdapter(clock=clock)
+        dispatcher = FinalDispatchArbiter(
+            adapter,
+            clock=clock,
+            safety_clock=clock,
+            io_timeout_ms=150,
+        )
+        runtime = ShadowRuntime(
+            lease_timeout_ms=100,
+            clock=clock,
+            auto_watchdog=False,
+            dispatch_io_timeout_ms=150,
+            dispatch_ack_timeout_ms=200,
+            dispatcher=dispatcher,
+        )
+        self.addCleanup(runtime.close)
+        self.addCleanup(adapter.release_stop.set)
+        session = new_session()
+        runtime.prepare_shadow(session)
+        adapter.block_reason = "operator_pause"
+        adapter.stop_entered.clear()
+        adapter.release_stop.clear()
+        results: list[dict] = []
+        errors: list[Exception] = []
+        worker = threading.Thread(
+            target=lambda: self._capture_call(
+                lambda: runtime.pause(identity(runtime, session)), results, errors
+            )
+        )
+        worker.start()
+        self.assertTrue(adapter.stop_entered.wait(1.0))
+        clock.advance(0.11)
+        expired = runtime.watchdog_tick()
+        self.assertEqual(("hold", "lease_timeout"), (expired["state"], expired["reason"]))
+        self.assertFalse(expired["authority_valid"])
+        adapter.release_stop.set()
+        worker.join(1.0)
+        self.assertFalse(worker.is_alive())
+        self.assertEqual([], errors)
+        final = self.wait_until(
+            lambda: (
+                state
+                if (state := runtime.status())["dispatch"]["stop_acknowledged"]
+                else None
+            )
+        )
+        self.assertEqual(("hold", "lease_timeout"), (final["state"], final["reason"]))
+        reasons = [
+            record["reason"]
+            for record in final["dispatch"]["adapter"]["records"]
+            if record["kind"] == "would_stop"
+        ]
+        self.assertLess(reasons.index("operator_pause"), reasons.index("lease_timeout"))
+        self.assertIsNone(final["dispatch"]["last_would_apply_sequence"])
+
+    @staticmethod
+    def _capture_call(call, results: list[dict], errors: list[Exception]) -> None:
+        try:
+            results.append(call())
+        except Exception as exc:  # noqa: BLE001 -- test captures thread failures
+            errors.append(exc)
+
+    def test_close_revokes_authority_stops_and_rejects_late_frame(self):
+        late = valid_frame(self.runtime, self.session, sequence=1)
+        self.runtime.close()
+        state = self.runtime.status()
+        self.assertEqual(("released", "service_close"), (state["state"], state["reason"]))
+        self.assertFalse(state["authority_valid"])
+        self.assertEqual("closed", state["dispatch"]["state"])
+        self.assertTrue(state["dispatch"]["stop_acknowledged"])
+        with self.assertRaisesRegex(ProtocolError, "process is closing"):
+            self.runtime.submit_shadow_frame(late, source="late")
+
+    def test_pose_never_renews_core_lease(self):
+        self.clock.advance(0.9)
+        self.runtime.submit_shadow_frame(valid_frame(self.runtime, self.session), source="test")
+        self.clock.advance(0.15)
+        status = self.runtime.watchdog_tick()
+        self.assertEqual("hold", status["state"])
+        self.assertEqual("lease_timeout", status["reason"])
+        self.assertFalse(status["authority_valid"])
+        self.assertTrue(status["lease"]["expired_latched"])
+        self.assertIsNone(status["pose"]["latest_sequence"])
+
+    def test_pose_timeout_holds_and_requires_higher_clutch(self):
+        self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1, clutch_sequence=4), source="test"
+        )
+        self.clock.advance(0.21)
+        self.assertEqual("pose_timeout", self.runtime.watchdog_tick()["reason"])
+        held = self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=2, clutch_sequence=4), source="test"
+        )
+        self.assertEqual("hold", held["state"])
+        resumed = self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=3, clutch_sequence=5), source="test"
+        )
+        self.assertEqual("active_shadow", resumed["state"])
+
+    def test_old_identity_is_rejected_after_new_epoch(self):
+        old_identity = identity(self.runtime, self.session)
+        newer = new_session(epoch=2, fence="n" * 32)
+        self.runtime.prepare_shadow(newer)
+        with self.assertRaisesRegex(ProtocolError, "session_id"):
+            self.runtime.heartbeat(old_identity)
+
+    def test_stale_peer_callbacks_cannot_pollute_new_session(self):
+        old_generation = self.runtime.session_generation()
+        self.runtime.mark_channel(old_generation, "teleop-control", True)
+        newer = new_session(epoch=2, fence="n" * 32)
+        self.runtime.prepare_shadow(newer)
+        before = self.runtime.status()
+
+        self.runtime.mark_channel(old_generation, "teleop-control", True)
+        self.runtime.mark_channel(old_generation, "teleop-pose", True)
+        self.runtime.mark_rtc_disconnected(old_generation, "rtc_closed")
+
+        after = self.runtime.status()
+        self.assertEqual("prepared_shadow", after["state"])
+        self.assertEqual(before["rtc"]["channels"], after["rtc"]["channels"])
+        self.assertFalse(after["rtc"]["connected"])
+        self.assertEqual(3, after["counters"]["stale_rtc_callbacks"])
+
+    def test_rtc_ping_cannot_renew_lease_by_runtime_contract(self):
+        initial = self.runtime.status()["lease"]["age_ms"]
+        generation = self.runtime.session_generation()
+        self.clock.advance(0.5)
+        self.runtime.mark_channel(generation, "teleop-control", True)
+        self.runtime.mark_channel(generation, "teleop-pose", True)
+        later = self.runtime.status()["lease"]["age_ms"]
+        self.assertGreater(later, initial)
+
+    def test_release_revokes_old_authority_and_is_not_revivable(self):
+        old_identity = identity(self.runtime, self.session)
+        old_generation = self.runtime.session_generation()
+        delayed_frame = valid_frame(
+            self.runtime,
+            self.session,
+            sequence=2,
+            clutch_sequence=999,
+        )
+        self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1), source="test"
+        )
+
+        released = self.runtime.release(old_identity)
+        self.assertEqual("released", released["state"])
+        self.assertIsNone(released["session_id"])
+        self.assertIsNone(released["lease"]["age_ms"])
+        self.assertIsNone(released["pose"]["latest_sequence"])
+        terminal_generation = self.runtime.session_generation()
+        self.assertGreater(terminal_generation, old_generation)
+
+        for old_command in (
+            self.runtime.heartbeat,
+            self.runtime.pause,
+            self.runtime.soft_stop,
+        ):
+            with self.assertRaisesRegex(ProtocolError, "new prepare_shadow"):
+                old_command(old_identity)
+            self.assertEqual("released", self.runtime.status()["state"])
+
+        with self.assertRaisesRegex(ProtocolError, "new prepare_shadow"):
+            self.runtime.submit_shadow_frame(delayed_frame, source="delayed_rtc")
+        with self.assertRaisesRegex(ProtocolError, "new prepare_shadow"):
+            self.runtime.ticket_binding()
+
+        # Both real stale callbacks and a fabricated callback using the
+        # terminal generation are diagnostics-only and cannot leave released.
+        self.runtime.mark_channel(old_generation, "teleop-control", True)
+        self.runtime.mark_rtc_disconnected(old_generation, "rtc_closed")
+        self.runtime.mark_channel(terminal_generation, "teleop-control", True)
+        self.runtime.mark_rtc_disconnected(terminal_generation, "rtc_closed")
+        terminal = self.runtime.watchdog_tick()
+        self.assertEqual("released", terminal["state"])
+        self.assertFalse(terminal["rtc"]["connected"])
+        self.assertEqual({"teleop-control": False, "teleop-pose": False}, terminal["rtc"]["channels"])
+
+        newer = new_session(epoch=2, fence="n" * 32)
+        prepared = self.runtime.prepare_shadow(newer)
+        self.assertEqual("prepared_shadow", prepared["state"])
+        with self.assertRaises(ProtocolError):
+            self.runtime.submit_shadow_frame(delayed_frame, source="delayed_rtc")
+
+    def test_pause_cannot_be_downgraded_to_recoverable_hold(self):
+        old_identity = identity(self.runtime, self.session)
+        self.runtime.pause(old_identity)
+        with self.assertRaisesRegex(ProtocolError, "paused session"):
+            self.runtime.soft_stop(old_identity)
+        with self.assertRaisesRegex(ProtocolError, "state paused"):
+            self.runtime.submit_shadow_frame(
+                valid_frame(self.runtime, self.session, clutch_sequence=999), source="test"
+            )
+        self.assertEqual("paused", self.runtime.status()["state"])
+
+    def test_rtc_pose_requires_both_channels_in_same_generation(self):
+        generation = self.runtime.session_generation()
+        self.runtime.mark_channel(generation, "teleop-pose", True)
+        with self.assertRaisesRegex(ProtocolError, "both teleop-control and teleop-pose"):
+            self.runtime.submit_shadow_frame(
+                valid_frame(self.runtime, self.session, sequence=1),
+                source="rtc",
+                rtc_generation=generation,
+            )
+        pose_only = self.runtime.status()
+        self.assertEqual("hold", pose_only["state"])
+        self.assertFalse(pose_only["rtc"]["connected"])
+        self.assertIsNone(pose_only["pose"]["latest_sequence"])
+
+        # The diagnostic MCP path remains deliberately independent from RTC.
+        diagnostic = self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1),
+            source="mcp_diagnostic",
+        )
+        self.assertEqual("active_shadow", diagnostic["state"])
+
+    def test_control_close_blocks_pose_recovery_until_full_transport(self):
+        generation = self.runtime.session_generation()
+        self.runtime.mark_channel(generation, "teleop-control", True)
+        self.runtime.mark_channel(generation, "teleop-pose", True)
+        active = self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1, clutch_sequence=4),
+            source="rtc",
+            rtc_generation=generation,
+        )
+        self.assertEqual("active_shadow", active["state"])
+
+        self.runtime.mark_channel(generation, "teleop-control", False)
+        with self.assertRaisesRegex(ProtocolError, "both teleop-control and teleop-pose"):
+            self.runtime.submit_shadow_frame(
+                valid_frame(self.runtime, self.session, sequence=2, clutch_sequence=999),
+                source="rtc",
+                rtc_generation=generation,
+            )
+        held = self.runtime.status()
+        self.assertEqual("hold", held["state"])
+        self.assertFalse(held["rtc"]["connected"])
+        self.assertEqual(1, held["pose"]["latest_sequence"])
+
+    def test_stale_generation_pose_cannot_enter_new_session(self):
+        stale_generation = self.runtime.session_generation()
+        newer = new_session(epoch=2, fence="n" * 32)
+        self.runtime.prepare_shadow(newer)
+        self.runtime.mark_channel(stale_generation, "teleop-control", True)
+        self.runtime.mark_channel(stale_generation, "teleop-pose", True)
+        with self.assertRaisesRegex(ProtocolError, "stale session generation"):
+            self.runtime.submit_shadow_frame(
+                valid_frame(self.runtime, newer, sequence=1),
+                source="rtc",
+                rtc_generation=stale_generation,
+            )
+        state = self.runtime.status()
+        self.assertEqual("prepared_shadow", state["state"])
+        self.assertFalse(state["rtc"]["connected"])
+        self.assertIsNone(state["pose"]["latest_sequence"])
+
+    def test_old_peer_authority_cannot_enter_new_session(self):
+        old_authority, old_generation = self.runtime.rtc_authority_snapshot()
+        delayed_wire_frame = rtc_wire_frame(
+            self.runtime,
+            self.session,
+            sequence=1,
+        )
+        newer = new_session(epoch=2, fence="n" * 32)
+        self.runtime.prepare_shadow(newer)
+        current_generation = self.runtime.session_generation()
+        self.runtime.mark_channel(current_generation, "teleop-control", True)
+        self.runtime.mark_channel(current_generation, "teleop-pose", True)
+
+        with self.assertRaises(ProtocolError) as raised:
+            self.runtime.submit_rtc_frame(
+                delayed_wire_frame,
+                authority=old_authority,
+                rtc_generation=old_generation,
+            )
+
+        self.assertEqual("session_mismatch", raised.exception.code)
+        state = self.runtime.status()
+        self.assertEqual("prepared_shadow", state["state"])
+        self.assertIsNone(state["pose"]["latest_sequence"])
+
+    def test_lease_timeout_latch_cannot_be_overwritten_or_reclutched(self):
+        old_identity = identity(self.runtime, self.session)
+        old_generation = self.runtime.session_generation()
+        delayed_frame = valid_frame(
+            self.runtime,
+            self.session,
+            sequence=2,
+            clutch_sequence=999,
+        )
+        self.runtime.submit_shadow_frame(
+            valid_frame(self.runtime, self.session, sequence=1), source="test"
+        )
+        self.clock.advance(1.01)
+        expired = self.runtime.watchdog_tick()
+        self.assertEqual(("hold", "lease_timeout"), (expired["state"], expired["reason"]))
+        self.assertFalse(expired["authority_valid"])
+        self.assertIsNone(expired["session_id"])
+        self.assertIsNone(expired["lease"]["age_ms"])
+        self.assertIsNone(expired["pose"]["latest_sequence"])
+        expired_generation = self.runtime.session_generation()
+        self.assertGreater(expired_generation, old_generation)
+
+        for old_command in (
+            self.runtime.soft_stop,
+            self.runtime.pause,
+            self.runtime.heartbeat,
+        ):
+            with self.assertRaisesRegex(ProtocolError, "lease expired"):
+                old_command(old_identity)
+            self.assertEqual(("hold", "lease_timeout"), (
+                self.runtime.status()["state"], self.runtime.status()["reason"]
+            ))
+        with self.assertRaisesRegex(ProtocolError, "lease expired"):
+            self.runtime.submit_shadow_frame(delayed_frame, source="mcp_diagnostic")
+        with self.assertRaisesRegex(ProtocolError, "lease expired"):
+            self.runtime.ticket_binding()
+
+        self.runtime.mark_channel(old_generation, "teleop-control", True)
+        self.runtime.mark_rtc_disconnected(old_generation, "rtc_closed")
+        self.runtime.mark_channel(expired_generation, "teleop-control", True)
+        self.assertEqual("hold", self.runtime.status()["state"])
+        self.assertFalse(self.runtime.status()["authority_valid"])
+        self.runtime.watchdog_tick()
+        self.assertEqual(1, self.runtime.status()["counters"]["lease_timeouts"])
+
+        newer = new_session(epoch=2, fence="n" * 32)
+        prepared = self.runtime.prepare_shadow(newer)
+        self.assertTrue(prepared["authority_valid"])
+        self.assertEqual("prepared_shadow", prepared["state"])
+        heartbeat = self.runtime.heartbeat(identity(self.runtime, newer))
+        self.assertTrue(heartbeat["lease"]["fresh"])
+
+    def test_authority_boundaries_latch_overdue_lease_without_watchdog(self):
+        boundaries = (
+            "heartbeat", "pause", "soft_stop", "frame", "ticket", "rtc_callback", "status"
+        )
+        for boundary in boundaries:
+            with self.subTest(boundary=boundary):
+                clock = FakeClock()
+                runtime = ShadowRuntime(clock=clock, auto_watchdog=False)
+                try:
+                    session = new_session()
+                    runtime.prepare_shadow(session)
+                    generation = runtime.session_generation()
+                    frame = valid_frame(runtime, session)
+                    old_identity = identity(runtime, session)
+                    clock.advance(1.01)
+
+                    if boundary == "rtc_callback":
+                        runtime.mark_channel(generation, "teleop-control", True)
+                    elif boundary == "status":
+                        runtime.status()
+                    else:
+                        with self.assertRaisesRegex(ProtocolError, "lease expired"):
+                            if boundary == "heartbeat":
+                                runtime.heartbeat(old_identity)
+                            elif boundary == "pause":
+                                runtime.pause(old_identity)
+                            elif boundary == "soft_stop":
+                                runtime.soft_stop(old_identity)
+                            elif boundary == "frame":
+                                runtime.submit_shadow_frame(frame, source="mcp_diagnostic")
+                            else:
+                                runtime.ticket_binding()
+
+                    state = runtime.status()
+                    self.assertEqual(
+                        ("hold", "lease_timeout"),
+                        (state["state"], state["reason"]),
+                    )
+                    self.assertFalse(state["authority_valid"])
+                    self.assertTrue(state["lease"]["expired_latched"])
+                    self.assertGreater(runtime.session_generation(), generation)
+                finally:
+                    runtime.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleop_shadow/tests/test_smoke_recording.py
+++ b/generic/teleop_shadow/tests/test_smoke_recording.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from smoke_recording import run_smoke
+
+
+class RecordingSmokeTests(unittest.TestCase):
+    def test_smoke_produces_visible_apply_stop_and_release_proof(self):
+        proof = run_smoke()
+        self.assertFalse(proof["actuation_enabled"])
+        self.assertEqual("active_shadow", proof["motion_state"])
+        self.assertEqual(1, proof["last_would_apply_sequence"])
+        self.assertEqual(
+            {"state": "hold", "reason": "soft_stop", "acknowledged": True},
+            proof["soft_stop"],
+        )
+        self.assertEqual("released", proof["release"]["state"])
+        self.assertIn(
+            {"kind": "would_apply", "sequence": 1},
+            proof["recorded_decisions"],
+        )
+        self.assertIn(
+            {"kind": "would_stop", "reason": "soft_stop"},
+            proof["recorded_decisions"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更目标

在不修改 PhanthyMotus Core 的前提下，提供可由现有 Canvas/MCP 调用的通用遥操作运行时，并把高频遥操作链路收敛到头显与 Driver 之间。

## 主要内容

- 新增 `teleop_session` 与 `teleop_state` 通用卡片，兼容现有 Core 注入的 `instance_id`。
- Driver 自主管理头显配对、会话、fence、租约、一次性 RTC ticket、审计状态与故障保持。
- 新增独立 TLS/WSS Capture 控制面；只有合法头显 presence 可以续租，姿态帧、RTC ping 和信令均不能续租。
- 新增 Meta Quest 与 PICO 4/PICO 4 Ultra 两个原生 OpenXR Android 变体，共用严格的姿态帧、双握把 deadman 和 WebRTC DataChannel 协议。
- Shadow 运行时只记录 `would_apply` / `would_stop`，不会产生硬件输出。
- 增加多实例渲染、注册错峰协调、目录隔离、证书 SAN/大小校验和凭据持久化边界。

## 验证结果

- Python：122 项通过；另 1 项仅因本机没有 Docker Compose 跳过。
- Native host：Meta/PICO 运行时策略、帧协议、会话、enrollment、wire、公开 fixture 与 G1 strict fixture 全部通过。
- Android：Meta 与 PICO Debug APK 均构建成功，权限、包名、签名、ABI、ELF 依赖和 zipalign 严格校验通过。
  - Meta：`com.phanthymotus.questcapture`，SHA-256 `18858f1fef8bdab09c28cbefb6ee7d930323f48eaebc10a029df6e0b28686992`
  - PICO：`com.phanthymotus.picocapture`，SHA-256 `53f5531512b8ab72853fa2a6240fc1374d03ec2d83d7feb0bab4daab65b92663`
- 未修改的 stock Core 的 MCP 发现、调用与卡片生命周期兼容路径已有自动化覆盖。
- `git diff --check` 通过；未提交 APK、Gradle/CMake 缓存或 Python 字节码。

## 明确边界

- 本 PR 不修改 Core，也不依赖 Core 提供 WebXR、WebRTC 信令或遥操作会话管理。
- 尚未在实体 Quest/PICO 上安装运行；真实 OpenXR 生命周期、WSS/ICE/DTLS/DataChannel 网络联调仍需设备验收。
- 当前 APK 为调试签名产物，不是发布签名产物。
- 本 PR 不包含 G1 硬件适配，也不会产生机器人控制输出。