### PR TITLE
Don't abort the build when there is no terminal to ask on

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -307,8 +307,13 @@ echo "全部完成。"
 
 # ── 注册到 Resource Center ──────────────────────────────────────────────────
 if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
+    # Ask only if there is a terminal to ask on; otherwise sync (the key being
+    # set is the opt-in). Test by opening /dev/tty, not with `[ -e ]`: the device
+    # node exists in any container, but opening it without a controlling
+    # terminal fails with ENXIO — which under `set -e` aborted the whole script
+    # here, reporting a successful build as failed.
     SYNC_CONFIRM="y"
-    if [ -t 0 ] || [ -e /dev/tty ]; then
+    if { : >/dev/tty; } 2>/dev/null; then
         printf "\nSync to resource-center (%s)? [Y/n]: " "${RESOURCE_CENTER_URL}" >/dev/tty
         read -r SYNC_CONFIRM </dev/tty || SYNC_CONFIRM="y"
     fi


### PR DESCRIPTION
The resource-center sync prompt guarded itself with `[ -e /dev/tty ]` before writing to it:

```bash
if [ -t 0 ] || [ -e /dev/tty ]; then
    printf "\nSync to resource-center (%s)? [Y/n]: " "${RESOURCE_CENTER_URL}" >/dev/tty
```

That device node exists inside any container, so `-e` passes — but with no controlling terminal the actual `open()` returns ENXIO. Under `set -euo pipefail` the failed `printf` took the whole script down:

```
build.sh: line 312: /dev/tty: No such device or address
```

This fires *after* `echo "全部完成。"`, so the image was already built and pushed. A successful build was reported as a failure — which is how the PR review agent saw it.

## Fix

Test whether `/dev/tty` can actually be opened, rather than whether the node exists.

Behaviour when it cannot is unchanged: `SYNC_CONFIRM` stays `y` and the image is registered, since setting `RESOURCE_CENTER_API_KEY` is itself the opt-in to publishing.

## Verification

Reproduced both paths locally (macOS renders ENXIO as "Device not configured"; Linux as the message above):

```
new guard, no controlling terminal:  survived, SYNC_CONFIRM=y   exit=0
old guard, no controlling terminal:  /dev/tty: Device not configured   exit=1
```

Under a real pty (`script -q /dev/null`) the prompt still renders and the `read` still runs, so interactive use is untouched. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)