### PR TITLE
fix(t800): 整合 #107/#149 并修复 ARM64 可移植构建

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,13 +34,16 @@ set -- "${REMAINING_ARGS[@]+"${REMAINING_ARGS[@]}"}"
 # ── 镜像源选择 ────────────────────────────────────────────────────────────
 select_mirror() {
     if [ -z "${MIRROR}" ]; then
-        echo ""
-        echo "Select mirror / 选择镜像源:"
-        echo "  1) tencent  — 腾讯云（VPC 内网）"
-        echo "  2) tuna     — 清华 TUNA（公网）"
-        echo "  3) none     — 官方源（海外 / 裸连）"
-        printf "Choice [1/2/3] (default: 2): "
-        read -r choice </dev/tty || choice=""
+        choice=""
+        if [ -t 0 ]; then
+            echo ""
+            echo "Select mirror / 选择镜像源:"
+            echo "  1) tencent  — 腾讯云（VPC 内网）"
+            echo "  2) tuna     — 清华 TUNA（公网）"
+            echo "  3) none     — 官方源（海外 / 裸连）"
+            printf "Choice [1/2/3] (default: 2): "
+            read -r choice || choice=""
+        fi
         case "${choice}" in
             1) MIRROR="tencent" ;;
             3) MIRROR="none" ;;
@@ -51,19 +54,25 @@ select_mirror() {
     case "${MIRROR}" in
         tencent)
             PYPI_MIRROR="https://mirrors.tencentyun.com/pypi/simple/"
+            ROS_APT_MIRROR="${ROS_APT_MIRROR:-https://mirrors.tuna.tsinghua.edu.cn/ros2/ubuntu}"
+            UBUNTU_APT_MIRROR="${UBUNTU_APT_MIRROR:-http://mirrors.tencentyun.com/ubuntu-ports}"
             BINFMT_IMAGE="mirror.ccs.tencentyun.com/tonistiigi/binfmt"
             ;;
         tuna)
             PYPI_MIRROR="https://pypi.tuna.tsinghua.edu.cn/simple/"
+            ROS_APT_MIRROR="${ROS_APT_MIRROR:-https://mirrors.tuna.tsinghua.edu.cn/ros2/ubuntu}"
+            UBUNTU_APT_MIRROR="${UBUNTU_APT_MIRROR:-https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports}"
             BINFMT_IMAGE="docker.io/tonistiigi/binfmt"
             ;;
         none|*)
             PYPI_MIRROR="https://pypi.org/simple/"
+            ROS_APT_MIRROR="${ROS_APT_MIRROR:-http://packages.ros.org/ros2/ubuntu}"
+            UBUNTU_APT_MIRROR="${UBUNTU_APT_MIRROR:-http://ports.ubuntu.com/ubuntu-ports}"
             BINFMT_IMAGE="docker.io/tonistiigi/binfmt"
             ;;
     esac
 
-    echo "Mirror: ${MIRROR} | PyPI: ${PYPI_MIRROR}"
+    echo "Mirror: ${MIRROR} | PyPI: ${PYPI_MIRROR} | ROS apt: ${ROS_APT_MIRROR} | Ubuntu apt: ${UBUNTU_APT_MIRROR}"
     echo ""
 }
 
@@ -133,15 +142,52 @@ fi
 declare -a SELECTED_INDICES
 
 if [ $# -gt 0 ]; then
-    # 直接传目录参数（CI 模式）
+    # CI may identify a driver by directory, manifest id, image name, model,
+    # or provider/model. Match exact aliases so a typo cannot silently no-op.
     for arg in "$@"; do
+        normalized_arg="${arg#./}"
+        normalized_arg="${normalized_arg%/}"
+        matched=false
         for i in "${!DRIVER_DIRS[@]}"; do
-            if [[ "${DRIVER_DIRS[$i]}" == *"${arg}"* ]]; then
-                SELECTED_INDICES+=("$i")
+            relative_dir="${DRIVER_DIRS[$i]#${SCRIPT_DIR}/}"
+            relative_dir="${relative_dir%/}"
+            absolute_dir="${DRIVER_DIRS[$i]%/}"
+            provider_model="${DRIVER_PROVIDERS[$i]}/${DRIVER_MODELS[$i]}"
+            case "${normalized_arg}" in
+                "${relative_dir}"|"${absolute_dir}"|"${DRIVER_IDS[$i]}"|"${DRIVER_IMAGES[$i]}"|\
+                "${DRIVER_MODELS[$i]}"|"${provider_model}")
+                    if [[ " ${SELECTED_INDICES[*]-} " != *" ${i} "* ]]; then
+                        SELECTED_INDICES+=("$i")
+                    fi
+                    matched=true
+                    ;;
+            esac
+            # Existing preview deployments used t800-dev before the manifest
+            # was normalized to t800. Accept those identifiers as migration
+            # aliases, while always building and registering the canonical
+            # engineai/t800 image.
+            if [ "${relative_dir}" = "engineai/t800" ]; then
+                case "${normalized_arg}" in
+                    t800-dev|engineai/t800-dev|engineai-t800-dev)
+                        if [[ " ${SELECTED_INDICES[*]-} " != *" ${i} "* ]]; then
+                            SELECTED_INDICES+=("$i")
+                        fi
+                        echo "[warn] legacy T800 alias '${arg}' maps to canonical engineai/t800." >&2
+                        matched=true
+                        ;;
+                esac
             fi
         done
+        if ! ${matched}; then
+            echo "错误：未知驱动参数 '${arg}'。请使用目录、driver id、image_name、hardware_model 或 provider/model。" >&2
+            exit 2
+        fi
     done
 else
+    if [ ! -t 0 ]; then
+        echo "错误：非交互环境必须显式传入 driver 参数。" >&2
+        exit 2
+    fi
     # 交互式选择（InquirerPy）——写入临时文件以便从 /dev/tty 读取键盘输入
     _PY_SEL=$(mktemp /tmp/build_select_XXXXXX.py)
     cat > "${_PY_SEL}" <<'PYEOF'
@@ -202,8 +248,8 @@ PYEOF
 fi
 
 if [ ${#SELECTED_INDICES[@]} -eq 0 ]; then
-    echo "未选择任何驱动，退出。"
-    exit 0
+    echo "错误：未选择任何驱动。" >&2
+    exit 2
 fi
 
 # ── 检查选中 driver 是否可构建 ────────────────────────────────────────────
@@ -218,7 +264,19 @@ done
 # ── 生成版本号 ─────────────────────────────────────────────────────────────
 DATE="$(date +%y%m%d)"
 COMMIT="$(git -C "${SCRIPT_DIR}" rev-parse --short=7 HEAD 2>/dev/null || echo "local")"
-TAG="release.${DATE}.${COMMIT}"
+DIRTY_SUFFIX=""
+if [ "${COMMIT}" = "local" ] && ${PUSH_ENABLED}; then
+    echo "错误：发布镜像需要可读取的 Git commit，当前工作副本没有可用版本元数据。" >&2
+    exit 1
+fi
+if [ -n "$(git -C "${SCRIPT_DIR}" status --porcelain --untracked-files=normal 2>/dev/null || true)" ]; then
+    if ${PUSH_ENABLED}; then
+        echo "错误：工作树包含未提交改动，拒绝发布无法复现的镜像。" >&2
+        exit 1
+    fi
+    DIRTY_SUFFIX=".dirty"
+fi
+TAG="release.${DATE}.${COMMIT}${DIRTY_SUFFIX}"
 
 echo ""
 echo "版本 tag：${TAG}"
@@ -236,11 +294,25 @@ select_mirror
 # natively. Registering binfmt there is unnecessary and may fail because
 # Docker Desktop does not expose /proc/sys/fs/binfmt_misc/register.
 HOST_ARCH="$(uname -m)"
-if [ "${HOST_ARCH}" != "arm64" ] && [ "${HOST_ARCH}" != "aarch64" ]; then
+# Some rootless Docker setups print a successful binfmt installation even
+# though the daemon cannot execute ARM64 layers. Probe execution before a
+# large build so the failure is immediate and actionable.
+BINFMT_PROBE_IMAGE="${BINFMT_PROBE_IMAGE:-docker.io/library/alpine:3.20}"
+PROBE_ARCH="$(docker run --rm --platform linux/arm64 "${BINFMT_PROBE_IMAGE}" uname -m 2>/dev/null || true)"
+if [ "${HOST_ARCH}" != "arm64" ] && [ "${HOST_ARCH}" != "aarch64" ] && \
+   [[ "${PROBE_ARCH}" != "arm64" && "${PROBE_ARCH}" != "aarch64" ]]; then
     docker run --privileged --rm "${BINFMT_IMAGE}" --install arm64
-else
+    PROBE_ARCH="$(docker run --rm --platform linux/arm64 "${BINFMT_PROBE_IMAGE}" uname -m 2>/dev/null || true)"
+elif [ "${HOST_ARCH}" = "arm64" ] || [ "${HOST_ARCH}" = "aarch64" ]; then
     echo "[info] Native ${HOST_ARCH} host — skipping ARM64 binfmt setup."
+else
+    echo "[info] ARM64 emulation already available — skipping binfmt registration."
 fi
+if [[ "${PROBE_ARCH}" != "arm64" && "${PROBE_ARCH}" != "aarch64" ]]; then
+    echo "错误：当前 Docker daemon 无法执行 linux/arm64 容器。请在宿主机启用 QEMU binfmt，并重启 Docker daemon。" >&2
+    exit 1
+fi
+echo "[info] ARM64 execution probe passed (${PROBE_ARCH})."
 
 # ── 构建 ──────────────────────────────────────────────────────────────────
 declare -a BUILT_INDICES
@@ -291,12 +363,27 @@ for idx in "${SELECTED_INDICES[@]}"; do
         --platform linux/arm64 \
         ${NO_CACHE} \
         --build-arg "PYPI_MIRROR=${PYPI_MIRROR}" \
+        --build-arg "ROS_APT_MIRROR=${ROS_APT_MIRROR}" \
+        --build-arg "UBUNTU_APT_MIRROR=${UBUNTU_APT_MIRROR}" \
         --file "${dir}Dockerfile" \
         --tag "${FULL_IMAGE}" \
-        $(${PUSH_ENABLED} && echo "--push" || echo "--output=type=docker") \
+        --output=type=docker \
         "${BUILD_CTX}"
 
     [ -n "${CLEANUP_CTX}" ] && rm -rf "${CLEANUP_CTX}"
+
+    relative_dir="${dir#${SCRIPT_DIR}/}"
+    if [ "${relative_dir%/}" = "engineai/t800" ]; then
+        echo "[smoke] 验证 T800 ARM64 镜像依赖和 ROS 接口..."
+        docker run --rm --platform linux/arm64 --entrypoint /bin/bash "${FULL_IMAGE}" -ce \
+            'source /opt/ros/humble/setup.bash; source /ros_ws/install/setup.bash; source /t800_ws/install/setup.bash; command -v pactl; command -v parec; ros2 pkg prefix rmw_cyclonedds_cpp; python3 -c "import main; from audio_msgs.msg import AudioChunk; from interface_protocol.msg import BodyVelCmd, Heartbeat, LinkInfo, MotionStateRequest; from nav_msgs.msg import Odometry; from sensor_msgs.msg import CompressedImage, Image, PointCloud2; import lcm, numpy, yaml"'
+    fi
+
+    # Publish only after the locally loaded image passes its architecture and
+    # driver-specific smoke checks. A failed smoke must never create a remote tag.
+    if ${PUSH_ENABLED}; then
+        docker push "${FULL_IMAGE}"
+    fi
 
     BUILT_INDICES+=("${idx}")
     echo "完成：${FULL_IMAGE}"
@@ -307,11 +394,22 @@ echo "全部完成。"
 
 # ── 注册到 Resource Center ──────────────────────────────────────────────────
 if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
-    SYNC_CONFIRM="y"
-    if [ -t 0 ] || [ -e /dev/tty ]; then
-        printf "\nSync to resource-center (%s)? [Y/n]: " "${RESOURCE_CENTER_URL}" >/dev/tty
-        read -r SYNC_CONFIRM </dev/tty || SYNC_CONFIRM="y"
-    fi
+    SYNC_CONFIRM="${RESOURCE_CENTER_SYNC:-}"
+    case "${SYNC_CONFIRM}" in
+        always|yes|y|Y) SYNC_CONFIRM="y" ;;
+        never|no|n|N) SYNC_CONFIRM="n" ;;
+        "")
+            SYNC_CONFIRM="y"
+            if [ -t 0 ] && [ -t 1 ]; then
+                printf "\nSync to resource-center (%s)? [Y/n]: " "${RESOURCE_CENTER_URL}"
+                read -r SYNC_CONFIRM || SYNC_CONFIRM="y"
+            fi
+            ;;
+        *)
+            echo "错误：RESOURCE_CENTER_SYNC 必须是 always/never。" >&2
+            exit 2
+            ;;
+    esac
     if [[ ! "${SYNC_CONFIRM}" =~ ^[Nn] ]]; then
         echo ""
         echo "注册镜像到 Resource Center (${RESOURCE_CENTER_URL})..."
@@ -338,13 +436,19 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
   \"port\": ${port:-null}
 }"
 
-            http_code=$(curl -s -o /tmp/rc_register_resp.json -w "%{http_code}" \
-                -X POST "${RESOURCE_CENTER_URL}/api/admin/register" \
-                -H "x-api-key: ${RESOURCE_CENTER_API_KEY}" \
-                -H "Content-Type: application/json" \
-                -d "${payload}")
+            response_file="$(mktemp /tmp/rc_register_resp.XXXXXX)"
+            if ! http_code=$(curl -s -o "${response_file}" -w "%{http_code}" \
+                    -X POST "${RESOURCE_CENTER_URL}/api/admin/register" \
+                    -H "x-api-key: ${RESOURCE_CENTER_API_KEY}" \
+                    -H "Content-Type: application/json" \
+                    -d "${payload}"); then
+                rm -f "${response_file}"
+                echo "  ✗ ${name} 注册请求失败" >&2
+                exit 1
+            fi
 
-            resp="$(cat /tmp/rc_register_resp.json)"
+            resp="$(cat "${response_file}")"
+            rm -f "${response_file}"
             if [ "${http_code}" = "200" ] || [ "${http_code}" = "201" ]; then
                 echo "  ✓ ${name}"
                 echo "    imageRef : ${FULL_IMAGE}"
@@ -353,7 +457,8 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
                 [ -n "${hw_model}" ]    && echo "    model    : ${hw_model}"
                 echo "    response : ${resp}"
             else
-                echo "  ✗ ${name} 注册失败 (HTTP ${http_code}): ${resp}"
+                echo "  ✗ ${name} 注册失败 (HTTP ${http_code}): ${resp}" >&2
+                exit 1
             fi
         done
     else

--- a/engineai/t800/Dockerfile
+++ b/engineai/t800/Dockerfile
@@ -5,7 +5,14 @@ ARG PYPI_MIRROR
 
 WORKDIR /work
 
+# Some ros-base revisions retain the ROS installation and signing key but not
+# the ROS 2 apt source. Restore the signed source before installing the RMW.
 RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
+    test -s /usr/share/keyrings/ros2-archive-keyring.gpg || \
+        { echo "ERROR: base image is missing /usr/share/keyrings/ros2-archive-keyring.gpg"; exit 1; } && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros2-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
+        > /etc/apt/sources.list.d/ros2.list && \
+    apt-get -o Acquire::AllowInsecureRepositories=true update && \
     apt-get install -y --no-install-recommends --allow-unauthenticated \
         python3-colcon-common-extensions \
         python3-pip \

--- a/engineai/t800/Dockerfile
+++ b/engineai/t800/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
         python3-colcon-common-extensions \
         python3-pip \
         ros-humble-rmw-cyclonedds-cpp \
+        pulseaudio-utils \
         build-essential \
         cmake && \
     rm -rf /var/lib/apt/lists/*

--- a/engineai/t800/Dockerfile
+++ b/engineai/t800/Dockerfile
@@ -1,7 +1,9 @@
 ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base:latest
 ARG PYPI_MIRROR=https://pypi.org/simple/
+ARG ROS_APT_MIRROR=https://mirrors.tuna.tsinghua.edu.cn/ros2/ubuntu
 FROM ${ROS_BASE_IMAGE}
 ARG PYPI_MIRROR
+ARG ROS_APT_MIRROR
 
 WORKDIR /work
 
@@ -9,7 +11,6 @@ RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
     apt-get install -y --no-install-recommends --allow-unauthenticated \
         python3-colcon-common-extensions \
         python3-pip \
-        ros-humble-rmw-cyclonedds-cpp \
         build-essential \
         cmake && \
     rm -rf /var/lib/apt/lists/*
@@ -18,19 +19,54 @@ COPY requirements.txt /tmp/t800-requirements.txt
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} -r /tmp/t800-requirements.txt
 
 COPY msgs/ /t800_ws/src/
-RUN . /opt/ros/humble/setup.sh && \
+RUN . /etc/os-release && \
+    echo "[t800] installing ROS interface build dependencies" && \
+    find /t800_ws/src -name '._*' -delete && \
+    echo "deb [arch=$(dpkg --print-architecture) trusted=yes] ${ROS_APT_MIRROR} ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/ros2.list && \
+    apt-get -o Acquire::AllowInsecureRepositories=true update && \
+    apt-get install -y --no-install-recommends --allow-unauthenticated --reinstall \
+        ros-humble-ament-cmake \
+        ros-humble-builtin-interfaces \
+        ros-humble-geometry-msgs \
+        ros-humble-rosidl-default-generators \
+        ros-humble-rosidl-default-runtime \
+        ros-humble-rosidl-generator-c \
+        ros-humble-std-msgs && \
+    ldconfig && \
+    . /opt/ros/humble/setup.sh && \
+    echo "[t800] ROS interface dependency diagnostics" && \
+    dpkg-query -W -f='[t800] ${Package} ${Version}\n' \
+        ros-humble-ament-cmake \
+        ros-humble-builtin-interfaces \
+        ros-humble-geometry-msgs \
+        ros-humble-rosidl-default-generators \
+        ros-humble-rosidl-default-runtime \
+        ros-humble-rosidl-generator-c \
+        ros-humble-std-msgs && \
+    test -f /opt/ros/humble/share/builtin_interfaces/cmake/ament_cmake_export_libraries-extras.cmake && \
+    test -e /opt/ros/humble/lib/libbuiltin_interfaces__rosidl_generator_c.so && \
+    printf '%s\n' \
+        'find_library(BUILTIN_GENERATOR_C builtin_interfaces__rosidl_generator_c PATHS /opt/ros/humble/lib NO_DEFAULT_PATH)' \
+        'message(STATUS "BUILTIN_GENERATOR_C=${BUILTIN_GENERATOR_C}")' \
+        'if(NOT BUILTIN_GENERATOR_C)' \
+        '  message(FATAL_ERROR "builtin_interfaces__rosidl_generator_c not found by CMake")' \
+        'endif()' > /tmp/t800_check_builtin.cmake && \
+    cmake -P /tmp/t800_check_builtin.cmake && \
     cd /t800_ws && \
-    colcon build --packages-select interface_protocol
+    colcon build --packages-select interface_protocol && \
+    . /t800_ws/install/setup.sh && \
+    python3 -c "from interface_protocol.msg import BodyVelCmd, Heartbeat, LinkInfo, MotionStateRequest; print('interface_protocol import ok')" && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY main.py device.py control.py native_sdk.py virtual_gamepad.py config.yaml driver.yaml /work/
 COPY resource/ /work/resource/
 COPY deploy/ /deploy/
 
-ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+ENV T800_PREFERRED_RMW=rmw_cyclonedds_cpp
 ENV ROS_LOCALHOST_ONLY=0
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/work
 
 EXPOSE 15708
 
-CMD ["/bin/bash", "-c", "source /opt/ros/humble/setup.bash && source /t800_ws/install/setup.bash && export CYCLONEDDS_URI=\"<CycloneDDS><Domain><General><Interfaces><NetworkInterface name='${NETWORK_INTERFACE:-eth0}'/></Interfaces></General></Domain></CycloneDDS>\" && python3 /work/main.py"]
+CMD ["/bin/bash", "-c", "source /opt/ros/humble/setup.bash && source /t800_ws/install/setup.bash && if [ -n \"${RMW_IMPLEMENTATION:-}\" ] && ! ros2 pkg prefix \"${RMW_IMPLEMENTATION}\" >/dev/null 2>&1; then echo \"[t800] ignoring unavailable RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}\"; unset RMW_IMPLEMENTATION; fi && if [ -n \"${T800_PREFERRED_RMW:-}\" ] && ros2 pkg prefix \"${T800_PREFERRED_RMW}\" >/dev/null 2>&1; then export RMW_IMPLEMENTATION=\"${T800_PREFERRED_RMW}\"; fi && export CYCLONEDDS_URI=\"<CycloneDDS><Domain><General><Interfaces><NetworkInterface name='${NETWORK_INTERFACE:-eth0}'/></Interfaces></General></Domain></CycloneDDS>\" && python3 /work/main.py"]

--- a/engineai/t800/Dockerfile
+++ b/engineai/t800/Dockerfile
@@ -1,16 +1,35 @@
-ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base:latest
+ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base@sha256:82d45949e7c3fd85e6baf4a2b24b384a3ec020a5e237c5f801bc2f2269ca649f
 ARG PYPI_MIRROR=https://pypi.org/simple/
 ARG ROS_APT_MIRROR=https://mirrors.tuna.tsinghua.edu.cn/ros2/ubuntu
+ARG UBUNTU_APT_MIRROR=http://ports.ubuntu.com/ubuntu-ports
 FROM ${ROS_BASE_IMAGE}
 ARG PYPI_MIRROR
 ARG ROS_APT_MIRROR
+ARG UBUNTU_APT_MIRROR
 
 WORKDIR /work
 
-RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
-    apt-get install -y --no-install-recommends --allow-unauthenticated \
+# Some ros-base revisions retain the ROS installation and signing key but not
+# the ROS 2 apt source. Restore the signed source before installing the RMW.
+RUN test -s /usr/share/keyrings/ros2-archive-keyring.gpg || \
+        { echo "ERROR: base image is missing /usr/share/keyrings/ros2-archive-keyring.gpg"; exit 1; } && \
+    . /etc/os-release && \
+    printf 'deb %s %s main restricted universe multiverse\ndeb %s %s-updates main restricted universe multiverse\ndeb %s %s-backports main restricted universe multiverse\ndeb %s %s-security main restricted universe multiverse\n' \
+        "${UBUNTU_APT_MIRROR}" "${UBUNTU_CODENAME}" \
+        "${UBUNTU_APT_MIRROR}" "${UBUNTU_CODENAME}" \
+        "${UBUNTU_APT_MIRROR}" "${UBUNTU_CODENAME}" \
+        "${UBUNTU_APT_MIRROR}" "${UBUNTU_CODENAME}" \
+        > /etc/apt/sources.list && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros2-archive-keyring.gpg] ${ROS_APT_MIRROR} $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
+        > /etc/apt/sources.list.d/ros2.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
         python3-colcon-common-extensions \
         python3-pip \
+        ros-humble-rmw-cyclonedds-cpp \
+        ros-humble-nav-msgs \
+        ros-humble-sensor-msgs \
+        pulseaudio-utils \
         build-essential \
         cmake && \
     rm -rf /var/lib/apt/lists/*
@@ -18,22 +37,15 @@ RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
 COPY requirements.txt /tmp/t800-requirements.txt
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} -r /tmp/t800-requirements.txt
 
+# The base image's audio workspace intentionally narrows CMAKE_PREFIX_PATH.
+# Restore the ROS underlay after sourcing it so colcon can discover both trees.
 COPY msgs/ /t800_ws/src/
-RUN . /etc/os-release && \
-    echo "[t800] installing ROS interface build dependencies" && \
+RUN echo "[t800] checking ROS interface build dependencies" && \
     find /t800_ws/src -name '._*' -delete && \
-    echo "deb [arch=$(dpkg --print-architecture) trusted=yes] ${ROS_APT_MIRROR} ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/ros2.list && \
-    apt-get -o Acquire::AllowInsecureRepositories=true update && \
-    apt-get install -y --no-install-recommends --allow-unauthenticated --reinstall \
-        ros-humble-ament-cmake \
-        ros-humble-builtin-interfaces \
-        ros-humble-geometry-msgs \
-        ros-humble-rosidl-default-generators \
-        ros-humble-rosidl-default-runtime \
-        ros-humble-rosidl-generator-c \
-        ros-humble-std-msgs && \
     ldconfig && \
     . /opt/ros/humble/setup.sh && \
+    . /ros_ws/install/setup.sh && \
+    export CMAKE_PREFIX_PATH="/ros_ws/install/audio_msgs:/opt/ros/humble" && \
     echo "[t800] ROS interface dependency diagnostics" && \
     dpkg-query -W -f='[t800] ${Package} ${Version}\n' \
         ros-humble-ament-cmake \
@@ -55,12 +67,18 @@ RUN . /etc/os-release && \
     cd /t800_ws && \
     colcon build --packages-select interface_protocol && \
     . /t800_ws/install/setup.sh && \
-    python3 -c "from interface_protocol.msg import BodyVelCmd, Heartbeat, LinkInfo, MotionStateRequest; print('interface_protocol import ok')" && \
-    rm -rf /var/lib/apt/lists/*
+    python3 -c "from interface_protocol.msg import BodyVelCmd, Heartbeat, LinkInfo, MotionStateRequest; from nav_msgs.msg import Odometry; from sensor_msgs.msg import CompressedImage, Image, PointCloud2; print('T800 ROS imports ok')"
 
 COPY main.py device.py control.py native_sdk.py virtual_gamepad.py config.yaml driver.yaml /work/
 COPY resource/ /work/resource/
 COPY deploy/ /deploy/
+RUN . /opt/ros/humble/setup.sh && \
+    . /ros_ws/install/setup.sh && \
+    . /t800_ws/install/setup.sh && \
+    command -v pactl >/dev/null && \
+    command -v parec >/dev/null && \
+    ros2 pkg prefix rmw_cyclonedds_cpp >/dev/null && \
+    python3 -c "import main; from audio_msgs.msg import AudioChunk; import lcm, numpy, yaml; print('T800 runtime imports ok')"
 
 ENV T800_PREFERRED_RMW=rmw_cyclonedds_cpp
 ENV ROS_LOCALHOST_ONLY=0
@@ -69,4 +87,4 @@ ENV PYTHONPATH=/work
 
 EXPOSE 15708
 
-CMD ["/bin/bash", "-c", "source /opt/ros/humble/setup.bash && source /t800_ws/install/setup.bash && if [ -n \"${RMW_IMPLEMENTATION:-}\" ] && ! ros2 pkg prefix \"${RMW_IMPLEMENTATION}\" >/dev/null 2>&1; then echo \"[t800] ignoring unavailable RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}\"; unset RMW_IMPLEMENTATION; fi && if [ -n \"${T800_PREFERRED_RMW:-}\" ] && ros2 pkg prefix \"${T800_PREFERRED_RMW}\" >/dev/null 2>&1; then export RMW_IMPLEMENTATION=\"${T800_PREFERRED_RMW}\"; fi && export CYCLONEDDS_URI=\"<CycloneDDS><Domain><General><Interfaces><NetworkInterface name='${NETWORK_INTERFACE:-eth0}'/></Interfaces></General></Domain></CycloneDDS>\" && python3 /work/main.py"]
+CMD ["/bin/bash", "-c", "source /opt/ros/humble/setup.bash && source /ros_ws/install/setup.bash && source /t800_ws/install/setup.bash && if [ -n \"${RMW_IMPLEMENTATION:-}\" ] && ! ros2 pkg prefix \"${RMW_IMPLEMENTATION}\" >/dev/null 2>&1; then echo \"[t800] ignoring unavailable RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}\"; unset RMW_IMPLEMENTATION; fi && if [ -n \"${T800_PREFERRED_RMW:-}\" ] && ros2 pkg prefix \"${T800_PREFERRED_RMW}\" >/dev/null 2>&1; then export RMW_IMPLEMENTATION=\"${T800_PREFERRED_RMW}\"; fi && if [ -z \"${CYCLONEDDS_URI:-}\" ]; then export CYCLONEDDS_URI=\"<CycloneDDS><Domain><General><Interfaces><NetworkInterface name='${NETWORK_INTERFACE:-eth1}'/></Interfaces></General></Domain></CycloneDDS>\"; fi && exec python3 /work/main.py"]

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -42,6 +42,10 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_bridge` | actuator | 全 25 关节最高 500 Hz 底层控制 |
 | `led` | actuator | 众擎协议定义的 11 种灯效 |
 | `tts` | actuator | 众擎 TTS 消息；topic 可配置 |
+| `mic` | sensor | 内置麦克风 PCM-16 16kHz 采集，缓冲 1024 字节发布（满足 perception ASR 协议） |
+| `pointcloud` | sensor | Odin2 原始/SLAM 点云转发（`sensor/pointcloud` 二进制渲染流） |
+| `camera` | sensor | Odin2 双目 JPEG 图像转发（左/右目 `image/jpeg` 流） |
+| `depth` | sensor | Odin2 官方标定深度图转 640×480 毫米 16UC1（`image/depth-z16`） |
 | `motor_power` | actuator | 电机 enable/disable 服务 |
 | `native_node_control` | actuator | Native SDK 已注册 LogicNode 的动态 start/stop |
 | `virtual_gamepad` | actuator | Native SDK LCM 虚拟手柄：12 按键、6 模拟量和 7 种官方组合键 |
@@ -52,9 +56,10 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 joint override 和 joint bridge 的 motion-state 门禁；完整高风险能力没有从
 MCP schema 中隐藏。
 
-`loco.move_displacement`、`turn_angle` 和 `arc` 由速度乘时间换算。当前官方
-T800 协议没有里程计/定位反馈，因此它们是开环动作，返回结果会明确携带
-`open_loop: true`，不能当作闭环导航精度承诺。
+`loco.move_displacement`、`turn_angle` 和 `arc` 由速度乘时间换算。T800
+基础运动协议没有供控制闭环使用的定位反馈，因此它们仍是开环动作并返回
+`open_loop: true`。若 Odin2 固件提供配置中的 odometry topic，
+`motion_command_trace` 会把它用于状态显示，但不会据此闭环控制动作。
 
 `gesture.play` 与旧的 `joint_plan.preset` 不同：前者执行官方示例里的完整多步
 动作（挥手包含准备、举手、5 次摆动和复位；握手包含伸手、收手和复位），
@@ -67,6 +72,19 @@ T800 协议没有里程计/定位反馈，因此它们是开环动作，返回�
 lie_down 组合键。LCM 输入会覆盖实体手柄输入，发送完成后 Driver 自动发布
 全零包释放控制权。
 
+`pointcloud`、`camera`、`depth` 桥接 T800-Odin2 激光雷达相机（飞书文档
+7.2 节）在 Orin 主板上发布的 `odin_ros_driver` topic。点云按
+`[uint32 point_step][uint32 total_points][PointCloud2 bytes]` 二进制格式
+重发布到 `sensor/pointcloud` 流；双目压缩图原样转发。深度订阅官方
+`pcd2depth_ros2_node` 发布的 `/manifold/ODIN2/device0/depth`（`32FC1`、米），
+转换为固定 640×480 的毫米 `16UC1`；点云到相机坐标系的标定投影、膨胀、
+Sobel 边缘抑制和最近邻上采样均由众擎节点完成。使用 `depth` 前需按众擎
+文档 7.2 节启动该深度图节点。
+点云源可用 `pointcloud` 工具的 `select_source` action 在 `raw`/`slam`
+之间切换。Odin2 topic 带逐设备前缀 `/{topic_prefix}/{model}/device{N}/`，
+默认按 `config.yaml:topics.vision_*` 的 `/manifold/ODIN2/device0` 订阅，
+上机前请用 `ros_graph` 工具核对实际前缀。
+
 ## 运行
 
 机器人必须通过主机内置以太网口访问；官方默认 ROS Domain 为 69。
@@ -75,7 +93,12 @@ lie_down 组合键。LCM 输入会覆盖实体手柄输入，发送完成后 Dri
 cd engineai/t800
 docker build -t engineai-t800-driver .
 docker run --rm --network host --privileged \
-  -e NETWORK_INTERFACE=eth0 \
+  -v /dev:/dev \
+  -v ${T800_NATIVE_SDK_DIR:-/opt/engineai/native_sdk}:/opt/engineai/native_sdk \
+  -v ${T800_PULSE_RUNTIME_DIR:-/run/user/1000/pulse}:/run/user/1000/pulse \
+  -v ${T800_PULSE_CONFIG_DIR:-/home/ubuntu/.config/pulse}:/root/.config/pulse:ro \
+  -e NETWORK_INTERFACE=${T800_NETWORK_INTERFACE:-eth1} \
+  -e PULSE_SERVER=unix:/run/user/1000/pulse/native \
   engineai-t800-driver
 ```
 
@@ -104,6 +127,8 @@ docker run --rm --network host --privileged \
 飞书私有文档和实际固件可能调整 topic 或状态名。首次上机前需要核对：
 
 - `ros2 topic list -t` 与 `config.yaml:topics`；
+- Odin2 实际 topic 前缀（`/{topic_prefix}/{model}/device{N}/`，默认按
+  `/manifold/ODIN2/device0` 配置）；
 - `/hardware/joint_state` 数组顺序是否仍为 J00..J24；
 - TTS 的实际 topic；
 - `motion_state.available_transition_motions` 返回的固件状态名；

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -41,6 +41,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_override` | actuator | 指定关节 100 Hz 覆盖控制 |
 | `joint_bridge` | actuator | 全 25 关节最高 500 Hz 底层控制 |
 | `led` | actuator | 众擎协议定义的 11 种灯效 |
+| `tts` | actuator | 众擎 TTS 消息；topic 可配置 |
 | `mic` | sensor | 内置麦克风 PCM-16 16kHz 采集，缓冲 1024 字节发布（满足 perception ASR 协议） |
 | `pointcloud` | sensor | Odin2 原始/SLAM 点云转发（`sensor/pointcloud` 二进制渲染流） |
 | `camera` | sensor | Odin2 双目 JPEG 图像转发（左/右目 `image/jpeg` 流） |
@@ -128,6 +129,7 @@ docker run --rm --network host --privileged \
 - Odin2 实际 topic 前缀（`/{topic_prefix}/{model}/device{N}/`，默认按
   `/manifold/ODIN2/device0` 配置）；
 - `/hardware/joint_state` 数组顺序是否仍为 J00..J24；
+- TTS 的实际 topic；
 - `motion_state.available_transition_motions` 返回的固件状态名；
 - `/motion/node_control` 是否由当前 Native SDK 配置启用；
 - 开发版的速度、刚度、阻尼和力矩允许范围。

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -41,7 +41,10 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_override` | actuator | 指定关节 100 Hz 覆盖控制 |
 | `joint_bridge` | actuator | 全 25 关节最高 500 Hz 底层控制 |
 | `led` | actuator | 众擎协议定义的 11 种灯效 |
-| `tts` | actuator | 众擎 TTS 消息；topic 可配置 |
+| `mic` | sensor | 内置麦克风 PCM-16 16kHz 采集，缓冲 1024 字节发布（满足 perception ASR 协议） |
+| `pointcloud` | sensor | Odin2 原始/SLAM 点云转发（`sensor/pointcloud` 二进制渲染流） |
+| `camera` | sensor | Odin2 双目 JPEG 图像转发（左/右目 `image/jpeg` 流） |
+| `depth` | sensor | Odin2 官方标定深度图转 640×480 毫米 16UC1（`image/depth-z16`） |
 | `motor_power` | actuator | 电机 enable/disable 服务 |
 | `native_node_control` | actuator | Native SDK 已注册 LogicNode 的动态 start/stop |
 | `virtual_gamepad` | actuator | Native SDK LCM 虚拟手柄：12 按键、6 模拟量和 7 种官方组合键 |
@@ -67,6 +70,19 @@ T800 协议没有里程计/定位反馈，因此它们是开环动作，返回�
 lie_down 组合键。LCM 输入会覆盖实体手柄输入，发送完成后 Driver 自动发布
 全零包释放控制权。
 
+`pointcloud`、`camera`、`depth` 桥接 T800-Odin2 激光雷达相机（飞书文档
+7.2 节）在 Orin 主板上发布的 `odin_ros_driver` topic。点云按
+`[uint32 point_step][uint32 total_points][PointCloud2 bytes]` 二进制格式
+重发布到 `sensor/pointcloud` 流；双目压缩图原样转发。深度订阅官方
+`pcd2depth_ros2_node` 发布的 `/manifold/ODIN2/device0/depth`（`32FC1`、米），
+转换为固定 640×480 的毫米 `16UC1`；点云到相机坐标系的标定投影、膨胀、
+Sobel 边缘抑制和最近邻上采样均由众擎节点完成。使用 `depth` 前需按众擎
+文档 7.2 节启动该深度图节点。
+点云源可用 `pointcloud` 工具的 `select_source` action 在 `raw`/`slam`
+之间切换。Odin2 topic 带逐设备前缀 `/{topic_prefix}/{model}/device{N}/`，
+默认按 `config.yaml:topics.vision_*` 的 `/manifold/ODIN2/device0` 订阅，
+上机前请用 `ros_graph` 工具核对实际前缀。
+
 ## 运行
 
 机器人必须通过主机内置以太网口访问；官方默认 ROS Domain 为 69。
@@ -75,7 +91,12 @@ lie_down 组合键。LCM 输入会覆盖实体手柄输入，发送完成后 Dri
 cd engineai/t800
 docker build -t engineai-t800-driver .
 docker run --rm --network host --privileged \
-  -e NETWORK_INTERFACE=eth0 \
+  -v /dev:/dev \
+  -v /opt/engineai/native_sdk:/opt/engineai/native_sdk \
+  -v /run/user/1000/pulse:/run/user/1000/pulse \
+  -v /home/ubuntu/.config/pulse:/root/.config/pulse:ro \
+  -e NETWORK_INTERFACE=${T800_NETWORK_INTERFACE:-eth1} \
+  -e PULSE_SERVER=unix:/run/user/1000/pulse/native \
   engineai-t800-driver
 ```
 
@@ -104,8 +125,9 @@ docker run --rm --network host --privileged \
 飞书私有文档和实际固件可能调整 topic 或状态名。首次上机前需要核对：
 
 - `ros2 topic list -t` 与 `config.yaml:topics`；
+- Odin2 实际 topic 前缀（`/{topic_prefix}/{model}/device{N}/`，默认按
+  `/manifold/ODIN2/device0` 配置）；
 - `/hardware/joint_state` 数组顺序是否仍为 J00..J24；
-- TTS 的实际 topic；
 - `motion_state.available_transition_motions` 返回的固件状态名；
 - `/motion/node_control` 是否由当前 Native SDK 配置启用；
 - 开发版的速度、刚度、阻尼和力矩允许范围。

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -38,6 +38,7 @@ topics:
   joint_plan_state: "/motion/joint_motion_plan/state"
   joint_override: "/motion/joint_override_command"
   joint_command: "/hardware/joint_command"
+  tts: "/hardware/tts"
   native_node_control: "/motion/node_control"
   # T800-Odin2 激光雷达相机（飞书文档 7.2 节）；实机按 ros_graph 发现的
   # /{topic_prefix}/{model}/device{N}/ 前缀校准
@@ -68,6 +69,8 @@ plugins:
   joint_bridge:
     enabled: true
   led:
+    enabled: true
+  tts:
     enabled: true
   motor_power:
     enabled: true

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -38,8 +38,14 @@ topics:
   joint_plan_state: "/motion/joint_motion_plan/state"
   joint_override: "/motion/joint_override_command"
   joint_command: "/hardware/joint_command"
-  tts: "/hardware/tts"
   native_node_control: "/motion/node_control"
+  # T800-Odin2 激光雷达相机（飞书文档 7.2 节）；实机按 ros_graph 发现的
+  # /{topic_prefix}/{model}/device{N}/ 前缀校准
+  vision_cloud_raw: "/manifold/ODIN2/device0/cloud/raw"
+  vision_cloud_slam: "/manifold/ODIN2/device0/cloud/slam"
+  vision_camera_left: "/manifold/ODIN2/device0/camera0/compressed"
+  vision_camera_right: "/manifold/ODIN2/device0/camera1/compressed"
+  vision_depth: "/manifold/ODIN2/device0/depth"
 
 services:
   enable_motor: "/hardware/enable_motor"
@@ -63,8 +69,6 @@ plugins:
     enabled: true
   led:
     enabled: true
-  tts:
-    enabled: true
   motor_power:
     enabled: true
   native_node_control:
@@ -84,3 +88,8 @@ plugins:
     command: ["./run_robot.sh", "t800"]
     service: "robotics.service"
     stop_timeout: 10
+  mic:
+    enabled: true
+  vision:
+    enabled: true
+    source: "raw"            # raw | slam —— 转发哪个点云源

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -5,7 +5,7 @@ name: "EngineAI T800 Development Edition"
 ros:
   robot_domain_id: 69
   core_domain_id: 42
-  robot_interface: "eth0"
+  robot_interface: "eth1"
   source_timeout_sec: 1.0
 
 control:
@@ -43,6 +43,13 @@ topics:
   heartbeat: "/heartbeat"
   link_info: "/motion/link_info"
   odometry: "/manifold/ODIN2/device0/odometry"
+  # T800-Odin2 激光雷达相机（飞书文档 7.2 节）；实机按 ros_graph 发现的
+  # /{topic_prefix}/{model}/device{N}/ 前缀校准
+  vision_cloud_raw: "/manifold/ODIN2/device0/cloud/raw"
+  vision_cloud_slam: "/manifold/ODIN2/device0/cloud/slam"
+  vision_camera_left: "/manifold/ODIN2/device0/camera0/compressed"
+  vision_camera_right: "/manifold/ODIN2/device0/camera1/compressed"
+  vision_depth: "/manifold/ODIN2/device0/depth"
 
 services:
   enable_motor: "/hardware/enable_motor"
@@ -101,3 +108,8 @@ plugins:
     command: ["./run_robot.sh", "t800"]
     service: "robotics.service"
     stop_timeout: 10
+  mic:
+    enabled: true
+  vision:
+    enabled: true
+    source: "raw"            # raw | slam —— 转发哪个点云源

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -40,12 +40,29 @@ topics:
   joint_command: "/hardware/joint_command"
   tts: "/hardware/tts"
   native_node_control: "/motion/node_control"
+  heartbeat: "/heartbeat"
+  link_info: "/motion/link_info"
+  odometry: "/manifold/ODIN2/device0/odometry"
 
 services:
   enable_motor: "/hardware/enable_motor"
 
+diagnostics:
+  command_trace_capacity: 20
+  motion_events_capacity: 100
+
 plugins:
   state:
+    enabled: true
+  motion_events:
+    enabled: true
+  heartbeat_status:
+    enabled: true
+  link_info:
+    enabled: true
+  motion_command_trace:
+    enabled: true
+  native_interface_probe:
     enabled: true
   locomotion:
     enabled: true

--- a/engineai/t800/control.py
+++ b/engineai/t800/control.py
@@ -226,12 +226,23 @@ class RepeatingCommand:
             self._stop_event = stop_event
             self._started_at = started_at
             self._deadline = deadline
-            self._last_publish_at = None
-            self._publish_count = 0
+            self._last_publish_at = started_at
+            self._publish_count = 1
+        try:
+            # Publish once before handing off to the worker. This guarantees a
+            # short command is not lost if the scheduler starts the thread late.
+            self._publisher(command)
+        except Exception:
+            with self._lock:
+                if self._stop_event is stop_event:
+                    self._stop_event = None
+                    self._publish_count = 0
+                    self._last_publish_at = None
+            raise
 
         def run() -> None:
             try:
-                while not stop_event.is_set():
+                while not stop_event.wait(self._period):
                     now = self._clock()
                     if deadline is not None and now >= deadline:
                         break
@@ -297,6 +308,20 @@ def action_schema(
     }
 
 
+def sensor_action_schema() -> dict:
+    """Lifecycle schema used by Agent Core to start and resolve sensor topics."""
+    actions = {
+        "start": ([], "启动卡片数据流"),
+        "info": ([], "返回卡片状态和实际输出 topic"),
+        "stop": ([], "停止卡片数据流"),
+        "status": ([], "返回最新传感器状态"),
+    }
+    schema = action_schema(actions, {}, "传感器生命周期动作")
+    # Reading a sensor directly without an action remains supported.
+    schema.pop("required", None)
+    return schema
+
+
 def array_property(description: str, *, item_type: str = "number") -> dict:
     return {
         "type": "array",
@@ -312,7 +337,7 @@ def sensor_tool(name: str, description: str, topic: str, fmt: str) -> dict:
         "multiInstance": False,
         "readOnly": True,
         "description": description,
-        "inputSchema": {"type": "object", "properties": {}},
+        "inputSchema": sensor_action_schema(),
         "topic_out": [{"topic": topic, "format": fmt}],
     }
 

--- a/engineai/t800/deploy/service.yml
+++ b/engineai/t800/deploy/service.yml
@@ -8,10 +8,14 @@ engineai-t800:
   volumes:
     - /dev:/dev
     - /opt/engineai/native_sdk:/opt/engineai/native_sdk
+    # T800 厂商 PulseAudio 已独占机身麦克风，mic 通过宿主音频服务采集。
+    - /run/user/1000/pulse:/run/user/1000/pulse
+    - /home/ubuntu/.config/pulse:/root/.config/pulse:ro
   environment:
     - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
     - ROS_LOCALHOST_ONLY=0
-    - NETWORK_INTERFACE=eth0
+    - NETWORK_INTERFACE=${T800_NETWORK_INTERFACE:-eth1}
+    - PULSE_SERVER=unix:/run/user/1000/pulse/native
     - PYTHONUNBUFFERED=1
   logging:
     driver: local

--- a/engineai/t800/deploy/service.yml
+++ b/engineai/t800/deploy/service.yml
@@ -7,11 +7,21 @@ engineai-t800:
   privileged: true
   volumes:
     - /dev:/dev
-    - /opt/engineai/native_sdk:/opt/engineai/native_sdk
+    - ${T800_NATIVE_SDK_DIR:-/opt/engineai/native_sdk}:/opt/engineai/native_sdk
+    # T800 厂商 PulseAudio 已独占机身麦克风，mic 通过宿主音频服务采集。
+    - ${T800_PULSE_RUNTIME_DIR:-/run/user/1000/pulse}:/run/user/1000/pulse
+    - ${T800_PULSE_CONFIG_DIR:-/home/ubuntu/.config/pulse}:/root/.config/pulse:ro
   environment:
     - ROS_LOCALHOST_ONLY=0
-    - NETWORK_INTERFACE=eth0
+    - NETWORK_INTERFACE=${T800_NETWORK_INTERFACE:-eth1}
+    - PULSE_SERVER=unix:/run/user/1000/pulse/native
     - PYTHONUNBUFFERED=1
+  healthcheck:
+    test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:15708/health', timeout=2)"]
+    interval: 10s
+    timeout: 3s
+    retries: 6
+    start_period: 15s
   logging:
     driver: local
     options:

--- a/engineai/t800/deploy/service.yml
+++ b/engineai/t800/deploy/service.yml
@@ -9,7 +9,6 @@ engineai-t800:
     - /dev:/dev
     - /opt/engineai/native_sdk:/opt/engineai/native_sdk
   environment:
-    - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
     - ROS_LOCALHOST_ONLY=0
     - NETWORK_INTERFACE=eth0
     - PYTHONUNBUFFERED=1

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import json
 import math
+import numbers
+import subprocess
 import threading
 import time
 from dataclasses import asdict
@@ -65,8 +67,30 @@ def _now_ms() -> int:
 
 
 def _json_message(payload: dict) -> String:
+    def scalar_default(value):
+        # ROS array fields on ARM64 can expose NumPy/array scalar values.
+        # Normalize them at the JSON boundary so a vendor scalar cannot stop
+        # the domain-42 executor and, with it, the four sensor cards.
+        item = getattr(value, "item", None)
+        if callable(item):
+            return item()
+        if isinstance(value, numbers.Integral):
+            return int(value)
+        if isinstance(value, numbers.Real):
+            return float(value)
+        if hasattr(value, "__float__"):
+            return float(value)
+        if hasattr(value, "__int__"):
+            return int(value)
+        raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
     msg = String()
-    msg.data = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+    msg.data = json.dumps(
+        payload,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=scalar_default,
+    )
     return msg
 
 
@@ -302,12 +326,12 @@ class StatePlugin:
                     "body_velocity", "open_loop_displacement", "open_loop_turn", "open_loop_arc",
                     "motion_fsm", "joint_plan", "joint_override", "joint_bridge", "native_node_control",
                     "gesture_sequences", "dance", "virtual_gamepad", "soft_emergency_stop",
-                    "motor_power", "led", "tts", "ros_graph_discovery",
+                    "motor_power", "led", "ros_graph_discovery",
                 ],
                 "feedback": list(self._STREAMS) + ["joint_plan_state"],
                 "limitations": [
                     "no odometry topic: displacement/turn/arc are time-integrated open-loop estimates",
-                    "no public camera/lidar/dexterous-hand interface in the referenced T800 protocol",
+                    "no public dexterous-hand interface in the referenced T800 protocol",
                 ],
                 "timestamp_ms": _now_ms(),
             }
@@ -1414,50 +1438,6 @@ class LedPlugin:
         return {"state": "set", "mode": mode, "value": LED_MODES[mode]}
 
 
-class TtsPlugin:
-    def __init__(self, config: dict, namespace: str, ros2):
-        self._config = config
-        self._node = Node("t800_tts", context=ros2.ctx_robot)
-        ros2.executor_robot.add_node(self._node)
-        self._publisher = None
-
-    def get_tool(self) -> dict:
-        return {
-            "name": "tts",
-            "type": "actuator",
-            "description": "T800 Native SDK TTS 消息接口；topic 可通过 config.yaml 校准",
-            "inputSchema": {"type": "object", "properties": {
-                "text": {"type": "string"}, "language": {"type": "string"},
-                "speaker": {"type": "string"}, "rate": {"type": "integer", "minimum": 50, "maximum": 300}},
-                "required": ["text"]},
-        }
-
-    def start(self) -> None:
-        from interface_protocol.msg import Tts
-        self._message_type = Tts
-        self._publisher = self._node.create_publisher(Tts, self._config["topics"]["tts"], _RELIABLE)
-
-    def stop(self) -> None:
-        pass
-
-    def dispatch(self, action: str, args: dict) -> dict:
-        if action in ("start", "info"):
-            return {"state": "ready", "topic": self._config["topics"]["tts"]}
-        if action == "stop":
-            return {"state": "idle"}
-        text = str(args.get("text", "")).strip()
-        if not text:
-            return {"error": "text is required"}
-        msg = self._message_type()
-        msg.text = text
-        msg.language = str(args.get("language", "zh"))
-        msg.speaker = str(args.get("speaker", "default"))
-        msg.rate = int(clamp(args.get("rate", 150), 50, 300))
-        self._publisher.publish(msg)
-        return {"state": "published", "characters": len(text), "language": msg.language,
-                "speaker": msg.speaker, "rate": msg.rate}
-
-
 class MotorPowerPlugin:
     def __init__(self, config: dict, namespace: str, ros2):
         self._config = config
@@ -1707,3 +1687,363 @@ class SafetyControlPlugin:
         msg.damping = [1.0] * len(T800_JOINT_NAMES)
         msg.parallel_parser_type = 0
         self._joint_pub.publish(msg)
+
+
+class MicPlugin:
+    """Capture the T800 microphone through the vendor-owned PulseAudio server."""
+
+    _CHUNK_SAMPLES = 512  # 16 kHz 下 1024 字节 = 512 samples
+    _CHUNK_BYTES = 1024
+
+    def __init__(self, config: dict, namespace: str, ros2):
+        self._config = config
+        self._ns = namespace
+        self._topic = f"/{namespace}/mic/audio"
+        self._node = Node("t800_mic", context=ros2.ctx_core)
+        ros2.executor_core.add_node(self._node)
+        self._publisher = None
+        self._message_type = None
+        self._header_type = None
+        self._running = False
+        self._process = None
+        self._thread = None
+        self._samples_published = 0
+        self._last_error = ""
+
+    def get_tool(self) -> dict:
+        return sensor_tool(
+            "mic",
+            f"T800 内置麦克风，经 PulseAudio 采集 PCM-16 16kHz 单声道并发布到 {self._topic}",
+            self._topic,
+            "audio/pcm-16k",
+        )
+
+    def start(self) -> None:
+        if self._running:
+            return
+        from audio_msgs.msg import AudioChunk
+        from std_msgs.msg import Header
+
+        self._message_type = AudioChunk
+        self._header_type = Header
+        self._publisher = self._node.create_publisher(AudioChunk, self._topic, _BEST_EFFORT)
+
+        try:
+            self._check_pulse()
+            self._process = self._spawn_capture()
+        except Exception as exc:
+            self._last_error = str(exc)
+            return
+        if self._process.poll() is not None:
+            self._last_error = f"parec exited with code {self._process.returncode}"
+            self._process = None
+            return
+        self._running = True
+        self._thread = threading.Thread(target=self._capture_loop, daemon=True, name="t800-mic")
+        self._thread.start()
+
+    def _spawn_capture(self):
+        return subprocess.Popen(
+            ["parec", "--raw", "--format=s16le", "--rate=16000", "--channels=1",
+             "--latency-msec=50"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            bufsize=0,
+        )
+
+    def _check_pulse(self) -> None:
+        subprocess.run(["pactl", "info"], capture_output=True, text=True, timeout=3, check=True)
+
+    def stop(self) -> None:
+        self._running = False
+        process = self._process
+        self._process = None
+        if process is not None and process.poll() is None:
+            try:
+                process.terminate()
+                process.wait(timeout=1)
+            except Exception:
+                process.kill()
+        thread = self._thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=1)
+        self._thread = None
+
+    def _capture_loop(self) -> None:
+        pending = bytearray()
+        process = self._process
+        try:
+            while self._running and process is not None and process.stdout is not None:
+                data = process.stdout.read(self._CHUNK_BYTES - len(pending))
+                if not data:
+                    if process.poll() is not None:
+                        break
+                    continue
+                pending.extend(data)
+                if len(pending) == self._CHUNK_BYTES:
+                    self._publish_chunk(bytes(pending))
+                    pending.clear()
+        except Exception as exc:  # noqa: BLE001
+            self._last_error = str(exc)
+        finally:
+            if self._running and process is not None and process.poll() is not None:
+                self._last_error = f"parec exited with code {process.returncode}"
+                self._running = False
+
+    def _publish_chunk(self, chunk: bytes) -> None:
+        msg = self._message_type()
+        msg.header = self._header_type()
+        msg.header.stamp = self._node.get_clock().now().to_msg()
+        msg.format = "audio/pcm-16k"
+        msg.data = list(chunk)
+        self._publisher.publish(msg)
+        self._samples_published += len(chunk) // 2
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action == "start":
+            self.start()
+            if self._running:
+                return {"state": "running", "topic_out": [{"topic": self._topic, "format": "audio/pcm-16k"}]}
+            message = f"mic capture failed: {self._last_error or 'no audio device'}"
+            return {"state": "error", "message": message, "error": message}
+        if action == "stop":
+            self.stop()
+            return {"state": "idle"}
+        if action == "info":
+            return {"state": "running" if self._running else "idle",
+                    "topic_out": [{"topic": self._topic, "format": "audio/pcm-16k"}],
+                    "samples_published": self._samples_published,
+                    "last_error": self._last_error}
+        return {"error": f"unknown mic action: {action}"}
+
+
+class VisionPlugin:
+    """T800-Odin2 激光雷达相机视觉数据桥接（飞书文档 7.2 节）。
+
+    Subscribes to the Odin2 raw/SLAM point clouds, stereo compressed images
+    and the calibrated ``32FC1`` depth image published by the official
+    ``pcd2depth_ros2_node`` on the Orin board.  It republishes normalized
+    streams on domain 42 for Agent Core and the dashboard renderers
+    (``sensor/pointcloud``, ``image/jpeg``, ``image/depth-z16``).  Topic names
+    follow the per-device prefix ``/{topic_prefix}/{model}/device{N}/`` and
+    must be calibrated against ``ros_graph`` on the real robot.
+    """
+
+    _SOURCES = ("raw", "slam")
+    _DEPTH_WIDTH = 640
+    _DEPTH_HEIGHT = 480
+
+    def __init__(self, config: dict, namespace: str, ros2):
+        self._config = config
+        self._ns = namespace
+        self._topics = config["topics"]
+        vision_config = config.get("plugins", {}).get("vision", {}) or {}
+        self._source = vision_config.get("source", "raw")
+        if self._source not in self._SOURCES:
+            self._source = "raw"
+        self._cloud_topic = f"/{namespace}/vision/cloud"
+        self._cam_left_topic = f"/{namespace}/vision/camera_left"
+        self._cam_right_topic = f"/{namespace}/vision/camera_right"
+        self._depth_topic = f"/{namespace}/vision/depth"
+        self._sub_node = Node("t800_vision_sub", context=ros2.ctx_robot)
+        self._pub_node = Node("t800_vision_pub", context=ros2.ctx_core)
+        ros2.executor_robot.add_node(self._sub_node)
+        ros2.executor_core.add_node(self._pub_node)
+        self._running = False
+        self._lock = threading.RLock()
+        self._frames = {"pointcloud": 0, "camera_left": 0, "camera_right": 0, "depth": 0}
+
+    def get_tools(self) -> list[dict]:
+        return [self._cloud_tool(), self._camera_tool(), self._depth_tool()]
+
+    def _cloud_tool(self) -> dict:
+        return sensor_tool(
+            "pointcloud",
+            f"T800-Odin2 {self._source} 点云转发（256×192）；二进制 [uint32 point_step][uint32 total_points]"
+            f"[PointCloud2 bytes]，发布到 {self._cloud_topic}",
+            self._cloud_topic,
+            "sensor/pointcloud",
+        )
+
+    def _camera_tool(self) -> dict:
+        return {
+            "name": "camera",
+            "type": "sensor",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": f"T800-Odin2 双目 JPEG 图像转发，发布到 {self._cam_left_topic}（左）和"
+                           f" {self._cam_right_topic}（右）",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [
+                {"topic": self._cam_left_topic, "format": "image/jpeg"},
+                {"topic": self._cam_right_topic, "format": "image/jpeg"},
+            ],
+        }
+
+    def _depth_tool(self) -> dict:
+        return sensor_tool(
+            "depth",
+            f"T800-Odin2 官方标定深度图（640×480，毫米 16UC1），发布到 {self._depth_topic}",
+            self._depth_topic,
+            "image/depth-z16",
+        )
+
+    def start(self) -> None:
+        if self._running:
+            return
+        import array as _array
+        import struct as _struct
+        import numpy as _np
+        from sensor_msgs.msg import CompressedImage, Image, PointCloud2
+        from std_msgs.msg import UInt8MultiArray
+
+        self._running = True
+        self._struct = _struct
+        self._np = _np
+        self._image_type = Image
+        self._array = _array
+        self._multi_type = UInt8MultiArray
+        self._cloud_pub = self._pub_node.create_publisher(UInt8MultiArray, self._cloud_topic, _BEST_EFFORT)
+        self._cam_left_pub = self._pub_node.create_publisher(CompressedImage, self._cam_left_topic, _BEST_EFFORT)
+        self._cam_right_pub = self._pub_node.create_publisher(CompressedImage, self._cam_right_topic, _BEST_EFFORT)
+        self._depth_pub = self._pub_node.create_publisher(Image, self._depth_topic, _BEST_EFFORT)
+        self._sub_node.create_subscription(
+            PointCloud2, self._topics["vision_cloud_raw"], self._on_cloud_raw, _BEST_EFFORT
+        )
+        self._sub_node.create_subscription(
+            PointCloud2, self._topics["vision_cloud_slam"], self._on_cloud_slam, _BEST_EFFORT
+        )
+        self._sub_node.create_subscription(
+            CompressedImage, self._topics["vision_camera_left"], self._on_camera_left, _BEST_EFFORT
+        )
+        self._sub_node.create_subscription(
+            CompressedImage, self._topics["vision_camera_right"], self._on_camera_right, _BEST_EFFORT
+        )
+        self._sub_node.create_subscription(
+            Image, self._topics["vision_depth"], self._on_depth, _RELIABLE
+        )
+
+    def stop(self) -> None:
+        self._running = False
+
+    def _on_cloud_raw(self, msg) -> None:
+        self._on_cloud(msg, "raw")
+
+    def _on_cloud_slam(self, msg) -> None:
+        self._on_cloud(msg, "slam")
+
+    def _on_cloud(self, msg, source: str) -> None:
+        if not self._running or source != self._source:
+            return
+        data = bytes(msg.data)
+        if not data:
+            return
+        point_step = int(msg.point_step) or 1
+        header = self._struct.pack("<II", point_step, len(data) // point_step)
+        buf = bytearray(8 + len(data))
+        buf[:8] = header
+        buf[8:] = data
+        out = self._multi_type()
+        out.data = self._array.array("B", buf)
+        self._cloud_pub.publish(out)
+        self._frames["pointcloud"] += 1
+
+    def _on_camera_left(self, msg) -> None:
+        if not self._running:
+            return
+        self._cam_left_pub.publish(msg)
+        self._frames["camera_left"] += 1
+
+    def _on_camera_right(self, msg) -> None:
+        if not self._running:
+            return
+        self._cam_right_pub.publish(msg)
+        self._frames["camera_right"] += 1
+
+    def _on_depth(self, msg) -> None:
+        if not self._running:
+            return
+        width = int(msg.width)
+        height = int(msg.height)
+        encoding = str(msg.encoding).upper()
+        if encoding == "32FC1":
+            item_size = 4
+            dtype = "f4"
+        elif encoding in ("16UC1", "MONO16"):
+            item_size = 2
+            dtype = "u2"
+        else:
+            return
+        row_step = int(msg.step)
+        if width <= 0 or height <= 0 or row_step < width * item_size:
+            return
+        data = memoryview(msg.data)
+        required = (height - 1) * row_step + width * item_size
+        if len(data) < required:
+            return
+        byte_order = ">" if bool(msg.is_bigendian) else "<"
+        depth = self._np.ndarray(
+            shape=(height, width),
+            dtype=self._np.dtype(f"{byte_order}{dtype}"),
+            buffer=data,
+            strides=(row_step, item_size),
+        )
+
+        if encoding == "32FC1":
+            # The vendor node has already transformed the lidar points into
+            # the camera frame and publishes optical-axis depth in metres.
+            valid = self._np.isfinite(depth) & (depth > 0.0)
+            depth_mm = self._np.zeros((height, width), dtype="<u2")
+            depth_mm[valid] = self._np.clip(
+                self._np.rint(depth[valid] * 1000.0), 1, 65535
+            ).astype("<u2")
+        else:
+            depth_mm = depth.astype("<u2", copy=True)
+
+        # Agent Core's depth renderer consumes the Image payload without its
+        # ROS metadata and therefore requires a fixed 640x480 uint16 buffer.
+        target_width = self._DEPTH_WIDTH
+        target_height = self._DEPTH_HEIGHT
+        if width * target_height > height * target_width:
+            crop_width = max(1, height * target_width // target_height)
+            x0 = (width - crop_width) // 2
+            depth_mm = depth_mm[:, x0:x0 + crop_width]
+        elif width * target_height < height * target_width:
+            crop_height = max(1, width * target_height // target_width)
+            y0 = (height - crop_height) // 2
+            depth_mm = depth_mm[y0:y0 + crop_height, :]
+        source_height, source_width = depth_mm.shape
+        rows = self._np.arange(target_height) * source_height // target_height
+        cols = self._np.arange(target_width) * source_width // target_width
+        depth_mm = depth_mm[rows[:, None], cols[None, :]].astype("<u2", copy=False)
+
+        out = self._image_type()
+        out.header = msg.header
+        out.height = target_height
+        out.width = target_width
+        out.encoding = "16UC1"
+        out.is_bigendian = False
+        out.step = target_width * 2
+        out.data = depth_mm.tobytes(order="C")
+        self._depth_pub.publish(out)
+        self._frames["depth"] += 1
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("start", "stop", "info", "pointcloud", "camera", "depth"):
+            return {"state": "running" if self._running else "idle",
+                    "source": self._source,
+                    "topic_out": [
+                        {"topic": self._cloud_topic, "format": "sensor/pointcloud"},
+                        {"topic": self._cam_left_topic, "format": "image/jpeg"},
+                        {"topic": self._cam_right_topic, "format": "image/jpeg"},
+                        {"topic": self._depth_topic, "format": "image/depth-z16"},
+                    ],
+                    "frames": dict(self._frames)}
+        if action == "select_source":
+            source = str(args.get("source", "")).strip()
+            if source not in self._SOURCES:
+                raise ValueError(f"invalid pointcloud source: {source}; expected {'|'.join(self._SOURCES)}")
+            with self._lock:
+                self._source = source
+            return {"state": "running" if self._running else "idle", "source": source}
+        return {"error": f"unknown vision action: {action}"}

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -36,6 +36,7 @@ from control import (
     joint_payload,
     list_or_default,
     optional_floats,
+    sensor_action_schema,
     sensor_tool,
     validate_joint_indices,
     validate_parallel_arrays,
@@ -61,6 +62,20 @@ _RELIABLE_ONE = QoSProfile(
     depth=1,
     durability=DurabilityPolicy.VOLATILE,
 )
+
+_LIFECYCLE_ACTIONS = {
+    "start": ([], "启动卡片数据流"),
+    "info": ([], "返回卡片状态和实际输出 topic"),
+    "stop": ([], "停止卡片数据流"),
+}
+
+
+def _with_lifecycle(actions: dict[str, tuple[list[str], str]]) -> dict[str, tuple[list[str], str]]:
+    return {**_LIFECYCLE_ACTIONS, **actions}
+
+
+def _with_topic_out(payload: dict, topic: str, fmt: str = "data/json") -> dict:
+    return {**payload, "topic_out": [{"topic": topic, "format": fmt}]}
 
 
 def _now_ms() -> int:
@@ -255,13 +270,13 @@ class StatePlugin:
             return {"state": "idle"}
         if action_or_tool == "info":
             name = args.get("_tool_name", "driver_health")
-            if name not in self._STREAMS:
-                return {"state": "running"}
-            relative, fmt, _ = self._STREAMS[name]
-            return {
-                "state": "running",
-                "topic_out": [{"topic": f"/{self._ns}/{relative}", "format": fmt}],
-            }
+            if name in self._STREAMS:
+                relative, fmt, _ = self._STREAMS[name]
+                return _with_topic_out({"state": "running"}, f"/{self._ns}/{relative}", fmt)
+            if name in self._DERIVED_STREAMS:
+                relative, _ = self._DERIVED_STREAMS[name]
+                return _with_topic_out({"state": "running"}, f"/{self._ns}/{relative}")
+            return {"state": "running"}
         return {"error": f"unknown state action: {action_or_tool}"}
 
     def _derived_snapshot(self, name: str) -> dict:
@@ -353,7 +368,7 @@ class StatePlugin:
                 ],
                 "limitations": [
                     "no odometry topic: displacement/turn/arc are time-integrated open-loop estimates",
-                    "no public camera/lidar/dexterous-hand interface in the referenced T800 protocol",
+                    "no public dexterous-hand interface in the referenced T800 protocol",
                 ],
                 "timestamp_ms": _now_ms(),
             }
@@ -557,8 +572,18 @@ class StatePlugin:
             }
         for value in sources.values():
             value["stale"] = value["age_sec"] is None or value["age_sec"] > self._timeout
+        connected = sum(1 for value in sources.values() if value["connected"])
+        fresh = sum(1 for value in sources.values() if value["connected"] and not value["stale"])
+        if fresh:
+            state = "running"
+        elif connected:
+            state = "degraded"
+        else:
+            state = "waiting"
         return {
-            "state": "running" if any(v["connected"] for v in sources.values()) else "waiting",
+            "state": state,
+            "connected_sources": connected,
+            "fresh_sources": fresh,
             "sources": sources,
             "robot_domain_id": self._config["ros"]["robot_domain_id"],
             "core_domain_id": self._config["ros"]["core_domain_id"],
@@ -713,10 +738,10 @@ class HeartbeatStatusPlugin:
             "readOnly": True,
             "description": "显示 T800 ROS2 节点心跳、健康状态和数据新鲜度",
             "inputSchema": action_schema(
-                {
+                _with_lifecycle({
                     "status": ([], "返回适合画布验收的简洁心跳状态"),
                     "debug": ([], "返回原始心跳字段，供研发排查"),
-                },
+                }),
                 {},
                 "心跳查询动作",
             ),
@@ -735,7 +760,9 @@ class HeartbeatStatusPlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict:
-        if action in ("heartbeat_status", "status", "info", "start"):
+        if action == "info":
+            return _with_topic_out(self._snapshot(), f"/{self._ns}/state/heartbeat_status")
+        if action in ("heartbeat_status", "status", "start"):
             return self._snapshot()
         if action == "debug":
             return self._debug_snapshot()
@@ -823,10 +850,10 @@ class LinkInfoPlugin:
             "readOnly": True,
             "description": "显示 T800 LinkInfo 位姿、高度、速度和数据新鲜度",
             "inputSchema": action_schema(
-                {
+                _with_lifecycle({
                     "status": ([], "返回适合画布验收的简洁 link 状态"),
                     "debug": ([], "返回原始 pose/twist 字段，供研发排查"),
-                },
+                }),
                 {},
                 "LinkInfo 查询动作",
             ),
@@ -845,7 +872,9 @@ class LinkInfoPlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict:
-        if action in ("link_info", "status", "info", "start"):
+        if action == "info":
+            return _with_topic_out(self._snapshot(), f"/{self._ns}/state/link_info")
+        if action in ("link_info", "status", "start"):
             return self._snapshot()
         if action == "debug":
             return self._debug_snapshot()
@@ -955,10 +984,10 @@ class MotionCommandTracePlugin:
             "readOnly": True,
             "description": "输出 T800 当前速度，兼容手柄、驱动指令和里程计来源",
             "inputSchema": action_schema(
-                {
+                _with_lifecycle({
                     "status": ([], "返回适合画布验收的简洁速度状态"),
                     "debug": ([], "返回最近命令、手柄、里程计原始摘要，供研发排查"),
-                },
+                }),
                 {},
                 "运动速度查询",
             ),
@@ -990,7 +1019,9 @@ class MotionCommandTracePlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict:
-        if action in ("motion_command_trace", "status", "info", "start"):
+        if action == "info":
+            return _with_topic_out(self._snapshot(), f"/{self._ns}/state/motion_command_trace")
+        if action in ("motion_command_trace", "status", "start"):
             return self._snapshot()
         if action == "debug":
             return self._debug_snapshot()
@@ -1065,7 +1096,14 @@ class MotionCommandTracePlugin:
         source = "none"
         speed = 0.0
         age_sec = None
-        if odometry is not None:
+        odometry_fresh = odometry is not None and odometry_age is not None and odometry_age <= timeout_sec
+        velocity_fresh = velocity is not None and velocity_age is not None and velocity_age <= timeout_sec
+        use_odometry = odometry_fresh or (
+            odometry is not None
+            and not velocity_fresh
+            and (velocity_age is None or (odometry_age is not None and odometry_age <= velocity_age))
+        )
+        if use_odometry:
             source = "odometry"
             speed = float(odometry.get("speed_m_s", 0.0))
             age_sec = odometry_age
@@ -1175,14 +1213,12 @@ class MotionEventsPlugin:
             "multiInstance": False,
             "readOnly": True,
             "description": "T800 motion event stream — motion state changes and motion command lifecycle events",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string",
-                        "enum": ["status", "info", "debug"],
-                        "description": "status returns the latest event summary; debug returns the buffered timeline",
-                    },
+            "inputSchema": action_schema(
+                _with_lifecycle({
+                    "status": ([], "返回最新事件摘要"),
+                    "debug": (["limit", "since_event_id", "source_tool", "severity"], "返回筛选后的事件时间线"),
+                }),
+                {
                     "limit": {
                         "type": "integer",
                         "minimum": 1,
@@ -1203,7 +1239,8 @@ class MotionEventsPlugin:
                         "description": "按事件级别过滤",
                     },
                 },
-            },
+                "运动事件查询动作",
+            ),
             "topic_out": [{"topic": f"/{self._ns}/state/motion_events", "format": "data/json"}],
         }
 
@@ -1221,7 +1258,9 @@ class MotionEventsPlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict:
-        if action in ("motion_events", "status", "info", "start"):
+        if action == "info":
+            return _with_topic_out(self._summary_snapshot(), f"/{self._ns}/state/motion_events")
+        if action in ("motion_events", "status", "start"):
             return self._summary_snapshot()
         if action in ("debug", "list"):
             return self._debug_snapshot(args)
@@ -1455,10 +1494,10 @@ class NativeInterfaceProbePlugin:
             "readOnly": True,
             "description": "扫描 T800 ROS 图，汇总已映射与未映射原生接口",
             "inputSchema": action_schema(
-                {
+                _with_lifecycle({
                     "scan": ([], "扫描 ROS2 topic/service 并输出适合画布验收的摘要"),
                     "debug": ([], "输出完整 topic/service/mapped/unmapped 清单，供研发排查"),
-                },
+                }),
                 {},
                 "原生接口探测动作",
             ),
@@ -1472,7 +1511,9 @@ class NativeInterfaceProbePlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict:
-        if action in ("native_interface_probe", "scan", "status", "info", "start"):
+        if action == "info":
+            return _with_topic_out(self._scan(), f"/{self._ns}/state/native_interface_probe")
+        if action in ("native_interface_probe", "scan", "status", "start"):
             return self._scan()
         if action == "debug":
             return self._scan(debug=True)
@@ -1968,7 +2009,10 @@ class JointPlanPlugin:
             return {"state": "running" if args.get("_tool_name") == "joint_plan_state" else "ready"}
         if action in ("info", "status", "joint_plan_state"):
             with self._state_lock:
-                return dict(self._last_state)
+                snapshot = dict(self._last_state)
+            if args.get("_tool_name") == "joint_plan_state" or action == "joint_plan_state":
+                return _with_topic_out(snapshot, self._core_topic)
+            return snapshot
         if action == "stop":
             return {"state": "idle"}
         if action == "reset":
@@ -2579,8 +2623,12 @@ class MotorPowerPlugin:
 
     def dispatch(self, action: str, args: dict) -> dict:
         if action in ("start", "info"):
+            available = bool(self._client and self._client.service_is_ready())
+            if action == "start" and not available:
+                return {"state": "error", "message": "motor enable service is unavailable",
+                        "service": self._config["services"]["enable_motor"], "available": False}
             return {"state": "ready", "service": self._config["services"]["enable_motor"],
-                    "available": bool(self._client and self._client.service_is_ready())}
+                    "available": available}
         if action == "stop":
             return {"state": "idle"}
         if action not in ("enable", "disable"):
@@ -2798,3 +2846,422 @@ class SafetyControlPlugin:
         msg.damping = [1.0] * len(T800_JOINT_NAMES)
         msg.parallel_parser_type = 0
         self._joint_pub.publish(msg)
+
+
+class MicPlugin:
+    """Capture the T800 microphone through the vendor-owned PulseAudio server."""
+
+    _CHUNK_SAMPLES = 512  # 16 kHz 下 1024 字节 = 512 samples
+    _CHUNK_BYTES = 1024
+
+    def __init__(self, config: dict, namespace: str, ros2):
+        self._config = config
+        self._ns = namespace
+        self._topic = f"/{namespace}/mic/audio"
+        self._node = Node("t800_mic", context=ros2.ctx_core)
+        ros2.executor_core.add_node(self._node)
+        self._publisher = None
+        self._message_type = None
+        self._header_type = None
+        self._running = False
+        self._process = None
+        self._thread = None
+        self._samples_published = 0
+        self._last_error = ""
+
+    def get_tool(self) -> dict:
+        return sensor_tool(
+            "mic",
+            f"T800 内置麦克风，经 PulseAudio 采集 PCM-16 16kHz 单声道并发布到 {self._topic}",
+            self._topic,
+            "audio/pcm-16k",
+        )
+
+    def start(self) -> None:
+        if self._running:
+            return
+        if self._publisher is None:
+            from audio_msgs.msg import AudioChunk
+            from std_msgs.msg import Header
+
+            self._message_type = AudioChunk
+            self._header_type = Header
+            self._publisher = self._node.create_publisher(AudioChunk, self._topic, _BEST_EFFORT)
+
+        try:
+            self._check_pulse()
+            self._process = self._spawn_capture()
+        except Exception as exc:
+            self._last_error = str(exc)
+            raise RuntimeError(f"PulseAudio capture is unavailable: {exc}") from exc
+        if self._process.poll() is not None:
+            self._last_error = f"parec exited with code {self._process.returncode}"
+            self._process = None
+            raise RuntimeError(self._last_error)
+        self._running = True
+        self._thread = threading.Thread(target=self._capture_loop, daemon=True, name="t800-mic")
+        self._thread.start()
+
+    def _spawn_capture(self):
+        return subprocess.Popen(
+            ["parec", "--raw", "--format=s16le", "--rate=16000", "--channels=1",
+             "--latency-msec=50"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            bufsize=0,
+        )
+
+    def _check_pulse(self) -> None:
+        subprocess.run(["pactl", "info"], capture_output=True, text=True, timeout=3, check=True)
+
+    def stop(self) -> None:
+        self._running = False
+        process = self._process
+        self._process = None
+        if process is not None and process.poll() is None:
+            try:
+                process.terminate()
+                process.wait(timeout=1)
+            except Exception:
+                process.kill()
+        thread = self._thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=1)
+        self._thread = None
+
+    def _capture_loop(self) -> None:
+        pending = bytearray()
+        process = self._process
+        try:
+            while self._running and process is not None and process.stdout is not None:
+                data = process.stdout.read(self._CHUNK_BYTES - len(pending))
+                if not data:
+                    if process.poll() is not None:
+                        break
+                    continue
+                pending.extend(data)
+                if len(pending) == self._CHUNK_BYTES:
+                    self._publish_chunk(bytes(pending))
+                    pending.clear()
+        except Exception as exc:  # noqa: BLE001
+            self._last_error = str(exc)
+        finally:
+            if self._running and process is not None and process.poll() is not None:
+                self._last_error = f"parec exited with code {process.returncode}"
+                self._running = False
+
+    def _publish_chunk(self, chunk: bytes) -> None:
+        msg = self._message_type()
+        msg.header = self._header_type()
+        msg.header.stamp = self._node.get_clock().now().to_msg()
+        msg.format = "audio/pcm-16k"
+        msg.data = list(chunk)
+        self._publisher.publish(msg)
+        self._samples_published += len(chunk) // 2
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action == "start":
+            try:
+                self.start()
+            except RuntimeError as exc:
+                message = f"mic capture failed: {exc}"
+                return {"state": "error", "message": message, "error": message}
+            if self._running:
+                return {"state": "running", "topic_out": [{"topic": self._topic, "format": "audio/pcm-16k"}]}
+            message = f"mic capture failed: {self._last_error or 'no audio device'}"
+            return {"state": "error", "message": message, "error": message}
+        if action == "stop":
+            self.stop()
+            return {"state": "idle"}
+        if action in ("info", "status"):
+            return {"state": "running" if self._running else "idle",
+                    "topic_out": [{"topic": self._topic, "format": "audio/pcm-16k"}],
+                    "samples_published": self._samples_published,
+                    "last_error": self._last_error}
+        return {"error": f"unknown mic action: {action}"}
+
+
+class VisionPlugin:
+    """T800-Odin2 激光雷达相机视觉数据桥接（飞书文档 7.2 节）。
+
+    Subscribes to the Odin2 raw/SLAM point clouds, stereo compressed images
+    and the calibrated ``32FC1`` depth image published by the official
+    ``pcd2depth_ros2_node`` on the Orin board.  It republishes normalized
+    streams on domain 42 for Agent Core and the dashboard renderers
+    (``sensor/pointcloud``, ``image/jpeg``, ``image/depth-z16``).  Topic names
+    follow the per-device prefix ``/{topic_prefix}/{model}/device{N}/`` and
+    must be calibrated against ``ros_graph`` on the real robot.
+    """
+
+    _SOURCES = ("raw", "slam")
+    _TOOL_NAMES = ("pointcloud", "camera", "depth")
+    _DEPTH_WIDTH = 640
+    _DEPTH_HEIGHT = 480
+
+    def __init__(self, config: dict, namespace: str, ros2):
+        self._config = config
+        self._ns = namespace
+        self._topics = config["topics"]
+        vision_config = config.get("plugins", {}).get("vision", {}) or {}
+        self._source = vision_config.get("source", "raw")
+        if self._source not in self._SOURCES:
+            self._source = "raw"
+        self._cloud_topic = f"/{namespace}/vision/cloud"
+        self._cam_left_topic = f"/{namespace}/vision/camera_left"
+        self._cam_right_topic = f"/{namespace}/vision/camera_right"
+        self._depth_topic = f"/{namespace}/vision/depth"
+        self._sub_node = Node("t800_vision_sub", context=ros2.ctx_robot)
+        self._pub_node = Node("t800_vision_pub", context=ros2.ctx_core)
+        ros2.executor_robot.add_node(self._sub_node)
+        ros2.executor_core.add_node(self._pub_node)
+        self._running = False
+        self._initialized = False
+        self._enabled_tools: set[str] = set()
+        self._lock = threading.RLock()
+        self._frames = {"pointcloud": 0, "camera_left": 0, "camera_right": 0, "depth": 0}
+
+    def get_tools(self) -> list[dict]:
+        return [self._cloud_tool(), self._camera_tool(), self._depth_tool()]
+
+    def _cloud_tool(self) -> dict:
+        tool = sensor_tool(
+            "pointcloud",
+            f"T800-Odin2 {self._source} 点云转发（256×192）；二进制 [uint32 point_step][uint32 total_points]"
+            f"[PointCloud2 bytes]，发布到 {self._cloud_topic}",
+            self._cloud_topic,
+            "sensor/pointcloud",
+        )
+        schema = action_schema(
+            _with_lifecycle({
+                "status": ([], "返回点云流状态"),
+                "select_source": (["source"], "切换 Odin2 raw 或 SLAM 点云源"),
+            }),
+            {"source": {"type": "string", "enum": list(self._SOURCES)}},
+            "点云生命周期和数据源选择",
+        )
+        schema.pop("required", None)
+        tool["inputSchema"] = schema
+        return tool
+
+    def _camera_tool(self) -> dict:
+        return {
+            "name": "camera",
+            "type": "sensor",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": f"T800-Odin2 双目 JPEG 图像转发，发布到 {self._cam_left_topic}（左）和"
+                           f" {self._cam_right_topic}（右）",
+            "inputSchema": sensor_action_schema(),
+            "topic_out": [
+                {"topic": self._cam_left_topic, "format": "image/jpeg"},
+                {"topic": self._cam_right_topic, "format": "image/jpeg"},
+            ],
+        }
+
+    def _depth_tool(self) -> dict:
+        return sensor_tool(
+            "depth",
+            f"T800-Odin2 官方标定深度图（640×480，毫米 16UC1），发布到 {self._depth_topic}",
+            self._depth_topic,
+            "image/depth-z16",
+        )
+
+    def start(self) -> None:
+        if self._running:
+            return
+        if self._initialized:
+            self._enabled_tools.update(self._TOOL_NAMES)
+            self._running = True
+            return
+        import array as _array
+        import struct as _struct
+        import numpy as _np
+        from sensor_msgs.msg import CompressedImage, Image, PointCloud2
+        from std_msgs.msg import UInt8MultiArray
+
+        self._running = True
+        self._struct = _struct
+        self._np = _np
+        self._image_type = Image
+        self._array = _array
+        self._multi_type = UInt8MultiArray
+        self._cloud_pub = self._pub_node.create_publisher(UInt8MultiArray, self._cloud_topic, _BEST_EFFORT)
+        self._cam_left_pub = self._pub_node.create_publisher(CompressedImage, self._cam_left_topic, _BEST_EFFORT)
+        self._cam_right_pub = self._pub_node.create_publisher(CompressedImage, self._cam_right_topic, _BEST_EFFORT)
+        self._depth_pub = self._pub_node.create_publisher(Image, self._depth_topic, _BEST_EFFORT)
+        self._sub_node.create_subscription(
+            PointCloud2, self._topics["vision_cloud_raw"], self._on_cloud_raw, _BEST_EFFORT
+        )
+        self._sub_node.create_subscription(
+            PointCloud2, self._topics["vision_cloud_slam"], self._on_cloud_slam, _BEST_EFFORT
+        )
+        self._sub_node.create_subscription(
+            CompressedImage, self._topics["vision_camera_left"], self._on_camera_left, _BEST_EFFORT
+        )
+        self._sub_node.create_subscription(
+            CompressedImage, self._topics["vision_camera_right"], self._on_camera_right, _BEST_EFFORT
+        )
+        self._sub_node.create_subscription(
+            Image, self._topics["vision_depth"], self._on_depth, _RELIABLE
+        )
+        self._initialized = True
+        self._enabled_tools.update(self._TOOL_NAMES)
+
+    def stop(self) -> None:
+        self._running = False
+        self._enabled_tools.clear()
+
+    def _on_cloud_raw(self, msg) -> None:
+        self._on_cloud(msg, "raw")
+
+    def _on_cloud_slam(self, msg) -> None:
+        self._on_cloud(msg, "slam")
+
+    def _on_cloud(self, msg, source: str) -> None:
+        if not self._running or "pointcloud" not in self._enabled_tools or source != self._source:
+            return
+        data = bytes(msg.data)
+        if not data:
+            return
+        point_step = int(msg.point_step) or 1
+        header = self._struct.pack("<II", point_step, len(data) // point_step)
+        buf = bytearray(8 + len(data))
+        buf[:8] = header
+        buf[8:] = data
+        out = self._multi_type()
+        out.data = self._array.array("B", buf)
+        self._cloud_pub.publish(out)
+        self._frames["pointcloud"] += 1
+
+    def _on_camera_left(self, msg) -> None:
+        if not self._running or "camera" not in self._enabled_tools:
+            return
+        self._cam_left_pub.publish(msg)
+        self._frames["camera_left"] += 1
+
+    def _on_camera_right(self, msg) -> None:
+        if not self._running or "camera" not in self._enabled_tools:
+            return
+        self._cam_right_pub.publish(msg)
+        self._frames["camera_right"] += 1
+
+    def _on_depth(self, msg) -> None:
+        if not self._running or "depth" not in self._enabled_tools:
+            return
+        width = int(msg.width)
+        height = int(msg.height)
+        encoding = str(msg.encoding).upper()
+        if encoding == "32FC1":
+            item_size = 4
+            dtype = "f4"
+        elif encoding in ("16UC1", "MONO16"):
+            item_size = 2
+            dtype = "u2"
+        else:
+            return
+        row_step = int(msg.step)
+        if width <= 0 or height <= 0 or row_step < width * item_size:
+            return
+        data = memoryview(msg.data)
+        required = (height - 1) * row_step + width * item_size
+        if len(data) < required:
+            return
+        byte_order = ">" if bool(msg.is_bigendian) else "<"
+        depth = self._np.ndarray(
+            shape=(height, width),
+            dtype=self._np.dtype(f"{byte_order}{dtype}"),
+            buffer=data,
+            strides=(row_step, item_size),
+        )
+
+        if encoding == "32FC1":
+            # The vendor node has already transformed the lidar points into
+            # the camera frame and publishes optical-axis depth in metres.
+            valid = self._np.isfinite(depth) & (depth > 0.0)
+            depth_mm = self._np.zeros((height, width), dtype="<u2")
+            depth_mm[valid] = self._np.clip(
+                self._np.rint(depth[valid] * 1000.0), 1, 65535
+            ).astype("<u2")
+        else:
+            depth_mm = depth.astype("<u2", copy=True)
+
+        # Agent Core's depth renderer consumes the Image payload without its
+        # ROS metadata and therefore requires a fixed 640x480 uint16 buffer.
+        target_width = self._DEPTH_WIDTH
+        target_height = self._DEPTH_HEIGHT
+        if width * target_height > height * target_width:
+            crop_width = max(1, height * target_width // target_height)
+            x0 = (width - crop_width) // 2
+            depth_mm = depth_mm[:, x0:x0 + crop_width]
+        elif width * target_height < height * target_width:
+            crop_height = max(1, width * target_height // target_width)
+            y0 = (height - crop_height) // 2
+            depth_mm = depth_mm[y0:y0 + crop_height, :]
+        source_height, source_width = depth_mm.shape
+        rows = self._np.arange(target_height) * source_height // target_height
+        cols = self._np.arange(target_width) * source_width // target_width
+        depth_mm = depth_mm[rows[:, None], cols[None, :]].astype("<u2", copy=False)
+
+        out = self._image_type()
+        out.header = msg.header
+        out.height = target_height
+        out.width = target_width
+        out.encoding = "16UC1"
+        out.is_bigendian = False
+        out.step = target_width * 2
+        out.data = depth_mm.tobytes(order="C")
+        self._depth_pub.publish(out)
+        self._frames["depth"] += 1
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        tool_name = str(args.get("_tool_name", ""))
+        if not tool_name and action in self._TOOL_NAMES:
+            tool_name = action
+        if tool_name not in self._TOOL_NAMES:
+            tool_name = ""
+
+        if action == "start":
+            was_initialized = self._initialized
+            if not was_initialized:
+                self.start()
+            if tool_name and not was_initialized:
+                # Direct use outside the bundle initializes all publishers and
+                # subscriptions once, but only activates the requested card.
+                self._enabled_tools = {tool_name}
+            elif tool_name:
+                self._enabled_tools.add(tool_name)
+            else:
+                self._enabled_tools.update(self._TOOL_NAMES)
+            self._running = bool(self._enabled_tools)
+        elif action == "stop":
+            if tool_name:
+                self._enabled_tools.discard(tool_name)
+                self._running = bool(self._enabled_tools)
+            else:
+                self.stop()
+        if action in ("start", "stop", "info", "status", "pointcloud", "camera", "depth"):
+            topic_out_by_tool = {
+                "pointcloud": [{"topic": self._cloud_topic, "format": "sensor/pointcloud"}],
+                "camera": [
+                    {"topic": self._cam_left_topic, "format": "image/jpeg"},
+                    {"topic": self._cam_right_topic, "format": "image/jpeg"},
+                ],
+                "depth": [{"topic": self._depth_topic, "format": "image/depth-z16"}],
+            }
+            selected_tools = (tool_name,) if tool_name else self._TOOL_NAMES
+            topic_out = [topic for name in selected_tools for topic in topic_out_by_tool[name]]
+            is_running = (
+                tool_name in self._enabled_tools if tool_name else bool(self._enabled_tools)
+            )
+            return {"state": "running" if is_running else "idle",
+                    "source": self._source,
+                    "topic_out": topic_out,
+                    "frames": dict(self._frames)}
+        if action == "select_source":
+            source = str(args.get("source", "")).strip()
+            if source not in self._SOURCES:
+                raise ValueError(f"invalid pointcloud source: {source}; expected {'|'.join(self._SOURCES)}")
+            with self._lock:
+                self._source = source
+            return {"state": "running" if self._running else "idle", "source": source}
+        return {"error": f"unknown vision action: {action}"}

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 
 import json
 import math
+import numbers
+import subprocess
 import threading
 import time
+from collections import deque
 from dataclasses import asdict
 from pathlib import Path
 
@@ -65,9 +68,38 @@ def _now_ms() -> int:
 
 
 def _json_message(payload: dict) -> String:
+    def scalar_default(value):
+        item = getattr(value, "item", None)
+        if callable(item):
+            return item()
+        if isinstance(value, numbers.Integral):
+            return int(value)
+        if isinstance(value, numbers.Real):
+            return float(value)
+        if hasattr(value, "__float__"):
+            return float(value)
+        if hasattr(value, "__int__"):
+            return int(value)
+        raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
     msg = String()
-    msg.data = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+    msg.data = json.dumps(
+        payload,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=scalar_default,
+    )
     return msg
+
+
+def _graph_items(node, method: str) -> list:
+    callback = getattr(node, method, None)
+    if callback is None:
+        return []
+    try:
+        return list(callback())
+    except Exception:
+        return []
 
 
 class StatePlugin:
@@ -92,13 +124,17 @@ class StatePlugin:
         "joint_groups": ("model/joint_groups", "T800 腿、躯干、双臂和头部关节分组"),
         "capabilities": ("model/capabilities", "T800 Driver 原生接口、高阶动作和限制说明"),
         "ros_graph": ("state/ros_graph", "实时发现 T800 ROS2 节点、topic、service 和固件扩展接口"),
+        "mainboard": ("state/mainboard", "展示 T800 主控板关联的温度、电源与电机诊断摘要"),
     }
+    _MAINBOARD_KEYWORDS = ("mainboard", "main_board", "board", "thermal", "temperature", "fan", "diagnostic")
+    _MAINBOARD_STRONG_KEYWORDS = ("mainboard", "main_board", "board")
 
-    def __init__(self, config: dict, namespace: str, ros2):
+    def __init__(self, config: dict, namespace: str, ros2, motion_events=None):
         self._config = config
         self._ns = namespace
         self._ros2 = ros2
         self._topics = config["topics"]
+        self._motion_events = motion_events
         self._timeout = float(config["ros"].get("source_timeout_sec", 1.0))
         self._running = False
         self._lock = threading.RLock()
@@ -207,6 +243,12 @@ class StatePlugin:
             return self._derived_snapshot(action_or_tool)
         if action_or_tool in self._STREAMS:
             return self._snapshot(action_or_tool)
+        if action_or_tool == "status":
+            name = args.get("_tool_name", "driver_health")
+            if name in self._DERIVED_STREAMS:
+                return self._derived_snapshot(name)
+            if name in self._STREAMS:
+                return self._snapshot(name)
         if action_or_tool == "start":
             return {"state": "running"}
         if action_or_tool == "stop":
@@ -304,7 +346,11 @@ class StatePlugin:
                     "gesture_sequences", "dance", "virtual_gamepad", "soft_emergency_stop",
                     "motor_power", "led", "tts", "ros_graph_discovery",
                 ],
-                "feedback": list(self._STREAMS) + ["joint_plan_state"],
+                "feedback": list(self._STREAMS) + [
+                    "joint_plan_state", "heartbeat_status", "link_info",
+                    "motion_command_trace", "native_interface_probe",
+                    "motion_events", "mainboard",
+                ],
                 "limitations": [
                     "no odometry topic: displacement/turn/arc are time-integrated open-loop estimates",
                     "no public camera/lidar/dexterous-hand interface in the referenced T800 protocol",
@@ -342,7 +388,145 @@ class StatePlugin:
                 "unmapped_topics": [item for item in topics if item["name"] not in configured],
                 "timestamp_ms": _now_ms(),
             }
+        if name == "mainboard":
+            return self._mainboard_snapshot()
         return {"error": f"unknown derived state: {name}"}
+
+    def _mainboard_snapshot(self) -> dict:
+        motor = self._snapshot("motor_health")
+        power = self._snapshot("battery")
+        if "mos_temperature_c" in motor or "voltage_v" in power:
+            return self._mainboard_hardware_snapshot(motor, power)
+
+        candidates = self._mainboard_candidates()
+        strong = [
+            item for item in candidates
+            if self._is_strong_mainboard_name(item["name"])
+        ]
+        state = "source_discovered" if strong else "no_data_source"
+        source = strong[0] if strong else None
+        return {
+            "state": state,
+            "ok": False,
+            "source": source,
+            "discovered_candidates": candidates,
+            "message": (
+                "mainboard candidate topic discovered; add a typed adapter after confirming the message contract"
+                if source else "No confirmed T800 mainboard telemetry topic or API was found."
+            ),
+            "search_keywords": list(self._MAINBOARD_KEYWORDS),
+            "timestamp_ms": _now_ms(),
+        }
+
+    def _mainboard_hardware_snapshot(self, motor: dict, power: dict) -> dict:
+        mos_temperatures = [float(value) for value in motor.get("mos_temperature_c", [])]
+        motor_errors = [int(value) for value in motor.get("error_code", [])]
+        offline = [int(value) for value in motor.get("offline", [])]
+        disabled = [0 if bool(value) else 1 for value in motor.get("enabled", [])]
+
+        board_temperature = max(mos_temperatures) if mos_temperatures else None
+        warning_temperature = float(self._config["control"].get("motor_warning_temperature_c", 70.0))
+        temperature_warning = board_temperature is not None and board_temperature >= warning_temperature
+        power_error = int(power.get("error_code", 0) or 0)
+        motor_error_count = sum(1 for value in motor_errors if value != 0)
+        offline_count = sum(1 for value in offline if value != 0)
+        disabled_count = sum(1 for value in disabled if value != 0)
+        stale = bool(motor.get("stale", True) or power.get("stale", True))
+
+        if stale:
+            state = "stale"
+        elif power_error or motor_error_count or offline_count or disabled_count:
+            state = "error"
+        elif temperature_warning:
+            state = "warning"
+        else:
+            state = "ok"
+
+        ages = [
+            value for value in (motor.get("age_sec"), power.get("age_sec"))
+            if value is not None
+        ]
+        message_parts = []
+        if stale:
+            message_parts.append("hardware telemetry is stale")
+        if temperature_warning:
+            message_parts.append(f"board temperature >= {warning_temperature:.0f} C")
+        if power_error:
+            message_parts.append(f"power error code {power_error}")
+        if motor_error_count:
+            message_parts.append(f"{motor_error_count} motor driver errors")
+        if offline_count:
+            message_parts.append(f"{offline_count} offline motor drivers")
+        if disabled_count:
+            message_parts.append(f"{disabled_count} disabled motor drivers")
+        message = "; ".join(message_parts) if message_parts else "hardware telemetry normal"
+
+        return {
+            "state": state,
+            "ok": state == "ok",
+            "temperature": [] if board_temperature is None else [round(board_temperature, 1)],
+            "power": {
+                "enabled": power.get("enabled"),
+                "battery_percentage": None if power.get("percentage") is None else round(float(power["percentage"]), 1),
+                "input_voltage_v": None if power.get("voltage_v") is None else round(float(power["voltage_v"]), 2),
+                "current_a": None if power.get("current_a") is None else round(float(power["current_a"]), 2),
+                "current_limit_a": None if power.get("current_limit_a") is None else round(float(power["current_limit_a"]), 1),
+            },
+            "diagnostics": {
+                "error_code": power_error,
+                "motor_error_count": motor_error_count,
+                "offline_count": offline_count,
+                "disabled_count": disabled_count,
+                "message": message,
+            },
+            "age_sec": round(max(ages), 1) if ages else None,
+            "timestamp_ms": _now_ms(),
+        }
+
+    def _mainboard_candidates(self) -> list[dict]:
+        candidates = []
+        configured = set(self._topics.values())
+        for name, types in _graph_items(self._sub_node, "get_topic_names_and_types"):
+            if not self._is_mainboard_candidate(name, types):
+                continue
+            candidates.append({
+                "kind": "topic",
+                "name": name,
+                "message_types": list(types),
+                "configured": name in configured,
+            })
+        for name, types in _graph_items(self._sub_node, "get_service_names_and_types"):
+            if not self._is_mainboard_candidate(name, types):
+                continue
+            candidates.append({
+                "kind": "service",
+                "name": name,
+                "message_types": list(types),
+                "configured": False,
+            })
+        return candidates
+
+    @classmethod
+    def _is_mainboard_candidate(cls, name: str, interface_types: list[str]) -> bool:
+        if cls._is_strong_mainboard_name(name):
+            return True
+        if any(cls._is_strong_mainboard_name(interface_type) for interface_type in interface_types):
+            return True
+        lowered = " ".join([name, *interface_types]).lower()
+        return any(
+            keyword in lowered
+            for keyword in ("thermal", "temperature", "fan", "diagnostic")
+        )
+
+    @staticmethod
+    def _is_strong_mainboard_name(name: str) -> bool:
+        lowered = name.lower().replace("-", "_")
+        if "mainboard" in lowered or "main_board" in lowered:
+            return True
+        tokenized = lowered
+        for separator in ("/", ".", "_", ":"):
+            tokenized = tokenized.replace(separator, " ")
+        return "board" in tokenized.split()
 
     def _set(self, name: str, payload: dict) -> None:
         with self._lock:
@@ -504,6 +688,913 @@ class StatePlugin:
             for name, publisher in self._derived_publishers.items():
                 publisher.publish(_json_message(self._derived_snapshot(name)))
 
+
+class HeartbeatStatusPlugin:
+    def __init__(self, config: dict, namespace: str, ros2):
+        self._config = config
+        self._ns = namespace
+        self._timeout = float(config["ros"].get("source_timeout_sec", 1.0))
+        self._node = Node("t800_heartbeat_status", context=ros2.ctx_robot)
+        self._pub_node = Node("t800_heartbeat_status_pub", context=ros2.ctx_core)
+        ros2.executor_robot.add_node(self._node)
+        ros2.executor_core.add_node(self._pub_node)
+        self._publisher = self._pub_node.create_publisher(
+            String, f"/{namespace}/state/heartbeat_status", _RELIABLE
+        )
+        self._lock = threading.RLock()
+        self._latest: dict | None = None
+        self._updated: float | None = None
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "heartbeat_status",
+            "type": "sensor",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": "显示 T800 ROS2 节点心跳、健康状态和数据新鲜度",
+            "inputSchema": action_schema(
+                {
+                    "status": ([], "返回适合画布验收的简洁心跳状态"),
+                    "debug": ([], "返回原始心跳字段，供研发排查"),
+                },
+                {},
+                "心跳查询动作",
+            ),
+            "topic_out": [{"topic": f"/{self._ns}/state/heartbeat_status", "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        from interface_protocol.msg import Heartbeat
+
+        self._node.create_subscription(
+            Heartbeat, self._config["topics"]["heartbeat"], self._on_heartbeat, _BEST_EFFORT
+        )
+        self._pub_node.create_timer(0.2, self._publish)
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("heartbeat_status", "status", "info", "start"):
+            return self._snapshot()
+        if action == "debug":
+            return self._debug_snapshot()
+        if action == "stop":
+            return {"state": "idle"}
+        return {"error": f"unknown heartbeat action: {action}"}
+
+    def _on_heartbeat(self, msg) -> None:
+        with self._lock:
+            self._latest = {
+                "node_name": str(msg.node_name),
+                "node_status": str(msg.node_status),
+                "startup_timestamp": int(msg.startup_timestamp),
+                "error_code": int(msg.error_code),
+                "error_message": str(msg.error_message),
+            }
+            self._updated = time.monotonic()
+
+    def _snapshot(self) -> dict:
+        with self._lock:
+            latest = dict(self._latest or {})
+            updated = self._updated
+        age_sec = None if updated is None else max(0.0, time.monotonic() - updated)
+        stale = updated is None or age_sec > self._timeout
+        if updated is None:
+            return {
+                "state": "no_data",
+                "health": "unknown",
+                "node": None,
+                "message": "no heartbeat data",
+                "age_sec": None,
+                "timestamp_ms": _now_ms(),
+            }
+        error_code = int(latest.get("error_code", 0))
+        message = str(latest.get("error_message") or latest.get("node_status") or "ok")
+        return {
+            "state": "stale" if stale else "running",
+            "health": "error" if error_code else "ok",
+            "node": latest.get("node_name"),
+            "message": message,
+            "age_sec": round(age_sec, 1),
+            "timestamp_ms": _now_ms(),
+        }
+
+    def _debug_snapshot(self) -> dict:
+        with self._lock:
+            latest = dict(self._latest or {})
+            updated = self._updated
+        age_sec = None if updated is None else max(0.0, time.monotonic() - updated)
+        stale = updated is None or age_sec > self._timeout
+        if updated is None:
+            return {
+                "state": "no_data", "node_name": None, "node_status": None,
+                "startup_timestamp": None, "error_code": None, "error_message": None,
+                "age_sec": None, "stale": True, "timestamp_ms": _now_ms(),
+            }
+        latest.update({"state": "stale" if stale else "running", "age_sec": age_sec,
+                       "stale": stale, "timestamp_ms": _now_ms()})
+        return latest
+
+    def _publish(self) -> None:
+        self._publisher.publish(_json_message(self._snapshot()))
+
+class LinkInfoPlugin:
+    def __init__(self, config: dict, namespace: str, ros2):
+        self._config = config
+        self._ns = namespace
+        self._timeout = float(config["ros"].get("source_timeout_sec", 1.0))
+        self._node = Node("t800_link_info", context=ros2.ctx_robot)
+        self._pub_node = Node("t800_link_info_pub", context=ros2.ctx_core)
+        ros2.executor_robot.add_node(self._node)
+        ros2.executor_core.add_node(self._pub_node)
+        self._publisher = self._pub_node.create_publisher(
+            String, f"/{namespace}/state/link_info", _RELIABLE
+        )
+        self._lock = threading.RLock()
+        self._latest: dict | None = None
+        self._updated: float | None = None
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "link_info",
+            "type": "sensor",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": "显示 T800 LinkInfo 位姿、高度、速度和数据新鲜度",
+            "inputSchema": action_schema(
+                {
+                    "status": ([], "返回适合画布验收的简洁 link 状态"),
+                    "debug": ([], "返回原始 pose/twist 字段，供研发排查"),
+                },
+                {},
+                "LinkInfo 查询动作",
+            ),
+            "topic_out": [{"topic": f"/{self._ns}/state/link_info", "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        from interface_protocol.msg import LinkInfo
+
+        self._node.create_subscription(
+            LinkInfo, self._config["topics"]["link_info"], self._on_link_info, _BEST_EFFORT
+        )
+        self._pub_node.create_timer(0.2, self._publish)
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("link_info", "status", "info", "start"):
+            return self._snapshot()
+        if action == "debug":
+            return self._debug_snapshot()
+        if action == "stop":
+            return {"state": "idle"}
+        return {"error": f"unknown link info action: {action}"}
+
+    def _on_link_info(self, msg) -> None:
+        header = getattr(msg, "header", None)
+        pose = msg.pose
+        twist = msg.twist
+        payload = {
+            "position": {"x": float(pose.position.x), "y": float(pose.position.y), "z": float(pose.position.z)},
+            "orientation": {
+                "x": float(pose.orientation.x), "y": float(pose.orientation.y),
+                "z": float(pose.orientation.z), "w": float(pose.orientation.w),
+            },
+            "linear_velocity": {
+                "x": float(twist.linear.x), "y": float(twist.linear.y), "z": float(twist.linear.z),
+            },
+            "angular_velocity": {
+                "x": float(twist.angular.x), "y": float(twist.angular.y), "z": float(twist.angular.z),
+            },
+            "frame_id": str(getattr(header, "frame_id", "")),
+        }
+        with self._lock:
+            self._latest = payload
+            self._updated = time.monotonic()
+
+    def _snapshot(self) -> dict:
+        with self._lock:
+            latest = dict(self._latest or {})
+            updated = self._updated
+        age_sec = None if updated is None else max(0.0, time.monotonic() - updated)
+        stale = updated is None or age_sec > self._timeout
+        if updated is None:
+            return {
+                "state": "no_data",
+                "link": None,
+                "position_text": None,
+                "height_m": None,
+                "speed": None,
+                "age_sec": None,
+                "timestamp_ms": _now_ms(),
+            }
+        position = latest.get("position", {})
+        linear = latest.get("linear_velocity", {})
+        px, py, pz = float(position.get("x", 0.0)), float(position.get("y", 0.0)), float(position.get("z", 0.0))
+        vx, vy, vz = float(linear.get("x", 0.0)), float(linear.get("y", 0.0)), float(linear.get("z", 0.0))
+        speed = math.sqrt(vx * vx + vy * vy + vz * vz)
+        return {
+            "state": "stale" if stale else "running",
+            "link": latest.get("frame_id") or "unknown",
+            "position_text": f"x={px:.2f}, y={py:.2f}, z={pz:.2f} m",
+            "height_m": round(pz, 2),
+            "speed": f"{speed:.2f} m/s",
+            "age_sec": round(age_sec, 1),
+            "timestamp_ms": _now_ms(),
+        }
+
+    def _debug_snapshot(self) -> dict:
+        with self._lock:
+            latest = dict(self._latest or {})
+            updated = self._updated
+        age_sec = None if updated is None else max(0.0, time.monotonic() - updated)
+        stale = updated is None or age_sec > self._timeout
+        if updated is None:
+            return {"state": "no_data", "age_sec": None, "stale": True, "timestamp_ms": _now_ms()}
+        latest.update({"state": "stale" if stale else "running", "age_sec": age_sec,
+                       "stale": stale, "timestamp_ms": _now_ms()})
+        return latest
+
+    def _publish(self) -> None:
+        self._publisher.publish(_json_message(self._snapshot()))
+
+class MotionCommandTracePlugin:
+    def __init__(self, config: dict, namespace: str, ros2):
+        self._config = config
+        self._ns = namespace
+        capacity = max(1, int(config.get("diagnostics", {}).get("command_trace_capacity", 20)))
+        self._node = Node("t800_motion_command_trace", context=ros2.ctx_robot)
+        self._pub_node = Node("t800_motion_command_trace_pub", context=ros2.ctx_core)
+        ros2.executor_robot.add_node(self._node)
+        ros2.executor_core.add_node(self._pub_node)
+        self._publisher = self._pub_node.create_publisher(
+            String, f"/{namespace}/state/motion_command_trace", _RELIABLE
+        )
+        self._lock = threading.RLock()
+        self._velocity_commands = deque(maxlen=capacity)
+        self._motion_requests = deque(maxlen=capacity)
+        self._gamepad_inputs = deque(maxlen=capacity)
+        self._odometry_samples = deque(maxlen=capacity)
+        self._velocity_count = 0
+        self._motion_count = 0
+        self._gamepad_count = 0
+        self._odometry_count = 0
+        self._velocity_updated: float | None = None
+        self._motion_updated: float | None = None
+        self._gamepad_updated: float | None = None
+        self._odometry_updated: float | None = None
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "motion_command_trace",
+            "type": "sensor",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": "输出 T800 当前速度，兼容手柄、驱动指令和里程计来源",
+            "inputSchema": action_schema(
+                {
+                    "status": ([], "返回适合画布验收的简洁速度状态"),
+                    "debug": ([], "返回最近命令、手柄、里程计原始摘要，供研发排查"),
+                },
+                {},
+                "运动速度查询",
+            ),
+            "topic_out": [{"topic": f"/{self._ns}/state/motion_command_trace", "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        from interface_protocol.msg import BodyVelCmd, GamepadKeys, MotionStateRequest
+        from nav_msgs.msg import Odometry
+
+        topics = self._config["topics"]
+        self._node.create_subscription(
+            BodyVelCmd, topics["body_velocity"], self._on_velocity, _RELIABLE
+        )
+        self._node.create_subscription(
+            MotionStateRequest, topics["motion_request"], self._on_motion_request, _RELIABLE_ONE
+        )
+        self._node.create_subscription(
+            GamepadKeys, topics["gamepad"], self._on_gamepad, _BEST_EFFORT
+        )
+        odometry_topic = str(topics.get("odometry", "")).strip()
+        if odometry_topic:
+            self._node.create_subscription(
+                Odometry, odometry_topic, self._on_odometry, _BEST_EFFORT
+            )
+        self._pub_node.create_timer(0.2, self._publish)
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("motion_command_trace", "status", "info", "start"):
+            return self._snapshot()
+        if action == "debug":
+            return self._debug_snapshot()
+        if action == "stop":
+            return {"state": "idle"}
+        return {"error": f"unknown motion trace action: {action}"}
+
+    def _on_velocity(self, msg) -> None:
+        entry = {
+            "linear_velocity": [float(value) for value in msg.linear_velocity],
+            "yaw_velocity": float(msg.yaw_velocity),
+            "timestamp_ms": _now_ms(),
+        }
+        with self._lock:
+            self._velocity_commands.append(entry)
+            self._velocity_count += 1
+            self._velocity_updated = time.monotonic()
+
+    def _on_motion_request(self, msg) -> None:
+        entry = {"target_motion_name": str(msg.target_motion_name), "timestamp_ms": _now_ms()}
+        with self._lock:
+            self._motion_requests.append(entry)
+            self._motion_count += 1
+            self._motion_updated = time.monotonic()
+
+    def _on_gamepad(self, msg) -> None:
+        analog = [float(value) for value in msg.analog_states]
+        entry = {
+            "hardware_connected": bool(msg.hardware_connected),
+            "digital_pressed": [index for index, value in enumerate(msg.digital_states) if int(value) != 0],
+            "analog_states": analog,
+            "left_stick": {"x": analog[2] if len(analog) > 2 else None, "y": analog[3] if len(analog) > 3 else None},
+            "right_stick": {"x": analog[4] if len(analog) > 4 else None, "y": analog[5] if len(analog) > 5 else None},
+            "timestamp_ms": _now_ms(),
+        }
+        with self._lock:
+            self._gamepad_inputs.append(entry)
+            self._gamepad_count += 1
+            self._gamepad_updated = time.monotonic()
+
+    def _on_odometry(self, msg) -> None:
+        linear = msg.twist.twist.linear
+        angular = msg.twist.twist.angular
+        vx, vy, vz = float(linear.x), float(linear.y), float(linear.z)
+        entry = {
+            "frame_id": str(getattr(msg.header, "frame_id", "")),
+            "child_frame_id": str(getattr(msg, "child_frame_id", "")),
+            "linear_velocity": {"x": vx, "y": vy, "z": vz},
+            "speed_m_s": math.sqrt(vx * vx + vy * vy + vz * vz),
+            "angular_velocity": {"x": float(angular.x), "y": float(angular.y), "z": float(angular.z)},
+            "yaw_rate_rad_s": float(angular.z),
+            "timestamp_ms": _now_ms(),
+        }
+        with self._lock:
+            self._odometry_samples.append(entry)
+            self._odometry_count += 1
+            self._odometry_updated = time.monotonic()
+
+    def _snapshot(self) -> dict:
+        now = time.monotonic()
+        with self._lock:
+            velocity = self._velocity_commands[-1] if self._velocity_commands else None
+            gamepad = self._gamepad_inputs[-1] if self._gamepad_inputs else None
+            odometry = self._odometry_samples[-1] if self._odometry_samples else None
+            velocity_updated = self._velocity_updated
+            gamepad_updated = self._gamepad_updated
+            odometry_updated = self._odometry_updated
+        timeout_sec = float(self._config["ros"].get("source_timeout_sec", 1.0))
+        odometry_age = None if odometry_updated is None else max(0.0, now - odometry_updated)
+        velocity_age = None if velocity_updated is None else max(0.0, now - velocity_updated)
+
+        source = "none"
+        speed = 0.0
+        age_sec = None
+        if odometry is not None:
+            source = "odometry"
+            speed = float(odometry.get("speed_m_s", 0.0))
+            age_sec = odometry_age
+        elif velocity is not None:
+            source = "body_velocity_command"
+            values = [float(value) for value in velocity.get("linear_velocity", [])]
+            speed = math.sqrt(sum(value * value for value in values))
+            age_sec = velocity_age
+
+        stale = age_sec is None or age_sec > timeout_sec
+        speed_rounded = round(speed, 2)
+        motion_state = "moving" if speed_rounded >= 0.03 else "stopped"
+        state = "no_data" if source == "none" else ("stale" if stale else "running")
+        return {
+            "state": state,
+            "speed": f"{speed_rounded:.2f} m/s",
+            "motion_state": motion_state,
+            "source": source,
+            "gamepad_connected": None if gamepad is None else bool(gamepad.get("hardware_connected")),
+            "age_sec": None if age_sec is None else round(age_sec, 1),
+            "timestamp_ms": _now_ms(),
+        }
+
+    def _debug_snapshot(self) -> dict:
+        now = time.monotonic()
+        with self._lock:
+            velocity = list(self._velocity_commands)
+            motions = list(self._motion_requests)
+            gamepad = list(self._gamepad_inputs)
+            odometry = list(self._odometry_samples)
+            velocity_updated = self._velocity_updated
+            motion_updated = self._motion_updated
+            gamepad_updated = self._gamepad_updated
+            odometry_updated = self._odometry_updated
+            counts = {
+                "body_velocity": self._velocity_count,
+                "motion_request": self._motion_count,
+                "gamepad": self._gamepad_count,
+                "odometry": self._odometry_count,
+            }
+        ages = {
+            "body_velocity": None if velocity_updated is None else max(0.0, now - velocity_updated),
+            "motion_request": None if motion_updated is None else max(0.0, now - motion_updated),
+            "gamepad": None if gamepad_updated is None else max(0.0, now - gamepad_updated),
+            "odometry": None if odometry_updated is None else max(0.0, now - odometry_updated),
+        }
+        return {
+            "state": "running" if velocity or motions or gamepad or odometry else "no_data",
+            "velocity_commands": velocity,
+            "motion_requests": motions,
+            "gamepad_inputs": gamepad,
+            "odometry_samples": odometry,
+            "latest_velocity_command": velocity[-1] if velocity else None,
+            "latest_motion_request": motions[-1] if motions else None,
+            "latest_gamepad_input": gamepad[-1] if gamepad else None,
+            "latest_measured_velocity": odometry[-1] if odometry else None,
+            "last_seen_age_sec": ages,
+            "command_count": {**counts, "total": sum(counts.values())},
+            "timestamp_ms": _now_ms(),
+        }
+
+    def _publish(self) -> None:
+        self._publisher.publish(_json_message(self._snapshot()))
+
+class MotionEventsPlugin:
+    """Read-only event timeline for T800 motion-related MCP calls and feedback."""
+
+    _MOTION_TOOLS = {
+        "loco",
+        "motion_mode",
+        "dance",
+        "joint_plan",
+        "joint_plan_state",
+        "gesture",
+        "joint_override",
+        "joint_bridge",
+        "motor_power",
+        "native_node_control",
+        "virtual_gamepad",
+        "safety",
+        "motion_state",
+    }
+
+    def __init__(self, config: dict, namespace: str, ros2):
+        self._config = config
+        self._ns = namespace
+        capacity = int(config.get("diagnostics", {}).get("motion_events_capacity", 100))
+        self._capacity = max(1, min(capacity, 1000))
+        self._robot_node = Node("t800_motion_events_sub", context=ros2.ctx_robot)
+        self._node = Node("t800_motion_events_pub", context=ros2.ctx_core)
+        ros2.executor_robot.add_node(self._robot_node)
+        ros2.executor_core.add_node(self._node)
+        self._publisher = self._node.create_publisher(
+            String, f"/{namespace}/state/motion_events", _RELIABLE
+        )
+        self._lock = threading.RLock()
+        self._events = deque(maxlen=self._capacity)
+        self._sequence = 0
+        self._moving = False
+        self._motion_start_threshold = 0.05
+        self._motion_stop_threshold = 0.03
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "motion_events",
+            "type": "sensor",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": "T800 motion event stream — motion state changes and motion command lifecycle events",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["status", "info", "debug"],
+                        "description": "status returns the latest event summary; debug returns the buffered timeline",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 200,
+                        "description": "最多返回事件条数",
+                    },
+                    "since_event_id": {
+                        "type": "string",
+                        "description": "只返回该事件之后的新事件",
+                    },
+                    "source_tool": {
+                        "type": "string",
+                        "description": "按来源 tool 过滤",
+                    },
+                    "severity": {
+                        "type": "string",
+                        "enum": ["debug", "info", "warning", "error"],
+                        "description": "按事件级别过滤",
+                    },
+                },
+            },
+            "topic_out": [{"topic": f"/{self._ns}/state/motion_events", "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        odometry_topic = str(self._config.get("topics", {}).get("odometry", "")).strip()
+        if odometry_topic:
+            from nav_msgs.msg import Odometry
+
+            self._robot_node.create_subscription(
+                Odometry, odometry_topic, self._on_odometry, _BEST_EFFORT
+            )
+        self._node.create_timer(0.2, self._publish)
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("motion_events", "status", "info", "start"):
+            return self._summary_snapshot()
+        if action in ("debug", "list"):
+            return self._debug_snapshot(args)
+        if action == "stop":
+            return {"state": "idle"}
+        return {"error": f"unknown motion events action: {action}"}
+
+    def _on_odometry(self, msg) -> None:
+        linear = msg.twist.twist.linear
+        vx, vy, vz = float(linear.x), float(linear.y), float(linear.z)
+        speed = math.sqrt(vx * vx + vy * vy + vz * vz)
+        with self._lock:
+            moving = self._moving
+            if not moving and speed >= self._motion_start_threshold:
+                self._moving = True
+                event = "motion_start"
+            elif moving and speed <= self._motion_stop_threshold:
+                self._moving = False
+                event = "motion_stop"
+            else:
+                event = ""
+        if not event:
+            return
+        self.record_event(
+            source_tool="odometry",
+            event_type=event,
+            severity="info",
+            phase="running" if event == "motion_start" else "completed",
+            summary=f"{event} detected from odometry speed {speed:.2f} m/s",
+            detail={
+                "speed": f"{speed:.2f} m/s",
+                "source": self._config.get("topics", {}).get("odometry"),
+            },
+        )
+
+    def record_tool_call(self, tool_name: str, action: str, args: dict, result: dict) -> None:
+        if tool_name not in self._MOTION_TOOLS:
+            return
+        event_type, severity, phase = self._classify(tool_name, action, result)
+        self.record_event(
+            source_tool=tool_name,
+            event_type=event_type,
+            severity=severity,
+            phase=phase,
+            summary=self._summary(tool_name, action, result),
+            detail={
+                "action": action,
+                "arguments": self._compact_value(args),
+                "result": self._compact_value(result),
+            },
+        )
+
+    def record_exception(self, tool_name: str, action: str, args: dict, exc: Exception) -> None:
+        if tool_name not in self._MOTION_TOOLS:
+            return
+        self.record_event(
+            source_tool=tool_name,
+            event_type="dispatch_exception",
+            severity="error",
+            phase="failed",
+            summary=f"{tool_name}.{action} raised {type(exc).__name__}",
+            detail={"action": action, "arguments": self._compact_value(args), "error": str(exc)},
+        )
+
+    def record_event(
+        self,
+        *,
+        source_tool: str,
+        event_type: str,
+        severity: str,
+        phase: str,
+        summary: str,
+        detail: dict | None = None,
+    ) -> dict:
+        with self._lock:
+            self._sequence += 1
+            event_id = f"t800-motion-{self._sequence:06d}"
+            timestamp_ms = _now_ms()
+            event = {
+                "type": event_type,
+                "timestamp": round(timestamp_ms / 1000.0, 3),
+                "event_id": event_id,
+                "timestamp_ms": timestamp_ms,
+                "source_tool": source_tool,
+                "event_type": event_type,
+                "severity": severity,
+                "phase": phase,
+                "summary": summary,
+                "detail": detail or {},
+            }
+            self._events.append(event)
+            return dict(event)
+
+    def _summary_snapshot(self) -> dict:
+        with self._lock:
+            latest_event = dict(self._events[-1]) if self._events else None
+            events = [dict(event) for event in self._events]
+            total_buffered = len(self._events)
+            total_recorded = self._sequence
+        warning_count = sum(1 for event in events if event["severity"] == "warning")
+        error_count = sum(1 for event in events if event["severity"] == "error")
+        return {
+            "state": "running" if latest_event else "no_data",
+            "type": None if latest_event is None else latest_event.get("type"),
+            "timestamp": None if latest_event is None else latest_event.get("timestamp"),
+            "source_tool": None if latest_event is None else latest_event.get("source_tool"),
+            "severity": None if latest_event is None else latest_event.get("severity"),
+            "phase": None if latest_event is None else latest_event.get("phase"),
+            "summary": None if latest_event is None else latest_event.get("summary"),
+            "event_id": None if latest_event is None else latest_event.get("event_id"),
+            "total_recorded": total_recorded,
+            "total_buffered": total_buffered,
+            "warning_count": warning_count,
+            "error_count": error_count,
+            "timestamp_ms": _now_ms(),
+        }
+
+    def _debug_snapshot(self, args: dict | None = None) -> dict:
+        args = args or {}
+        limit = int(args.get("limit", 50))
+        limit = max(1, min(limit, 200))
+        since_event_id = str(args.get("since_event_id", "") or "")
+        source_tool = str(args.get("source_tool", "") or "")
+        severity = str(args.get("severity", "") or "")
+        with self._lock:
+            events = [dict(event) for event in self._events]
+            total_buffered = len(self._events)
+            latest_event_id = events[-1]["event_id"] if events else None
+            total_recorded = self._sequence
+        if since_event_id:
+            events = self._after_event(events, since_event_id)
+        if source_tool:
+            events = [event for event in events if event["source_tool"] == source_tool]
+        if severity:
+            events = [event for event in events if event["severity"] == severity]
+        events = events[-limit:]
+        warning_count = sum(1 for event in events if event["severity"] == "warning")
+        error_count = sum(1 for event in events if event["severity"] == "error")
+        return {
+            "state": "running" if events else "no_data",
+            "ok": True,
+            "robot": "t800",
+            "tool": "motion_events",
+            "events": events,
+            "summary": {
+                "capacity": self._capacity,
+                "total_recorded": total_recorded,
+                "total_buffered": total_buffered,
+                "returned": len(events),
+                "latest_event_id": latest_event_id,
+                "warning_count": warning_count,
+                "error_count": error_count,
+            },
+            "timestamp_ms": _now_ms(),
+        }
+
+    @staticmethod
+    def _after_event(events: list[dict], since_event_id: str) -> list[dict]:
+        for index, event in enumerate(events):
+            if event["event_id"] == since_event_id:
+                return events[index + 1:]
+        return events
+
+    @staticmethod
+    def _classify(tool_name: str, action: str, result: dict) -> tuple[str, str, str]:
+        if "error" in result:
+            return "command_rejected", "warning", "rejected"
+        state = str(result.get("state", "completed"))
+        if state in ("timeout", "error", "failed"):
+            return "command_failed", "error", "failed"
+        if state == "rejected":
+            return "command_rejected", "warning", "rejected"
+        if action in ("status", "info", "start") or tool_name in ("motion_state", "joint_plan_state"):
+            return "status_read", "debug", "completed"
+        if action in ("stop", "stop_move", "stop_dance", "stop_gesture", "release", "stop_command", "soft_stop"):
+            return "motion_stop", "info", "completed"
+        if tool_name == "safety":
+            return "safety_request", "warning", "dispatch"
+        return "command_requested", "info", "dispatch"
+
+    @staticmethod
+    def _summary(tool_name: str, action: str, result: dict) -> str:
+        if "error" in result:
+            return f"{tool_name}.{action} rejected: {result['error']}"
+        state = result.get("state", "completed")
+        target = result.get("target") or result.get("target_motion") or result.get("node_name")
+        suffix = f" -> {target}" if target else ""
+        return f"{tool_name}.{action} {state}{suffix}"
+
+    @classmethod
+    def _compact_value(cls, value):
+        if isinstance(value, dict):
+            return {
+                str(key): cls._compact_value(inner)
+                for key, inner in value.items()
+                if not str(key).startswith("_")
+            }
+        if isinstance(value, (list, tuple)):
+            if len(value) > 8:
+                return {"length": len(value), "preview": [cls._compact_value(item) for item in value[:8]]}
+            return [cls._compact_value(item) for item in value]
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            return value
+        return str(value)
+
+    def _publish(self) -> None:
+        self._publisher.publish(_json_message(self._summary_snapshot()))
+
+class NativeInterfaceProbePlugin:
+    _NAME_KEYWORDS = ("engineai", "motion", "hardware")
+    _PRIORITY_RANK = {"high": 3, "medium": 2, "low": 1}
+
+    def __init__(self, config: dict, namespace: str, ros2):
+        self._config = config
+        self._ns = namespace
+        self._node = Node("t800_native_interface_probe", context=ros2.ctx_robot)
+        self._pub_node = Node("t800_native_interface_probe_pub", context=ros2.ctx_core)
+        ros2.executor_robot.add_node(self._node)
+        ros2.executor_core.add_node(self._pub_node)
+        self._publisher = self._pub_node.create_publisher(
+            String, f"/{namespace}/state/native_interface_probe", _RELIABLE
+        )
+        self._latest_scan: dict | None = None
+        self._last_scan_at = 0.0
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "native_interface_probe",
+            "type": "sensor",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": "扫描 T800 ROS 图，汇总已映射与未映射原生接口",
+            "inputSchema": action_schema(
+                {
+                    "scan": ([], "扫描 ROS2 topic/service 并输出适合画布验收的摘要"),
+                    "debug": ([], "输出完整 topic/service/mapped/unmapped 清单，供研发排查"),
+                },
+                {},
+                "原生接口探测动作",
+            ),
+            "topic_out": [{"topic": f"/{self._ns}/state/native_interface_probe", "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        self._pub_node.create_timer(1.0, self._publish)
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("native_interface_probe", "scan", "status", "info", "start"):
+            return self._scan()
+        if action == "debug":
+            return self._scan(debug=True)
+        if action == "stop":
+            return {"state": "idle"}
+        return {"error": f"unknown native interface probe action: {action}"}
+
+    def _scan(self, debug: bool = False) -> dict:
+        topics = self._graph("get_topic_names_and_types")
+        services = self._graph("get_service_names_and_types")
+        configured_topics = set(self._config.get("topics", {}).values())
+        configured_services = set(self._config.get("services", {}).values())
+        mapped, unmapped = [], []
+        for name, types in topics:
+            for message_type in types:
+                if not self._is_relevant(name, message_type):
+                    continue
+                candidate = {
+                    "kind": "topic", "name": name, "message_type": message_type,
+                    "publishers": self._count("count_publishers", name),
+                    "subscribers": self._count("count_subscribers", name),
+                    "suggested_priority": self._priority(name, message_type),
+                }
+                (mapped if name in configured_topics else unmapped).append(candidate)
+        for name, types in services:
+            for service_type in types:
+                if not self._is_relevant(name, service_type):
+                    continue
+                candidate = {
+                    "kind": "service", "name": name, "message_type": service_type,
+                    "servers": self._count("count_services", name),
+                    "clients": self._count("count_clients", name),
+                    "suggested_priority": self._priority(name, service_type),
+                }
+                (mapped if name in configured_services else unmapped).append(candidate)
+        result = {
+            "state": "available" if topics or services else "no_data",
+            "topics": [{"name": name, "types": list(types)} for name, types in topics],
+            "services": [{"name": name, "types": list(types)} for name, types in services],
+            "mapped": mapped,
+            "unmapped_candidates": unmapped,
+            "topic_count": len(topics),
+            "service_count": len(services),
+            "timestamp_ms": _now_ms(),
+        }
+        compact = self._compact_scan(result)
+        self._latest_scan = compact
+        self._last_scan_at = time.monotonic()
+        return result if debug else compact
+
+    @classmethod
+    def _compact_scan(cls, result: dict) -> dict:
+        unmapped = sorted(
+            result.get("unmapped_candidates", []),
+            key=lambda item: cls._PRIORITY_RANK.get(str(item.get("suggested_priority")), 0),
+            reverse=True,
+        )
+        high_priority = [
+            {
+                "kind": item.get("kind"),
+                "name": item.get("name"),
+                "type": item.get("message_type"),
+                "priority": item.get("suggested_priority"),
+            }
+            for item in unmapped[:5]
+        ]
+        return {
+            "state": result.get("state"),
+            "topic_count": result.get("topic_count", 0),
+            "service_count": result.get("service_count", 0),
+            "mapped_count": len(result.get("mapped", [])),
+            "unmapped_count": len(result.get("unmapped_candidates", [])),
+            "top_unmapped": high_priority,
+            "summary_text": (
+                f"{result.get('topic_count', 0)} topics, "
+                f"{result.get('service_count', 0)} services, "
+                f"{len(result.get('unmapped_candidates', []))} unmapped"
+            ),
+            "timestamp_ms": result.get("timestamp_ms", _now_ms()),
+        }
+
+    def _publish(self) -> None:
+        payload = self._latest_scan
+        if payload is None or time.monotonic() - self._last_scan_at > 5.0:
+            payload = self._scan()
+        self._publisher.publish(_json_message(payload))
+
+    def _graph(self, method: str) -> list:
+        callback = getattr(self._node, method, None)
+        if callback is None:
+            return []
+        try:
+            return list(callback())
+        except Exception:
+            return []
+
+    def _count(self, method: str, name: str) -> int:
+        callback = getattr(self._node, method, None)
+        if callback is None:
+            return 0
+        try:
+            return int(callback(name))
+        except Exception:
+            return 0
+
+    @classmethod
+    def _is_relevant(cls, name: str, interface_type: str) -> bool:
+        lowered_name = name.lower()
+        lowered_type = interface_type.lower()
+        return "interface_protocol" in lowered_type or any(
+            keyword in lowered_name or keyword in lowered_type for keyword in cls._NAME_KEYWORDS
+        )
+
+    @staticmethod
+    def _priority(name: str, interface_type: str) -> str:
+        lowered_type = interface_type.lower()
+        lowered_name = name.lower()
+        if "interface_protocol" in lowered_type:
+            return "high"
+        if "motion" in lowered_name or "hardware" in lowered_name:
+            return "medium"
+        return "low"
 
 class LocomotionPlugin:
     def __init__(self, config: dict, namespace: str, ros2, state: StatePlugin):

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 import math
-import numbers
 import subprocess
 import threading
 import time
@@ -67,30 +66,8 @@ def _now_ms() -> int:
 
 
 def _json_message(payload: dict) -> String:
-    def scalar_default(value):
-        # ROS array fields on ARM64 can expose NumPy/array scalar values.
-        # Normalize them at the JSON boundary so a vendor scalar cannot stop
-        # the domain-42 executor and, with it, the four sensor cards.
-        item = getattr(value, "item", None)
-        if callable(item):
-            return item()
-        if isinstance(value, numbers.Integral):
-            return int(value)
-        if isinstance(value, numbers.Real):
-            return float(value)
-        if hasattr(value, "__float__"):
-            return float(value)
-        if hasattr(value, "__int__"):
-            return int(value)
-        raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
-
     msg = String()
-    msg.data = json.dumps(
-        payload,
-        separators=(",", ":"),
-        ensure_ascii=False,
-        default=scalar_default,
-    )
+    msg.data = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
     return msg
 
 
@@ -326,7 +303,7 @@ class StatePlugin:
                     "body_velocity", "open_loop_displacement", "open_loop_turn", "open_loop_arc",
                     "motion_fsm", "joint_plan", "joint_override", "joint_bridge", "native_node_control",
                     "gesture_sequences", "dance", "virtual_gamepad", "soft_emergency_stop",
-                    "motor_power", "led", "ros_graph_discovery",
+                    "motor_power", "led", "tts", "ros_graph_discovery",
                 ],
                 "feedback": list(self._STREAMS) + ["joint_plan_state"],
                 "limitations": [
@@ -1436,6 +1413,50 @@ class LedPlugin:
         msg.color = LED_MODES[mode]
         self._publisher.publish(msg)
         return {"state": "set", "mode": mode, "value": LED_MODES[mode]}
+
+
+class TtsPlugin:
+    def __init__(self, config: dict, namespace: str, ros2):
+        self._config = config
+        self._node = Node("t800_tts", context=ros2.ctx_robot)
+        ros2.executor_robot.add_node(self._node)
+        self._publisher = None
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "tts",
+            "type": "actuator",
+            "description": "T800 Native SDK TTS 消息接口；topic 可通过 config.yaml 校准",
+            "inputSchema": {"type": "object", "properties": {
+                "text": {"type": "string"}, "language": {"type": "string"},
+                "speaker": {"type": "string"}, "rate": {"type": "integer", "minimum": 50, "maximum": 300}},
+                "required": ["text"]},
+        }
+
+    def start(self) -> None:
+        from interface_protocol.msg import Tts
+        self._message_type = Tts
+        self._publisher = self._node.create_publisher(Tts, self._config["topics"]["tts"], _RELIABLE)
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("start", "info"):
+            return {"state": "ready", "topic": self._config["topics"]["tts"]}
+        if action == "stop":
+            return {"state": "idle"}
+        text = str(args.get("text", "")).strip()
+        if not text:
+            return {"error": "text is required"}
+        msg = self._message_type()
+        msg.text = text
+        msg.language = str(args.get("language", "zh"))
+        msg.speaker = str(args.get("speaker", "default"))
+        msg.rate = int(clamp(args.get("rate", 150), 50, 300))
+        self._publisher.publish(msg)
+        return {"state": "published", "characters": len(text), "language": msg.language,
+                "speaker": msg.speaker, "rate": msg.rate}
 
 
 class MotorPowerPlugin:

--- a/engineai/t800/driver.yaml
+++ b/engineai/t800/driver.yaml
@@ -2,7 +2,7 @@ id: engineai-t800-driver
 name: EngineAI T800 Development Edition Bundle
 category: driver
 hardware_provider: engineai
-hardware_model: "t800-dev"
+hardware_model: "t800"
 image_name: engineai-t800
 port: 15708
 mcp_url: "http://localhost:15708/mcp"

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -86,10 +86,15 @@ class T800DeviceBundle:
             JointBridgePlugin,
             JointOverridePlugin,
             JointPlanPlugin,
+            HeartbeatStatusPlugin,
             LedPlugin,
+            LinkInfoPlugin,
             LocomotionPlugin,
+            MotionCommandTracePlugin,
+            MotionEventsPlugin,
             MotionModePlugin,
             MotorPowerPlugin,
+            NativeInterfaceProbePlugin,
             NativeNodeControlPlugin,
             NativeSdkPlugin,
             SafetyControlPlugin,
@@ -101,11 +106,22 @@ class T800DeviceBundle:
         self._plugins: list = []
         plugins = config.get("plugins", {})
 
-        state = StatePlugin(config, namespace, ros2)
+        motion_events = None
+        if plugins.get("motion_events", {}).get("enabled", False):
+            motion_events = MotionEventsPlugin(config, namespace, ros2)
+        self._motion_events = motion_events
+
+        state = StatePlugin(config, namespace, ros2, motion_events=motion_events)
         if plugins.get("state", {}).get("enabled", True):
             self._plugins.append(state)
+        if motion_events is not None:
+            self._plugins.append(motion_events)
 
         plugin_types = (
+            ("heartbeat_status", HeartbeatStatusPlugin, (config, namespace, ros2)),
+            ("link_info", LinkInfoPlugin, (config, namespace, ros2)),
+            ("motion_command_trace", MotionCommandTracePlugin, (config, namespace, ros2)),
+            ("native_interface_probe", NativeInterfaceProbePlugin, (config, namespace, ros2)),
             ("locomotion", LocomotionPlugin, (config, namespace, ros2, state)),
             ("motion_mode", MotionModePlugin, (config, namespace, ros2, state)),
             ("joint_plan", JointPlanPlugin, (config, namespace, ros2, state)),
@@ -182,10 +198,21 @@ class T800DeviceBundle:
                     continue
                 args = dict(arguments)
                 if definition["type"] == "resource":
-                    return plugin.dispatch(tool_name, args)
+                    result = plugin.dispatch(tool_name, args)
+                    if self._motion_events is not None:
+                        self._motion_events.record_tool_call(tool_name, tool_name, args, result)
+                    return result
                 action = args.pop("action", tool_name)
                 args["_tool_name"] = tool_name
-                return plugin.dispatch(action, args)
+                try:
+                    result = plugin.dispatch(action, args)
+                except Exception as exc:
+                    if self._motion_events is not None:
+                        self._motion_events.record_exception(tool_name, action, args, exc)
+                    raise
+                if self._motion_events is not None:
+                    self._motion_events.record_tool_call(tool_name, action, args, result)
+                return result
         return None
 
 

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -88,13 +88,14 @@ class T800DeviceBundle:
             JointPlanPlugin,
             LedPlugin,
             LocomotionPlugin,
+            MicPlugin,
             MotionModePlugin,
             MotorPowerPlugin,
             NativeNodeControlPlugin,
             NativeSdkPlugin,
             SafetyControlPlugin,
             StatePlugin,
-            TtsPlugin,
+            VisionPlugin,
         )
         from virtual_gamepad import VirtualGamepadPlugin
 
@@ -112,7 +113,8 @@ class T800DeviceBundle:
             ("joint_override", JointOverridePlugin, (config, namespace, ros2, state)),
             ("joint_bridge", JointBridgePlugin, (config, namespace, ros2, state)),
             ("led", LedPlugin, (config, namespace, ros2)),
-            ("tts", TtsPlugin, (config, namespace, ros2)),
+            ("mic", MicPlugin, (config, namespace, ros2)),
+            ("vision", VisionPlugin, (config, namespace, ros2)),
             ("motor_power", MotorPowerPlugin, (config, namespace, ros2)),
             ("native_node_control", NativeNodeControlPlugin, (config, namespace, ros2)),
             ("safety", SafetyControlPlugin, (config, namespace, ros2, state)),

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -95,6 +95,7 @@ class T800DeviceBundle:
             NativeSdkPlugin,
             SafetyControlPlugin,
             StatePlugin,
+            TtsPlugin,
             VisionPlugin,
         )
         from virtual_gamepad import VirtualGamepadPlugin
@@ -113,6 +114,7 @@ class T800DeviceBundle:
             ("joint_override", JointOverridePlugin, (config, namespace, ros2, state)),
             ("joint_bridge", JointBridgePlugin, (config, namespace, ros2, state)),
             ("led", LedPlugin, (config, namespace, ros2)),
+            ("tts", TtsPlugin, (config, namespace, ros2)),
             ("mic", MicPlugin, (config, namespace, ros2)),
             ("vision", VisionPlugin, (config, namespace, ros2)),
             ("motor_power", MotorPowerPlugin, (config, namespace, ros2)),

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -30,9 +30,15 @@ def _resolve_namespace(config: dict) -> str:
 
 
 def _configure_cyclonedds(config: dict) -> str:
-    interface = os.environ.get("NETWORK_INTERFACE") or str(config["ros"].get("robot_interface", "eth0"))
+    interface = os.environ.get("NETWORK_INTERFACE") or str(config["ros"].get("robot_interface", "eth1"))
     if not re.fullmatch(r"[a-zA-Z0-9_.:-]+", interface):
         raise ValueError(f"invalid robot network interface: {interface}")
+    available = {name for _index, name in socket.if_nameindex()}
+    if available and interface not in available:
+        names = ", ".join(sorted(available))
+        raise ValueError(
+            f"robot network interface {interface!r} does not exist; available interfaces: {names}"
+        )
     os.environ.setdefault(
         "CYCLONEDDS_URI",
         "<CycloneDDS><Domain><General><Interfaces>"
@@ -92,6 +98,7 @@ class T800DeviceBundle:
             LocomotionPlugin,
             MotionCommandTracePlugin,
             MotionEventsPlugin,
+            MicPlugin,
             MotionModePlugin,
             MotorPowerPlugin,
             NativeInterfaceProbePlugin,
@@ -100,10 +107,14 @@ class T800DeviceBundle:
             SafetyControlPlugin,
             StatePlugin,
             TtsPlugin,
+            VisionPlugin,
         )
         from virtual_gamepad import VirtualGamepadPlugin
 
         self._plugins: list = []
+        self._active_plugins: list = []
+        self._startup_errors: dict[str, str] = {}
+        self._started = False
         plugins = config.get("plugins", {})
 
         motion_events = None
@@ -129,6 +140,8 @@ class T800DeviceBundle:
             ("joint_bridge", JointBridgePlugin, (config, namespace, ros2, state)),
             ("led", LedPlugin, (config, namespace, ros2)),
             ("tts", TtsPlugin, (config, namespace, ros2)),
+            ("mic", MicPlugin, (config, namespace, ros2)),
+            ("vision", VisionPlugin, (config, namespace, ros2)),
             ("motor_power", MotorPowerPlugin, (config, namespace, ros2)),
             ("native_node_control", NativeNodeControlPlugin, (config, namespace, ros2)),
             ("safety", SafetyControlPlugin, (config, namespace, ros2, state)),
@@ -170,28 +183,69 @@ class T800DeviceBundle:
             self._plugins.append(NativeSdkPlugin(native_config, namespace, ros2))
 
     def start_all(self) -> None:
+        if self._started:
+            return
+        self._active_plugins = []
+        self._startup_errors = {}
         for plugin in self._plugins:
             try:
                 plugin.start()
                 print(f"[bundle] {type(plugin).__name__} started", flush=True)
             except Exception as exc:
+                plugin_name = type(plugin).__name__
+                self._startup_errors[plugin_name] = str(exc)
                 print(f"[bundle] {type(plugin).__name__} start failed: {exc}", flush=True)
+                try:
+                    plugin.stop()
+                except Exception as stop_exc:
+                    print(f"[bundle] {plugin_name} cleanup failed: {stop_exc}", flush=True)
+            else:
+                self._active_plugins.append(plugin)
+        self._started = True
 
     def stop_all(self) -> None:
-        for plugin in reversed(self._plugins):
+        if not self._started:
+            return
+        for plugin in reversed(self._active_plugins):
             try:
                 plugin.stop()
             except Exception as exc:
                 print(f"[bundle] {type(plugin).__name__} stop failed: {exc}", flush=True)
+        self._active_plugins = []
+        self._started = False
 
     def get_all_tools(self) -> list[dict]:
         tools: list[dict] = []
-        for plugin in self._plugins:
+        for plugin in self._active_plugins:
             tools.extend(plugin.get_tools() if hasattr(plugin, "get_tools") else [plugin.get_tool()])
         return tools
 
-    def dispatch(self, tool_name: str, arguments: dict) -> dict | None:
+    def health(self) -> dict:
+        configured_tools = 0
         for plugin in self._plugins:
+            definitions = plugin.get_tools() if hasattr(plugin, "get_tools") else [plugin.get_tool()]
+            configured_tools += len(definitions)
+        active_tools = len(self.get_all_tools())
+        if not self._started:
+            state = "starting"
+        elif self._startup_errors and not self._active_plugins:
+            state = "failed"
+        elif self._startup_errors:
+            state = "degraded"
+        else:
+            state = "running"
+        return {
+            "state": state,
+            "driver": "engineai-t800",
+            "configured_plugins": len(self._plugins),
+            "active_plugins": len(self._active_plugins),
+            "configured_tools": configured_tools,
+            "active_tools": active_tools,
+            "startup_errors": dict(self._startup_errors),
+        }
+
+    def dispatch(self, tool_name: str, arguments: dict) -> dict | None:
+        for plugin in self._active_plugins:
             tools = plugin.get_tools() if hasattr(plugin, "get_tools") else [plugin.get_tool()]
             for definition in tools:
                 if definition["name"] != tool_name:
@@ -239,7 +293,11 @@ def make_handler():
 
         def do_GET(self):
             if self.path == "/health":
-                self._send_json(200, {"state": "running", "driver": "engineai-t800"})
+                if _bundle is None:
+                    self._send_json(503, {"state": "starting", "driver": "engineai-t800"})
+                    return
+                payload = _bundle.health()
+                self._send_json(200 if payload.get("state") == "running" else 503, payload)
             else:
                 self._send_json(404, {"error": "not found"})
 
@@ -349,10 +407,10 @@ def main() -> None:
     ros2.start_spin()
     _bundle = T800DeviceBundle(config, namespace, ros2)
     _bundle.start_all()
-    _start_registration(port, config)
 
     server = ThreadingHTTPServer(("", port), make_handler())
     print(f"[bundle] MCP server http://localhost:{port}/mcp", flush=True)
+    _start_registration(port, config)
 
     stopping = threading.Event()
 

--- a/engineai/t800/msgs/interface_protocol/CMakeLists.txt
+++ b/engineai/t800/msgs/interface_protocol/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(std_msgs REQUIRED)
 
 file(GLOB MSG_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "msg/*.msg")
 file(GLOB SRV_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "srv/*.srv")
+list(FILTER MSG_FILES EXCLUDE REGEX "(^|/)\\._")
+list(FILTER SRV_FILES EXCLUDE REGEX "(^|/)\\._")
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${MSG_FILES}
   ${SRV_FILES}

--- a/engineai/t800/msgs/interface_protocol/CMakeLists.txt
+++ b/engineai/t800/msgs/interface_protocol/CMakeLists.txt
@@ -1,6 +1,22 @@
 cmake_minimum_required(VERSION 3.8)
 project(interface_protocol)
 
+# CMake 3.22 under x86-to-ARM64 BuildKit emulation can report this existing
+# ROS library as missing when it is first looked up from a nested ament package
+# config (geometry_msgs -> std_msgs -> builtin_interfaces). Probe it once in
+# this configure process so clean cross-architecture builds behave like native
+# ARM64 builds, and fail with an explicit dependency error if it is truly absent.
+find_library(
+  T800_ROS_LIBRARY_PROBE
+  NAMES builtin_interfaces__rosidl_generator_c
+  PATHS /opt/ros/humble/lib
+  NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH
+)
+if(NOT T800_ROS_LIBRARY_PROBE)
+  message(FATAL_ERROR "Missing ROS library: builtin_interfaces__rosidl_generator_c")
+endif()
+unset(T800_ROS_LIBRARY_PROBE CACHE)
+
 find_package(ament_cmake REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)

--- a/engineai/t800/requirements.txt
+++ b/engineai/t800/requirements.txt
@@ -1,2 +1,3 @@
-pyyaml
+PyYAML==6.0.3
 lcm==1.5.0
+numpy==2.0.2

--- a/engineai/t800/requirements.txt
+++ b/engineai/t800/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml
 lcm==1.5.0
+numpy

--- a/engineai/t800/tests/test_build_script.py
+++ b/engineai/t800/tests/test_build_script.py
@@ -1,0 +1,164 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+T800_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = T800_ROOT.parents[1]
+BUILD_SCRIPT = REPO_ROOT / "build.sh"
+
+
+class BuildScriptContractTests(unittest.TestCase):
+    def _environment(self, tool_dir: Path, log_path: Path) -> dict[str, str]:
+        env = os.environ.copy()
+        for name in (
+            "REGISTRY",
+            "REGISTRY_USER",
+            "REGISTRY_PASSWORD",
+            "IMAGE_NAMESPACE",
+            "RESOURCE_CENTER_API_KEY",
+        ):
+            env.pop(name, None)
+        env["PATH"] = f"{tool_dir}:{env['PATH']}"
+        env["DOCKER_LOG"] = str(log_path)
+        return env
+
+    def test_unknown_driver_is_a_nonzero_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tool_dir = Path(tmp)
+            log_path = tool_dir / "docker.log"
+            result = subprocess.run(
+                ["bash", str(BUILD_SCRIPT), "--mirror", "none", "engineai/not-a-driver"],
+                cwd=REPO_ROOT,
+                env=self._environment(tool_dir, log_path),
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        self.assertEqual(2, result.returncode)
+        self.assertIn("未知驱动参数", result.stderr)
+        self.assertFalse(log_path.exists())
+
+    def test_t800_manifest_aliases_select_the_same_driver_and_forward_ros_mirror(self):
+        aliases = (
+            "engineai/t800",
+            "engineai-t800-driver",
+            "engineai-t800",
+            "t800",
+            "engineai-t800-dev",
+            "engineai/t800-dev",
+            "t800-dev",
+            str(T800_ROOT),
+        )
+        for alias in aliases:
+            with self.subTest(alias=alias), tempfile.TemporaryDirectory() as tmp:
+                tool_dir = Path(tmp)
+                log_path = tool_dir / "docker.log"
+                docker = tool_dir / "docker"
+                docker.write_text(
+                    "#!/bin/sh\n"
+                    "printf '%s\\n' \"$*\" >> \"$DOCKER_LOG\"\n"
+                    "case \"$*\" in *'alpine:3.20 uname -m'*) echo aarch64 ;; esac\n",
+                    encoding="utf-8",
+                )
+                docker.chmod(0o755)
+                result = subprocess.run(
+                    ["bash", str(BUILD_SCRIPT), "--mirror", "none", alias],
+                    cwd=REPO_ROOT,
+                    env=self._environment(tool_dir, log_path),
+                    stdin=subprocess.DEVNULL,
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                )
+                self.assertEqual(0, result.returncode, result.stderr + result.stdout)
+                calls = log_path.read_text(encoding="utf-8")
+                self.assertIn("buildx build", calls)
+                self.assertIn("ROS_APT_MIRROR=http://packages.ros.org/ros2/ubuntu", calls)
+                self.assertIn("UBUNTU_APT_MIRROR=http://ports.ubuntu.com/ubuntu-ports", calls)
+                self.assertIn("/engineai/t800:", calls)
+                self.assertNotIn("/engineai/t800-dev:", calls)
+                self.assertIn("--platform linux/arm64", calls)
+                if "dev" in alias:
+                    self.assertIn("legacy T800 alias", result.stderr)
+
+    def test_noninteractive_publish_sync_does_not_open_dev_tty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tool_dir = Path(tmp)
+            docker_log = tool_dir / "docker.log"
+            curl_log = tool_dir / "curl.log"
+            docker = tool_dir / "docker"
+            docker.write_text(
+                "#!/bin/sh\n"
+                "printf '%s\\n' \"$*\" >> \"$DOCKER_LOG\"\n"
+                "case \"$*\" in *'alpine:3.20 uname -m'*) echo aarch64 ;; esac\n",
+                encoding="utf-8",
+            )
+            docker.chmod(0o755)
+            git = tool_dir / "git"
+            git.write_text(
+                "#!/bin/sh\n"
+                "case \"$*\" in *'rev-parse --short=7 HEAD'*) echo abcdef0 ;; esac\n",
+                encoding="utf-8",
+            )
+            git.chmod(0o755)
+            curl = tool_dir / "curl"
+            curl.write_text(
+                "#!/bin/sh\n"
+                "printf '%s\\n' \"$*\" >> \"$CURL_LOG\"\n"
+                "out=''\n"
+                "while [ $# -gt 0 ]; do [ \"$1\" = -o ] && { shift; out=$1; }; shift; done\n"
+                "[ -n \"$out\" ] && printf '{\"ok\":true}' > \"$out\"\n"
+                "printf '%s' \"${FAKE_HTTP_CODE:-201}\"\n",
+                encoding="utf-8",
+            )
+            curl.chmod(0o755)
+            env = self._environment(tool_dir, docker_log)
+            env.update({
+                "REGISTRY": "registry.example.test",
+                "REGISTRY_USER": "robot",
+                "REGISTRY_PASSWORD": "secret",
+                "IMAGE_NAMESPACE": "drivers",
+                "RESOURCE_CENTER_API_KEY": "test-key",
+                "RESOURCE_CENTER_URL": "https://resource.example.test",
+                "CURL_LOG": str(curl_log),
+            })
+            result = subprocess.run(
+                ["bash", str(BUILD_SCRIPT), "--mirror", "none", "engineai/t800"],
+                cwd=REPO_ROOT,
+                env=env,
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            self.assertEqual(0, result.returncode, result.stderr + result.stdout)
+            self.assertNotIn("/dev/tty", result.stderr)
+            self.assertIn("/api/admin/register", curl_log.read_text(encoding="utf-8"))
+            self.assertIn("✓ EngineAI T800", result.stdout)
+            calls = docker_log.read_text(encoding="utf-8")
+            self.assertIn("--output=type=docker", calls)
+            self.assertNotIn("buildx build --push", calls)
+            smoke_at = calls.index("run --rm --platform linux/arm64 --entrypoint /bin/bash")
+            push_at = calls.index("push registry.example.test/drivers/engineai/t800:")
+            self.assertLess(smoke_at, push_at)
+
+            failed_env = dict(env, FAKE_HTTP_CODE="500")
+            failed = subprocess.run(
+                ["bash", str(BUILD_SCRIPT), "--mirror", "none", "engineai/t800"],
+                cwd=REPO_ROOT,
+                env=failed_env,
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            self.assertEqual(1, failed.returncode)
+            self.assertIn("注册失败 (HTTP 500)", failed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/engineai/t800/tests/test_contracts.py
+++ b/engineai/t800/tests/test_contracts.py
@@ -35,8 +35,14 @@ def load_main_without_ros():
 
 
 class FakeBundle:
+    def __init__(self, state="running"):
+        self.state = state
+
     def get_all_tools(self):
         return [{"name": "echo", "type": "actuator", "inputSchema": {"type": "object"}}]
+
+    def health(self):
+        return {"state": self.state, "driver": "engineai-t800"}
 
     def dispatch(self, name, arguments):
         if name == "echo":
@@ -88,7 +94,20 @@ class McpHttpContractTests(unittest.TestCase):
 
     def test_health_endpoint(self):
         with urllib.request.urlopen(self.url + "/health", timeout=2) as response:
-            self.assertEqual("engineai-t800", json.loads(response.read())["driver"])
+            payload = json.loads(response.read())
+            self.assertEqual("engineai-t800", payload["driver"])
+            self.assertEqual("running", payload["state"])
+
+    def test_degraded_health_is_not_reported_as_healthy(self):
+        previous = self.module._bundle
+        self.module._bundle = FakeBundle(state="degraded")
+        try:
+            with self.assertRaises(urllib.error.HTTPError) as captured:
+                urllib.request.urlopen(self.url + "/health", timeout=2)
+            self.assertEqual(503, captured.exception.code)
+            self.assertEqual("degraded", json.loads(captured.exception.read())["state"])
+        finally:
+            self.module._bundle = previous
 
     def test_non_mcp_path_is_404(self):
         with self.assertRaises(urllib.error.HTTPError) as captured:
@@ -98,6 +117,8 @@ class McpHttpContractTests(unittest.TestCase):
     def test_cyclonedds_interface_is_validated(self):
         previous = os.environ.pop("CYCLONEDDS_URI", None)
         previous_interface = os.environ.pop("NETWORK_INTERFACE", None)
+        previous_if_nameindex = self.module.socket.if_nameindex
+        self.module.socket.if_nameindex = lambda: [(1, "lo"), (2, "eno1")]
         try:
             interface = self.module._configure_cyclonedds({"ros": {"robot_interface": "eno1"}})
             self.assertEqual("eno1", interface)
@@ -105,12 +126,53 @@ class McpHttpContractTests(unittest.TestCase):
             os.environ.pop("CYCLONEDDS_URI", None)
             with self.assertRaisesRegex(ValueError, "invalid"):
                 self.module._configure_cyclonedds({"ros": {"robot_interface": "bad iface"}})
+            with self.assertRaisesRegex(ValueError, "does not exist"):
+                self.module._configure_cyclonedds({"ros": {"robot_interface": "eth9"}})
         finally:
+            self.module.socket.if_nameindex = previous_if_nameindex
             os.environ.pop("CYCLONEDDS_URI", None)
             if previous is not None:
                 os.environ["CYCLONEDDS_URI"] = previous
             if previous_interface is not None:
                 os.environ["NETWORK_INTERFACE"] = previous_interface
+
+    def test_bundle_hides_failed_plugins_and_reports_degraded(self):
+        class Plugin:
+            def __init__(self, name, fail=False):
+                self.name = name
+                self.fail = fail
+                self.stops = 0
+
+            def get_tool(self):
+                return {"name": self.name, "type": "sensor", "inputSchema": {"type": "object"}}
+
+            def start(self):
+                if self.fail:
+                    raise RuntimeError(f"{self.name} failed")
+
+            def stop(self):
+                self.stops += 1
+
+            def dispatch(self, action, _args):
+                return {"state": action}
+
+        good = Plugin("good")
+        bad = Plugin("bad", fail=True)
+        bundle = self.module.T800DeviceBundle.__new__(self.module.T800DeviceBundle)
+        bundle._plugins = [good, bad]
+        bundle._active_plugins = []
+        bundle._startup_errors = {}
+        bundle._started = False
+        bundle._motion_events = None
+
+        bundle.start_all()
+        self.assertEqual(["good"], [tool["name"] for tool in bundle.get_all_tools()])
+        self.assertEqual("degraded", bundle.health()["state"])
+        self.assertIn("Plugin", bundle.health()["startup_errors"])
+        self.assertIsNone(bundle.dispatch("bad", {}))
+        bundle.stop_all()
+        bundle.stop_all()
+        self.assertEqual(1, good.stops)
 
 
 class VendoredContractTests(unittest.TestCase):

--- a/engineai/t800/tests/test_contracts.py
+++ b/engineai/t800/tests/test_contracts.py
@@ -142,6 +142,10 @@ class VendoredContractTests(unittest.TestCase):
                                  if line.startswith("port:")))
         self.assertEqual(config_port, metadata_port)
         self.assertIn(f":{config_port}/mcp", metadata_text)
+        self.assertIn('hardware_model: "t800"', metadata_text)
+        self.assertNotIn("t800-dev", metadata_text)
+        deploy_text = (ROOT / "deploy" / "service.yml").read_text()
+        self.assertNotIn("RMW_IMPLEMENTATION=rmw_cyclonedds_cpp", deploy_text)
 
 
 if __name__ == "__main__":

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -186,6 +186,11 @@ class DevicePluginContractTests(unittest.TestCase):
             self.device.NativeNodeControlPlugin(CONFIG, "robot", self.ros),
             self.device.SafetyControlPlugin(CONFIG, "robot", self.ros, self.state),
             self.device.NativeSdkPlugin({"mode": "external"}, "robot", self.ros),
+            self.device.HeartbeatStatusPlugin(CONFIG, "robot", self.ros),
+            self.device.LinkInfoPlugin(CONFIG, "robot", self.ros),
+            self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros),
+            self.device.MotionEventsPlugin(CONFIG, "robot", self.ros),
+            self.device.NativeInterfaceProbePlugin(CONFIG, "robot", self.ros),
             VirtualGamepadPlugin({}, "robot", self.ros),
         ]
         names = set()
@@ -196,12 +201,14 @@ class DevicePluginContractTests(unittest.TestCase):
             {"joints", "imu", "battery", "motor_health", "motor_state", "motor_command", "joint_command_feedback",
              "gamepad", "motion_state", "driver_health", "model",
              "robot_snapshot", "fault_summary", "stability", "joint_groups", "capabilities", "ros_graph",
+             "mainboard", "heartbeat_status", "link_info", "motion_command_trace", "motion_events",
+             "native_interface_probe",
              "loco", "motion_mode", "dance", "joint_plan", "joint_plan_state", "gesture",
              "joint_override", "joint_bridge",
              "led", "tts", "motor_power", "native_node_control", "virtual_gamepad", "safety", "native_sdk"},
             names,
         )
-        self.assertEqual(32, len(names))
+        self.assertEqual(38, len(names))
 
     def test_derived_diagnostics_and_capability_resources(self):
         self.state._set("imu", {

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1,4 +1,6 @@
 import importlib.util
+import json
+import struct
 import sys
 import time
 import types
@@ -108,14 +110,31 @@ def install_ros_stubs():
     sys.modules["rclpy.qos"] = rclpy_qos
 
     std_msgs = types.ModuleType("std_msgs.msg")
+    std_msgs.Header = type("Header", (Message,), {})
     std_msgs.String = type("String", (Message,), {"__init__": lambda self: setattr(self, "data", "")})
+    std_msgs.UInt8MultiArray = type("UInt8MultiArray", (Message,), {})
     sys.modules["std_msgs.msg"] = std_msgs
+
+    sensor_msgs = types.ModuleType("sensor_msgs.msg")
+    sensor_msgs.PointCloud2 = type("PointCloud2", (Message,), {})
+    sensor_msgs.CompressedImage = type("CompressedImage", (Message,), {})
+    sensor_msgs.Image = type("Image", (Message,), {})
+    sys.modules["sensor_msgs.msg"] = sensor_msgs
+
+    audio_msgs = types.ModuleType("audio_msgs.msg")
+    audio_msgs.AudioChunk = type(
+        "AudioChunk",
+        (Message,),
+        {"__init__": lambda self: (Message.__init__(self), setattr(self, "format", ""),
+                                    setattr(self, "data", []))[-1]},
+    )
+    sys.modules["audio_msgs.msg"] = audio_msgs
 
     protocol_msg = types.ModuleType("interface_protocol.msg")
     for name in (
         "BodyVelCmd", "GamepadKeys", "ImuInfo", "JointCommand", "JointMotionPlanState",
         "JointOverrideCommand", "JointState", "LedControl", "MotionState", "MotionStateRequest",
-        "MotorDebug", "NodeControl", "PowerInfo", "Tts",
+        "MotorDebug", "NodeControl", "PowerInfo",
     ):
         setattr(protocol_msg, name, type(name, (Message,), {}))
     protocol_msg.JointMotionPlanRequest = JointMotionPlanRequest
@@ -151,7 +170,12 @@ CONFIG = {
         "led": "/hardware/led_control", "joint_plan_request": "/motion/joint_motion_plan/request",
         "joint_plan_state": "/motion/joint_motion_plan/state",
         "joint_override": "/motion/joint_override_command", "joint_command": "/hardware/joint_command",
-        "tts": "/hardware/tts", "native_node_control": "/motion/node_control",
+        "native_node_control": "/motion/node_control",
+        "vision_cloud_raw": "/manifold/ODIN2/device0/cloud/raw",
+        "vision_cloud_slam": "/manifold/ODIN2/device0/cloud/slam",
+        "vision_camera_left": "/manifold/ODIN2/device0/camera0/compressed",
+        "vision_camera_right": "/manifold/ODIN2/device0/camera1/compressed",
+        "vision_depth": "/manifold/ODIN2/device0/depth",
     },
     "services": {"enable_motor": "/hardware/enable_motor"},
 }
@@ -181,7 +205,8 @@ class DevicePluginContractTests(unittest.TestCase):
             self.device.JointOverridePlugin(CONFIG, "robot", self.ros, self.state),
             self.device.JointBridgePlugin(CONFIG, "robot", self.ros, self.state),
             self.device.LedPlugin(CONFIG, "robot", self.ros),
-            self.device.TtsPlugin(CONFIG, "robot", self.ros),
+            self.device.MicPlugin(CONFIG, "robot", self.ros),
+            self.device.VisionPlugin(CONFIG, "robot", self.ros),
             self.device.MotorPowerPlugin(CONFIG, "robot", self.ros),
             self.device.NativeNodeControlPlugin(CONFIG, "robot", self.ros),
             self.device.SafetyControlPlugin(CONFIG, "robot", self.ros, self.state),
@@ -198,10 +223,11 @@ class DevicePluginContractTests(unittest.TestCase):
              "robot_snapshot", "fault_summary", "stability", "joint_groups", "capabilities", "ros_graph",
              "loco", "motion_mode", "dance", "joint_plan", "joint_plan_state", "gesture",
              "joint_override", "joint_bridge",
-             "led", "tts", "motor_power", "native_node_control", "virtual_gamepad", "safety", "native_sdk"},
+             "led", "mic", "pointcloud", "camera", "depth",
+             "motor_power", "native_node_control", "virtual_gamepad", "safety", "native_sdk"},
             names,
         )
-        self.assertEqual(32, len(names))
+        self.assertEqual(35, len(names))
 
     def test_derived_diagnostics_and_capability_resources(self):
         self.state._set("imu", {
@@ -327,22 +353,55 @@ class DevicePluginContractTests(unittest.TestCase):
         plugin.dispatch("stop_command", {})
         self.assertEqual([1.0] * 25, plugin._publisher.messages[-1].damping)
 
-    def test_led_tts_and_motor_service_paths(self):
+    def test_led_and_motor_service_paths(self):
         led = self.device.LedPlugin(CONFIG, "robot", self.ros)
         led.start()
         self.assertEqual("set", led.dispatch("led", {"mode": "breathe_red"})["state"])
         self.assertEqual(9, led._publisher.messages[-1].color)
-
-        tts = self.device.TtsPlugin(CONFIG, "robot", self.ros)
-        tts.start()
-        self.assertEqual("published", tts.dispatch("tts", {"text": "你好", "rate": 150})["state"])
-        self.assertEqual("你好", tts._publisher.messages[-1].text)
 
         motor = self.device.MotorPowerPlugin(CONFIG, "robot", self.ros)
         motor.start()
         result = motor.dispatch("disable", {})
         self.assertTrue(result["success"])
         self.assertFalse(result["enabled"])
+
+    def test_mic_uses_pulseaudio_capture_and_publishes_pcm_chunks(self):
+        plugin = self.device.MicPlugin(CONFIG, "robot", self.ros)
+
+        class FakeStdout:
+            def __init__(self):
+                self.reads = [b"\x01\x00" * 512, b""]
+
+            def read(self, _size):
+                return self.reads.pop(0)
+
+        class FakeProcess:
+            def __init__(self):
+                self.stdout = FakeStdout()
+                self.returncode = None
+
+            def poll(self):
+                return self.returncode
+
+            def terminate(self):
+                self.returncode = 0
+
+            def wait(self, timeout=None):
+                return self.returncode
+
+            def kill(self):
+                self.returncode = -9
+
+        process = FakeProcess()
+        plugin._check_pulse = lambda: None
+        plugin._spawn_capture = lambda: process
+        self.assertEqual("running", plugin.dispatch("start", {})["state"])
+        deadline = time.monotonic() + 1
+        while not plugin._publisher.messages and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertEqual("audio/pcm-16k", plugin._publisher.messages[0].format)
+        self.assertEqual(1024, len(plugin._publisher.messages[0].data))
+        self.assertEqual("idle", plugin.dispatch("stop", {})["state"])
 
     def test_native_node_control_and_composed_safety(self):
         native = self.device.NativeNodeControlPlugin(CONFIG, "robot", self.ros)
@@ -369,6 +428,84 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual(0.0, safety._override_pub.messages[-1].weight)
         self.assertEqual([1.0] * 25, safety._joint_pub.messages[-1].damping)
         self.assertTrue(all(control.stopped for control in active_controls))
+
+    def test_vision_pointcloud_passthrough_binary_header(self):
+        import struct
+
+        plugin = self.device.VisionPlugin(CONFIG, "robot", self.ros)
+        plugin.start()
+        data = bytes(range(64))  # 4 点 × 16 字节 point_step
+        plugin._on_cloud_raw(types.SimpleNamespace(point_step=16, data=data))
+        out = plugin._cloud_pub.messages[-1]
+        self.assertEqual(struct.pack("<II", 16, 4), bytes(out.data[:8]))
+        self.assertEqual(bytes(range(64)), bytes(out.data[8:]))
+        self.assertEqual(1, plugin._frames["pointcloud"])
+
+    def test_json_message_normalizes_numpy_scalars(self):
+        import numpy as np
+
+        msg = self.device._json_message(
+            {"signed": np.int32(-7), "unsigned": np.uint16(42), "value": np.float32(1.5)}
+        )
+        self.assertEqual(
+            {"signed": -7, "unsigned": 42, "value": 1.5},
+            json.loads(msg.data),
+        )
+
+    def test_vision_select_source_switches_cloud(self):
+        plugin = self.device.VisionPlugin(CONFIG, "robot", self.ros)
+        plugin.start()
+        plugin.dispatch("select_source", {"source": "slam"})
+        self.assertEqual("slam", plugin._source)
+        data = bytes(32)
+        plugin._on_cloud_raw(types.SimpleNamespace(point_step=16, data=data))  # raw 被忽略
+        self.assertEqual(0, len(plugin._cloud_pub.messages))
+        plugin._on_cloud_slam(types.SimpleNamespace(point_step=16, data=data))
+        self.assertEqual(1, len(plugin._cloud_pub.messages))
+        info = plugin.dispatch("info", {})
+        self.assertEqual("slam", info["source"])
+        self.assertEqual(4, len(info["topic_out"]))
+        self.assertEqual("sensor/pointcloud", info["topic_out"][0]["format"])
+
+    def test_vision_camera_passthrough_and_native_depth_conversion(self):
+        plugin = self.device.VisionPlugin(CONFIG, "robot", self.ros)
+        plugin.start()
+        left = types.SimpleNamespace(format="jpeg", data=bytes([0xFF, 0xD8]))
+        right = types.SimpleNamespace(format="jpeg", data=bytes([0xFF, 0xD9]))
+        plugin._on_camera_left(left)
+        plugin._on_camera_right(right)
+        self.assertIs(left, plugin._cam_left_pub.messages[-1])
+        self.assertIs(right, plugin._cam_right_pub.messages[-1])
+        # The official pcd2depth node publishes camera optical-axis depth in
+        # metres.  Include invalid values and an over-range value to exercise
+        # normalization into the dashboard's uint16 millimetre contract.
+        values = (
+            2.0, float("nan"), -1.0, 70.0,
+            1.5, 1.0, 0.0, 0.5,
+            3.0, 2.5, 2.0, 1.5,
+        )
+        depth = types.SimpleNamespace(
+            header=types.SimpleNamespace(stamp="source-stamp", frame_id="camera"),
+            width=4,
+            height=3,
+            encoding="32FC1",
+            is_bigendian=False,
+            step=16,
+            data=struct.pack("<12f", *values),
+        )
+        plugin._on_depth(depth)
+        out = plugin._depth_pub.messages[-1]
+        self.assertEqual("16UC1", out.encoding)
+        self.assertEqual((640, 480, 1280), (out.width, out.height, out.step))
+        self.assertEqual(640 * 480 * 2, len(out.data))
+        self.assertEqual("source-stamp", out.header.stamp)
+        self.assertEqual("camera", out.header.frame_id)
+        row = struct.unpack("<640H", bytes(out.data[:1280]))
+        self.assertEqual((2000, 0, 0, 65535), (row[0], row[160], row[320], row[480]))
+        tools = {tool["name"]: tool for tool in plugin.get_tools()}
+        self.assertEqual("image/jpeg", tools["camera"]["topic_out"][0]["format"])
+        self.assertEqual(2, len(tools["camera"]["topic_out"]))
+        self.assertEqual("image/depth-z16", tools["depth"]["topic_out"][0]["format"])
 
 
 if __name__ == "__main__":

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1,5 +1,4 @@
 import importlib.util
-import json
 import struct
 import sys
 import time
@@ -134,7 +133,7 @@ def install_ros_stubs():
     for name in (
         "BodyVelCmd", "GamepadKeys", "ImuInfo", "JointCommand", "JointMotionPlanState",
         "JointOverrideCommand", "JointState", "LedControl", "MotionState", "MotionStateRequest",
-        "MotorDebug", "NodeControl", "PowerInfo",
+        "MotorDebug", "NodeControl", "PowerInfo", "Tts",
     ):
         setattr(protocol_msg, name, type(name, (Message,), {}))
     protocol_msg.JointMotionPlanRequest = JointMotionPlanRequest
@@ -170,7 +169,7 @@ CONFIG = {
         "led": "/hardware/led_control", "joint_plan_request": "/motion/joint_motion_plan/request",
         "joint_plan_state": "/motion/joint_motion_plan/state",
         "joint_override": "/motion/joint_override_command", "joint_command": "/hardware/joint_command",
-        "native_node_control": "/motion/node_control",
+        "tts": "/hardware/tts", "native_node_control": "/motion/node_control",
         "vision_cloud_raw": "/manifold/ODIN2/device0/cloud/raw",
         "vision_cloud_slam": "/manifold/ODIN2/device0/cloud/slam",
         "vision_camera_left": "/manifold/ODIN2/device0/camera0/compressed",
@@ -205,6 +204,7 @@ class DevicePluginContractTests(unittest.TestCase):
             self.device.JointOverridePlugin(CONFIG, "robot", self.ros, self.state),
             self.device.JointBridgePlugin(CONFIG, "robot", self.ros, self.state),
             self.device.LedPlugin(CONFIG, "robot", self.ros),
+            self.device.TtsPlugin(CONFIG, "robot", self.ros),
             self.device.MicPlugin(CONFIG, "robot", self.ros),
             self.device.VisionPlugin(CONFIG, "robot", self.ros),
             self.device.MotorPowerPlugin(CONFIG, "robot", self.ros),
@@ -223,11 +223,11 @@ class DevicePluginContractTests(unittest.TestCase):
              "robot_snapshot", "fault_summary", "stability", "joint_groups", "capabilities", "ros_graph",
              "loco", "motion_mode", "dance", "joint_plan", "joint_plan_state", "gesture",
              "joint_override", "joint_bridge",
-             "led", "mic", "pointcloud", "camera", "depth",
+             "led", "tts", "mic", "pointcloud", "camera", "depth",
              "motor_power", "native_node_control", "virtual_gamepad", "safety", "native_sdk"},
             names,
         )
-        self.assertEqual(35, len(names))
+        self.assertEqual(36, len(names))
 
     def test_derived_diagnostics_and_capability_resources(self):
         self.state._set("imu", {
@@ -353,11 +353,16 @@ class DevicePluginContractTests(unittest.TestCase):
         plugin.dispatch("stop_command", {})
         self.assertEqual([1.0] * 25, plugin._publisher.messages[-1].damping)
 
-    def test_led_and_motor_service_paths(self):
+    def test_led_tts_and_motor_service_paths(self):
         led = self.device.LedPlugin(CONFIG, "robot", self.ros)
         led.start()
         self.assertEqual("set", led.dispatch("led", {"mode": "breathe_red"})["state"])
         self.assertEqual(9, led._publisher.messages[-1].color)
+
+        tts = self.device.TtsPlugin(CONFIG, "robot", self.ros)
+        tts.start()
+        self.assertEqual("published", tts.dispatch("tts", {"text": "你好", "rate": 150})["state"])
+        self.assertEqual("你好", tts._publisher.messages[-1].text)
 
         motor = self.device.MotorPowerPlugin(CONFIG, "robot", self.ros)
         motor.start()
@@ -440,17 +445,6 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual(struct.pack("<II", 16, 4), bytes(out.data[:8]))
         self.assertEqual(bytes(range(64)), bytes(out.data[8:]))
         self.assertEqual(1, plugin._frames["pointcloud"])
-
-    def test_json_message_normalizes_numpy_scalars(self):
-        import numpy as np
-
-        msg = self.device._json_message(
-            {"signed": np.int32(-7), "unsigned": np.uint16(42), "value": np.float32(1.5)}
-        )
-        self.assertEqual(
-            {"signed": -7, "unsigned": 42, "value": 1.5},
-            json.loads(msg.data),
-        )
 
     def test_vision_select_source_switches_cloud(self):
         plugin = self.device.VisionPlugin(CONFIG, "robot", self.ros)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1,4 +1,5 @@
 import importlib.util
+import struct
 import sys
 import time
 import types
@@ -79,6 +80,24 @@ class FakeNode:
     def get_clock(self):
         return types.SimpleNamespace(now=lambda: types.SimpleNamespace(to_msg=lambda: "stamp"))
 
+    def get_topic_names_and_types(self):
+        return []
+
+    def get_service_names_and_types(self):
+        return []
+
+    def count_publishers(self, _name):
+        return 0
+
+    def count_subscribers(self, _name):
+        return 0
+
+    def count_services(self, _name):
+        return 0
+
+    def count_clients(self, _name):
+        return 0
+
 
 class FakeExecutor:
     def __init__(self):
@@ -108,14 +127,35 @@ def install_ros_stubs():
     sys.modules["rclpy.qos"] = rclpy_qos
 
     std_msgs = types.ModuleType("std_msgs.msg")
+    std_msgs.Header = type("Header", (Message,), {})
     std_msgs.String = type("String", (Message,), {"__init__": lambda self: setattr(self, "data", "")})
+    std_msgs.UInt8MultiArray = type("UInt8MultiArray", (Message,), {})
     sys.modules["std_msgs.msg"] = std_msgs
+
+    sensor_msgs = types.ModuleType("sensor_msgs.msg")
+    sensor_msgs.PointCloud2 = type("PointCloud2", (Message,), {})
+    sensor_msgs.CompressedImage = type("CompressedImage", (Message,), {})
+    sensor_msgs.Image = type("Image", (Message,), {})
+    sys.modules["sensor_msgs.msg"] = sensor_msgs
+
+    nav_msgs = types.ModuleType("nav_msgs.msg")
+    nav_msgs.Odometry = type("Odometry", (Message,), {})
+    sys.modules["nav_msgs.msg"] = nav_msgs
+
+    audio_msgs = types.ModuleType("audio_msgs.msg")
+    audio_msgs.AudioChunk = type(
+        "AudioChunk",
+        (Message,),
+        {"__init__": lambda self: (Message.__init__(self), setattr(self, "format", ""),
+                                    setattr(self, "data", []))[-1]},
+    )
+    sys.modules["audio_msgs.msg"] = audio_msgs
 
     protocol_msg = types.ModuleType("interface_protocol.msg")
     for name in (
         "BodyVelCmd", "GamepadKeys", "ImuInfo", "JointCommand", "JointMotionPlanState",
         "JointOverrideCommand", "JointState", "LedControl", "MotionState", "MotionStateRequest",
-        "MotorDebug", "NodeControl", "PowerInfo", "Tts",
+        "Heartbeat", "LinkInfo", "MotorDebug", "NodeControl", "PowerInfo", "Tts",
     ):
         setattr(protocol_msg, name, type(name, (Message,), {}))
     protocol_msg.JointMotionPlanRequest = JointMotionPlanRequest
@@ -152,8 +192,16 @@ CONFIG = {
         "joint_plan_state": "/motion/joint_motion_plan/state",
         "joint_override": "/motion/joint_override_command", "joint_command": "/hardware/joint_command",
         "tts": "/hardware/tts", "native_node_control": "/motion/node_control",
+        "heartbeat": "/heartbeat", "link_info": "/motion/link_info",
+        "odometry": "/manifold/ODIN2/device0/odometry",
+        "vision_cloud_raw": "/manifold/ODIN2/device0/cloud/raw",
+        "vision_cloud_slam": "/manifold/ODIN2/device0/cloud/slam",
+        "vision_camera_left": "/manifold/ODIN2/device0/camera0/compressed",
+        "vision_camera_right": "/manifold/ODIN2/device0/camera1/compressed",
+        "vision_depth": "/manifold/ODIN2/device0/depth",
     },
     "services": {"enable_motor": "/hardware/enable_motor"},
+    "diagnostics": {"command_trace_capacity": 20, "motion_events_capacity": 100},
 }
 
 
@@ -182,6 +230,8 @@ class DevicePluginContractTests(unittest.TestCase):
             self.device.JointBridgePlugin(CONFIG, "robot", self.ros, self.state),
             self.device.LedPlugin(CONFIG, "robot", self.ros),
             self.device.TtsPlugin(CONFIG, "robot", self.ros),
+            self.device.MicPlugin(CONFIG, "robot", self.ros),
+            self.device.VisionPlugin(CONFIG, "robot", self.ros),
             self.device.MotorPowerPlugin(CONFIG, "robot", self.ros),
             self.device.NativeNodeControlPlugin(CONFIG, "robot", self.ros),
             self.device.SafetyControlPlugin(CONFIG, "robot", self.ros, self.state),
@@ -194,8 +244,10 @@ class DevicePluginContractTests(unittest.TestCase):
             VirtualGamepadPlugin({}, "robot", self.ros),
         ]
         names = set()
+        definitions = []
         for plugin in plugins:
             tools = plugin.get_tools() if hasattr(plugin, "get_tools") else [plugin.get_tool()]
+            definitions.extend(tools)
             names.update(tool["name"] for tool in tools)
         self.assertEqual(
             {"joints", "imu", "battery", "motor_health", "motor_state", "motor_command", "joint_command_feedback",
@@ -205,10 +257,74 @@ class DevicePluginContractTests(unittest.TestCase):
              "native_interface_probe",
              "loco", "motion_mode", "dance", "joint_plan", "joint_plan_state", "gesture",
              "joint_override", "joint_bridge",
-             "led", "tts", "motor_power", "native_node_control", "virtual_gamepad", "safety", "native_sdk"},
+             "led", "tts", "mic", "pointcloud", "camera", "depth",
+             "motor_power", "native_node_control", "virtual_gamepad", "safety", "native_sdk"},
             names,
         )
-        self.assertEqual(38, len(names))
+        self.assertEqual(42, len(names))
+        self.assertEqual(42, len(definitions), "tool names must be unique")
+        for tool in definitions:
+            schema = tool.get("inputSchema")
+            self.assertEqual("object", schema.get("type"), tool["name"])
+            properties = schema.get("properties", {})
+            action = properties.get("action")
+            if not action:
+                continue
+            enum = action.get("enum", [])
+            self.assertEqual(len(enum), len(set(enum)), tool["name"])
+            for action_name, detail in schema.get("x-action-params", {}).items():
+                self.assertIn(action_name, enum, tool["name"])
+                for parameter in detail.get("params", []):
+                    self.assertIn(parameter, properties, f"{tool['name']}.{action_name}")
+
+    def test_sensor_lifecycle_schemas_and_info_topics_match_agent_core(self):
+        plugins = [
+            self.state,
+            self.device.HeartbeatStatusPlugin(CONFIG, "robot", self.ros),
+            self.device.LinkInfoPlugin(CONFIG, "robot", self.ros),
+            self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros),
+            self.device.MotionEventsPlugin(CONFIG, "robot", self.ros),
+            self.device.NativeInterfaceProbePlugin(CONFIG, "robot", self.ros),
+            self.device.VisionPlugin(CONFIG, "robot", self.ros),
+            self.device.JointPlanPlugin(CONFIG, "robot", self.ros),
+        ]
+        for plugin in plugins:
+            tools = plugin.get_tools() if hasattr(plugin, "get_tools") else [plugin.get_tool()]
+            for tool in tools:
+                if tool["type"] != "sensor":
+                    continue
+                action = tool["inputSchema"]["properties"]["action"]
+                self.assertTrue({"start", "info", "stop"}.issubset(action["enum"]), tool["name"])
+                info = plugin.dispatch("info", {"_tool_name": tool["name"]})
+                self.assertTrue(info.get("topic_out"), tool["name"])
+
+    def test_new_status_plugins_can_start_with_declared_ros_dependencies(self):
+        plugins = [
+            self.device.HeartbeatStatusPlugin(CONFIG, "robot", self.ros),
+            self.device.LinkInfoPlugin(CONFIG, "robot", self.ros),
+            self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros),
+            self.device.MotionEventsPlugin(CONFIG, "robot", self.ros),
+            self.device.NativeInterfaceProbePlugin(CONFIG, "robot", self.ros),
+        ]
+        for plugin in plugins:
+            plugin.start()
+            plugin.stop()
+
+    def test_motion_trace_prefers_fresh_command_over_stale_odometry(self):
+        plugin = self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(types.SimpleNamespace(
+            header=types.SimpleNamespace(frame_id="odom"),
+            child_frame_id="base",
+            twist=types.SimpleNamespace(twist=types.SimpleNamespace(
+                linear=types.SimpleNamespace(x=0.1, y=0.0, z=0.0),
+                angular=types.SimpleNamespace(x=0.0, y=0.0, z=0.0),
+            )),
+        ))
+        plugin._odometry_updated = time.monotonic() - 5.0
+        plugin._on_velocity(types.SimpleNamespace(linear_velocity=[0.8, 0.0, 0.0], yaw_velocity=0.0))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("body_velocity_command", snapshot["source"])
+        self.assertEqual("0.80 m/s", snapshot["speed"])
 
     def test_derived_diagnostics_and_capability_resources(self):
         self.state._set("imu", {
@@ -351,6 +467,48 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertFalse(result["enabled"])
 
+        motor._client = types.SimpleNamespace(service_is_ready=lambda: False)
+        unavailable = motor.dispatch("start", {})
+        self.assertEqual("error", unavailable["state"])
+
+    def test_mic_uses_pulseaudio_capture_and_publishes_pcm_chunks(self):
+        plugin = self.device.MicPlugin(CONFIG, "robot", self.ros)
+
+        class FakeStdout:
+            def __init__(self):
+                self.reads = [b"\x01\x00" * 512, b""]
+
+            def read(self, _size):
+                return self.reads.pop(0)
+
+        class FakeProcess:
+            def __init__(self):
+                self.stdout = FakeStdout()
+                self.returncode = None
+
+            def poll(self):
+                return self.returncode
+
+            def terminate(self):
+                self.returncode = 0
+
+            def wait(self, timeout=None):
+                return self.returncode
+
+            def kill(self):
+                self.returncode = -9
+
+        process = FakeProcess()
+        plugin._check_pulse = lambda: None
+        plugin._spawn_capture = lambda: process
+        self.assertEqual("running", plugin.dispatch("start", {})["state"])
+        deadline = time.monotonic() + 1
+        while not plugin._publisher.messages and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertEqual("audio/pcm-16k", plugin._publisher.messages[0].format)
+        self.assertEqual(1024, len(plugin._publisher.messages[0].data))
+        self.assertEqual("idle", plugin.dispatch("stop", {})["state"])
+
     def test_native_node_control_and_composed_safety(self):
         native = self.device.NativeNodeControlPlugin(CONFIG, "robot", self.ros)
         native.start()
@@ -376,6 +534,97 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual(0.0, safety._override_pub.messages[-1].weight)
         self.assertEqual([1.0] * 25, safety._joint_pub.messages[-1].damping)
         self.assertTrue(all(control.stopped for control in active_controls))
+
+    def test_vision_pointcloud_passthrough_binary_header(self):
+        import struct
+
+        plugin = self.device.VisionPlugin(CONFIG, "robot", self.ros)
+        plugin.start()
+        data = bytes(range(64))  # 4 点 × 16 字节 point_step
+        plugin._on_cloud_raw(types.SimpleNamespace(point_step=16, data=data))
+        out = plugin._cloud_pub.messages[-1]
+        self.assertEqual(struct.pack("<II", 16, 4), bytes(out.data[:8]))
+        self.assertEqual(bytes(range(64)), bytes(out.data[8:]))
+        self.assertEqual(1, plugin._frames["pointcloud"])
+
+    def test_vision_select_source_switches_cloud(self):
+        plugin = self.device.VisionPlugin(CONFIG, "robot", self.ros)
+        plugin.start()
+        plugin.dispatch("select_source", {"source": "slam"})
+        self.assertEqual("slam", plugin._source)
+        data = bytes(32)
+        plugin._on_cloud_raw(types.SimpleNamespace(point_step=16, data=data))  # raw 被忽略
+        self.assertEqual(0, len(plugin._cloud_pub.messages))
+        plugin._on_cloud_slam(types.SimpleNamespace(point_step=16, data=data))
+        self.assertEqual(1, len(plugin._cloud_pub.messages))
+        info = plugin.dispatch("info", {})
+        self.assertEqual("slam", info["source"])
+        self.assertEqual(4, len(info["topic_out"]))
+        self.assertEqual("sensor/pointcloud", info["topic_out"][0]["format"])
+
+    def test_vision_lifecycle_resolves_and_stops_only_the_requested_card(self):
+        plugin = self.device.VisionPlugin(CONFIG, "robot", self.ros)
+        plugin.start()
+        tools = {tool["name"]: tool for tool in plugin.get_tools()}
+        cloud_schema = tools["pointcloud"]["inputSchema"]
+        self.assertIn("select_source", cloud_schema["properties"]["action"]["enum"])
+        self.assertEqual(["raw", "slam"], cloud_schema["properties"]["source"]["enum"])
+
+        for tool_name, tool in tools.items():
+            info = plugin.dispatch("info", {"_tool_name": tool_name})
+            self.assertEqual(tool["topic_out"], info["topic_out"], tool_name)
+
+        stopped = plugin.dispatch("stop", {"_tool_name": "depth"})
+        camera = plugin.dispatch("info", {"_tool_name": "camera"})
+        self.assertEqual("idle", stopped["state"])
+        self.assertEqual("running", camera["state"])
+        self.assertTrue(plugin._running)
+        self.assertNotIn("depth", plugin._enabled_tools)
+
+        plugin.stop()
+        restarted = plugin.dispatch("start", {"_tool_name": "pointcloud"})
+        self.assertEqual("running", restarted["state"])
+        self.assertEqual({"pointcloud"}, plugin._enabled_tools)
+
+    def test_vision_camera_passthrough_and_native_depth_conversion(self):
+        plugin = self.device.VisionPlugin(CONFIG, "robot", self.ros)
+        plugin.start()
+        left = types.SimpleNamespace(format="jpeg", data=bytes([0xFF, 0xD8]))
+        right = types.SimpleNamespace(format="jpeg", data=bytes([0xFF, 0xD9]))
+        plugin._on_camera_left(left)
+        plugin._on_camera_right(right)
+        self.assertIs(left, plugin._cam_left_pub.messages[-1])
+        self.assertIs(right, plugin._cam_right_pub.messages[-1])
+        # The official pcd2depth node publishes camera optical-axis depth in
+        # metres.  Include invalid values and an over-range value to exercise
+        # normalization into the dashboard's uint16 millimetre contract.
+        values = (
+            2.0, float("nan"), -1.0, 70.0,
+            1.5, 1.0, 0.0, 0.5,
+            3.0, 2.5, 2.0, 1.5,
+        )
+        depth = types.SimpleNamespace(
+            header=types.SimpleNamespace(stamp="source-stamp", frame_id="camera"),
+            width=4,
+            height=3,
+            encoding="32FC1",
+            is_bigendian=False,
+            step=16,
+            data=struct.pack("<12f", *values),
+        )
+        plugin._on_depth(depth)
+        out = plugin._depth_pub.messages[-1]
+        self.assertEqual("16UC1", out.encoding)
+        self.assertEqual((640, 480, 1280), (out.width, out.height, out.step))
+        self.assertEqual(640 * 480 * 2, len(out.data))
+        self.assertEqual("source-stamp", out.header.stamp)
+        self.assertEqual("camera", out.header.frame_id)
+        row = struct.unpack("<640H", bytes(out.data[:1280]))
+        self.assertEqual((2000, 0, 0, 65535), (row[0], row[160], row[320], row[480]))
+        tools = {tool["name"]: tool for tool in plugin.get_tools()}
+        self.assertEqual("image/jpeg", tools["camera"]["topic_out"][0]["format"])
+        self.assertEqual(2, len(tools["camera"]["topic_out"]))
+        self.assertEqual("image/depth-z16", tools["depth"]["topic_out"][0]["format"])
 
 
 if __name__ == "__main__":

--- a/engineai/t800/tests/test_virtual_gamepad.py
+++ b/engineai/t800/tests/test_virtual_gamepad.py
@@ -1,7 +1,9 @@
 import struct
 import sys
 import time
+import types
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
@@ -46,6 +48,14 @@ class VirtualGamepadTests(unittest.TestCase):
         result = plugin.dispatch("command", {"buttons": [], "analogs": [2, -2, 0, 0, 0, 0], "duration": -1})
         self.assertEqual([1.0, -1.0, 0.0, 0.0, 0.0, 0.0], result["analogs"])
         plugin.dispatch("release", {})
+
+    def test_start_reports_lcm_initialization_failure_to_bundle(self):
+        plugin = VirtualGamepadPlugin({}, "robot", None)
+        fake_lcm = types.SimpleNamespace(LCM=mock.Mock(side_effect=OSError("no multicast route")))
+        with mock.patch.dict(sys.modules, {"lcm": fake_lcm}):
+            with self.assertRaisesRegex(RuntimeError, "no multicast route"):
+                plugin.start()
+        self.assertEqual("unavailable", plugin.dispatch("status", {})["state"])
 
 
 if __name__ == "__main__":

--- a/engineai/t800/virtual_gamepad.py
+++ b/engineai/t800/virtual_gamepad.py
@@ -118,6 +118,7 @@ class VirtualGamepadPlugin:
         except Exception as exc:
             self._lcm = None
             self._error = str(exc)
+            raise RuntimeError(f"LCM virtual gamepad initialization failed: {exc}") from exc
 
     def stop(self) -> None:
         self._stream.stop()


### PR DESCRIPTION
## 背景

本 PR 将 #107 中已经在机器人侧验证过的 T800 音视频能力，与 #149 后续增加的诊断能力和环境兼容修复整合到同一套实现中，同时修复了在机器人以外的干净环境中重新构建时发现的问题。

整合后统一使用标准 Driver `engineai/t800`，共提供 42 个工具，并支持在原生 ARM64 主机以及通过 ARM64 仿真的 x86_64 主机上复现 `linux/arm64` 镜像构建。

## 本次改动

- 合并 #107 的音视频卡片与 #149 的状态诊断卡片。
- 补齐并验证 42 个工具，其中包括：
  - `mic`
  - `pointcloud`
  - `camera`
  - `depth`
  - `heartbeat_status`
  - `link_info`
  - `motion_command_trace`
  - `motion_events`
  - `native_interface_probe`
  - `mainboard`
- 修复视觉插件的逐卡生命周期和 Topic 解析，避免 `pointcloud`、`camera`、`depth` 三张卡互相覆盖连线。
- 在 PointCloud schema 中声明 raw/SLAM 数据源切换能力。
- 修复 `joint_plan_state.info` 未返回已声明 `topic_out` 的问题。
- 修复虚拟手柄初始化失败、电机服务不可用时仍显示“已就绪”的假成功问题。
- 插件启动失败时，Driver 会返回 `degraded/failed`，并且不再向 Agent Core 暴露不可用工具。

## ARM64 构建兼容

- 通过 digest 固定 ROS 基础镜像，避免浮动 `latest` 导致环境漂移。
- 支持配置 Ubuntu、ROS apt 和 PyPI 镜像源。
- 显式安装 CycloneDDS、ROS 消息、colcon、音频和 Python 运行依赖。
- 显式加载以下 ROS workspace：
  - `/opt/ros/humble`
  - `/ros_ws/install`
  - `/t800_ws/install`
- 针对 x86_64 通过 QEMU/BuildKit 构建 ARM64 镜像时，CMake 错误判断 `builtin_interfaces__rosidl_generator_c` 不存在的问题，增加同一 CMake 进程内的依赖预检。
- `colcon` 构建失败会直接终止，不再吞掉错误并产出无效镜像。
- 增加构建期和运行期 ROS/Python import 检查。
- 容器入口使用 `exec python3`，确保停止容器时信号能够正确传递给 Driver。

## 构建与发布保护

- Driver 参数无法识别时返回非零，不再静默退出并显示“成功”。
- 兼容旧的 `t800-dev` 构建参数，但会明确提示并映射到标准 `engineai/t800`。
- 工作树存在未提交改动时禁止发布，避免生成无法复现的版本标签。
- 镜像先加载到本地并完成 ARM64 烟测，成功后才允许执行 `docker push`。
- 非交互构建不再依赖 `/dev/tty`。
- Resource Center 请求失败或返回非 2xx 状态时，构建脚本返回非零。

## 验证结果

基于提交 `74009b0` 完成以下验证：

- `bash -n build.sh`：通过。
- Python、YAML、XML 静态检查：通过。
- 56 项单元测试和契约测试：全部通过。
- 在 x86_64/QEMU 环境中真实完成 `linux/arm64` Docker 镜像构建。
- ARM64 容器内 ROS、音频、接口消息、CycloneDDS 和 Python 依赖烟测：通过。
- 容器服务成功启动。在测试环境没有 PulseAudio 服务时，Driver 正确返回 `degraded`，保留其余 41 个可用工具，同时不再错误暴露不可用的 `mic` 工具。

本 PR 尚未向公司镜像仓库推送镜像，也没有替换机器人上的现有容器或执行真机部署。

## 部署注意事项

- 正式镜像统一发布到 `engineai/t800`；`t800-dev` 仅作为构建参数兼容别名。
- `NETWORK_INTERFACE` 需要设置为连接 T800 机器人内网的实际网卡；当前机器人环境使用 `eth1`。
- 真机部署前确认 ROS Domain 为机器人侧 69、Agent Core 侧 42，并核对实际 Topic 名称。
- `mic` 卡片依赖 `deploy/service.yml` 中声明的 PulseAudio socket/config 挂载，以及可用的音频采集设备。
- 必须从干净的 Git 工作树构建和发布。
