### PR TITLE
feat(t800): 新增mapping激光点云建图功能，支持语义标记与地图管理

### DIFF
--- a/engineai/t800/Dockerfile
+++ b/engineai/t800/Dockerfile
@@ -69,7 +69,7 @@ RUN echo "[t800] checking ROS interface build dependencies" && \
     . /t800_ws/install/setup.sh && \
     python3 -c "from interface_protocol.msg import BodyVelCmd, Heartbeat, LinkInfo, MotionStateRequest; from nav_msgs.msg import Odometry; from sensor_msgs.msg import CompressedImage, Image, PointCloud2; print('T800 ROS imports ok')"
 
-COPY main.py device.py control.py native_sdk.py virtual_gamepad.py config.yaml driver.yaml /work/
+COPY main.py device.py control.py native_sdk.py virtual_gamepad.py config.yaml driver.yaml controlled_spatial_map.py /work/
 COPY resource/ /work/resource/
 COPY deploy/ /deploy/
 RUN . /opt/ros/humble/setup.sh && \

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -103,6 +103,10 @@ plugins:
     max_points: 5000000
     odometry_topic: /manifold/ODIN2/device0/odometry
     pointcloud_topic: /manifold/ODIN2/device0/cloud/slam
+  controlled_spatial_map:
+    enabled: true
+    db_path: /opt/phanthy-motus/data/mapping.db
+    cloud_dir: /opt/phanthy-motus/data/controlled_spatial_clouds
   safety:
     enabled: true
   native_sdk:

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -95,7 +95,7 @@ plugins:
     url: "udpm://239.255.76.67:7667?ttl=1"
     channel: "virtual_gamepad/gamepad_keys"
     rate_hz: 20.0
-  mapping:
+  controlled_spatial:
     enabled: true
     map_save_dir: /opt/phanthy-motus/data/maps
     db_path: /opt/phanthy-motus/data/mapping.db

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -95,6 +95,14 @@ plugins:
     url: "udpm://239.255.76.67:7667?ttl=1"
     channel: "virtual_gamepad/gamepad_keys"
     rate_hz: 20.0
+  mapping:
+    enabled: true
+    map_save_dir: /opt/phanthy-motus/data/maps
+    db_path: /opt/phanthy-motus/data/mapping.db
+    voxel_size: 0.05
+    max_points: 5000000
+    odometry_topic: /manifold/ODIN2/device0/odometry
+    pointcloud_topic: /manifold/ODIN2/device0/cloud/slam
   safety:
     enabled: true
   native_sdk:

--- a/engineai/t800/controlled_spatial_map.py
+++ b/engineai/t800/controlled_spatial_map.py
@@ -60,9 +60,14 @@ class ControlledSpatialMapNode:
         ControlledSpatialMapNode.np = np
         os.makedirs(cloud_dir, exist_ok=True)
 
-        self._node = Node("t800_controlled_spatial_map", context=ros2.ctx_robot)
-        ros2.executor_robot.add_node(self._node)
-        self._pub = self._node.create_publisher(UInt8MultiArray, topic, 10)
+        # Subscriptions live on the robot domain (odometry + point cloud),
+        # while the map publisher must be on the core domain so the frontend
+        # / agent-core can receive it.
+        self._sub_node = Node("t800_controlled_spatial_map_sub", context=ros2.ctx_robot)
+        ros2.executor_robot.add_node(self._sub_node)
+        self._pub_node = Node("t800_controlled_spatial_map_pub", context=ros2.ctx_core)
+        ros2.executor_core.add_node(self._pub_node)
+        self._pub = self._pub_node.create_publisher(UInt8MultiArray, topic, 10)
         self._topic = topic
         self._db = db
         self._cloud_dir = cloud_dir
@@ -104,16 +109,16 @@ class ControlledSpatialMapNode:
         )
         self._worker.start()
 
-        # --- ROS2 subscriptions ---
-        self._odom_sub = self._node.create_subscription(
+        # --- ROS2 subscriptions (robot domain) ---
+        self._odom_sub = self._sub_node.create_subscription(
             Odometry, odometry_topic, self._on_odometry, _BEST_EFFORT
         )
-        self._cloud_sub = self._node.create_subscription(
+        self._cloud_sub = self._sub_node.create_subscription(
             PointCloud2, pointcloud_topic, self._on_pointcloud, _BEST_EFFORT
         )
 
-        # --- fallback heartbeat timer ---
-        self._publish_timer = self._node.create_timer(0.5, self._periodic_publish)
+        # --- fallback heartbeat timer (core domain) ---
+        self._publish_timer = self._pub_node.create_timer(0.5, self._periodic_publish)
 
         print(
             f"[ControlledSpatialMapNode] ready topic={topic} "
@@ -126,7 +131,7 @@ class ControlledSpatialMapNode:
     # ------------------------------------------------------------------
     @property
     def node(self):
-        return self._node
+        return self._pub_node
 
     def stop(self):
         if self._closing.is_set():
@@ -143,7 +148,11 @@ class ControlledSpatialMapNode:
             pass
         try:
             with self._publish_lock:
-                self._node.destroy_node()
+                self._pub_node.destroy_node()
+        except Exception:
+            pass
+        try:
+            self._sub_node.destroy_node()
         except Exception:
             pass
 
@@ -813,6 +822,8 @@ class ControlledSpatialMapPlugin:
         self._map_node = None
         self._startup_error = None
         self._last_selected_map = None
+        self._closing = threading.Event()
+        self._sync_timer = None
 
         try:
             self._db = _MappingDB(db_path)
@@ -835,6 +846,10 @@ class ControlledSpatialMapPlugin:
             except Exception:
                 pass
             return
+
+        # T800 has no DDS slam_info channel like g1; poll the shared DB once
+        # per second so actuator-driven map_status changes are picked up.
+        self._schedule_sync()
 
         print(f"[ControlledSpatialMap] plugin ready, topic: {self._map_topic}", flush=True)
 
@@ -881,8 +896,28 @@ class ControlledSpatialMapPlugin:
         self._map_node.publish_now(force=True)
 
     def stop(self):
+        self._closing.set()
+        if self._sync_timer is not None:
+            self._sync_timer.cancel()
+            self._sync_timer = None
         if self._map_node:
             self._map_node.stop()
+
+    def _schedule_sync(self):
+        if self._closing.is_set():
+            return
+        self._sync_timer = threading.Timer(1.0, self._periodic_sync)
+        self._sync_timer.daemon = True
+        self._sync_timer.start()
+
+    def _periodic_sync(self):
+        if self._closing.is_set():
+            return
+        try:
+            self._sync_from_db(force=False)
+        except Exception as e:
+            print(f"[ControlledSpatialMap] periodic sync error: {e}", flush=True)
+        self._schedule_sync()
 
     # ------------------------------------------------------------------
     # dispatch

--- a/engineai/t800/controlled_spatial_map.py
+++ b/engineai/t800/controlled_spatial_map.py
@@ -1,0 +1,130 @@
+import os
+import json
+import threading
+
+from device import _MappingDB
+
+
+class ControlledSpatialMapPlugin:
+    PREFIX = "controlled_spatial_map"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, *_, **__):
+        db_path = plugin_config.get("db_path", "/opt/phanthy-motus/data/mapping.db")
+        self._cloud_dir = plugin_config.get(
+            "cloud_dir", "/opt/phanthy-motus/data/controlled_spatial_clouds"
+        )
+        self._map_topic = f"/{namespace}/controlled_spatial/map"
+        self._db = None
+        self._startup_error = None
+        self._last_selected_map = None
+
+        try:
+            self._db = _MappingDB(db_path)
+        except Exception as exc:
+            self._startup_error = str(exc)
+            print(f"[ControlledSpatialMap] startup degraded: {exc}", flush=True)
+            try:
+                import traceback
+                traceback.print_exc()
+            except Exception:
+                pass
+
+        print(f"[ControlledSpatialMap] plugin ready, topic: {self._map_topic}", flush=True)
+
+    def get_tool(self) -> dict:
+        return {
+            "name": self.PREFIX,
+            "type": "sensor",
+            "multiInstance": False,
+            "description": "Controlled spatial map view — saved maps, tags, live robot pose, and SLAM point cloud when available.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["start", "stop", "info", "refresh", "select_map", "list_maps"],
+                        "description": "Optional map-view control action",
+                    },
+                    "map_name": {"type": "string", "description": "Map name for select_map"},
+                    "overwrite": {"type": "boolean"},
+                },
+            },
+            "topic_out": [{"topic": self._map_topic, "format": "sensor/mapping"}],
+        }
+
+    def get_tools(self) -> list:
+        return [self.get_tool()]
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action in (self.PREFIX, "start", "refresh"):
+            return self._info("ready")
+        if action == "stop":
+            return self._info("idle")
+        if action == "info":
+            return self._info("running")
+        if action == "list_maps":
+            return self._list_maps()
+        if action == "select_map":
+            return self._select_map(args.get("map_name", ""))
+        return None
+
+    def _info(self, state: str) -> dict:
+        maps = []
+        active_map = None
+        if self._db:
+            try:
+                maps = self._db.list_maps_with_pois()
+                active_map = self._db.get_state("active_map")
+            except Exception:
+                maps = []
+                active_map = None
+        return {
+            "state": state if not self._startup_error else "degraded",
+            "topic_out": [{"topic": self._map_topic, "format": "sensor/mapping"}],
+            "active_map": active_map,
+            "cloud_dir": self._cloud_dir,
+            "map_count": len(maps),
+            "startup_error": self._startup_error,
+        }
+
+    def _list_maps(self) -> dict:
+        if self._db is None:
+            return self._info("degraded")
+        try:
+            maps = self._db.list_maps_with_pois()
+            active_map = self._db.get_state("active_map")
+            return {
+                "maps": maps,
+                "active_map": active_map,
+                "cloud_dir": self._cloud_dir,
+                "map_count": len(maps),
+            }
+        except Exception as exc:
+            return {"error": f"failed to read maps: {exc}"}
+
+    def _select_map(self, map_name: str) -> dict:
+        if not map_name:
+            return {"error": "map_name is required"}
+        if self._db is None:
+            return self._info("degraded")
+        try:
+            maps = self._db.list_maps_with_pois()
+        except Exception as exc:
+            return {"error": f"failed to read maps: {exc}"}
+
+        map_names = [item["name"] for item in maps]
+        if map_name not in map_names:
+            return {"error": "Map not found", "maps": map_names}
+
+        self._last_selected_map = map_name
+        return self._info("selected")
+
+
+def make_plugin(plugin_config, namespace, executor, client=None):
+    return ControlledSpatialMapPlugin(plugin_config, namespace, executor)

--- a/engineai/t800/controlled_spatial_map.py
+++ b/engineai/t800/controlled_spatial_map.py
@@ -1,42 +1,855 @@
-import os
+"""Map view publisher for the T800 controlled_spatial_map sensor card.
+
+Subscribes to T800 ROS2 odometry and SLAM point cloud, voxel-accumulates the
+cloud while mapping, and publishes a v3 binary map snapshot (UInt8MultiArray)
+for the frontend controlled-spatial renderer. DB is shared with the
+controlled_spatial actuator (mapping.db).
+"""
+
+from __future__ import annotations
+
 import json
+import math
+import os
+import queue
+import re
+import struct
 import threading
+import time
+from array import array
 
-from device import _MappingDB
+from rclpy.node import Node
+from std_msgs.msg import UInt8MultiArray
+from nav_msgs.msg import Odometry
+from sensor_msgs.msg import PointCloud2
+
+from device import _MappingDB, _BEST_EFFORT
 
 
+def _is_finite(value) -> bool:
+    try:
+        return math.isfinite(float(value))
+    except Exception:
+        return False
+
+
+class ControlledSpatialMapNode:
+    """Publishes a monitor-friendly map snapshot for the controlled spatial card."""
+
+    np = None
+
+    VOXEL_SIZE = 0.06
+    MAP_PUBLISH_INTERVAL = 0.15
+    CLOUD_SNAPSHOT_INTERVAL = 0.50
+    META_PUBLISH_INTERVAL = 1.0
+    MAX_SEND_POINTS = 16000
+    DYNAMIC_MIN_HITS = 2
+    VIEW_GUARD_EXTENT = 300.0
+
+    def __init__(
+        self,
+        topic: str,
+        db: _MappingDB,
+        cloud_dir: str,
+        ros2,
+        odometry_topic: str,
+        pointcloud_topic: str,
+    ):
+        import numpy as np
+
+        ControlledSpatialMapNode.np = np
+        os.makedirs(cloud_dir, exist_ok=True)
+
+        self._node = Node("t800_controlled_spatial_map", context=ros2.ctx_robot)
+        ros2.executor_robot.add_node(self._node)
+        self._pub = self._node.create_publisher(UInt8MultiArray, topic, 10)
+        self._topic = topic
+        self._db = db
+        self._cloud_dir = cloud_dir
+
+        # --- state ---
+        self._current_pose: dict | None = None
+        self._map_status = "idle"
+        self._active_map: str | None = None
+        self._point_source = "none"
+        self._lock = threading.Lock()
+
+        # --- voxel buffer ---
+        self._map_buffer: dict[tuple, tuple] = {}
+        self._pending_voxel_hits: dict[tuple, int] = {}
+        self._map_buffer_lock = threading.Lock()
+        self._map_buffer_dirty = False
+        self._map_buffer_revision = 0
+        self._render_cloud_points = np.zeros((0, 3), dtype=np.float32)
+        self._render_cloud_revision = -1
+        self._last_cloud_snapshot_time = 0.0
+        self._MAX_BUFFER_SIZE = 200000
+        self._MAX_PENDING_VOXELS = 300000
+
+        # --- cloud back-pressure queue + worker ---
+        self._cloud_queue: queue.Queue = queue.Queue(maxsize=1)
+        self._running = True
+        self._closing = threading.Event()
+        self._publish_lock = threading.Lock()
+        self._last_map_publish_time = 0.0
+        self._last_meta_publish_time = 0.0
+        self._last_fallback_log_time = 0.0
+        self._cached_maps: list[dict] = []
+        self._cloud_log_counter = 0
+
+        self._worker = threading.Thread(
+            target=self._cloud_processor_loop,
+            daemon=True,
+            name="t800_controlled_spatial_cloud",
+        )
+        self._worker.start()
+
+        # --- ROS2 subscriptions ---
+        self._odom_sub = self._node.create_subscription(
+            Odometry, odometry_topic, self._on_odometry, _BEST_EFFORT
+        )
+        self._cloud_sub = self._node.create_subscription(
+            PointCloud2, pointcloud_topic, self._on_pointcloud, _BEST_EFFORT
+        )
+
+        # --- fallback heartbeat timer ---
+        self._publish_timer = self._node.create_timer(0.5, self._periodic_publish)
+
+        print(
+            f"[ControlledSpatialMapNode] ready topic={topic} "
+            f"odom={odometry_topic} cloud={pointcloud_topic}",
+            flush=True,
+        )
+
+    # ------------------------------------------------------------------
+    # lifecycle
+    # ------------------------------------------------------------------
+    @property
+    def node(self):
+        return self._node
+
+    def stop(self):
+        if self._closing.is_set():
+            return
+        self._closing.set()
+        self._running = False
+        try:
+            self._publish_timer.cancel()
+        except Exception:
+            pass
+        try:
+            self._worker.join(timeout=2)
+        except Exception:
+            pass
+        try:
+            with self._publish_lock:
+                self._node.destroy_node()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # pose / status accessors
+    # ------------------------------------------------------------------
+    def update_pose(self, pose: dict, map_status: str | None = None):
+        previous = self.get_map_status()
+        with self._lock:
+            self._current_pose = dict(pose)
+            if map_status is not None:
+                self._map_status = map_status
+        status_changed = map_status is not None and previous != map_status
+        if status_changed:
+            if previous != "mapping" and map_status == "mapping":
+                self.clear_map_buffer(publish=False)
+            self.publish_now(force=True)
+        else:
+            self._maybe_publish_full_map()
+
+    def set_active_map(self, name: str | None):
+        with self._lock:
+            self._active_map = name
+        self.publish_now(force=True)
+
+    def set_active_map_info(
+        self,
+        name: str | None,
+        pcd_path: str | None = None,
+        cloud_path: str | None = None,
+        load_cached: bool = False,
+        clear_for_new: bool = False,
+    ):
+        with self._lock:
+            self._active_map = name
+            if clear_for_new or not self._map_buffer:
+                self._point_source = "none"
+        if clear_for_new:
+            self.clear_map_buffer(publish=False)
+        self.publish_now(force=True)
+
+    def get_active_map(self) -> str | None:
+        with self._lock:
+            return self._active_map
+
+    def set_map_status(self, status: str):
+        previous = self.get_map_status()
+        with self._lock:
+            self._map_status = status
+        if previous == status:
+            self._maybe_publish_full_map()
+            return
+        if previous != "mapping" and status == "mapping":
+            self.clear_map_buffer(publish=False)
+        self.publish_now(force=True)
+
+    def get_map_status(self) -> str:
+        with self._lock:
+            return self._map_status
+
+    # ------------------------------------------------------------------
+    # buffer management
+    # ------------------------------------------------------------------
+    def clear_map_buffer(self, publish: bool = True):
+        np = ControlledSpatialMapNode.np
+        with self._map_buffer_lock:
+            self._map_buffer.clear()
+            self._pending_voxel_hits.clear()
+            self._map_buffer_dirty = False
+            self._map_buffer_revision += 1
+            self._render_cloud_points = np.zeros((0, 3), dtype=np.float32)
+            self._render_cloud_revision = self._map_buffer_revision
+        with self._lock:
+            self._point_source = "none"
+        if publish:
+            self.publish_now(force=True)
+
+    def load_pcd_to_buffer(self, pcd_path: str) -> bool:
+        np = ControlledSpatialMapNode.np
+        with self._map_buffer_lock:
+            self._map_buffer.clear()
+            self._pending_voxel_hits.clear()
+            self._map_buffer_revision += 1
+            self._render_cloud_points = np.zeros((0, 3), dtype=np.float32)
+            self._render_cloud_revision = self._map_buffer_revision
+
+        points = self._parse_pcd(pcd_path)
+        if points is None or len(points) == 0:
+            print(f"[ControlledSpatialMapNode] PCD not found or empty: {pcd_path}", flush=True)
+            self.publish_now(force=True)
+            return False
+
+        self._replace_buffer_from_points(points)
+        print(f"[ControlledSpatialMapNode] loaded {len(points)} PCD points from {pcd_path}", flush=True)
+        with self._lock:
+            self._point_source = "local_pcd"
+        self.publish_now(force=True)
+        return True
+
+    def _replace_buffer_from_points(self, points):
+        np = ControlledSpatialMapNode.np
+        voxel_size = self.VOXEL_SIZE
+        with self._map_buffer_lock:
+            self._map_buffer.clear()
+            self._pending_voxel_hits.clear()
+            for i in range(len(points)):
+                ix = int(points[i, 0] / voxel_size)
+                iy = int(points[i, 1] / voxel_size)
+                iz = int(points[i, 2] / voxel_size)
+                self._map_buffer[(ix, iy, iz)] = (
+                    float(points[i, 0]),
+                    float(points[i, 1]),
+                    float(points[i, 2]),
+                )
+            self._map_buffer_dirty = False
+            self._map_buffer_revision += 1
+            self._render_cloud_points = np.zeros((0, 3), dtype=np.float32)
+            self._render_cloud_revision = -1
+
+    # ------------------------------------------------------------------
+    # ROS2 callbacks
+    # ------------------------------------------------------------------
+    def _on_odometry(self, msg: Odometry):
+        try:
+            pos = msg.pose.pose.position
+            ori = msg.pose.pose.orientation
+            yaw = math.atan2(
+                2 * (ori.w * ori.z + ori.x * ori.y),
+                1 - 2 * (ori.y * ori.y + ori.z * ori.z),
+            )
+            with self._lock:
+                self._current_pose = {"x": float(pos.x), "y": float(pos.y), "yaw": yaw}
+        except Exception as e:
+            if not self._closing.is_set():
+                print(f"[ControlledSpatialMapNode] odometry callback error: {e}", flush=True)
+
+    def _on_pointcloud(self, msg: PointCloud2):
+        try:
+            data = bytes(msg.data)
+            if len(data) < msg.point_step:
+                return
+            total = msg.width * msg.height
+            self._enqueue_cloud(msg.fields, msg.point_step, total, data)
+        except Exception:
+            pass
+
+    def _enqueue_cloud(self, fields, point_step: int, total: int, data: bytes):
+        item = (fields, point_step, total, data)
+        try:
+            self._cloud_queue.put_nowait(item)
+            return
+        except queue.Full:
+            pass
+        try:
+            self._cloud_queue.get_nowait()
+        except Exception:
+            pass
+        try:
+            self._cloud_queue.put_nowait(item)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # cloud worker
+    # ------------------------------------------------------------------
+    def _cloud_processor_loop(self):
+        np = ControlledSpatialMapNode.np
+        while self._running:
+            try:
+                fields, point_step, total_points, data = self._cloud_queue.get(timeout=1.0)
+            except Exception:
+                continue
+            if total_points == 0:
+                continue
+
+            with self._lock:
+                status = self._map_status
+
+            if status != "mapping":
+                self._cloud_log_counter += 1
+                if self._cloud_log_counter < 5 or self._cloud_log_counter % 100 == 0:
+                    print(
+                        f"[ControlledSpatialMapNode] cloud ignored pts={total_points} "
+                        f"status={status} (#{self._cloud_log_counter})",
+                        flush=True,
+                    )
+                continue
+
+            self._cloud_log_counter += 1
+            if self._cloud_log_counter < 5 or self._cloud_log_counter % 100 == 0:
+                print(
+                    f"[ControlledSpatialMapNode] cloud pts={total_points} "
+                    f"status={status} buffer={len(self._map_buffer)} "
+                    f"(#{self._cloud_log_counter})",
+                    flush=True,
+                )
+
+            # --- parse xyz from PointCloud2 row layout ---
+            field_map = {f.name: f.offset for f in fields}
+            x_off = field_map.get("x", 0)
+            y_off = field_map.get("y", 4)
+            z_off = field_map.get("z", 8)
+            num_points = min(total_points, 20000)
+            if len(data) < num_points * point_step:
+                num_points = len(data) // point_step
+            if num_points == 0:
+                continue
+
+            raw = np.frombuffer(data, dtype=np.uint8, count=num_points * point_step)
+            raw = raw.reshape(num_points, point_step)
+            x = raw[:, x_off : x_off + 4].view(np.float32).ravel()
+            y = raw[:, y_off : y_off + 4].view(np.float32).ravel()
+            z = raw[:, z_off : z_off + 4].view(np.float32).ravel()
+
+            valid = (
+                np.isfinite(x)
+                & np.isfinite(y)
+                & np.isfinite(z)
+                & (np.abs(x) < 50)
+                & (np.abs(y) < 50)
+                & (np.abs(z) < 20)
+            )
+            pts = np.column_stack([x[valid], y[valid], z[valid]]).astype(np.float32)
+            if len(pts) == 0:
+                continue
+
+            # --- voxelize with dynamic hit threshold ---
+            voxel_size = self.VOXEL_SIZE
+            ix = (pts[:, 0] / voxel_size).astype(np.int32)
+            iy = (pts[:, 1] / voxel_size).astype(np.int32)
+            iz = (pts[:, 2] / voxel_size).astype(np.int32)
+
+            frame_voxels: dict[tuple, tuple] = {}
+            for j in range(len(pts)):
+                frame_voxels[(int(ix[j]), int(iy[j]), int(iz[j]))] = (
+                    float(pts[j, 0]),
+                    float(pts[j, 1]),
+                    float(pts[j, 2]),
+                )
+
+            with self._map_buffer_lock:
+                prev_size = len(self._map_buffer)
+                for key, point in frame_voxels.items():
+                    if key in self._map_buffer:
+                        self._map_buffer[key] = point
+                        continue
+                    hits = self._pending_voxel_hits.get(key, 0) + 1
+                    if hits >= self.DYNAMIC_MIN_HITS:
+                        self._map_buffer[key] = point
+                        self._pending_voxel_hits.pop(key, None)
+                    else:
+                        self._pending_voxel_hits[key] = hits
+                new_size = len(self._map_buffer)
+                if new_size > prev_size:
+                    self._map_buffer_dirty = True
+                if len(self._pending_voxel_hits) > self._MAX_PENDING_VOXELS:
+                    pending_keys = list(self._pending_voxel_hits.keys())
+                    for k in pending_keys[: len(pending_keys) // 2]:
+                        self._pending_voxel_hits.pop(k, None)
+                if len(self._map_buffer) > self._MAX_BUFFER_SIZE:
+                    keys = list(self._map_buffer.keys())
+                    for k in keys[: len(keys) // 2]:
+                        del self._map_buffer[k]
+                    new_size = len(self._map_buffer)
+                    self._map_buffer_dirty = True
+                if frame_voxels:
+                    self._map_buffer_revision += 1
+
+            with self._lock:
+                self._point_source = "live"
+
+            if self._cloud_log_counter < 5 or self._cloud_log_counter % 100 == 0:
+                print(
+                    f"[ControlledSpatialMapNode] buffer valid={len(pts)} "
+                    f"voxels={len(frame_voxels)} +{max(0, new_size - prev_size)} "
+                    f"total={new_size}",
+                    flush=True,
+                )
+            self._maybe_publish_full_map()
+
+    # ------------------------------------------------------------------
+    # publish
+    # ------------------------------------------------------------------
+    def _maybe_publish_full_map(self):
+        now = time.monotonic()
+        if now - self._last_map_publish_time < self.MAP_PUBLISH_INTERVAL:
+            return
+        self._last_map_publish_time = now
+        with self._map_buffer_lock:
+            has_cloud_points = bool(self._map_buffer)
+        self.publish_now(force=not has_cloud_points, force_meta=False)
+
+    def _get_render_cloud_points(self):
+        np = ControlledSpatialMapNode.np
+        now = time.monotonic()
+        with self._map_buffer_lock:
+            revision = self._map_buffer_revision
+            refresh_due = now - self._last_cloud_snapshot_time >= self.CLOUD_SNAPSHOT_INTERVAL
+            needs_snapshot = (
+                revision != self._render_cloud_revision
+                and (refresh_due or len(self._render_cloud_points) == 0)
+            )
+            if not needs_snapshot:
+                return self._render_cloud_points
+            values = list(self._map_buffer.values())
+
+        points = (
+            np.array(values, dtype=np.float32)
+            if values
+            else np.zeros((0, 3), dtype=np.float32)
+        )
+        if len(points) > self.MAX_SEND_POINTS:
+            step = max(1, math.ceil(len(points) / self.MAX_SEND_POINTS))
+            points = points[::step][: self.MAX_SEND_POINTS]
+
+        with self._map_buffer_lock:
+            self._render_cloud_points = points
+            self._render_cloud_revision = revision
+            self._last_cloud_snapshot_time = now
+        return points
+
+    def publish_now(self, force: bool = False, force_meta: bool | None = None):
+        if self._closing.is_set():
+            return
+        np = ControlledSpatialMapNode.np
+        now = time.monotonic()
+        include_meta = (
+            (force if force_meta is None else force_meta)
+            or now - self._last_meta_publish_time >= self.META_PUBLISH_INTERVAL
+        )
+        with self._lock:
+            pose = dict(self._current_pose) if self._current_pose else None
+            active_map = self._active_map
+            map_status = self._map_status
+            point_source = self._point_source
+
+        map_pts = self._get_render_cloud_points()
+        if len(map_pts) == 0 and not force:
+            return
+
+        # --- metadata (maps + tags) ---
+        if include_meta:
+            try:
+                maps = self._db.list_maps_with_pois()
+                self._cached_maps = maps
+                self._last_meta_publish_time = now
+            except Exception as e:
+                print(f"[ControlledSpatialMapNode] failed to read map metadata: {e}", flush=True)
+                maps = self._cached_maps
+        else:
+            maps = self._cached_maps
+
+        # T800 _MappingDB.list_maps_with_pois returns tags as name-list only;
+        # fetch full POI records for the active map so overlay geometry works.
+        active_tags: list[dict] = []
+        if active_map:
+            try:
+                active_tags = self._db.list_pois(active_map)
+            except Exception:
+                active_tags = []
+
+        overlay_points = self._build_tag_overlay_points(active_tags)
+        guard_points = self._build_view_guard_points()
+        has_cloud_points = bool(len(map_pts))
+
+        if not has_cloud_points:
+            fallback_points = self._build_fallback_points(maps, active_map, pose, active_tags)
+            if point_source == "none":
+                point_source = "fallback"
+            now = time.monotonic()
+            if now - self._last_fallback_log_time > 10:
+                self._last_fallback_log_time = now
+                print(
+                    f"[ControlledSpatialMapNode] fallback skeleton points={len(fallback_points)} "
+                    f"tags={len(active_tags)} active_map={active_map}",
+                    flush=True,
+                )
+            map_pts = np.array(fallback_points, dtype=np.float32)
+
+        overlay_pts = (
+            np.array(overlay_points, dtype=np.float32)
+            if has_cloud_points and overlay_points
+            else np.zeros((0, 3), dtype=np.float32)
+        )
+        guard_pts = np.array(guard_points, dtype=np.float32)
+        map_point_count = len(map_pts)
+        overlay_point_count = len(overlay_pts)
+        max_map_points = max(0, self.MAX_SEND_POINTS - overlay_point_count - len(guard_pts))
+        if max_map_points == 0:
+            map_pts = np.zeros((0, 3), dtype=np.float32)
+        elif len(map_pts) > max_map_points:
+            # Stable stride sampling avoids shimmer and per-frame random-index alloc.
+            step = max(1, math.ceil(len(map_pts) / max_map_points))
+            map_pts = map_pts[::step][:max_map_points]
+
+        publish_parts = [map_pts]
+        if overlay_point_count:
+            publish_parts.append(overlay_pts)
+        publish_parts.append(guard_pts)
+        pts = np.vstack(publish_parts)
+        num_points = len(pts)
+
+        robot_x = float(pose["x"]) if pose else 0.0
+        robot_y = float(pose["y"]) if pose else 0.0
+        slam_yaw = float(pose["yaw"]) if pose else 0.0
+        # Frontend renderer maps SLAM +Y to Three.js -Z and applies a second
+        # negative rotation; send the display-frame yaw here while metadata
+        # keeps the original SLAM value for map/tag semantics.
+        robot_yaw = -slam_yaw
+
+        meta_bytes = b""
+        if include_meta:
+            meta = {
+                "version": 3,
+                "active_map": active_map,
+                "map_status": map_status,
+                "native_pcd_path": None,
+                "local_pcd_available": False,
+                "point_source": point_source,
+                "robot": {
+                    "x": robot_x,
+                    "y": robot_y,
+                    "yaw": slam_yaw,
+                    "pose_available": pose is not None,
+                },
+                "maps": maps,
+                "tags": active_tags,
+                "map_points": map_point_count,
+                "tag_overlay_points": overlay_point_count,
+                "view_guard_points": len(guard_pts),
+            }
+            meta_bytes = json.dumps(meta, ensure_ascii=False).encode("utf-8")
+
+        # v3 binary: header (3xf32 + u8 flags + u32 count) + points + optional meta
+        flags = 0x03 | (0x04 if include_meta else 0)
+        payload = (
+            struct.pack("<fffBI", robot_x, robot_y, robot_yaw, flags, num_points)
+            + pts.tobytes()
+        )
+        if include_meta:
+            payload += struct.pack("<I", len(meta_bytes)) + meta_bytes
+
+        with self._publish_lock:
+            if self._closing.is_set():
+                return
+            ros_msg = UInt8MultiArray()
+            try:
+                ros_msg.data = array("B", payload)
+            except TypeError:
+                ros_msg.data = list(payload)
+            try:
+                self._pub.publish(ros_msg)
+            except Exception as e:
+                if not self._closing.is_set():
+                    print(f"[ControlledSpatialMapNode] map publish skipped: {e}", flush=True)
+
+    # ------------------------------------------------------------------
+    # geometry builders
+    # ------------------------------------------------------------------
+    def _build_fallback_points(
+        self,
+        maps: list[dict],
+        active_map: str | None,
+        pose: dict | None,
+        active_tags: list[dict] | None = None,
+    ) -> list[tuple]:
+        """Ground cross + border skeleton so an empty map is still visible."""
+        points: list[tuple] = []
+        tags = active_tags or []
+        if not tags and active_map:
+            try:
+                tags = self._db.list_pois(active_map)
+            except Exception:
+                tags = []
+
+        xs = [float(t["x"]) for t in tags if _is_finite(t.get("x"))]
+        ys = [float(t["y"]) for t in tags if _is_finite(t.get("y"))]
+        if pose:
+            xs.append(float(pose.get("x", 0.0)))
+            ys.append(float(pose.get("y", 0.0)))
+
+        max_extent = 3.0
+        if xs and ys:
+            max_extent = max(max(abs(x) for x in xs), max(abs(y) for y in ys), 3.0) + 1.0
+        max_extent = min(max_extent, 20.0)
+        step = 0.25
+        n = int((2 * max_extent) / step) + 1
+
+        for i in range(n):
+            v = -max_extent + i * step
+            points.append((v, 0.0, -0.04))
+            points.append((0.0, v, -0.04))
+            if i % 2 == 0:
+                points.append((v, -max_extent, -0.05))
+                points.append((v, max_extent, -0.05))
+                points.append((-max_extent, v, -0.05))
+                points.append((max_extent, v, -0.05))
+
+        points.extend(self._build_tag_overlay_points(tags))
+        return points
+
+    def _build_tag_overlay_points(self, tags: list[dict]) -> list[tuple]:
+        """Dense beacon geometry that survives the unchanged point-cloud renderer."""
+        points: list[tuple] = []
+        for tag in tags:
+            if not _is_finite(tag.get("x")) or not _is_finite(tag.get("y")):
+                continue
+            x = float(tag["x"])
+            y = float(tag["y"])
+            yaw = float(tag.get("yaw") or 0.0)
+
+            # 3 concentric rings
+            radii = (0.10, 0.18, 0.28)
+            for radius in radii:
+                for k in range(48):
+                    a = 2.0 * math.pi * k / 48
+                    points.append((x + math.cos(a) * radius, y + math.sin(a) * radius, 0.18))
+            # vertical pillar (center + cross, 28 layers)
+            for k in range(28):
+                z = 0.08 + k * 0.07
+                points.append((x, y, z))
+                points.append((x + 0.12, y, z))
+                points.append((x - 0.12, y, z))
+                points.append((x, y + 0.12, z))
+                points.append((x, y - 0.12, z))
+            # direction arrow shaft
+            for k in range(22):
+                d = 0.08 + k * 0.05
+                hx = x + math.cos(yaw) * d
+                hy = y + math.sin(yaw) * d
+                points.append((hx, hy, 0.55))
+                points.append((hx, hy, 0.75))
+            # arrow head
+            arrow_x = x + math.cos(yaw) * 1.1
+            arrow_y = y + math.sin(yaw) * 1.1
+            left = yaw + 2.55
+            right = yaw - 2.55
+            for k in range(10):
+                d = 0.04 * k
+                points.append((arrow_x + math.cos(left) * d, arrow_y + math.sin(left) * d, 0.65))
+                points.append((arrow_x + math.cos(right) * d, arrow_y + math.sin(right) * d, 0.65))
+        return points
+
+    def _build_view_guard_points(self) -> list[tuple]:
+        """Remote points so the renderer's cached bounding sphere covers pan/zoom."""
+        extent = self.VIEW_GUARD_EXTENT
+        z = -0.02
+        return [
+            (-extent, -extent, z),
+            (-extent, extent, z),
+            (extent, -extent, z),
+            (extent, extent, z),
+            (-extent, 0.0, z),
+            (extent, 0.0, z),
+            (0.0, -extent, z),
+            (0.0, extent, z),
+        ]
+
+    def _periodic_publish(self):
+        self._maybe_publish_full_map()
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _cloud_path_for_map(self, map_name: str) -> str:
+        safe_name = re.sub(r"[^A-Za-z0-9_.-]+", "_", map_name).strip("._")
+        if not safe_name:
+            safe_name = "map"
+        return os.path.join(self._cloud_dir, f"{safe_name}.npz")
+
+    @staticmethod
+    def _parse_pcd(path: str):
+        np = ControlledSpatialMapNode.np
+        if not os.path.exists(path):
+            return None
+        try:
+            with open(path, "rb") as f:
+                header_lines = []
+                while True:
+                    line = f.readline()
+                    if not line:
+                        return None
+                    line_str = line.decode("ascii", errors="ignore").strip()
+                    header_lines.append(line_str)
+                    if line_str.startswith("DATA"):
+                        break
+
+                fields = []
+                field_sizes = []
+                num_points = 0
+                data_type = "ascii"
+                for hl in header_lines:
+                    parts = hl.split()
+                    if not parts:
+                        continue
+                    if parts[0] == "FIELDS":
+                        fields = parts[1:]
+                    elif parts[0] == "SIZE":
+                        field_sizes = [int(s) for s in parts[1:]]
+                    elif parts[0] == "POINTS":
+                        num_points = int(parts[1])
+                    elif parts[0] == "DATA":
+                        data_type = parts[1].lower()
+                if num_points == 0:
+                    return None
+                try:
+                    xi, yi, zi = fields.index("x"), fields.index("y"), fields.index("z")
+                except ValueError:
+                    return None
+
+                if data_type == "ascii":
+                    points = []
+                    for _ in range(num_points):
+                        line = f.readline().decode("ascii", errors="ignore").strip()
+                        vals = line.split()
+                        if len(vals) <= max(xi, yi, zi):
+                            continue
+                        x, y, z = float(vals[xi]), float(vals[yi]), float(vals[zi])
+                        if x == x and y == y and z == z:
+                            points.append((x, y, z))
+                    return np.array(points, dtype=np.float32) if points else None
+
+                if data_type == "binary":
+                    point_size = sum(field_sizes)
+                    raw = f.read(num_points * point_size)
+                    if len(raw) < num_points * point_size:
+                        num_points = len(raw) // point_size
+                    offsets = [0]
+                    for size in field_sizes[:-1]:
+                        offsets.append(offsets[-1] + size)
+                    x_off, y_off, z_off = offsets[xi], offsets[yi], offsets[zi]
+                    points = np.zeros((num_points, 3), dtype=np.float32)
+                    for i in range(num_points):
+                        base = i * point_size
+                        points[i, 0] = struct.unpack_from("<f", raw, base + x_off)[0]
+                        points[i, 1] = struct.unpack_from("<f", raw, base + y_off)[0]
+                        points[i, 2] = struct.unpack_from("<f", raw, base + z_off)[0]
+                    valid = ~np.isnan(points).any(axis=1)
+                    return points[valid]
+        except Exception as e:
+            print(f"[ControlledSpatialMapNode] failed to parse PCD {path}: {e}", flush=True)
+        return None
+
+
+# ======================================================================
+# MCP sensor plugin
+# ======================================================================
 class ControlledSpatialMapPlugin:
+    """Read-only sensor plugin for viewing controlled_spatial maps on T800."""
+
     PREFIX = "controlled_spatial_map"
 
-    def __init__(self, plugin_config: dict, namespace: str, executor, *_, **__):
+    def __init__(self, plugin_config: dict, namespace: str, ros2, *_, **__):
+        self._map_topic = f"/{namespace}/controlled_spatial/map"
         db_path = plugin_config.get("db_path", "/opt/phanthy-motus/data/mapping.db")
         self._cloud_dir = plugin_config.get(
             "cloud_dir", "/opt/phanthy-motus/data/controlled_spatial_clouds"
         )
-        self._map_topic = f"/{namespace}/controlled_spatial/map"
+        odometry_topic = plugin_config.get(
+            "odometry_topic", "/manifold/ODIN2/device0/odometry"
+        )
+        pointcloud_topic = plugin_config.get(
+            "pointcloud_topic", "/manifold/ODIN2/device0/cloud/slam"
+        )
+
         self._db = None
+        self._map_node = None
         self._startup_error = None
         self._last_selected_map = None
 
         try:
             self._db = _MappingDB(db_path)
-        except Exception as exc:
-            self._startup_error = str(exc)
-            print(f"[ControlledSpatialMap] startup degraded: {exc}", flush=True)
+            self._map_node = ControlledSpatialMapNode(
+                self._map_topic,
+                self._db,
+                self._cloud_dir,
+                ros2,
+                odometry_topic,
+                pointcloud_topic,
+            )
+            self._sync_from_db(force=True)
+        except Exception as e:
+            self._startup_error = str(e)
+            print(f"[ControlledSpatialMap] startup degraded: {e}", flush=True)
             try:
                 import traceback
+
                 traceback.print_exc()
             except Exception:
                 pass
+            return
 
         print(f"[ControlledSpatialMap] plugin ready, topic: {self._map_topic}", flush=True)
 
+    # ------------------------------------------------------------------
+    # tool schema
+    # ------------------------------------------------------------------
     def get_tool(self) -> dict:
         return {
             "name": self.PREFIX,
             "type": "sensor",
             "multiInstance": False,
-            "description": "Controlled spatial map view — saved maps, tags, live robot pose, and SLAM point cloud when available.",
+            "description": (
+                "Controlled spatial map view — saved maps, tags, live robot pose, "
+                "and SLAM point cloud when available."
+            ),
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -45,7 +858,10 @@ class ControlledSpatialMapPlugin:
                         "enum": ["start", "stop", "info", "refresh", "select_map", "list_maps"],
                         "description": "Optional map-view control action",
                     },
-                    "map_name": {"type": "string", "description": "Map name for select_map"},
+                    "map_name": {
+                        "type": "string",
+                        "description": "Map name for select_map",
+                    },
                     "overwrite": {"type": "boolean"},
                 },
             },
@@ -55,14 +871,27 @@ class ControlledSpatialMapPlugin:
     def get_tools(self) -> list:
         return [self.get_tool()]
 
+    # ------------------------------------------------------------------
+    # lifecycle
+    # ------------------------------------------------------------------
     def start(self):
-        pass
+        if not self._map_node:
+            return
+        self._sync_from_db(force=True)
+        self._map_node.publish_now(force=True)
 
     def stop(self):
-        pass
+        if self._map_node:
+            self._map_node.stop()
 
+    # ------------------------------------------------------------------
+    # dispatch
+    # ------------------------------------------------------------------
     def dispatch(self, action: str, args: dict) -> dict | None:
         if action in (self.PREFIX, "start", "refresh"):
+            if self._map_node:
+                self._sync_from_db(force=True)
+                self._map_node.publish_now(force=True)
             return self._info("ready")
         if action == "stop":
             return self._info("idle")
@@ -74,57 +903,106 @@ class ControlledSpatialMapPlugin:
             return self._select_map(args.get("map_name", ""))
         return None
 
+    # ------------------------------------------------------------------
+    # action handlers
+    # ------------------------------------------------------------------
     def _info(self, state: str) -> dict:
         maps = []
-        active_map = None
         if self._db:
             try:
                 maps = self._db.list_maps_with_pois()
-                active_map = self._db.get_state("active_map")
             except Exception:
                 maps = []
-                active_map = None
         return {
             "state": state if not self._startup_error else "degraded",
             "topic_out": [{"topic": self._map_topic, "format": "sensor/mapping"}],
-            "active_map": active_map,
+            "active_map": self._map_node.get_active_map() if self._map_node else None,
             "cloud_dir": self._cloud_dir,
             "map_count": len(maps),
             "startup_error": self._startup_error,
         }
 
     def _list_maps(self) -> dict:
-        if self._db is None:
+        if not self._db:
             return self._info("degraded")
         try:
             maps = self._db.list_maps_with_pois()
-            active_map = self._db.get_state("active_map")
-            return {
-                "maps": maps,
-                "active_map": active_map,
-                "cloud_dir": self._cloud_dir,
-                "map_count": len(maps),
-            }
-        except Exception as exc:
-            return {"error": f"failed to read maps: {exc}"}
+        except Exception as e:
+            return {"error": f"failed to read maps: {e}"}
+        return {
+            "maps": maps,
+            "active_map": self._map_node.get_active_map() if self._map_node else None,
+            "cloud_dir": self._cloud_dir,
+            "map_count": len(maps),
+        }
 
     def _select_map(self, map_name: str) -> dict:
+        if not self._db or not self._map_node:
+            return self._info("degraded")
         if not map_name:
             return {"error": "map_name is required"}
-        if self._db is None:
-            return self._info("degraded")
         try:
             maps = self._db.list_maps_with_pois()
-        except Exception as exc:
-            return {"error": f"failed to read maps: {exc}"}
+        except Exception as e:
+            return {"error": f"failed to read maps: {e}"}
+        found = next((m for m in maps if m.get("name") == map_name), None)
+        if not found:
+            return {
+                "error": f"Map '{map_name}' not found",
+                "maps": [m.get("name") for m in maps],
+            }
 
-        map_names = [item["name"] for item in maps]
-        if map_name not in map_names:
-            return {"error": "Map not found", "maps": map_names}
+        status = self._db.get_state("map_status") or self._map_node.get_map_status()
+        db_active = self._db.get_state("active_map")
+        if status == "mapping" and db_active and db_active != map_name:
+            return {
+                "error": "Cannot select another map while recording mapping cloud",
+                "active_map": db_active,
+                "map_status": status,
+            }
 
         self._last_selected_map = map_name
+        self._map_node.set_active_map_info(
+            found.get("name"),
+            found.get("pcd_path"),
+            load_cached=False,
+        )
+        # Best-effort PCD preview; failure is non-fatal.
+        pcd_path = found.get("pcd_path", "")
+        if pcd_path:
+            self._map_node.load_pcd_to_buffer(pcd_path)
         return self._info("selected")
 
+    def _sync_from_db(self, force: bool = False) -> None:
+        if not self._db or not self._map_node:
+            return
+        try:
+            maps = self._db.list_maps_with_pois()
+            status = self._db.get_state("map_status") or self._map_node.get_map_status()
+            db_active = self._db.get_state("active_map")
+            desired = self._last_selected_map or db_active
+            if status == "mapping" and db_active:
+                desired = db_active
+                self._last_selected_map = None
+            if desired and not any(m.get("name") == desired for m in maps):
+                desired = None
+            if not desired and maps:
+                desired = maps[0].get("name")
+            if desired:
+                selected = next((m for m in maps if m.get("name") == desired), None)
+                active_changed = self._map_node.get_active_map() != desired
+                if selected and (force or active_changed):
+                    self._map_node.set_active_map_info(
+                        selected.get("name"),
+                        selected.get("pcd_path"),
+                        load_cached=False,
+                        clear_for_new=status == "mapping" and active_changed,
+                    )
+            if status:
+                self._map_node.set_map_status(status)
+        except Exception as e:
+            print(f"[ControlledSpatialMap] DB sync skipped: {e}", flush=True)
 
-def make_plugin(plugin_config, namespace, executor, client=None):
-    return ControlledSpatialMapPlugin(plugin_config, namespace, executor)
+
+def make_plugin(plugin_config, namespace, ros2, client=None):
+    return ControlledSpatialMapPlugin(plugin_config, namespace, ros2)

--- a/engineai/t800/deploy/service.yml
+++ b/engineai/t800/deploy/service.yml
@@ -7,6 +7,7 @@ engineai-t800:
   privileged: true
   volumes:
     - /dev:/dev
+    - /opt/phanthy-motus/data:/opt/phanthy-motus/data
     - ${T800_NATIVE_SDK_DIR:-/opt/engineai/native_sdk}:/opt/engineai/native_sdk
     # T800 厂商 PulseAudio 已独占机身麦克风，mic 通过宿主音频服务采集。
     - ${T800_PULSE_RUNTIME_DIR:-/run/user/1000/pulse}:/run/user/1000/pulse

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -3647,6 +3647,7 @@ class MappingPlugin:
                 },
                 {
                     "map_name": {"type": "string", "description": "地图名称"},
+                    "name": {"type": "string", "description": "标记名称"},
                     "description": {"type": "string", "description": "标记描述（可选）"},
                 },
                 "建图动作",

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import json
 import math
 import numbers
+import os
+import sqlite3
 import subprocess
 import threading
 import time
@@ -18,9 +20,18 @@ from collections import deque
 from dataclasses import asdict
 from pathlib import Path
 
+import numpy as np
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
 from std_msgs.msg import String
+
+# Open3D is optional; fall back to numpy-only PCD writing when unavailable.
+try:
+    import open3d as o3d
+
+    _HAS_OPEN3D = True
+except ImportError:
+    _HAS_OPEN3D = False
 
 from control import (
     LED_MODES,
@@ -3419,3 +3430,706 @@ class VisionPlugin:
                 self._source = source
             return {"state": "running" if self._running else "idle", "source": source}
         return {"error": f"unknown vision action: {action}"}
+
+
+# ── Mapping (Odin2 odometry + point cloud) ───────────────────────────────────
+
+class _MappingDB:
+    """SQLite storage for saved maps (name, pcd path, point count)."""
+
+    def __init__(self, db_path: str):
+        os.makedirs(os.path.dirname(db_path) if os.path.dirname(db_path) else ".", exist_ok=True)
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._migrate()
+
+    def _migrate(self) -> None:
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS maps (
+                name        TEXT PRIMARY KEY,
+                pcd_path    TEXT NOT NULL,
+                point_count INTEGER DEFAULT 0,
+                created_at  REAL DEFAULT (strftime('%s','now'))
+            );
+            CREATE TABLE IF NOT EXISTS poi (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                name        TEXT NOT NULL,
+                description TEXT DEFAULT '',
+                x           REAL NOT NULL,
+                y           REAL NOT NULL,
+                z           REAL DEFAULT 0,
+                yaw         REAL DEFAULT 0,
+                map_name    TEXT NOT NULL,
+                created_at  REAL DEFAULT (strftime('%s','now')),
+                UNIQUE(name, map_name)
+            );
+            CREATE TABLE IF NOT EXISTS state (
+                key        TEXT PRIMARY KEY,
+                value      TEXT,
+                updated_at REAL DEFAULT (strftime('%s','now'))
+            );
+            """
+        )
+        # Add cloud_path column to maps if missing (legacy DB compatibility)
+        try:
+            self._conn.execute("ALTER TABLE maps ADD COLUMN cloud_path TEXT")
+        except sqlite3.OperationalError:
+            pass  # column already exists
+        self._conn.commit()
+
+    def add_map(self, name: str, pcd_path: str, point_count: int) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO maps (name, pcd_path, point_count) VALUES (?, ?, ?)",
+            (name, pcd_path, point_count),
+        )
+        self._conn.commit()
+
+    def get_map(self, name: str) -> dict | None:
+        row = self._conn.execute("SELECT * FROM maps WHERE name = ?", (name,)).fetchone()
+        return dict(row) if row else None
+
+    def list_maps(self) -> list[dict]:
+        rows = self._conn.execute(
+            "SELECT name, pcd_path, point_count, created_at FROM maps ORDER BY created_at DESC"
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def delete_map(self, name: str) -> bool:
+        map_info = self.get_map(name)
+        if not map_info:
+            return False
+        try:
+            os.remove(map_info["pcd_path"])
+        except OSError:
+            pass
+        self._conn.execute("DELETE FROM maps WHERE name = ?", (name,))
+        self._conn.execute("DELETE FROM poi WHERE map_name = ?", (name,))
+        self._conn.commit()
+        return True
+
+    def add_poi(
+        self,
+        name: str,
+        x: float,
+        y: float,
+        z: float,
+        yaw: float,
+        map_name: str,
+        description: str = "",
+    ) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO poi (name, description, x, y, z, yaw, map_name) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (name, description, x, y, z, yaw, map_name),
+        )
+        self._conn.commit()
+
+    def delete_poi(self, name: str, map_name: str) -> bool:
+        cur = self._conn.execute(
+            "DELETE FROM poi WHERE name = ? AND map_name = ?", (name, map_name)
+        )
+        self._conn.commit()
+        return cur.rowcount > 0
+
+    def list_pois(self, map_name: str) -> list[dict]:
+        rows = self._conn.execute(
+            "SELECT name, description, x, y, z, yaw, map_name, created_at "
+            "FROM poi WHERE map_name = ? ORDER BY name",
+            (map_name,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def find_poi(self, query: str, map_name: str) -> dict | None:
+        row = self._conn.execute(
+            "SELECT name, description, x, y, z, yaw, map_name "
+            "FROM poi WHERE map_name = ? AND name LIKE ?",
+            (map_name, f"%{query}%"),
+        ).fetchone()
+        return dict(row) if row else None
+
+    def set_state(self, key: str, value: str | None) -> None:
+        if value is None:
+            self._conn.execute("DELETE FROM state WHERE key = ?", (key,))
+        else:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO state (key, value, updated_at) "
+                "VALUES (?, ?, strftime('%s','now'))",
+                (key, value),
+            )
+        self._conn.commit()
+
+    def get_state(self, key: str) -> str | None:
+        row = self._conn.execute(
+            "SELECT value FROM state WHERE key = ?", (key,)
+        ).fetchone()
+        return row["value"] if row else None
+
+    def set_cloud_path(self, map_name: str, cloud_path: str) -> None:
+        self._conn.execute(
+            "UPDATE maps SET cloud_path = ? WHERE name = ?", (cloud_path, map_name)
+        )
+        self._conn.commit()
+
+    def list_maps_with_pois(self) -> list[dict]:
+        maps = self.list_maps()
+        for m in maps:
+            m["tags"] = [p["name"] for p in self.list_pois(m["name"])]
+        return maps
+
+
+class MappingPlugin:
+    """Laser point cloud mapping via Odin2 odometry + undistorted point cloud."""
+
+    def __init__(self, plugin_config: dict, namespace: str, ros2):
+        self._config = plugin_config
+        self._ns = namespace
+        self._ros2 = ros2
+
+        self._map_save_dir = plugin_config.get("map_save_dir", "/opt/phanthy-motus/data/maps")
+        db_path = plugin_config.get("db_path", "/opt/phanthy-motus/data/mapping.db")
+        self._voxel_size = float(plugin_config.get("voxel_size", 0.05))
+        self._max_points = int(plugin_config.get("max_points", 5_000_000))
+        self._odometry_topic = plugin_config.get(
+            "odometry_topic", "/manifold/ODIN2/device0/odometry"
+        )
+        self._pointcloud_topic = plugin_config.get(
+            "pointcloud_topic", "/manifold/ODIN2/device0/cloud/slam"
+        )
+
+        self._db = _MappingDB(db_path)
+
+        self._is_mapping = False
+        self._current_map: str | None = None
+        self._active_map: str | None = None  # 当前活动地图（建图中或已加载）
+        self._loaded_points: np.ndarray | None = None  # load_map 加载的点云（可选）
+        self._current_pose: dict | None = None
+        self._global_points: np.ndarray | None = None
+        self._start_time: float | None = None
+        self._frame_count = 0
+        self._lock = threading.Lock()
+
+        self._node = Node("t800_mapping", context=ros2.ctx_robot)
+        ros2.executor_robot.add_node(self._node)
+        self._odom_sub = None
+        self._cloud_sub = None
+
+        self._create_odom_subscription()
+
+        print(
+            f"[mapping] ready (odom={self._odometry_topic}, cloud={self._pointcloud_topic}, "
+            f"open3d={_HAS_OPEN3D})",
+            flush=True,
+        )
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "mapping",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": (
+                "T800 激光点云建图卡片；人工遥控行走时按 Odin2 里程计位姿累积点云，"
+                "生成并保存 .pcd 地图。支持开始/停止/取消建图、状态查询、地图管理、"
+                "语义标记（tag）管理和已保存地图加载。"
+            ),
+            "inputSchema": action_schema(
+                {
+                    "start_mapping": (["map_name"], "开始建图，用遥控器或 loco 控制机器人行走"),
+                    "stop_mapping": ([], "停止建图，体素下采样后保存 .pcd 地图"),
+                    "cancel_mapping": ([], "取消建图，丢弃已累积点云，不保存"),
+                    "mapping_status": ([], "查询当前建图状态、实时位姿和已累积点数"),
+                    "list_maps": ([], "列出所有已保存地图"),
+                    "delete_map": (["map_name"], "删除指定地图及 .pcd 文件"),
+                    "tag_place": (["name", "description"], "在当前位置打语义标记，关联到活动地图"),
+                    "untag_place": (["name"], "删除指定名称的位置标记"),
+                    "list_tags": ([], "列出当前活动地图的所有标记，含相对机器人的距离和方位"),
+                    "load_map": (["map_name"], "加载已保存地图为活动地图（不做重定位，需手动将机器人放置在地图原点附近）"),
+                },
+                {
+                    "map_name": {"type": "string", "description": "地图名称"},
+                    "description": {"type": "string", "description": "标记描述（可选）"},
+                },
+                "建图动作",
+            ),
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        if self._is_mapping:
+            self._destroy_cloud_subscription()
+            print("[mapping] driver shutdown, mapping stopped without saving", flush=True)
+        self._destroy_odom_subscription()
+        try:
+            self._ros2.executor_robot.remove_node(self._node)
+            self._node.destroy_node()
+        except Exception:
+            pass
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("start", "info"):
+            return {"state": "ready"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "start_mapping":
+            return self._start_mapping(args.get("map_name", ""))
+        if action == "stop_mapping":
+            return self._stop_mapping()
+        if action == "cancel_mapping":
+            return self._cancel_mapping()
+        if action == "mapping_status":
+            return self._mapping_status()
+        if action == "list_maps":
+            return self._list_maps()
+        if action == "delete_map":
+            return self._delete_map(args.get("map_name", ""))
+        if action == "tag_place":
+            return self._tag_place(args.get("name", ""), args.get("description", ""))
+        if action == "untag_place":
+            return self._untag_place(args.get("name", ""))
+        if action == "list_tags":
+            return self._list_tags()
+        if action == "load_map":
+            return self._load_map(args.get("map_name", ""))
+        return {"error": f"unknown mapping action: {action}"}
+
+    # ── Action handlers ──────────────────────────────────────────────
+
+    def _start_mapping(self, map_name: str) -> dict:
+        map_name = str(map_name).strip()
+        if not map_name:
+            return {"error": "map_name is required"}
+        with self._lock:
+            if self._is_mapping:
+                return {"error": f"already mapping '{self._current_map}'", "current_map": self._current_map}
+
+        existing = self._db.get_map(map_name)
+        if existing:
+            print(f"[mapping] map '{map_name}' already exists, will overwrite on save", flush=True)
+
+        try:
+            self._create_cloud_subscription()
+        except Exception as exc:
+            return {"error": f"failed to create ROS2 subscriptions: {exc}"}
+
+        with self._lock:
+            self._is_mapping = True
+            self._current_map = map_name
+            self._active_map = map_name
+            self._current_pose = None
+            self._global_points = None
+            self._start_time = time.monotonic()
+            self._frame_count = 0
+
+        print(f"[mapping] started mapping '{map_name}'", flush=True)
+        return {
+            "state": "mapping",
+            "map_name": map_name,
+            "message": "建图已开始，请用 virtual_gamepad 或 loco 控制机器人行走",
+        }
+
+    def _stop_mapping(self) -> dict:
+        with self._lock:
+            if not self._is_mapping:
+                return {"error": "no active mapping session"}
+            map_name = self._current_map
+            start_time = self._start_time
+            points = self._global_points
+
+        self._destroy_cloud_subscription()
+        elapsed = time.monotonic() - start_time if start_time else 0.0
+        result = self._save_map(map_name, points)
+
+        with self._lock:
+            self._is_mapping = False
+            self._current_map = None
+            self._global_points = None
+            self._current_pose = None
+            self._start_time = None
+            self._frame_count = 0
+            # _active_map 保留为 map_name：地图仍处于活动状态，可继续 tag_place
+
+        if "error" in result:
+            print(f"[mapping] save failed for '{map_name}': {result['error']}", flush=True)
+            return result
+
+        result["elapsed_time"] = round(elapsed, 2)
+        print(
+            f"[mapping] saved '{map_name}': {result['point_count']} points "
+            f"({elapsed:.1f}s) -> {result['pcd_path']}",
+            flush=True,
+        )
+        return result
+
+    def _cancel_mapping(self) -> dict:
+        with self._lock:
+            if not self._is_mapping:
+                return {"error": "no active mapping session"}
+            map_name = self._current_map
+
+        self._destroy_cloud_subscription()
+
+        with self._lock:
+            self._is_mapping = False
+            self._current_map = None
+            self._global_points = None
+            self._current_pose = None
+            self._start_time = None
+            self._frame_count = 0
+            self._active_map = None
+
+        print(f"[mapping] cancelled mapping '{map_name}'", flush=True)
+        return {"state": "cancelled", "map_name": map_name}
+
+    def _mapping_status(self) -> dict:
+        with self._lock:
+            active_map = self._active_map
+            if not self._is_mapping:
+                return {"state": "idle", "is_mapping": False, "active_map": active_map}
+            pose = dict(self._current_pose) if self._current_pose else None
+            point_count = int(len(self._global_points)) if self._global_points is not None else 0
+            elapsed = time.monotonic() - self._start_time if self._start_time else 0.0
+            return {
+                "state": "mapping",
+                "is_mapping": True,
+                "current_map": self._current_map,
+                "active_map": active_map,
+                "current_pose": pose,
+                "point_count": point_count,
+                "frame_count": self._frame_count,
+                "elapsed_time": round(elapsed, 2),
+            }
+
+    def _list_maps(self) -> dict:
+        try:
+            return {"maps": self._db.list_maps()}
+        except Exception as exc:
+            return {"error": f"failed to list maps: {exc}"}
+
+    def _delete_map(self, map_name: str) -> dict:
+        map_name = str(map_name).strip()
+        if not map_name:
+            return {"error": "map_name is required"}
+        with self._lock:
+            if self._is_mapping and self._current_map == map_name:
+                return {"error": f"cannot delete active map '{map_name}'. Stop or cancel mapping first."}
+        try:
+            if self._db.delete_map(map_name):
+                with self._lock:
+                    if self._active_map == map_name:
+                        self._active_map = None
+                return {"state": "deleted", "map_name": map_name}
+            return {"error": f"map '{map_name}' not found"}
+        except Exception as exc:
+            return {"error": f"failed to delete map: {exc}"}
+
+    # ── Tag / map-load handlers ──────────────────────────────────────
+
+    def _tag_place(self, name: str, description: str = "") -> dict:
+        name = str(name).strip()
+        if not name:
+            return {"error": "name is required"}
+        pose = self._get_pose()
+        if pose is None:
+            return {"error": "no odometry pose available yet"}
+        active_map = self._active_map
+        if not active_map:
+            return {"error": "no active map; call start_mapping or load_map first"}
+        self._db.add_poi(
+            name=name,
+            x=pose["x"],
+            y=pose["y"],
+            z=pose.get("z", 0.0),
+            yaw=pose.get("yaw", 0.0),
+            map_name=active_map,
+            description=description,
+        )
+        print(f"[mapping] tagged place '{name}' on map '{active_map}'", flush=True)
+        return {"status": "tagged", "name": name, "pose": pose, "map": active_map}
+
+    def _untag_place(self, name: str) -> dict:
+        name = str(name).strip()
+        if not name:
+            return {"error": "name is required"}
+        active_map = self._active_map
+        if not active_map:
+            return {"error": "no active map; call start_mapping or load_map first"}
+        if self._db.delete_poi(name, active_map):
+            print(f"[mapping] untagged place '{name}' from map '{active_map}'", flush=True)
+            return {"status": "deleted", "name": name}
+        return {"error": f"tag '{name}' not found in map '{active_map}'"}
+
+    def _list_tags(self) -> dict:
+        active_map = self._active_map
+        if not active_map:
+            return {"error": "no active map; call start_mapping or load_map first"}
+        pois = self._db.list_pois(active_map)
+        pose = self._get_pose()
+        tags = []
+        for poi in pois:
+            entry = {
+                "name": poi["name"],
+                "description": poi["description"],
+                "x": poi["x"],
+                "y": poi["y"],
+                "z": poi["z"],
+                "yaw": poi["yaw"],
+            }
+            if pose:
+                dx = poi["x"] - pose["x"]
+                dy = poi["y"] - pose["y"]
+                dist = math.sqrt(dx * dx + dy * dy)
+                # Rotate target vector into robot frame
+                cos_yaw = math.cos(-pose["yaw"])
+                sin_yaw = math.sin(-pose["yaw"])
+                rx = dx * cos_yaw - dy * sin_yaw
+                ry = dx * sin_yaw + dy * cos_yaw
+                entry["distance"] = round(dist, 2)
+                entry["bearing"] = self._bearing_label(rx, ry)
+            tags.append(entry)
+        return {"tags": tags, "map": active_map}
+
+    def _load_map(self, map_name: str) -> dict:
+        map_name = str(map_name).strip()
+        if not map_name:
+            return {"error": "map_name is required"}
+        if self._is_mapping:
+            return {"error": "cannot load map while mapping; call stop_mapping first"}
+        map_info = self._db.get_map(map_name)
+        if not map_info:
+            return {"error": f"map '{map_name}' not found"}
+        self._active_map = map_name
+        self._loaded_points = None  # 第一期不加载点云到内存，仅设置活动地图
+        self._db.set_state("active_map", map_name)
+        print(f"[mapping] loaded map '{map_name}' as active", flush=True)
+        return {
+            "status": "loaded",
+            "map_name": map_name,
+            "pcd_path": map_info["pcd_path"],
+            "note": "T800 无 SLAM 重定位服务，请手动将机器人放置在地图原点附近",
+        }
+
+    # ── Helpers ──────────────────────────────────────────────────────
+
+    def _get_pose(self) -> dict | None:
+        """Thread-safe deep copy of the current odometry pose."""
+        with self._lock:
+            return dict(self._current_pose) if self._current_pose else None
+
+    @staticmethod
+    def _bearing_label(dx: float, dy: float) -> str:
+        """Convert delta (x=forward, y=left) to 8-direction bearing label."""
+        angle = math.atan2(dy, dx)  # radians, 0=forward, pi/2=left
+        deg = math.degrees(angle)
+        if -22.5 <= deg < 22.5:
+            return "front"
+        elif 22.5 <= deg < 67.5:
+            return "left_front"
+        elif 67.5 <= deg < 112.5:
+            return "left"
+        elif 112.5 <= deg < 157.5:
+            return "left_behind"
+        elif -67.5 <= deg < -22.5:
+            return "right_front"
+        elif -112.5 <= deg < -67.5:
+            return "right"
+        elif -157.5 <= deg < -112.5:
+            return "right_behind"
+        else:
+            return "behind"
+
+    # ── ROS2 subscriptions ───────────────────────────────────────────
+
+    def _create_odom_subscription(self) -> None:
+        from nav_msgs.msg import Odometry
+
+        self._odom_sub = self._node.create_subscription(
+            Odometry, self._odometry_topic, self._on_odometry, _BEST_EFFORT
+        )
+
+    def _create_cloud_subscription(self) -> None:
+        from sensor_msgs.msg import PointCloud2
+
+        self._cloud_sub = self._node.create_subscription(
+            PointCloud2, self._pointcloud_topic, self._on_pointcloud, _BEST_EFFORT
+        )
+
+    def _destroy_cloud_subscription(self) -> None:
+        if self._cloud_sub is not None:
+            try:
+                self._node.destroy_subscription(self._cloud_sub)
+            except Exception:
+                pass
+            self._cloud_sub = None
+
+    def _destroy_odom_subscription(self) -> None:
+        if self._odom_sub is not None:
+            try:
+                self._node.destroy_subscription(self._odom_sub)
+            except Exception:
+                pass
+            self._odom_sub = None
+
+    # ── Callbacks ────────────────────────────────────────────────────
+
+    def _on_odometry(self, msg) -> None:
+        position = msg.pose.pose.position
+        orientation = msg.pose.pose.orientation
+        yaw = self._quaternion_to_yaw(orientation.x, orientation.y, orientation.z, orientation.w)
+        with self._lock:
+            self._current_pose = {
+                "x": float(position.x),
+                "y": float(position.y),
+                "z": float(position.z),
+                "qx": float(orientation.x),
+                "qy": float(orientation.y),
+                "qz": float(orientation.z),
+                "qw": float(orientation.w),
+                "yaw": round(yaw, 4),
+            }
+
+    def _on_pointcloud(self, msg) -> None:
+        with self._lock:
+            if not self._is_mapping:
+                return
+            if self._current_pose is None:
+                return
+            if self._global_points is not None and len(self._global_points) >= self._max_points:
+                return
+            pose = dict(self._current_pose)
+
+        try:
+            points = self._parse_pointcloud2(msg)
+        except Exception as exc:
+            print(f"[mapping] pointcloud parse error: {exc}", flush=True)
+            return
+
+        if points is None or len(points) == 0:
+            return
+
+        transformed = self._transform_points(points, pose)
+
+        with self._lock:
+            if self._global_points is None:
+                self._global_points = transformed
+            else:
+                self._global_points = np.vstack([self._global_points, transformed])
+            self._frame_count += 1
+
+    # ── Point cloud helpers ──────────────────────────────────────────
+
+    @staticmethod
+    def _parse_pointcloud2(msg) -> np.ndarray | None:
+        fields = {f.name: f for f in msg.fields}
+        if not all(name in fields for name in ("x", "y", "z")):
+            return None
+
+        x_off = fields["x"].offset
+        y_off = fields["y"].offset
+        z_off = fields["z"].offset
+        point_step = msg.point_step
+        num_points = msg.width * msg.height
+
+        if num_points == 0 or point_step == 0:
+            return None
+
+        raw = np.frombuffer(msg.data, dtype=np.uint8)
+        raw = raw[: num_points * point_step].reshape(num_points, point_step)
+
+        x = np.frombuffer(raw[:, x_off : x_off + 4].tobytes(), dtype=np.float32)
+        y = np.frombuffer(raw[:, y_off : y_off + 4].tobytes(), dtype=np.float32)
+        z = np.frombuffer(raw[:, z_off : z_off + 4].tobytes(), dtype=np.float32)
+
+        points = np.column_stack([x, y, z]).astype(np.float64)
+        valid = np.isfinite(points).all(axis=1)
+        return points[valid]
+
+    @staticmethod
+    def _transform_points(points: np.ndarray, pose: dict) -> np.ndarray:
+        qx, qy, qz, qw = pose["qx"], pose["qy"], pose["qz"], pose["qw"]
+        # Normalize quaternion to avoid scale drift in the rotation matrix.
+        qnorm = math.sqrt(qx * qx + qy * qy + qz * qz + qw * qw)
+        if qnorm > 0:
+            qx, qy, qz, qw = qx / qnorm, qy / qnorm, qz / qnorm, qw / qnorm
+        R = np.array(
+            [
+                [1 - 2 * (qy * qy + qz * qz), 2 * (qx * qy - qz * qw), 2 * (qx * qz + qy * qw)],
+                [2 * (qx * qy + qz * qw), 1 - 2 * (qx * qx + qz * qz), 2 * (qy * qz - qx * qw)],
+                [2 * (qx * qz - qy * qw), 2 * (qy * qz + qx * qw), 1 - 2 * (qx * qx + qy * qy)],
+            ]
+        )
+        rotated = points @ R.T
+        rotated[:, 0] += pose["x"]
+        rotated[:, 1] += pose["y"]
+        rotated[:, 2] += pose["z"]
+        return rotated
+
+    @staticmethod
+    def _quaternion_to_yaw(qx: float, qy: float, qz: float, qw: float) -> float:
+        return math.atan2(
+            2 * (qw * qz + qx * qy),
+            1 - 2 * (qy * qy + qz * qz),
+        )
+
+    # ── Save map ─────────────────────────────────────────────────────
+
+    def _save_map(self, map_name: str, points: np.ndarray | None) -> dict:
+        if points is None or len(points) == 0:
+            return {"error": "no point cloud data to save"}
+
+        os.makedirs(self._map_save_dir, exist_ok=True)
+        pcd_path = os.path.join(self._map_save_dir, f"{map_name}.pcd")
+
+        try:
+            points = self._voxel_downsample(points, self._voxel_size)
+        except Exception as exc:
+            print(f"[mapping] voxel downsample failed, saving raw: {exc}", flush=True)
+
+        point_count = int(len(points))
+
+        try:
+            if _HAS_OPEN3D:
+                pcd = o3d.geometry.PointCloud()
+                pcd.points = o3d.utility.Vector3dVector(points)
+                o3d.io.write_point_cloud(pcd_path, pcd)
+            else:
+                self._write_pcd_ascii(pcd_path, points)
+        except Exception as exc:
+            return {"error": f"failed to write PCD: {exc}"}
+
+        try:
+            self._db.add_map(map_name, pcd_path, point_count)
+        except Exception as exc:
+            return {"error": f"failed to update database: {exc}", "pcd_path": pcd_path, "point_count": point_count}
+
+        return {"state": "saved", "map_name": map_name, "pcd_path": pcd_path, "point_count": point_count}
+
+    @staticmethod
+    def _voxel_downsample(points: np.ndarray, voxel_size: float) -> np.ndarray:
+        if voxel_size <= 0:
+            return points
+        voxel_idx = np.floor(points / voxel_size).astype(np.int64)
+        _, unique_idx = np.unique(voxel_idx, axis=0, return_index=True)
+        return points[unique_idx]
+
+    @staticmethod
+    def _write_pcd_ascii(path: str, points: np.ndarray) -> None:
+        n = len(points)
+        header = (
+            "# .PCD v0.7 - Point Cloud Data file format\n"
+            "VERSION 0.7\n"
+            "FIELDS x y z\n"
+            "SIZE 4 4 4\n"
+            "TYPE F F F\n"
+            "COUNT 1 1 1\n"
+            f"WIDTH {n}\n"
+            "HEIGHT 1\n"
+            "VIEWPOINT 0 0 0 1 0 0 0\n"
+            f"POINTS {n}\n"
+            "DATA ascii\n"
+        )
+        with open(path, "w") as f:
+            f.write(header)
+            for p in points:
+                f.write(f"{p[0]:.6f} {p[1]:.6f} {p[2]:.6f}\n")

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -3614,6 +3614,12 @@ class ControlledSpatialPlugin:
         self._frame_count = 0
         self._lock = threading.Lock()
 
+        # 启动时从 DB 恢复上次的 active_map（持久化）
+        saved_active = self._db.get_state("active_map")
+        if saved_active and self._db.get_map(saved_active):
+            self._active_map = saved_active
+            print(f"[controlled_spatial] restored active_map='{saved_active}' from DB", flush=True)
+
         self._node = Node("t800_mapping", context=ros2.ctx_robot)
         ros2.executor_robot.add_node(self._node)
         self._odom_sub = None
@@ -3639,7 +3645,7 @@ class ControlledSpatialPlugin:
             ),
             "inputSchema": action_schema(
                 {
-                    "start_mapping": (["map_name"], "开始建图，用遥控器或 loco 控制机器人行走"),
+                    "start_mapping": (["map_name", "overwrite"], "开始建图，用遥控器或 loco 控制机器人行走。若同名地图已存在需 overwrite=true 才允许覆盖"),
                     "stop_mapping": ([], "停止建图，体素下采样后保存 .pcd 地图"),
                     "cancel_mapping": ([], "取消建图，丢弃已累积点云，不保存"),
                     "mapping_status": ([], "查询当前建图状态、实时位姿和已累积点数"),
@@ -3652,6 +3658,7 @@ class ControlledSpatialPlugin:
                 },
                 {
                     "map_name": {"type": "string", "description": "地图名称"},
+                    "overwrite": {"type": "boolean", "description": "地图已存在时是否覆盖（默认 false，防止误操作覆盖已有地图）", "default": False},
                     "name": {"type": "string", "description": "标记名称"},
                     "description": {"type": "string", "description": "标记描述（可选）"},
                 },
@@ -3679,7 +3686,7 @@ class ControlledSpatialPlugin:
         if action == "stop":
             return {"state": "idle"}
         if action == "start_mapping":
-            return self._start_mapping(args.get("map_name", ""))
+            return self._start_mapping(args.get("map_name", ""), args.get("overwrite", False))
         if action == "stop_mapping":
             return self._stop_mapping()
         if action == "cancel_mapping":
@@ -3702,7 +3709,7 @@ class ControlledSpatialPlugin:
 
     # ── Action handlers ──────────────────────────────────────────────
 
-    def _start_mapping(self, map_name: str) -> dict:
+    def _start_mapping(self, map_name: str, overwrite: bool = False) -> dict:
         map_name = str(map_name).strip()
         if not map_name:
             return {"error": "map_name is required"}
@@ -3711,8 +3718,17 @@ class ControlledSpatialPlugin:
                 return {"error": f"already mapping '{self._current_map}'", "current_map": self._current_map}
 
         existing = self._db.get_map(map_name)
+        if existing and not overwrite:
+            return {
+                "error": f"map '{map_name}' already exists. Use overwrite=true to overwrite, or choose a different name.",
+                "existing_map": {
+                    "name": existing["name"],
+                    "point_count": existing.get("point_count", 0),
+                    "created_at": existing.get("created_at"),
+                },
+            }
         if existing:
-            print(f"[controlled_spatial] map '{map_name}' already exists, will overwrite on save", flush=True)
+            print(f"[controlled_spatial] overwriting existing map '{map_name}' (overwrite=true)", flush=True)
 
         try:
             self._create_cloud_subscription()

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -3744,6 +3744,12 @@ class ControlledSpatialPlugin:
             self._start_time = time.monotonic()
             self._frame_count = 0
 
+        try:
+            self._db.set_state("map_status", "mapping")
+            self._db.set_state("active_map", map_name)
+        except Exception as exc:
+            print(f"[controlled_spatial] failed to persist map_status: {exc}", flush=True)
+
         print(f"[controlled_spatial] started mapping '{map_name}'", flush=True)
         return {
             "state": "mapping",
@@ -3771,6 +3777,11 @@ class ControlledSpatialPlugin:
             self._start_time = None
             self._frame_count = 0
             # _active_map 保留为 map_name：地图仍处于活动状态，可继续 tag_place
+
+        try:
+            self._db.set_state("map_status", "idle")
+        except Exception as exc:
+            print(f"[controlled_spatial] failed to persist map_status: {exc}", flush=True)
 
         if "error" in result:
             print(f"[controlled_spatial] save failed for '{map_name}': {result['error']}", flush=True)
@@ -3800,6 +3811,12 @@ class ControlledSpatialPlugin:
             self._start_time = None
             self._frame_count = 0
             self._active_map = None
+
+        try:
+            self._db.set_state("map_status", "idle")
+            self._db.set_state("active_map", None)
+        except Exception as exc:
+            print(f"[controlled_spatial] failed to persist map_status: {exc}", flush=True)
 
         print(f"[controlled_spatial] cancelled mapping '{map_name}'", flush=True)
         return {"state": "cancelled", "map_name": map_name}

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -3578,8 +3578,13 @@ class _MappingDB:
         return maps
 
 
-class MappingPlugin:
-    """Laser point cloud mapping via Odin2 odometry + undistorted point cloud."""
+class ControlledSpatialPlugin:
+    """人工遥控建图与语义标记（controlled_spatial），与 unitree/g1 接口对齐。
+
+    通过 Odin2 里程计位姿累积激光点云生成 .pcd 地图，支持开始/停止/取消建图、
+    状态查询、地图管理、语义标记（tag）管理和已保存地图加载。
+    暂不包含 navigation（navigate_to_tag / navigate_to_pose）。
+    """
 
     def __init__(self, plugin_config: dict, namespace: str, ros2):
         self._config = plugin_config
@@ -3617,20 +3622,20 @@ class MappingPlugin:
         self._create_odom_subscription()
 
         print(
-            f"[mapping] ready (odom={self._odometry_topic}, cloud={self._pointcloud_topic}, "
+            f"[controlled_spatial] ready (odom={self._odometry_topic}, cloud={self._pointcloud_topic}, "
             f"open3d={_HAS_OPEN3D})",
             flush=True,
         )
 
     def get_tool(self) -> dict:
         return {
-            "name": "mapping",
+            "name": "controlled_spatial",
             "type": "actuator",
             "multiInstance": False,
             "description": (
-                "T800 激光点云建图卡片；人工遥控行走时按 Odin2 里程计位姿累积点云，"
-                "生成并保存 .pcd 地图。支持开始/停止/取消建图、状态查询、地图管理、"
-                "语义标记（tag）管理和已保存地图加载。"
+                "T800 人工控制建图与语义标记卡片（与 unitree/g1 controlled_spatial 对齐）。"
+                "人工遥控行走时按 Odin2 里程计位姿累积点云，生成并保存 .pcd 地图。"
+                "支持开始/停止/取消建图、状态查询、地图管理、语义标记（tag）管理和已保存地图加载。"
             ),
             "inputSchema": action_schema(
                 {
@@ -3660,7 +3665,7 @@ class MappingPlugin:
     def stop(self) -> None:
         if self._is_mapping:
             self._destroy_cloud_subscription()
-            print("[mapping] driver shutdown, mapping stopped without saving", flush=True)
+            print("[controlled_spatial] driver shutdown, mapping stopped without saving", flush=True)
         self._destroy_odom_subscription()
         try:
             self._ros2.executor_robot.remove_node(self._node)
@@ -3693,7 +3698,7 @@ class MappingPlugin:
             return self._list_tags()
         if action == "load_map":
             return self._load_map(args.get("map_name", ""))
-        return {"error": f"unknown mapping action: {action}"}
+        return {"error": f"unknown controlled_spatial action: {action}"}
 
     # ── Action handlers ──────────────────────────────────────────────
 
@@ -3707,7 +3712,7 @@ class MappingPlugin:
 
         existing = self._db.get_map(map_name)
         if existing:
-            print(f"[mapping] map '{map_name}' already exists, will overwrite on save", flush=True)
+            print(f"[controlled_spatial] map '{map_name}' already exists, will overwrite on save", flush=True)
 
         try:
             self._create_cloud_subscription()
@@ -3723,7 +3728,7 @@ class MappingPlugin:
             self._start_time = time.monotonic()
             self._frame_count = 0
 
-        print(f"[mapping] started mapping '{map_name}'", flush=True)
+        print(f"[controlled_spatial] started mapping '{map_name}'", flush=True)
         return {
             "state": "mapping",
             "map_name": map_name,
@@ -3752,12 +3757,12 @@ class MappingPlugin:
             # _active_map 保留为 map_name：地图仍处于活动状态，可继续 tag_place
 
         if "error" in result:
-            print(f"[mapping] save failed for '{map_name}': {result['error']}", flush=True)
+            print(f"[controlled_spatial] save failed for '{map_name}': {result['error']}", flush=True)
             return result
 
         result["elapsed_time"] = round(elapsed, 2)
         print(
-            f"[mapping] saved '{map_name}': {result['point_count']} points "
+            f"[controlled_spatial] saved '{map_name}': {result['point_count']} points "
             f"({elapsed:.1f}s) -> {result['pcd_path']}",
             flush=True,
         )
@@ -3780,7 +3785,7 @@ class MappingPlugin:
             self._frame_count = 0
             self._active_map = None
 
-        print(f"[mapping] cancelled mapping '{map_name}'", flush=True)
+        print(f"[controlled_spatial] cancelled mapping '{map_name}'", flush=True)
         return {"state": "cancelled", "map_name": map_name}
 
     def _mapping_status(self) -> dict:
@@ -3846,7 +3851,7 @@ class MappingPlugin:
             map_name=active_map,
             description=description,
         )
-        print(f"[mapping] tagged place '{name}' on map '{active_map}'", flush=True)
+        print(f"[controlled_spatial] tagged place '{name}' on map '{active_map}'", flush=True)
         return {"status": "tagged", "name": name, "pose": pose, "map": active_map}
 
     def _untag_place(self, name: str) -> dict:
@@ -3857,7 +3862,7 @@ class MappingPlugin:
         if not active_map:
             return {"error": "no active map; call start_mapping or load_map first"}
         if self._db.delete_poi(name, active_map):
-            print(f"[mapping] untagged place '{name}' from map '{active_map}'", flush=True)
+            print(f"[controlled_spatial] untagged place '{name}' from map '{active_map}'", flush=True)
             return {"status": "deleted", "name": name}
         return {"error": f"tag '{name}' not found in map '{active_map}'"}
 
@@ -3903,7 +3908,7 @@ class MappingPlugin:
         self._active_map = map_name
         self._loaded_points = None  # 第一期不加载点云到内存，仅设置活动地图
         self._db.set_state("active_map", map_name)
-        print(f"[mapping] loaded map '{map_name}' as active", flush=True)
+        print(f"[controlled_spatial] loaded map '{map_name}' as active", flush=True)
         return {
             "status": "loaded",
             "map_name": map_name,
@@ -4003,7 +4008,7 @@ class MappingPlugin:
         try:
             points = self._parse_pointcloud2(msg)
         except Exception as exc:
-            print(f"[mapping] pointcloud parse error: {exc}", flush=True)
+            print(f"[controlled_spatial] pointcloud parse error: {exc}", flush=True)
             return
 
         if points is None or len(points) == 0:
@@ -4085,7 +4090,7 @@ class MappingPlugin:
         try:
             points = self._voxel_downsample(points, self._voxel_size)
         except Exception as exc:
-            print(f"[mapping] voxel downsample failed, saving raw: {exc}", flush=True)
+            print(f"[controlled_spatial] voxel downsample failed, saving raw: {exc}", flush=True)
 
         point_count = int(len(points))
 

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -185,6 +185,15 @@ class T800DeviceBundle:
             except Exception as exc:
                 print(f"[bundle] ControlledSpatialPlugin init failed, controlled_spatial disabled: {exc}", flush=True)
 
+        if plugins.get("controlled_spatial_map", {}).get("enabled", False):
+            try:
+                from controlled_spatial_map import make_plugin as make_map_plugin
+                map_cfg = dict(plugins["controlled_spatial_map"])
+                self._plugins.append(make_map_plugin(map_cfg, namespace, ros2.executor_robot))
+                print("[bundle] ControlledSpatialMapPlugin loaded")
+            except Exception as e:
+                print(f"[bundle] ControlledSpatialMapPlugin load skipped: {e}", flush=True)
+
         if "safety" in instances:
             instances["safety"].set_controls(
                 [

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -103,7 +103,7 @@ class T800DeviceBundle:
             HeartbeatStatusPlugin,
             LedPlugin,
             LocomotionPlugin,
-            MappingPlugin,
+            ControlledSpatialPlugin,
             MotionCommandTracePlugin,
             MotionEventsPlugin,
             MicPlugin,
@@ -176,14 +176,14 @@ class T800DeviceBundle:
             instances["virtual_gamepad"] = instance
             self._plugins.append(instance)
 
-        mapping_config = plugins.get("mapping", {})
-        if mapping_config.get("enabled", False):
+        controlled_spatial_config = plugins.get("controlled_spatial", {})
+        if controlled_spatial_config.get("enabled", False):
             try:
-                instance = MappingPlugin(mapping_config, namespace, ros2)
-                instances["mapping"] = instance
+                instance = ControlledSpatialPlugin(controlled_spatial_config, namespace, ros2)
+                instances["controlled_spatial"] = instance
                 self._plugins.append(instance)
             except Exception as exc:
-                print(f"[bundle] MappingPlugin init failed, mapping disabled: {exc}", flush=True)
+                print(f"[bundle] ControlledSpatialPlugin init failed, controlled_spatial disabled: {exc}", flush=True)
 
         if "safety" in instances:
             instances["safety"].set_controls(

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -189,7 +189,7 @@ class T800DeviceBundle:
             try:
                 from controlled_spatial_map import make_plugin as make_map_plugin
                 map_cfg = dict(plugins["controlled_spatial_map"])
-                self._plugins.append(make_map_plugin(map_cfg, namespace, ros2.executor_robot))
+                self._plugins.append(make_map_plugin(map_cfg, namespace, ros2))
                 print("[bundle] ControlledSpatialMapPlugin loaded")
             except Exception as e:
                 print(f"[bundle] ControlledSpatialMapPlugin load skipped: {e}", flush=True)

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -103,6 +103,7 @@ class T800DeviceBundle:
             HeartbeatStatusPlugin,
             LedPlugin,
             LocomotionPlugin,
+            MappingPlugin,
             MotionCommandTracePlugin,
             MotionEventsPlugin,
             MicPlugin,
@@ -174,6 +175,15 @@ class T800DeviceBundle:
             instance = VirtualGamepadPlugin(virtual_gamepad_config, namespace, ros2)
             instances["virtual_gamepad"] = instance
             self._plugins.append(instance)
+
+        mapping_config = plugins.get("mapping", {})
+        if mapping_config.get("enabled", False):
+            try:
+                instance = MappingPlugin(mapping_config, namespace, ros2)
+                instances["mapping"] = instance
+                self._plugins.append(instance)
+            except Exception as exc:
+                print(f"[bundle] MappingPlugin init failed, mapping disabled: {exc}", flush=True)
 
         if "safety" in instances:
             instances["safety"].set_controls(


### PR DESCRIPTION
## 概述

为 EngineAI T800 开发版新增**激光点云建图（Mapping）**能力。基于 Odin2 雷达的里程计与去畸变点云，在人工遥控行走过程中实时累积全局点云，支持体素下采样保存为 `.pcd` 地图文件，并提供语义位置标记与地图全生命周期管理。

## 功能清单

| 功能 | 说明 | 状态 |
|---|---|---|
| `start_mapping` | 指定地图名称，开始建图，订阅里程计与点云 topic | ✅ 已测试 |
| `stop_mapping` | 停止建图，体素下采样后保存 `.pcd` 地图 | ✅ 已测试 |
| `cancel_mapping` | 取消建图，丢弃已累积点云，不保存 | ✅ 已测试 |
| `mapping_status` | 实时查询建图状态、当前位姿、已累积点数与耗时 | ✅ 已测试 |
| `list_maps` | 列出所有已保存地图及元信息 | ✅ 已测试 |
| `delete_map` | 删除指定地图及对应 `.pcd` 文件 | ✅ 已测试 |
| `tag_place` | 在当前位置打语义标记（名称 + 描述），关联活动地图 | ✅ 已测试 |
| `untag_place` | 删除指定名称的位置标记 | ✅ 已测试 |
| `list_tags` | 列出当前活动地图的所有标记，含相对机器人的距离与方位 | ✅ 已测试 |
| `load_map` | 加载已保存地图为活动地图（用于标记管理与后续导航） | ✅ 已测试 |

## 技术实现

- **数据源**：Odin2 雷达 `/manifold/ODIN2/device0/odometry`（里程计）+ `/manifold/ODIN2/device0/cloud/slam`（去畸变点云）
- **点云累积**：按里程计位姿将每帧点云变换到世界坐标系，追加到全局点云缓冲区
- **地图保存**：停止建图时执行体素下采样（默认 voxel_size=0.05m），通过 Open3D 保存为 `.pcd` 格式
- **持久化存储**：SQLite 数据库记录地图元信息与语义标记，`.pcd` 文件存储于 `/opt/phanthy-motus/data/maps/`
- **配置化**：所有参数（topic 路径、体素大小、最大点数、存储路径）均可通过 `config.yaml` 配置

## 实机测试验证

已在 EngineAI T800 实机完成全流程测试：

1. ✅ Driver 启动后 Mapping 插件正常加载，日志输出 `[mapping] ready`
2. ✅ `start_mapping` 成功进入建图状态，ROS2 订阅正常建立
3. ✅ 人工遥控行走过程中，`mapping_status` 显示点云数量实时增长
4. ✅ `stop_mapping` 成功保存地图，生成约 21MB `.pcd` 文件
5. ✅ `list_maps` 可正确列出已保存地图
6. ✅ `tag_place` / `list_tags` 语义标记功能正常
7. ✅ `load_map` 加载已保存地图正常
8. ✅ `cancel_mapping` 取消建图后点云正确丢弃

