### PR TITLE
feat(q5): add aggregated robot_status + arm_gesture + odom + teleop_state

### DIFF
--- a/robotera/q5_bundle/.dockerignore
+++ b/robotera/q5_bundle/.dockerignore
@@ -1,0 +1,1 @@
+致命错误：路径 'robotera/q5_bundle/.dockerignore' 在磁盘上，但是不在 'feat/q5-status-cards' 中

--- a/robotera/q5_bundle/Dockerfile
+++ b/robotera/q5_bundle/Dockerfile
@@ -55,6 +55,7 @@ COPY arm_control.py /work/arm_control.py
 COPY joint_limits.py /work/joint_limits.py
 COPY hand_control.py /work/hand_control.py
 COPY hand_gesture.py /work/hand_gesture.py
+COPY arm_gesture.py /work/arm_gesture.py
 COPY head_control.py /work/head_control.py
 COPY mic.py /work/mic.py
 COPY speaker.py /work/speaker.py
@@ -65,6 +66,9 @@ COPY q5_control_mode.py /work/q5_control_mode.py
 COPY legacy_device.py /work/legacy_device.py
 COPY legacy_direct_control.py /work/legacy_direct_control.py
 COPY q5_media_bridge.py /work/q5_media_bridge.py
+COPY odom.py /work/odom.py
+COPY teleop_state.py /work/teleop_state.py
+COPY robot_status.py /work/robot_status.py
 COPY config.yaml /work/config.yaml
 COPY resource/q5_model.urdf /work/resource/q5_model.urdf
 COPY resource/fastdds_udp_only.xml /work/resource/fastdds_udp_only.xml

--- a/robotera/q5_bundle/arm_gesture.py
+++ b/robotera/q5_bundle/arm_gesture.py
@@ -1,0 +1,641 @@
+# -*- coding: utf-8 -*-
+# arm_gesture —— Q5 手臂语义手势 (composes arm_control low-level joint positioning)
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+import json
+import urllib.request
+import ssl
+import os
+
+try:
+    from arm_control import ArmControlPlugin
+except ImportError:
+    ArmControlPlugin = None
+
+from body_command import get_router as _get_body_router, BodyCommandRouter
+from control_contract import q5_active_status, q5_is_control_ready
+from joint_limits import JOINT_LIMITS, limits_for
+
+_Q5_ARM_JOINTS = (
+    "left_shoulder_pitch_joint", "left_shoulder_roll_joint", "left_arm_yaw_joint",
+    "left_elbow_pitch_joint", "left_elbow_yaw_joint", "left_wrist_pitch_joint",
+    "left_wrist_roll_joint", "right_shoulder_pitch_joint", "right_shoulder_roll_joint",
+    "right_arm_yaw_joint", "right_elbow_pitch_joint", "right_elbow_yaw_joint",
+    "right_wrist_pitch_joint", "right_wrist_roll_joint",
+)
+
+CARD = "arm_gesture"
+TYPE = "actuator"
+TOPIC = "/{ns}/q5/arm_gesture"
+FMT = "data/json"
+HZ = 2.0
+NODE = "q5_arm_gesture"
+DESC = "Q5 手臂语义手势：敬礼、欢迎、举手、握手、击掌及归零，由 arm_control 绝对关节插补驱动"
+
+# ── Joint definitions ────────────────────────────────────────────────────────
+
+ARM_JOINTS_LEFT = (
+    "left_shoulder_pitch_joint", "left_shoulder_roll_joint", "left_arm_yaw_joint",
+    "left_elbow_pitch_joint", "left_elbow_yaw_joint", "left_wrist_pitch_joint",
+    "left_wrist_roll_joint",
+)
+ARM_JOINTS_RIGHT = (
+    "right_shoulder_pitch_joint", "right_shoulder_roll_joint", "right_arm_yaw_joint",
+    "right_elbow_pitch_joint", "right_elbow_yaw_joint", "right_wrist_pitch_joint",
+    "right_wrist_roll_joint",
+)
+ARM_JOINT_NAMES = ARM_JOINTS_LEFT + ARM_JOINTS_RIGHT
+
+# Mirrored index: shoulder_roll(1), arm_yaw(2), elbow_yaw(4) flip sign
+_MIRROR_MASK = [1, 2, 4]
+
+# ── Gesture definitions (degrees) ────────────────────────────────────────────
+
+_GESTURES_DEG = {
+    "salute":          [-10, 90, 60, -110, 50, 0, 0],
+    "welcome":         [-10, 65, 75, -100, 0, 0, 0],
+    "raise":           [0, 103, 0, -15, 0, 0, 0],
+    "shake_hands":     [-55, 15, 5, -35, 0, 0, 0],
+    "high_five":       [-40, 40, -20, -80, 0, 0, 50],
+}
+
+_PREPARE_DEG = {
+    "salute":          [-10, 40, 35, -45, 25, 0, 0],
+    "welcome":         [-10, 45, 45, -60, 0, 0, 0],
+    "raise":           [0, 75, 0, -30, 0, 0, 0],
+    "shake_hands":     [-30, 10, 0, -20, 0, 0, 0],
+    "high_five":       [-25, 25, -10, -45, 0, 0, 10],
+}
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+_GESTURE_LABELS = {
+    "salute": "敬礼", "welcome": "欢迎", "raise": "举手",
+    "shake_hands": "握手", "high_five": "击掌",
+}
+
+
+def _deg2rad(deg: float) -> float:
+    return deg * math.pi / 180.0
+
+
+def _rad2deg(rad: float) -> float:
+    return rad * 180.0 / math.pi
+
+
+def _mirror_deg(pose: list[float]) -> list[float]:
+    """Return a right-arm mirror of a left-arm degree pose."""
+    mirrored = list(pose)
+    for i in _MIRROR_MASK:
+        mirrored[i] = -mirrored[i]
+    return mirrored
+
+
+def _gesture_to_positions(gesture: str, side: str, deg_pose: list[float]) -> dict:
+    """Map a 7-element degree list to {joint_name: position_rad} for *side*."""
+    if side == "right":
+        deg_list = _mirror_deg(deg_pose)
+        joints = ARM_JOINTS_RIGHT
+    else:
+        deg_list = deg_pose
+        joints = ARM_JOINTS_LEFT
+    return {joints[i]: _deg2rad(deg_list[i]) for i in range(7)}
+
+
+def _mirrored_positions(gesture: str, side: str, deg_pose: list[float]) -> dict:
+    """Build a side-aware {joint_name: rad} dict, mirroring for right arm."""
+    result = {}
+    if side in ("left", "both"):
+        result.update(_gesture_to_positions(gesture, "left", deg_pose))
+    if side in ("right", "both"):
+        result.update(_gesture_to_positions(gesture, "right", deg_pose))
+    return result
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+def _failure(code: str, message: str, **details) -> dict:
+    return {"ok": False, "code": code, "message": message, "details": details}
+
+
+def _acp_notify(action_id: str, status: str, result: dict, tool: str = ""):
+    """POST action completion to Agent Core (module-level ACP helper)."""
+    agent_core_url = os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    payload = json.dumps({
+        "action_id": action_id,
+        "status": status,
+        "result": result,
+        "tool": tool,
+        "ts": time.time(),
+    }).encode()
+    try:
+        req = urllib.request.Request(
+            f"{agent_core_url}/api/acp/complete",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=5, context=ctx)
+    except Exception:
+        pass  # ACP failure must not block gesture execution
+
+
+# ── Frame builder ────────────────────────────────────────────────────────────
+
+def _build_frames(gesture: str, cycles: int) -> list:
+    """Return a list of (pose_deg, hold_seconds, transition_ratio) tuples."""
+    frames: list[tuple[list[float], float, float]] = []
+
+    prepare = _PREPARE_DEG.get(gesture, _GESTURES_DEG[gesture])
+    target = _GESTURES_DEG[gesture]
+
+    frames.append((prepare, 0.25, 0.90))
+
+    if gesture == "salute":
+        frames.append((target, 1.1, 1.0))
+    else:
+        frames.append((target, 0.8, 0.90))
+
+    if gesture == "shake_hands":
+        for i in range(cycles * 2):
+            pose = list(target)
+            pose[3] = -28 if i % 2 == 0 else -42
+            frames.append((pose, 0.30, 0.85))
+    elif gesture == "welcome":
+        for i in range(cycles * 2):
+            pose = list(target)
+            pose[3] = -110 if i % 2 == 0 else -90
+            frames.append((pose, 0.35, 0.85))
+
+    frames.append(([0.0] * 7, 1.0, 1.0))
+    return frames
+
+
+# ── Pose validation ─────────────────────────────────────────────────────────
+
+def _validate_pose_rad(positions: dict) -> list[str]:
+    """Check *positions* against URDF-derived JOINT_LIMITS. Returns violation list."""
+    violations = []
+    for name, rad in positions.items():
+        lim = JOINT_LIMITS.get(name)
+        if lim is None:
+            continue  # non-arm joint, skip
+        lo, hi = lim
+        if rad < lo - 1e-6:
+            violations.append(f"{name}: {rad:.4f} < {lo:.4f}")
+        if rad > hi + 1e-6:
+            violations.append(f"{name}: {rad:.4f} > {hi:.4f}")
+    return violations
+
+
+# ── Plugin ───────────────────────────────────────────────────────────────────
+
+class Plugin:
+    """Semantic arm-gesture actuator built on arm_control / BodyCommandRouter."""
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, client):
+        self._client = client
+        self._namespace = namespace
+
+        # Delegate low-level joint control to arm_control when available.
+        self._arm_control: ArmControlPlugin | None = None
+        if ArmControlPlugin is not None:
+            ctrl_cfg = dict(plugin_config)
+            ctrl_cfg.setdefault("max_step_rad", 0.010)
+            ctrl_cfg.setdefault("publish_rate_hz", 20.0)
+            ctrl_cfg.setdefault("hold_repetitions", 3)
+            try:
+                self._arm_control = ArmControlPlugin(ctrl_cfg, namespace, executor, client)
+            except Exception:
+                self._arm_control = None
+
+        # Shared body publisher (single-router pattern).
+        self._router: BodyCommandRouter = _get_body_router(client, executor)
+
+        # Motion parameters.
+        self._max_step = float(plugin_config.get("max_step_rad", 0.010))
+        self._publish_rate = float(plugin_config.get("publish_rate_hz", 20.0))
+        self._hold_repetitions = int(plugin_config.get("hold_repetitions", 3))
+        self._settle_tolerance = float(plugin_config.get("settle_tolerance_rad", 0.02))
+
+        # Thread-safe state.
+        self._lock = threading.Lock()
+        self._stop_event: threading.Event | None = None
+        self._motion_thread: threading.Thread | None = None
+        self._status: dict = {"state": "idle", "gesture": None, "updated_at_ms": int(time.time() * 1000)}
+
+    # ── Tool definition ──────────────────────────────────────────────────
+
+    def get_tool(self) -> dict:
+        actions = ["salute", "welcome", "raise", "shake_hands", "high_five", "reset",
+                    "cancel", "stop", "start", "info"]
+        one_of_actions = [
+            {"const": "start", "title": "检查连接状态"},
+            *[{"const": name, "title": label} for name, label in _GESTURE_LABELS.items()],
+            {"const": "reset", "title": "归零"},
+            {"const": "cancel", "title": "取消并保持"},
+            {"const": "stop", "title": "停止并归零"},
+            {"const": "info", "title": "查看状态"},
+        ]
+        return {
+            "name": CARD,
+            "type": TYPE,
+            "multiInstance": False,
+            "description": DESC,
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string", "enum": actions, "oneOf": one_of_actions},
+                    "side": {
+                        "type": "string", "title": "执行侧", "enum": ["left", "right", "both"],
+                        "default": "right",
+                        "oneOf": [
+                            {"const": "left", "title": "左臂"},
+                            {"const": "right", "title": "右臂"},
+                            {"const": "both", "title": "双臂"},
+                        ],
+                        "description": "执行手臂选择。",
+                    },
+                    "salute_side": {
+                        "type": "string", "title": "敬礼侧", "enum": ["left", "right"],
+                        "default": "right",
+                        "oneOf": [
+                            {"const": "left", "title": "左臂敬礼"},
+                            {"const": "right", "title": "右臂敬礼"},
+                        ],
+                        "description": "敬礼只支持单臂，默认右臂。",
+                    },
+                    "cycles": {
+                        "type": "integer", "title": "循环次数",
+                        "minimum": 1, "maximum": 5, "default": 2,
+                        "description": "握手/欢迎的摆动循环次数 [1,5]。",
+                    },
+                    "speed": {
+                        "type": "number", "title": "关节速度(rad/s)",
+                        "minimum": 0.2, "maximum": 1.5, "default": 0.5,
+                        "description": "关节插补速度，范围[0.2,1.5]，默认0.5。",
+                    },
+                },
+                "required": ["action"],
+                "additionalProperties": False,
+                "x-action-params": {
+                    "salute": {"params": ["salute_side", "speed"], "description": "抬起小臂、将手靠近额侧、停留后回正"},
+                    "welcome": {"params": ["side", "cycles", "speed"], "description": "在身体侧上方抬起手掌并左右摆动后回正"},
+                    "raise": {"params": ["side", "speed"], "description": "将手臂高举到头部上方后回正"},
+                    "shake_hands": {"params": ["side", "cycles", "speed"], "description": "向前伸手并轻柔上下摆动，做出握手动作"},
+                    "high_five": {"params": ["side", "speed"], "description": "将手掌伸到身体前方并保持在肩部附近，做出击掌等待姿势"},
+                    "reset": {"params": ["speed"], "description": "取消序列并回到中性姿态"},
+                    "cancel": {"params": [], "description": "取消尚未发送的后续动作帧，并保持当前位置"},
+                    "stop": {"params": [], "description": "停止当前手势并回到中性姿态（归零）"},
+                    "start": {"params": [], "description": "检查 ROS 连接和机器人状态"},
+                    "info": {"params": [], "description": "查看当前运动和安全条件"},
+                },
+                "x-completion": {
+                    "actions": ["salute", "welcome", "raise", "shake_hands", "high_five"],
+                    "timeout": 60,
+                },
+            },
+        }
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────
+
+    def start(self) -> dict:
+        if self._arm_control is not None:
+            return self._arm_control.start()
+        return {"state": "ready" if self._router is not None else "unavailable"}
+
+    def stop(self) -> dict:
+        self._stop("driver_shutdown")
+        if self._arm_control is not None:
+            self._arm_control.stop()
+        return {"state": "idle"}
+
+    # ── Safety ────────────────────────────────────────────────────────────
+
+    def _safety(self) -> dict:
+        router_status = self._router.status()
+        status = {
+            "ros_publisher_available": router_status["ros_publisher_available"],
+            "other_publishers": router_status["other_publishers"],
+            "same_name_publisher_count": router_status.get("same_name_publisher_count", 0),
+            "lifecycle_state": self._client.get_lifecycle_state(),
+            "joint_state_fresh": bool(self._client.snapshot().get("fresh", False)),
+            "q5_fsm": q5_active_status(self._client),
+            "limits": {"max_step_rad": self._max_step,
+                        "publish_rate_hz": self._publish_rate,
+                        "hold_repetitions": self._hold_repetitions},
+        }
+        if self._arm_control is not None:
+            arm_safety = self._arm_control._safety()
+            status.update(arm_safety)
+        return status
+
+    def _validate_run(self, gesture: str, side: str) -> dict | None:
+        """Pre-flight checks. Returns None on success or an error dict.
+        If gesture is empty string, skip gesture-name validation but still
+        check side, publisher, lifecycle, and Q5 FSM state."""
+        if gesture and gesture not in _GESTURES_DEG:
+            return _failure("UNKNOWN_GESTURE", f"Unknown gesture: {gesture}")
+        if side not in ("left", "right", "both"):
+            return _failure("INVALID_ARGUMENT", "side must be left, right, or both")
+
+        status = self._safety()
+
+        if not status["ros_publisher_available"]:
+            return _failure("ROS_UNAVAILABLE", "Q5 arm command publisher is unavailable", status=status)
+
+        if status.get("same_name_publisher_count", 0) > 1:
+            return _failure("DUPLICATE_BODY_PUBLISHER",
+                            "Multiple q5_body_command publishers detected on /wr1_controller/commands",
+                            status=status)
+
+        if status["lifecycle_state"] != "active":
+            return _failure("LIFECYCLE_NOT_ACTIVE", "Q5 motion_manager must be active", status=status)
+
+        ready, q5_fsm = q5_is_control_ready(self._client)
+        if not ready:
+            return _failure("Q5_FSM_NOT_READY", "Q5 /xbot_state must be fresh and READY or ACTIVE",
+                            status={**status, "q5_fsm": q5_fsm})
+
+        # Check position-control preparation (same gate as arm_control).
+        if self._arm_control is not None:
+            arm_ctrl_prep = self._arm_control._client.q5_position_control_prepared
+            if not arm_ctrl_prep:
+                return _failure(
+                    "DIRECT_CONTROL_NOT_PREPARED",
+                    "Run q5_control_mode action=prepare_position_control first",
+                    status=status,
+                )
+
+        if not status["joint_state_fresh"]:
+            return _failure("JOINT_STATE_UNAVAILABLE", "Refusing gesture without fresh /joint_states",
+                            status=status)
+
+        return None
+
+    # ── Publish & hold ────────────────────────────────────────────────────
+
+    def _publish_positions(self, positions: dict) -> bool:
+        """Publish a position dict via the shared BodyCommandRouter."""
+        return self._router.publish(positions)
+
+    def _hold_positions(self, positions: dict) -> bool:
+        """Hold positions for self._hold_repetitions at self._publish_rate."""
+        published = False
+        for _ in range(self._hold_repetitions):
+            published = self._publish_positions(positions) or published
+            time.sleep(1.0 / self._publish_rate)
+        return published
+
+    def _hold_current(self) -> dict:
+        """Snapshot and hold all left/right arm joints at their current positions."""
+        snap = self._client.snapshot()
+        if not snap.get("fresh"):
+            return {}
+        joints = snap.get("joints", {})
+        current: dict[str, float] = {}
+        for name in ARM_JOINT_NAMES:
+            v = joints.get(name)
+            if v is not None:
+                current[name] = float(v)
+        if current:
+            self._hold_positions(current)
+        return current
+
+    # ── Move worker ───────────────────────────────────────────────────────
+
+    def _run_move(self, stop_event: threading.Event, frames, speed: float, side: str,
+                  gesture: str, action_id: str | None):
+        """Interpolate through gesture frames, honoring stop_event and commanded side."""
+        cancelled = True  # default: cancelled on any error/exception
+        try:
+            previous_positions = dict(self._hold_current())  # start from current pose
+
+            for frame_deg, hold_s, transition_ratio in frames:
+                if stop_event.is_set():
+                    break
+
+                positions = _mirrored_positions("_current", side, frame_deg)
+                if stop_event.is_set():
+                    break
+
+                # Validate pose against limits
+                violations = _validate_pose_rad(positions)
+                if violations:
+                    print(f"[arm_gesture] Pose violation, stopping: {violations}")
+                    break
+
+                # Compute transition duration from max joint delta
+                max_delta_rad = 0.0
+                for name in ARM_JOINT_NAMES:
+                    if name in positions and name in previous_positions:
+                        delta = abs(positions[name] - previous_positions[name])
+                        max_delta_rad = max(max_delta_rad, delta)
+
+                transition_s = max_delta_rad / speed if speed > 0 else 0.5
+                delay = max(0.12, transition_s * transition_ratio) + hold_s
+
+                # Interpolate
+                steps = max(
+                    int(math.ceil(max_delta_rad / self._max_step)),
+                    int(math.ceil(transition_s * self._publish_rate)),
+                    1,
+                )
+
+                acquired = self._router.acquire(CARD)
+                if not acquired:
+                    break
+
+                try:
+                    for step in range(1, steps + 1):
+                        if stop_event.is_set():
+                            break
+                        t = step / steps
+                        for name in ARM_JOINT_NAMES:
+                            if name in positions and name in previous_positions:
+                                prev = previous_positions[name]
+                                tgt = positions[name]
+                                interp = prev + (tgt - prev) * t
+                                self._publish_positions({name: interp})
+                        stop_event.wait(transition_s / steps)
+                finally:
+                    if stop_event.is_set():
+                        self._hold_current()
+                    else:
+                        self._hold_positions(positions)
+                    self._router.release(CARD)
+
+                previous_positions = {
+                    name: positions[name] for name in ARM_JOINT_NAMES
+                    if name in positions
+                }
+
+                if not stop_event.wait(delay):
+                    pass  # normal hold completed
+            cancelled = False  # all frames completed successfully
+        except Exception:
+            pass
+        finally:
+            # ACP completion callback
+            if action_id:
+                if cancelled and not stop_event.is_set():
+                    _acp_notify(action_id, "error", {"gesture": gesture, "error": "unexpected_failure"}, CARD)
+                elif stop_event.is_set():
+                    _acp_notify(action_id, "cancelled", {"gesture": gesture, "side": side}, CARD)
+                else:
+                    _acp_notify(action_id, "completed", {"gesture": gesture, "side": side}, CARD)
+
+            with self._lock:
+                if self._status.get("state") != "error":
+                    self._status["state"] = "idle"
+                self._stop_event = None
+                self._motion_thread = None
+
+    # ── Stop / Cancel ─────────────────────────────────────────────────────
+
+    def _stop(self, reason: str) -> dict:
+        with self._lock:
+            stop_event = self._stop_event
+            motion_thread = self._motion_thread
+            self._stop_event = None
+            self._motion_thread = None
+
+        if stop_event is not None:
+            stop_event.set()
+        if motion_thread is not None and motion_thread is not threading.current_thread():
+            motion_thread.join(timeout=1.0)
+
+        held = self._hold_current()
+        self._status = {"state": "stopped", "gesture": self._status.get("gesture"),
+                        "updated_at_ms": int(time.time() * 1000), "reason": reason}
+        return {"ok": True, "state": "stopped", "reason": reason,
+                "hold_command_published": bool(held)}
+
+    # ── Dispatch ──────────────────────────────────────────────────────────
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("start", "info"):
+            if self._arm_control is not None:
+                return self._arm_control.dispatch(action, args)
+            result = {"state": "ready" if self._router is not None else "unavailable",
+                      "safety": self._safety()}
+            if action == "info":
+                with self._lock:
+                    result["status"] = dict(self._status)
+            return result
+
+        if action == "cancel":
+            return self._stop("command")
+
+        if action == "stop":
+            return self.stop()
+
+        if action == "reset":
+            speed = _clamp(args.get("speed", 0.5), 0.2, 1.5)
+            # reset bypasses gesture validation; check side/robot safety instead
+            side = "right"
+            check = self._validate_run("", side)
+            if isinstance(check, dict):
+                return check
+            # Check for active motion outside the lock to avoid deadlock:
+            # _stop() also acquires self._lock, so we peek first then call
+            # _stop() only if needed (and _stop() will re-acquire the lock).
+            need_cancel = False
+            with self._lock:
+                if self._motion_thread is not None and self._motion_thread.is_alive():
+                    need_cancel = True
+            if need_cancel:
+                self._stop("preempt")
+            # Publish neutral to all arm joints
+            neutral = {name: 0.0 for name in ARM_JOINT_NAMES}
+            violations = _validate_pose_rad(neutral)
+            if violations:
+                return _failure("LIMIT_EXCEEDED", "Neutral pose out of range", violations=violations)
+            acquired = self._router.acquire(CARD)
+            if not acquired:
+                return _failure("COMMAND_IN_PROGRESS", "Another arm card owns the command path")
+            try:
+                self._hold_positions(neutral)
+            finally:
+                self._router.release(CARD)
+            self._status = {"state": "idle", "gesture": "reset",
+                            "updated_at_ms": int(time.time() * 1000)}
+            return {"ok": True, "state": "stopped", "gesture": "reset"}
+
+        # Gesture actions
+        if action not in _GESTURES_DEG:
+            return None
+
+        # Resolve side: salute uses salute_side, others use side
+        if action == "salute":
+            side = args.get("salute_side", args.get("side", "right"))
+        else:
+            side = args.get("side", "right")
+
+        if side == "both" and action == "salute":
+            return _failure("UNSAFE_BILATERAL_SALUTE",
+                            "salute only supports one arm at a time to avoid head/arm interference")
+
+        speed = _clamp(args.get("speed", 0.5), 0.2, 1.5)
+        cycles = int(_clamp(args.get("cycles", 2), 1, 5))
+
+        # Validate pre-flight
+        check = self._validate_run(action, side)
+        if isinstance(check, dict):
+            return check
+
+        # Check for concurrent motion
+        with self._lock:
+            if self._motion_thread is not None and self._motion_thread.is_alive():
+                return _failure("MOTION_IN_PROGRESS",
+                                "An arm gesture is already active; call cancel before starting another")
+
+        # Build frames
+        frames = _build_frames(action, cycles)
+
+        # Validate all frames
+        for frame_deg, _, _ in frames:
+            positions = _mirrored_positions(action, side, frame_deg)
+            violations = _validate_pose_rad(positions)
+            if violations:
+                return _failure("ARM_POSE_OUT_OF_RANGE",
+                                "Semantic arm pose exceeds Q5 joint limits",
+                                gesture=action, violations=violations)
+
+        # ACP: generate action_id and completion callback for long gestures
+        action_id = None
+        if action in _GESTURES_DEG:
+            action_id = f"arm_gesture_{action}_{int(time.time()*1000)}"
+
+        # Start motion thread
+        stop_event = threading.Event()
+        with self._lock:
+            self._stop_event = stop_event
+            self._motion_thread = threading.Thread(
+                target=self._run_move,
+                args=(stop_event, frames, speed, side, action, action_id),
+                daemon=True,
+                name="q5_arm_gesture",
+            )
+            self._motion_thread.start()
+
+        self._status = {"state": "running", "gesture": action, "side": side,
+                        "cycles": cycles, "speed": speed,
+                        "updated_at_ms": int(time.time() * 1000)}
+
+        return {"ok": True, "state": "running", "gesture": action,
+                "side": side, "cycles": cycles, "speed": speed,
+                "action_id": action_id}
+
+
+def make_plugin(plugin_config, namespace, executor, client):
+    return Plugin(plugin_config, namespace, executor, client)

--- a/robotera/q5_bundle/config.yaml
+++ b/robotera/q5_bundle/config.yaml
@@ -18,17 +18,17 @@ plugins:
   joints_state:
     enabled: true
   robot_ready:
-    enabled: true
+    enabled: false  # merged into robot_status
   battery:
     enabled: true
   system_health:
-    enabled: true
+    enabled: false  # merged into robot_status
   hand_state:
     enabled: true
   estop:
-    enabled: true
+    enabled: false  # merged into robot_status
   diagnostics:
-    enabled: true
+    enabled: false  # merged into robot_status
   imu:
     enabled: false
   simple_action:
@@ -90,8 +90,19 @@ plugins:
     enabled: true
     max_duration_s: 2.0
     publish_rate_hz: 20.0
+  arm_gesture:
+    enabled: true
+    max_step_rad: 0.010
+    publish_rate_hz: 20.0
+    hold_repetitions: 3
   head_control:
     enabled: true
     max_step_rad: 0.025
     publish_rate_hz: 20.0
     hold_repetitions: 3
+  odom:
+    enabled: true
+  teleop_state:
+    enabled: true
+  robot_status:
+    enabled: true

--- a/robotera/q5_bundle/diagnostics.py
+++ b/robotera/q5_bundle/diagnostics.py
@@ -15,7 +15,7 @@ try:
     from std_msgs.msg import String
 
     _HAS_ROS2 = True
-    _QOS = QoSProfile(reliability=ReliabilityPolicy.RELIABLE,
+    _QOS = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT,
                       history=HistoryPolicy.KEEP_LAST, depth=10)
 except Exception:
     _HAS_ROS2 = False

--- a/robotera/q5_bundle/odom.py
+++ b/robotera/q5_bundle/odom.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+# odom —— Q5 里程计 (nav_msgs/msg/Odometry)
+# 自建 ROS2 Node 订阅 /wr1_base_drive_controller/odom，解析位置/姿态/速度。
+
+from __future__ import annotations
+
+import json
+import time
+
+from sensor_contract import topic_out
+
+try:
+    from rclpy.node import Node
+    from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+    from nav_msgs.msg import Odometry
+    from std_msgs.msg import String
+
+    _HAS_ROS2 = True
+    _QOS = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT,
+                      history=HistoryPolicy.KEEP_LAST, depth=1,
+                      durability=DurabilityPolicy.VOLATILE)
+except Exception:
+    _HAS_ROS2 = False
+
+CARD = "odom"
+TYPE = "sensor"
+SOURCE_TOPIC = "/wr1_base_drive_controller/odom"
+TOPIC = "/{ns}/q5/odom"
+FMT = "data/json"
+HZ = 2.0
+NODE = "q5_odom"
+DESC = "Q5 里程计：底盘位置、姿态和速度"
+
+
+def build(msg, received_at_ms) -> dict:
+    now_ms = int(time.time() * 1000)
+    if msg is None:
+        return {"timestamp_ms": now_ms, "received_at_ms": received_at_ms,
+                "fresh": False, "available": False, "source_topic": SOURCE_TOPIC,
+                "message": "未收到里程计消息"}
+    age_ms = None if received_at_ms is None else now_ms - received_at_ms
+    p = msg.pose.pose
+    t = msg.twist.twist
+    return {"timestamp_ms": now_ms, "received_at_ms": received_at_ms,
+            "age_ms": age_ms, "fresh": age_ms is not None and age_ms <= 5000,
+            "available": True,
+            "frame_id": msg.header.frame_id,
+            "child_frame_id": msg.child_frame_id,
+            "position": {"x": float(p.position.x), "y": float(p.position.y), "z": float(p.position.z)},
+            "orientation": {"x": float(p.orientation.x), "y": float(p.orientation.y),
+                            "z": float(p.orientation.z), "w": float(p.orientation.w)},
+            "linear": {"x": float(t.linear.x), "y": float(t.linear.y), "z": float(t.linear.z)},
+            "angular": {"x": float(t.angular.x), "y": float(t.angular.y), "z": float(t.angular.z)},
+            "source_topic": SOURCE_TOPIC}
+
+
+class Plugin:
+    def __init__(self, plugin_config, namespace, executor, client):
+        self._topic = TOPIC.format(ns=namespace)
+        self._node = None
+        self._pub = None
+        self._last_msg = None
+        self._received_at_ms = None
+        if _HAS_ROS2 and executor is not None:
+            try:
+                self._node = Node(NODE)
+                self._pub = self._node.create_publisher(String, self._topic, _QOS)
+                self._node.create_subscription(Odometry, SOURCE_TOPIC, self._on_msg, _QOS)
+                self._node.create_timer(1.0 / HZ, self._tick)
+                executor.add_node(self._node)
+            except Exception as e:
+                print(f"[{CARD}] ROS2 subscription unavailable: {e}", flush=True)
+                self._node = None
+                self._pub = None
+
+    def _on_msg(self, msg):
+        self._last_msg = msg
+        self._received_at_ms = int(time.time() * 1000)
+
+    def _data(self):
+        return build(self._last_msg, self._received_at_ms)
+
+    def _tick(self):
+        if self._pub is None:
+            return
+        msg = String()
+        msg.data = json.dumps(self._data(), ensure_ascii=False)
+        self._pub.publish(msg)
+
+    def get_tool(self):
+        return {"name": CARD, "type": TYPE, "multiInstance": False,
+                "description": DESC + f" ({SOURCE_TOPIC})",
+                "inputSchema": {"type": "object", "properties": {"action": {"type": "string", "enum": ["info", "start", "stop"]}}, "required": ["action"], "additionalProperties": False},
+                "topic_out": topic_out(self._topic, FMT)}
+
+    def start(self):
+        return {"state": "running" if self._pub else "unavailable"}
+
+    def stop(self):
+        return {"state": "idle"}
+
+    def dispatch(self, action, args):
+        if action == "start":
+            return self.start()
+        if action == "stop":
+            return self.stop()
+        if action in ("info", "read", "get", CARD):
+            return {"state": "running" if self._pub else "unavailable", "data": self._data(),
+                    "topic_out": topic_out(self._topic, FMT)}
+        return None
+
+
+def make_plugin(plugin_config, namespace, executor, client):
+    return Plugin(plugin_config, namespace, executor, client)

--- a/robotera/q5_bundle/robot_status.py
+++ b/robotera/q5_bundle/robot_status.py
@@ -1,0 +1,422 @@
+# -*- coding: utf-8 -*-
+# robot_status —— 聚合 robot_ready + system_health + diagnostics + estop
+# 一个插件聚合五个维度：
+#   1. 机器人业务状态 FSM (from /xbot_state → robot_ready / estop)
+#   2. 运动管理器生命周期 (from /motion_manager/get_state → robot_ready)
+#   3. 系统健康: motion + temperature + faults (from system_health)
+#   4. 诊断数组 (from /diagnostics_agg → diagnostics)
+#   5. 急停状态 (from /xbot_state → estop)
+
+from __future__ import annotations
+
+import json
+import time
+from array import array
+
+from sensor_contract import topic_out
+
+try:
+    from rclpy.node import Node
+    from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+    from std_msgs.msg import String
+    from xbot_common_interfaces.msg import RobotStatus, MotionStatus, Temperature
+
+    try:
+        from xbot_common_interfaces.msg import FaultArray
+    except Exception:
+        FaultArray = None
+
+    from diagnostic_msgs.msg import DiagnosticArray
+    from lifecycle_msgs.srv import GetState
+
+    _HAS_ROS2 = True
+    _VOLATILE_QOS = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT,
+                               history=HistoryPolicy.KEEP_LAST, depth=1,
+                               durability=DurabilityPolicy.VOLATILE)
+    _LATCHED_QOS = QoSProfile(reliability=ReliabilityPolicy.RELIABLE,
+                              history=HistoryPolicy.KEEP_LAST, depth=1,
+                              durability=DurabilityPolicy.TRANSIENT_LOCAL)
+    _DIAG_QOS = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT,
+                            history=HistoryPolicy.KEEP_LAST, depth=10)
+    _MOTION_QOS = QoSProfile(reliability=ReliabilityPolicy.RELIABLE,
+                             history=HistoryPolicy.KEEP_LAST, depth=10,
+                             durability=DurabilityPolicy.VOLATILE)
+except Exception:
+    _HAS_ROS2 = False
+
+CARD = "robot_status"
+TYPE = "sensor"
+TOPIC = "/{ns}/q5/robot_status"
+FMT = "data/json"
+HZ = 2.0
+NODE = "q5_robot_status"
+DESC = "Q5 机器人综合状态：聚合 robot_ready + system_health + diagnostics + estop"
+STALE_THRESHOLD_MS = 5000
+
+ROBOT_STATE_LABELS = {
+    0: "INIT", 1: "SELF_TEST", 2: "IDLE", 3: "READY", 4: "ACTIVE",
+    5: "SHUTDOWN", 6: "OTA", 7: "E_STOP", -1: "ERROR",
+}
+CONTROL_READY_STATES = {3, 4}
+E_STOP = 7
+
+
+def _jsonable(value):
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (bytes, bytearray)):
+        return list(value)
+    if isinstance(value, array):
+        return value.tolist()
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    fields = getattr(value, "get_fields_and_field_types", None)
+    if callable(fields):
+        return {name: _jsonable(getattr(value, name)) for name in fields()}
+    return str(value)
+
+
+def _temperature_summary(payload: dict | None) -> dict | None:
+    if not isinstance(payload, dict):
+        return None
+    names, values = payload.get("name"), payload.get("temperature")
+    if not isinstance(names, list) or not isinstance(values, list) or len(names) != len(values):
+        return None
+    readings = [(name, value) for name, value in zip(names, values)
+                if isinstance(name, str) and isinstance(value, (int, float))]
+    if not readings:
+        return None
+    maximum = max(readings, key=lambda item: item[1])
+    minimum = min(readings, key=lambda item: item[1])
+    return {
+        "reading_count": len(readings),
+        "maximum_celsius": maximum[1], "maximum_sensor": maximum[0],
+        "minimum_celsius": minimum[1], "minimum_sensor": minimum[0],
+    }
+
+
+def _source_status(payload, received_at_ms, publisher_count: int | None,
+                   now_ms: int) -> dict:
+    age_ms = None if received_at_ms is None else now_ms - received_at_ms
+    fresh = age_ms is not None and age_ms <= STALE_THRESHOLD_MS
+    available = payload is not None
+    if payload is not None and fresh:
+        report_state = "fresh"
+    elif payload is not None:
+        report_state = "stale"
+    elif publisher_count == 0:
+        report_state = "publisher_not_running"
+    elif publisher_count is not None:
+        report_state = "awaiting_event"
+    else:
+        report_state = "awaiting_message"
+    return {
+        "available": available,
+        "fresh": fresh,
+        "age_ms": age_ms,
+        "received_at_ms": received_at_ms,
+        "publisher_count": publisher_count,
+        "report_state": report_state,
+        "data": payload,
+    }
+
+
+def build(fsm_state, fsm_message, fsm_received_at_ms,
+          lifecycle_state, diag_payload, diag_received_at_ms, diag_publisher_count,
+          motion_payload, motion_received_at_ms, motion_publisher_count,
+          temp_payload, temp_received_at_ms, temp_publisher_count,
+          fault_payload, fault_received_at_ms, fault_publisher_count,
+          now_ms=None):
+    now_ms = int(time.time() * 1000) if now_ms is None else now_ms
+
+    # === Dimension 1: FSM (robot_ready) ===
+    fsm_age = None if fsm_received_at_ms is None else now_ms - fsm_received_at_ms
+    fsm_fresh = fsm_age is not None and fsm_age <= STALE_THRESHOLD_MS
+    state_label = ROBOT_STATE_LABELS.get(fsm_state, "UNKNOWN")
+    ready = fsm_fresh and fsm_state in CONTROL_READY_STATES
+
+    # === Dimension 2: motion manager lifecycle (robot_ready) ===
+    motion_manager_active = lifecycle_state == "active"
+
+    # === Dimension 3: estop (estop) ===
+    estop_active = fsm_fresh and fsm_state == E_STOP
+
+    # === Dimension 4: diagnostics (diagnostics) ===
+    diag_age = None if diag_received_at_ms is None else now_ms - diag_received_at_ms
+    diag_fresh = diag_age is not None and diag_age <= STALE_THRESHOLD_MS
+    diag_connected = diag_publisher_count is not None and diag_publisher_count > 0
+
+    # === Dimension 5: system_health (motion, temperature, faults) ===
+    motion_st = _source_status(motion_payload, motion_received_at_ms,
+                               motion_publisher_count, now_ms)
+    temp_st = _source_status(temp_payload, temp_received_at_ms,
+                             temp_publisher_count, now_ms)
+    fault_st = _source_status(fault_payload, fault_received_at_ms,
+                              fault_publisher_count, now_ms)
+    temp_summary = _temperature_summary(temp_payload)
+
+    # === Composite message ===
+    if not fsm_fresh:
+        message = "机器人状态未知：未收到新鲜 /xbot_state"
+    elif estop_active:
+        message = "急停激活"
+    elif not ready:
+        message = f"状态: {state_label} | 运动管理器: {lifecycle_state.upper()}"
+    else:
+        message = f"状态: {state_label} | 运动管理器: {lifecycle_state.upper()}"
+
+    return {
+        "timestamp_ms": now_ms,
+
+        # --- 综合 ---
+        "fresh": fsm_fresh and temp_st["fresh"],
+        "available": fsm_state is not None,
+        "ready": ready and motion_manager_active,
+        "message": message,
+
+        # --- robot_ready (业务状态 + 运动管理器) ---
+        "robot_status": {
+            "state": state_label,
+            "state_code": fsm_state,
+            "fresh": fsm_fresh,
+            "ready": ready,
+            "message": fsm_message,
+            "source": "/xbot_state",
+        },
+        "motion_manager": {
+            "state": lifecycle_state,
+            "active": motion_manager_active,
+            "motion_ready": fsm_fresh and motion_manager_active,
+            "source": "/motion_manager/get_state",
+        },
+
+        # --- estop (急停) ---
+        "estop": {
+            "active": estop_active,
+            "reported": fsm_state == E_STOP,
+            "fresh": fsm_fresh,
+            "state_code": fsm_state,
+            "message": "急停激活" if estop_active else None,
+            "source": "/xbot_state",
+        },
+
+        # --- diagnostics (诊断数组) ---
+        "diagnostics": {
+            "fresh": diag_fresh,
+            "available": diag_payload is not None,
+            "connected": diag_connected,
+            "publisher_count": diag_publisher_count,
+            "age_ms": diag_age,
+            "data": diag_payload if diag_fresh else None,
+            "source": "/diagnostics_agg",
+        },
+
+        # --- system_health (运动 + 温度 + 故障) ---
+        "system_health": {
+            "motion": {
+                **motion_st,
+                "source": "/motion_manager/motion_status",
+            },
+            "temperature": {
+                **temp_st,
+                "summary": temp_summary,
+                "source": "/temperature",
+            },
+            "faults": {
+                **fault_st,
+                "source": "/fault_array_agg",
+            },
+        },
+
+        "source_topics": {
+            "fsm": "/xbot_state",
+            "motion_manager": "/motion_manager/get_state",
+            "estop": "/xbot_state",
+            "diagnostics": "/diagnostics_agg",
+            "motion": "/motion_manager/motion_status",
+            "temperature": "/temperature",
+            "faults": "/fault_array_agg",
+        },
+    }
+
+
+class Plugin:
+    def __init__(self, plugin_config, namespace, executor, client):
+        self._topic = TOPIC.format(ns=namespace)
+        self._node = None
+        self._pub = None
+
+        # Dimension 1+3: FSM + estop (from /xbot_state)
+        self._fsm_state = None
+        self._fsm_message = None
+        self._fsm_received_at_ms = None
+
+        # Dimension 2: motion manager lifecycle
+        self._lifecycle_state = "unknown"
+        self._lifecycle_client = None
+        self._lifecycle_request_type = None
+        self._lifecycle_pending = False
+
+        # Dimension 4: diagnostics
+        self._diag_payload = None
+        self._diag_received_at_ms = None
+
+        # Dimension 5: system_health
+        self._motion_payload = None
+        self._motion_received_at_ms = None
+        self._temp_payload = None
+        self._temp_received_at_ms = None
+        self._fault_payload = None
+        self._fault_received_at_ms = None
+
+        if _HAS_ROS2 and executor is not None:
+            try:
+                self._node = Node(NODE)
+                self._pub = self._node.create_publisher(String, self._topic, _VOLATILE_QOS)
+
+                # /xbot_state: FSM + estop
+                self._node.create_subscription(RobotStatus, "/xbot_state", self._on_robot, _LATCHED_QOS)
+
+                # /diagnostics_agg
+                self._node.create_subscription(DiagnosticArray, "/diagnostics_agg", self._on_diag, _DIAG_QOS)
+
+                # /motion_manager/motion_status
+                self._node.create_subscription(MotionStatus, "/motion_manager/motion_status",
+                                               self._on_motion, _MOTION_QOS)
+
+                # /temperature
+                self._node.create_subscription(Temperature, "/temperature",
+                                               self._on_temperature, _MOTION_QOS)
+
+                # /fault_array_agg (optional)
+                if FaultArray is not None:
+                    self._node.create_subscription(FaultArray, "/fault_array_agg",
+                                                   self._on_faults, _MOTION_QOS)
+
+                # motion_manager lifecycle
+                self._lifecycle_client = self._node.create_client(GetState, "/motion_manager/get_state")
+                self._lifecycle_request_type = GetState.Request
+                self._node.create_timer(1.0, self._poll_lifecycle)
+
+                self._node.create_timer(1.0 / HZ, self._tick)
+                executor.add_node(self._node)
+            except Exception as e:
+                print(f"[{CARD}] ROS2 init failed: {e}", flush=True)
+                self._node = None
+                self._pub = None
+
+    def _on_robot(self, msg):
+        self._fsm_state = int(msg.state)
+        self._fsm_message = str(msg.msg)
+        self._fsm_received_at_ms = int(time.time() * 1000)
+
+    def _on_diag(self, msg):
+        self._diag_payload = _jsonable(msg)
+        self._diag_received_at_ms = int(time.time() * 1000)
+
+    def _on_motion(self, msg):
+        value = getattr(msg, "state", getattr(msg, "status", None))
+        state = int(value) if value is not None else None
+        self._motion_payload = {
+            "state": state,
+            "status": state,
+            "message": str(getattr(msg, "msg", "")) or None,
+        }
+        self._motion_received_at_ms = int(time.time() * 1000)
+
+    def _on_temperature(self, msg):
+        self._temp_payload = _jsonable(msg)
+        self._temp_received_at_ms = int(time.time() * 1000)
+
+    def _on_faults(self, msg):
+        self._fault_payload = _jsonable(msg)
+        self._fault_received_at_ms = int(time.time() * 1000)
+
+    def _poll_lifecycle(self):
+        if self._lifecycle_client is None or self._lifecycle_pending:
+            return
+        if not self._lifecycle_client.service_is_ready():
+            self._lifecycle_state = "service_unavailable"
+            return
+        try:
+            future = self._lifecycle_client.call_async(self._lifecycle_request_type())
+            self._lifecycle_pending = True
+            future.add_done_callback(self._on_lifecycle)
+        except Exception:
+            self._lifecycle_pending = False
+
+    def _on_lifecycle(self, future):
+        try:
+            response = future.result()
+            state = getattr(response, "current_state", None)
+            label = str(getattr(state, "label", "unknown") or "unknown")
+            self._lifecycle_state = label
+        except Exception:
+            pass
+        finally:
+            self._lifecycle_pending = False
+
+    def _publisher_counts(self):
+        if self._node is None:
+            return None, None, None, None
+        try:
+            diag = len(self._node.get_publishers_info_by_topic("/diagnostics_agg"))
+        except Exception:
+            diag = None
+        try:
+            motion = len(self._node.get_publishers_info_by_topic("/motion_manager/motion_status"))
+        except Exception:
+            motion = None
+        try:
+            temp = len(self._node.get_publishers_info_by_topic("/temperature"))
+        except Exception:
+            temp = None
+        try:
+            fault = len(self._node.get_publishers_info_by_topic("/fault_array_agg"))
+        except Exception:
+            fault = None
+        return diag, motion, temp, fault
+
+    def _data(self):
+        diag, motion, temp, fault = self._publisher_counts()
+        return build(
+            self._fsm_state, self._fsm_message, self._fsm_received_at_ms,
+            self._lifecycle_state,
+            self._diag_payload, self._diag_received_at_ms, diag,
+            self._motion_payload, self._motion_received_at_ms, motion,
+            self._temp_payload, self._temp_received_at_ms, temp,
+            self._fault_payload, self._fault_received_at_ms, fault,
+        )
+
+    def _tick(self):
+        if self._pub is None:
+            return
+        msg = String()
+        msg.data = json.dumps(self._data(), ensure_ascii=False)
+        self._pub.publish(msg)
+
+    def get_tool(self):
+        return {"name": CARD, "type": TYPE, "multiInstance": False,
+                "description": DESC,
+                "inputSchema": {"type": "object", "properties": {"action": {"type": "string", "enum": ["info", "start", "stop"]}}, "required": ["action"], "additionalProperties": False},
+                "topic_out": topic_out(self._topic, FMT)}
+
+    def start(self):
+        return {"state": "running" if self._pub else "unavailable"}
+
+    def stop(self):
+        return {"state": "idle"}
+
+    def dispatch(self, action, args):
+        if action == "start":
+            return self.start()
+        if action == "stop":
+            return self.stop()
+        if action in ("info", "read", "get", CARD):
+            return {"state": "running" if self._pub else "unavailable", "data": self._data(),
+                    "topic_out": topic_out(self._topic, FMT)}
+        return None
+
+
+def make_plugin(plugin_config, namespace, executor, client):
+    return Plugin(plugin_config, namespace, executor, client)

--- a/robotera/q5_bundle/teleop_state.py
+++ b/robotera/q5_bundle/teleop_state.py
@@ -1,0 +1,100 @@
+
+"""Q5 遥操作状态 card (read-only)."""
+
+from __future__ import annotations
+
+import json
+import time
+
+from sensor_contract import topic_out
+
+try:
+    from rclpy.node import Node
+    from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+    from std_msgs.msg import String
+
+    _HAS_ROS2 = True
+    _QOS = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT,
+                      history=HistoryPolicy.KEEP_LAST, depth=1,
+                      durability=DurabilityPolicy.VOLATILE)
+except Exception:
+    _HAS_ROS2 = False
+
+CARD = "teleop_state"
+TYPE = "sensor"
+SOURCE_TOPIC = "/teleop_state"
+TOPIC = "/{ns}/q5/teleop_state"
+FMT = "data/json"
+HZ = 2.0
+NODE = "q5_teleop_state"
+DESC = "Q5 遥操作状态：判断机器人是否处于人工遥操作模式"
+
+
+def build(msg, received_at_ms) -> dict:
+    now_ms = int(time.time() * 1000)
+    if msg is None:
+        return {"timestamp_ms": now_ms, "received_at_ms": received_at_ms,
+                "fresh": False, "available": False, "source_topic": SOURCE_TOPIC,
+                "message": "未收到遥操作状态消息"}
+    age_ms = None if received_at_ms is None else now_ms - received_at_ms
+    return {"timestamp_ms": now_ms, "received_at_ms": received_at_ms,
+            "age_ms": age_ms, "fresh": age_ms is not None and age_ms <= 5000,
+            "available": True, "state": str(msg.data),
+            "source_topic": SOURCE_TOPIC}
+
+class Plugin:
+    def __init__(self, plugin_config, namespace, executor, client):
+        self._topic = TOPIC.format(ns=namespace)
+        self._node = None
+        self._pub = None
+        self._last_msg = None
+        self._received_at_ms = None
+        if _HAS_ROS2 and executor is not None:
+            try:
+                self._node = Node(NODE)
+                self._pub = self._node.create_publisher(String, self._topic, _QOS)
+                self._node.create_subscription(String, SOURCE_TOPIC, self._on_msg, _QOS)
+                self._node.create_timer(1.0 / HZ, self._tick)
+                executor.add_node(self._node)
+            except Exception as e:
+                print(f"[{CARD}] ROS2 subscription unavailable: {e}", flush=True)
+                self._node = None
+                self._pub = None
+
+    def _on_msg(self, msg):
+        self._last_msg = msg
+        self._received_at_ms = int(time.time() * 1000)
+
+    def _data(self):
+        return build(self._last_msg, self._received_at_ms)
+
+    def _tick(self):
+        msg = String()
+        msg.data = json.dumps(self._data(), ensure_ascii=False)
+        self._pub.publish(msg)
+
+    def get_tool(self):
+        return {"name": CARD, "type": TYPE, "multiInstance": False,
+                "description": DESC + f" ({SOURCE_TOPIC})",
+                "inputSchema": {"type": "object", "properties": {"action": {"type": "string", "enum": ["info", "start", "stop"]}}, "required": ["action"], "additionalProperties": False},
+                "topic_out": topic_out(self._topic, FMT)}
+
+    def start(self):
+        return {"state": "running" if self._pub else "unavailable"}
+
+    def stop(self):
+        return {"state": "idle"}
+
+    def dispatch(self, action, args):
+        if action == "start":
+            return self.start()
+        if action == "stop":
+            return self.stop()
+        if action in ("info", "read", "get", CARD):
+            return {"state": "running" if self._pub else "unavailable", "data": self._data(),
+                    "topic_out": topic_out(self._topic, FMT)}
+        return None
+
+
+def make_plugin(plugin_config, namespace, executor, client):
+    return Plugin(plugin_config, namespace, executor, client)


### PR DESCRIPTION
## Summary
- Add `robot_status` card aggregating 5 dimensions from robot_ready + system_health + diagnostics + estop
  - FSM state from `/xbot_state`
  - Motion manager lifecycle from `/motion_manager/get_state`
  - Diagnostics from `/diagnostics_agg`
  - System health: motion + temperature + faults
  - E-stop state
- Add `arm_gesture` for semantic arm gestures (641 lines)
- Add `odom` for chassis position/orientation/velocity
- Add `teleop_state` for teleoperation mode
- Update Dockerfile to include new cards

## Verification
- [ ] Container builds successfully
- [ ] Cards return live data on Q5 robot
- [ ] Full functional validation on device

🤖 Generated with [phanthy code](https://phanthy.dev/phanthy-code)