### PR TITLE
fix(t800): 优化 Gesture 挥手握手动作与安全控制

### DIFF
--- a/engineai/t800/control.py
+++ b/engineai/t800/control.py
@@ -57,6 +57,38 @@ T800_JOINT_GROUPS = {
 
 T800_JOINT_INDEX = {name: index for index, name in enumerate(T800_JOINT_NAMES)}
 
+# Hard position limits copied from resource/serial_t800.urdf.  Gesture
+# choreography validates every requested target against this table before it
+# reaches the robot-facing planner; keeping the layout next to the canonical
+# joint names makes index drift visible in the pure control tests.
+T800_JOINT_POSITION_LIMITS = (
+    (-3.316, 2.269),
+    (-1.082, 2.059),
+    (-1.42244667, 3.6022778),
+    (0.0, 2.355),
+    (-0.68068, 0.68068),
+    (-0.3491, 0.1745),
+    (-3.316, 2.269),
+    (-2.059, 1.082),
+    (-3.6022778, 1.42244667),
+    (0.0, 2.355),
+    (-0.68068, 0.68068),
+    (-0.1745, 0.3491),
+    (-4.381, 1.2392),
+    (-2.967, 2.793),
+    (-0.384, 2.443),
+    (-2.618, 2.618),
+    (-2.286, 0.262),
+    (-2.618, 2.618),
+    (-2.967, 2.793),
+    (-2.443, 0.384),
+    (-2.618, 2.618),
+    (-2.286, 0.262),
+    (-2.618, 2.618),
+    (-0.523, 0.523),
+    (-1.222, 1.222),
+)
+
 MOTION_STATES = (
     "idle",
     "passive",
@@ -143,6 +175,35 @@ def validate_joint_indices(indices: object, *, allow_empty: bool = False) -> lis
     if invalid:
         raise ValueError(f"joint_indices out of range: {invalid}")
     return result
+
+
+def validate_joint_positions(
+    indices: object,
+    positions: object,
+    *,
+    limit_margin_rad: float = 0.0,
+) -> tuple[list[int], list[float]]:
+    """Validate finite targets against the T800 URDF joint limits."""
+    validated_indices = validate_joint_indices(indices)
+    validated_positions = float_list(
+        positions, "target_positions", size=len(validated_indices)
+    )
+    margin = float(limit_margin_rad)
+    if not math.isfinite(margin) or margin < 0:
+        raise ValueError("limit_margin_rad must be a non-negative finite number")
+    violations = []
+    for index, position in zip(validated_indices, validated_positions):
+        hard_lower, hard_upper = T800_JOINT_POSITION_LIMITS[index]
+        lower = hard_lower + margin
+        upper = hard_upper - margin
+        if lower > upper or position < lower or position > upper:
+            violations.append(
+                f"{T800_JOINT_NAMES[index]}={position:.6g} outside "
+                f"[{lower:.6g}, {upper:.6g}]"
+            )
+    if violations:
+        raise ValueError("joint target exceeds safe position limit: " + "; ".join(violations))
+    return validated_indices, validated_positions
 
 
 def validate_parallel_arrays(indices: Sequence[int], **arrays: Sequence[float]) -> None:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2431,34 +2431,39 @@ class GesturePlugin:
         }
 
     def get_tool(self) -> dict:
+        schema = action_schema(
+            _with_lifecycle({
+                "list": ([], "列出内置手势及步数"),
+                "play": (["name", "repetitions", "reset_after", "wait", "force"], "播放一次实机验证手势"),
+                "sequence": (["steps", "reset_after", "wait", "force"], "执行经过关节限位校验的自定义序列"),
+                "stop_gesture": (["reset_after"], "取消当前步骤并停止手势"),
+                "status": ([], "查询手势、步骤和错误"),
+            }),
+            {
+                "name": {"type": "string", "enum": list(self._GESTURES)},
+                "repetitions": {"type": "integer", "minimum": 1, "maximum": 1,
+                                "description": "安全限制：内置手势每次只执行一次"},
+                "reset_after": {"type": "boolean"},
+                "wait": {"type": "boolean", "description": "等待整套动作完成"},
+                "force": {"type": "boolean", "description": "忽略 lower_body_balance 状态门禁"},
+                "steps": {
+                    "type": "array",
+                    "description": "每步支持 joint_indices 或 joint_names、target_positions、duration、hold_after_sec、stiffness、damping",
+                    "items": {"type": "object"},
+                },
+            },
+            "手势动作",
+        )
+        schema["x-completion"] = {
+            "actions": ["play", "sequence"],
+            "timeout": 300,
+        }
         return {
             "name": "gesture",
             "type": "actuator",
             "multiInstance": False,
             "description": "T800 完整多步手势编排；内置官方挥手和握手序列，也支持任意关节动作队列",
-            "inputSchema": action_schema(
-                {
-                    "list": ([], "列出内置手势及步数"),
-                    "play": (["name", "repetitions", "reset_after", "wait", "force"], "播放一次实机验证手势"),
-                    "sequence": (["steps", "reset_after", "wait", "force"], "执行经过关节限位校验的自定义序列"),
-                    "stop_gesture": (["reset_after"], "取消当前步骤并停止手势"),
-                    "status": ([], "查询手势、步骤和错误"),
-                },
-                {
-                    "name": {"type": "string", "enum": list(self._GESTURES)},
-                    "repetitions": {"type": "integer", "minimum": 1, "maximum": 1,
-                                    "description": "安全限制：内置手势每次只执行一次"},
-                    "reset_after": {"type": "boolean"},
-                    "wait": {"type": "boolean", "description": "等待整套动作完成"},
-                    "force": {"type": "boolean", "description": "忽略 lower_body_balance 状态门禁"},
-                    "steps": {
-                        "type": "array",
-                        "description": "每步支持 joint_indices 或 joint_names、target_positions、duration、hold_after_sec、stiffness、damping",
-                        "items": {"type": "object"},
-                    },
-                },
-                "手势动作",
-            ),
+            "inputSchema": schema,
         }
 
     def start(self) -> None:
@@ -2494,7 +2499,10 @@ class GesturePlugin:
                         0.0, self._COOLDOWN_SEC - (time.monotonic() - self._last_finished_at)
                     )
                 return result
-        if action in ("stop", "stop_gesture"):
+        if action == "stop":
+            self._stop(reset_after=bool(args.get("reset_after", False)))
+            return {"state": "idle"}
+        if action == "stop_gesture":
             return self._stop(reset_after=bool(args.get("reset_after", False)))
         if action == "play":
             name = str(args.get("name", ""))
@@ -2595,12 +2603,19 @@ class GesturePlugin:
     def _start_sequence(self, label: str, steps: list[dict], *, reset_after: bool, wait: bool) -> dict:
         with self._lock:
             if self._thread is not None and self._thread.is_alive():
-                return {"error": "another gesture sequence is already running", **self._status}
+                current = dict(self._status)
+                current.pop("action_id", None)
+                return {**current, "error": "another gesture sequence is already running"}
+            action_id = None
+            if not wait:
+                from uuid import uuid4
+
+                action_id = f"t800_gesture_{uuid4().hex[:12]}"
             self._cancel = threading.Event()
             self._status = {
                 "state": "running", "gesture": label, "step": 0,
                 "step_name": None, "total_steps": len(steps),
-                "request_id": None, "error": None,
+                "request_id": None, "action_id": action_id, "error": None,
             }
 
         def run() -> None:
@@ -2644,7 +2659,11 @@ class GesturePlugin:
                         minimum_request_id=request_id,
                     )
                 with self._lock:
-                    self._status["state"] = "completed"
+                    if self._cancel.is_set() or self._status.get("state") == "cancelled":
+                        self._status["state"] = "cancelled"
+                        self._status["error"] = ""
+                    else:
+                        self._status["state"] = "completed"
             except Exception as exc:
                 cancelled = self._cancel.is_set()
                 if request_id is not None:
@@ -2655,6 +2674,17 @@ class GesturePlugin:
             finally:
                 with self._lock:
                     self._last_finished_at = time.monotonic()
+                    final_status = str(self._status.get("state", "error"))
+                    final_result = {
+                        "gesture": label,
+                        "step": self._status.get("step"),
+                        "step_name": self._status.get("step_name"),
+                        "total_steps": self._status.get("total_steps"),
+                        "request_id": self._status.get("request_id"),
+                        "error": self._status.get("error"),
+                    }
+                if action_id is not None:
+                    self._acp_notify(action_id, final_status, final_result)
 
         thread = threading.Thread(target=run, daemon=True, name="t800-gesture-sequence")
         with self._lock:
@@ -2664,19 +2694,63 @@ class GesturePlugin:
             thread.join()
             with self._lock:
                 return dict(self._status)
-        return {"state": "running", "gesture": label, "total_steps": len(steps)}
+        return {
+            "state": "running",
+            "gesture": label,
+            "total_steps": len(steps),
+            "action_id": action_id,
+        }
 
     def _stop(self, *, reset_after: bool) -> dict:
-        self._cancel.set()
         with self._lock:
-            request_id = self._status.get("request_id")
+            active = (
+                self._status.get("state") == "running"
+                and self._thread is not None
+                and self._thread.is_alive()
+            )
+            if active:
+                self._cancel.set()
+                self._status["state"] = "cancelled"
+                self._status["error"] = ""
+                request_id = self._status.get("request_id")
+            else:
+                request_id = None
+            result = dict(self._status)
         if request_id is not None:
             self._joint_plan.dispatch("cancel", {"request_id": request_id})
         if reset_after:
             self._joint_plan.dispatch("reset", {})
-        with self._lock:
-            self._status["state"] = "cancelled"
-            return dict(self._status)
+        return result
+
+    @staticmethod
+    def _acp_notify(action_id: str, status: str, result: dict) -> None:
+        """Report asynchronous gesture completion to Agent Core."""
+        import json as _json
+        import os as _os
+        import ssl as _ssl
+        import urllib.request as _urllib
+
+        agent_core_url = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+        context = _ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = _ssl.CERT_NONE
+        payload = _json.dumps({
+            "action_id": action_id,
+            "status": status,
+            "result": result,
+            "tool": "gesture",
+            "ts": time.time(),
+        }).encode()
+        try:
+            request = _urllib.Request(
+                f"{agent_core_url}/api/acp/complete",
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            _urllib.urlopen(request, timeout=5, context=context)
+        except Exception as exc:
+            print(f"[gesture] ACP callback failed for {action_id}: {exc}", flush=True)
 
 
 class _JointStreamBase:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2376,6 +2376,10 @@ class GesturePlugin:
     _READY_TIMEOUT_SEC = 10.0
     _STEP_TIMEOUT_SEC = 15.0
     _COOLDOWN_SEC = 3.0
+    _ACP_TIMEOUT_SEC = 300.0
+    _ACP_CALLBACK_TIMEOUT_SEC = 5.0
+    _ACP_SAFETY_MARGIN_SEC = 5.0
+    _MAX_SEQUENCE_STEPS = 16
     _NEUTRAL = [0.0, 0.028, 0.084, -0.001, -0.066, 0.0, 0.024, -0.081, 0.001, -0.069, 0.0, 0.0, 0.0]
     _RAISED = [0.0, -1.29568, 1.17971, 0.0757227, -1.06603, -0.0989933,
                -0.0211716, -0.322156, 0.0440607, -0.0871668, 0.0196457, 0.0, 0.0]
@@ -2448,6 +2452,7 @@ class GesturePlugin:
                 "steps": {
                     "type": "array",
                     "description": "每步支持 joint_indices 或 joint_names、target_positions、duration、hold_after_sec、stiffness、damping",
+                    "maxItems": self._MAX_SEQUENCE_STEPS,
                     "items": {"type": "object"},
                 },
             },
@@ -2455,7 +2460,7 @@ class GesturePlugin:
         )
         schema["x-completion"] = {
             "actions": ["play", "sequence"],
-            "timeout": 300,
+            "timeout": int(self._ACP_TIMEOUT_SEC),
         }
         return {
             "name": "gesture",
@@ -2486,6 +2491,8 @@ class GesturePlugin:
                     "planner_state_synchronised": True,
                     "cooldown_sec": self._COOLDOWN_SEC,
                     "maximum_repetitions": 1,
+                    "maximum_sequence_steps": self._MAX_SEQUENCE_STEPS,
+                    "acp_timeout_sec": self._ACP_TIMEOUT_SEC,
                 },
             }
         if action == "status":
@@ -2527,6 +2534,8 @@ class GesturePlugin:
             steps = args.get("steps")
             if not isinstance(steps, list) or not steps:
                 return {"error": "steps must be a non-empty array"}
+            if len(steps) > self._MAX_SEQUENCE_STEPS:
+                return {"error": f"steps cannot contain more than {self._MAX_SEQUENCE_STEPS} items"}
             if any(not isinstance(step, dict) for step in steps):
                 return {"error": "every gesture step must be an object"}
             steps = [dict(step) for step in steps]
@@ -2539,14 +2548,16 @@ class GesturePlugin:
                 "error": "gesture requires motion state 'lower_body_balance' "
                          f"(current: {motion or 'unknown'})"
             }
+        reset_after = bool(args.get("reset_after", True))
         try:
             steps = self._prepare_steps(steps)
+            self._validate_completion_budget(steps, reset_after=reset_after)
         except (TypeError, ValueError) as exc:
             return {"error": str(exc)}
         return self._start_sequence(
             label,
             steps,
-            reset_after=bool(args.get("reset_after", True)),
+            reset_after=reset_after,
         )
 
     def _official_steps(self, name: str) -> list[dict]:
@@ -2603,6 +2614,23 @@ class GesturePlugin:
             prepared.append(step)
         return prepared
 
+    def _validate_completion_budget(self, steps: list[dict], *, reset_after: bool) -> None:
+        worst_case = self._READY_TIMEOUT_SEC + self._ACP_CALLBACK_TIMEOUT_SEC
+        worst_case += self._ACP_SAFETY_MARGIN_SEC
+        for step in steps:
+            worst_case += max(
+                self._STEP_TIMEOUT_SEC,
+                float(step["duration"]) + 5.0,
+            )
+            worst_case += float(step.get("hold_after_sec", 0.0))
+        if reset_after:
+            worst_case += self._STEP_TIMEOUT_SEC
+        if worst_case > self._ACP_TIMEOUT_SEC:
+            raise ValueError(
+                f"gesture worst-case runtime {worst_case:.1f}s exceeds "
+                f"ACP completion timeout {self._ACP_TIMEOUT_SEC:.0f}s"
+            )
+
     def _start_sequence(self, label: str, steps: list[dict], *, reset_after: bool) -> dict:
         with self._lock:
             if self._thread is not None and self._thread.is_alive():
@@ -2654,10 +2682,10 @@ class GesturePlugin:
                     with self._lock:
                         self._status["request_id"] = request_id
                         self._status["step_name"] = "reset"
-                    self._joint_plan.wait_until_idle(
+                    self._joint_plan.wait_for_request(
+                        request_id,
                         self._STEP_TIMEOUT_SEC,
                         self._cancel,
-                        minimum_request_id=request_id,
                     )
                 with self._lock:
                     if self._cancel.is_set() or self._status.get("state") == "cancelled":
@@ -2753,7 +2781,11 @@ class GesturePlugin:
                 headers={"Content-Type": "application/json"},
                 method="POST",
             )
-            _urllib.urlopen(request, timeout=5, context=context)
+            _urllib.urlopen(
+                request,
+                timeout=GesturePlugin._ACP_CALLBACK_TIMEOUT_SEC,
+                context=context,
+            )
         except Exception as exc:
             print(f"[gesture] ACP callback failed for {action_id}: {exc}", flush=True)
 

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2085,6 +2085,7 @@ class DancePlugin:
 
 
 class JointPlanPlugin:
+    _LIMIT_MARGIN_RAD = 0.0
     _PRESETS = {
         "shake_hand": {
             "indices": list(range(12, 25)),
@@ -2329,8 +2330,11 @@ class JointPlanPlugin:
                 self._request_type.REQUEST_RESET if action == "reset" else self._request_type.REQUEST_PLAN_EXECUTE
             )
         if action == "plan":
-            indices = validate_joint_indices(args.get("joint_indices"))
-            positions = float_list(args.get("target_positions"), "target_positions", size=len(indices))
+            indices, positions = validate_joint_positions(
+                args.get("joint_indices"),
+                args.get("target_positions"),
+                limit_margin_rad=self._LIMIT_MARGIN_RAD,
+            )
             velocities = optional_floats(args, "target_velocities", len(indices))
             stiffness = optional_floats(args, "stiffness", len(indices))
             damping = optional_floats(args, "damping", len(indices))
@@ -2435,14 +2439,16 @@ class GesturePlugin:
         }
 
     def get_tool(self) -> dict:
+        actions = _with_lifecycle({
+            "list": ([], "列出内置手势及步数"),
+            "play": (["name", "repetitions", "reset_after", "force"], "异步播放一次实机验证手势"),
+            "sequence": (["steps", "reset_after", "force"], "异步执行经过关节限位校验的自定义序列"),
+            "stop_gesture": (["reset_after"], "取消当前步骤并停止手势"),
+            "status": ([], "查询手势、步骤和错误"),
+        })
+        actions["stop"] = (["reset_after"], "停止当前手势并进入空闲状态")
         schema = action_schema(
-            _with_lifecycle({
-                "list": ([], "列出内置手势及步数"),
-                "play": (["name", "repetitions", "reset_after", "force"], "异步播放一次实机验证手势"),
-                "sequence": (["steps", "reset_after", "force"], "异步执行经过关节限位校验的自定义序列"),
-                "stop_gesture": (["reset_after"], "取消当前步骤并停止手势"),
-                "status": ([], "查询手势、步骤和错误"),
-            }),
+            actions,
             {
                 "name": {"type": "string", "enum": list(self._GESTURES)},
                 "repetitions": {"type": "integer", "minimum": 1, "maximum": 1,

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -50,6 +50,7 @@ from control import (
     sensor_action_schema,
     sensor_tool,
     validate_joint_indices,
+    validate_joint_positions,
     validate_parallel_arrays,
 )
 from native_sdk import NativeSdkManager
@@ -2106,9 +2107,12 @@ class JointPlanPlugin:
         ros2.executor_robot.add_node(self._sub_node)
         ros2.executor_core.add_node(self._pub_node)
         self._publisher = None
-        self._state_lock = threading.Lock()
+        self._state_lock = threading.RLock()
+        self._state_changed = threading.Condition(self._state_lock)
         self._last_state = {"state": "no_data"}
+        self._executing_requests: set[int] = set()
         self._request_id = 0
+        self._state_type = None
         self._state = state
         self._core_topic = f"/{namespace}/state/joint_plan"
         self._core_pub = self._pub_node.create_publisher(String, self._core_topic, _BEST_EFFORT)
@@ -2159,6 +2163,7 @@ class JointPlanPlugin:
         from interface_protocol.msg import JointMotionPlanRequest, JointMotionPlanState
 
         self._request_type = JointMotionPlanRequest
+        self._state_type = JointMotionPlanState
         self._publisher = self._sub_node.create_publisher(
             JointMotionPlanRequest, self._config["topics"]["joint_plan_request"], _RELIABLE_ONE
         )
@@ -2235,6 +2240,79 @@ class JointPlanPlugin:
             return self._publish_request("plan", args)
         return {"error": f"unknown joint plan action: {action}"}
 
+    def current_motion(self) -> tuple[str, list[str]]:
+        if self._state is None:
+            return "", []
+        return self._state.current_motion()
+
+    def wait_until_idle(
+        self,
+        timeout: float,
+        cancel_event: threading.Event,
+        *,
+        minimum_request_id: int | None = None,
+    ) -> dict:
+        """Wait for an IDLE planner state without inventing time-based progress."""
+        if self._state_type is None:
+            raise RuntimeError("joint planner is not started")
+        deadline = time.monotonic() + float(timeout)
+        idle = int(self._state_type.IDLE)
+        with self._state_changed:
+            while True:
+                if cancel_event.is_set():
+                    raise RuntimeError("gesture cancelled")
+                state = dict(self._last_state)
+                request_id = state.get("request_id")
+                # The official planner may not publish until it receives its
+                # first request. Allow that first request, then require an
+                # observed state for every subsequent transition.
+                if request_id is None and minimum_request_id is None:
+                    return state
+                if (
+                    request_id is not None
+                    and int(state.get("status", -1)) == idle
+                    and (minimum_request_id is None or int(request_id) >= minimum_request_id)
+                ):
+                    return state
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("joint planner did not become IDLE")
+                self._state_changed.wait(timeout=min(remaining, 0.2))
+
+    def wait_for_request(
+        self,
+        request_id: int,
+        timeout: float,
+        cancel_event: threading.Event,
+    ) -> dict:
+        """Require the planner to execute and finish the exact request."""
+        if self._state_type is None:
+            raise RuntimeError("joint planner is not started")
+        target = int(request_id)
+        deadline = time.monotonic() + float(timeout)
+        idle = int(self._state_type.IDLE)
+        with self._state_changed:
+            while True:
+                if cancel_event.is_set():
+                    raise RuntimeError("gesture cancelled")
+                state = dict(self._last_state)
+                current_id = state.get("request_id")
+                status = int(state.get("status", -1))
+                if (
+                    current_id is not None
+                    and int(current_id) == target
+                    and target in self._executing_requests
+                    and status == idle
+                ):
+                    self._executing_requests.discard(target)
+                    return state
+                if current_id is not None and int(current_id) > target:
+                    raise RuntimeError(f"joint planner request {target} was superseded")
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(f"joint planner did not complete request {target}")
+                self._state_changed.wait(timeout=min(remaining, 0.2))
+
     def _next_request_id(self) -> int:
         with self._state_lock:
             self._request_id += 1
@@ -2281,16 +2359,23 @@ class JointPlanPlugin:
             "progress": float(msg.progress),
             "timestamp_ms": _now_ms(),
         }
-        with self._state_lock:
+        with self._state_changed:
             self._request_id = max(self._request_id, int(msg.request_id))
             self._last_state = payload
+            if self._state_type is not None and int(msg.status) == int(self._state_type.EXECUTING):
+                self._executing_requests.add(int(msg.request_id))
+            self._state_changed.notify_all()
         self._core_pub.publish(_json_message(payload))
 
 
 class GesturePlugin:
-    """Multi-step gesture choreography using the official joint planner."""
+    """Planner-synchronised upper-body gestures validated against URDF limits."""
 
     _INDICES = list(range(12, 25))
+    _LIMIT_MARGIN_RAD = 0.02
+    _READY_TIMEOUT_SEC = 10.0
+    _STEP_TIMEOUT_SEC = 15.0
+    _COOLDOWN_SEC = 3.0
     _NEUTRAL = [0.0, 0.028, 0.084, -0.001, -0.066, 0.0, 0.024, -0.081, 0.001, -0.069, 0.0, 0.0, 0.0]
     _RAISED = [0.0, -1.29568, 1.17971, 0.0757227, -1.06603, -0.0989933,
                -0.0211716, -0.322156, 0.0440607, -0.0871668, 0.0196457, 0.0, 0.0]
@@ -2300,24 +2385,37 @@ class GesturePlugin:
                       -0.47, 0.255, 0.161, -0.731, 0.028, 0.0, 0.0]
     _HAND_WITHDRAWN = [0.0, 0.024, 0.081, -0.001, -0.069, 0.0,
                        0.028, -0.084, 0.001, -0.066, 0.0, 0.0, 0.0]
-    _BASE_STIFFNESS = [200.0, 30.0, 30.0, 15.0, 30.0, 15.0,
-                       40.0, 40.0, 20.0, 40.0, 20.0, 100.0, 100.0]
-    _WAVE_STIFFNESS = [500.0, 30.0, 30.0, 15.0, 30.0, 15.0,
-                       40.0, 40.0, 20.0, 40.0, 20.0, 100.0, 100.0]
     _SHAKE_STIFFNESS = [400.0, 40.0, 40.0, 20.0, 40.0, 20.0,
                         40.0, 40.0, 20.0, 40.0, 20.0, 100.0, 100.0]
-    _BASE_DAMPING = [3.0, 1.0, 1.0, 1.0, 1.0, 1.0,
-                     1.0, 1.0, 1.0, 1.0, 1.0, 3.0, 3.0]
+    _SHAKE_DAMPING = [3.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 3.0, 3.0]
     _GESTURES = {
         "wave_hands": [
-            (_NEUTRAL, 1.0, _BASE_STIFFNESS), (_RAISED, 2.0, _BASE_STIFFNESS),
-            (_WAVE, 0.3, _WAVE_STIFFNESS), (_RAISED, 0.3, _WAVE_STIFFNESS),
-            (_WAVE, 0.3, _WAVE_STIFFNESS), (_RAISED, 0.3, _WAVE_STIFFNESS),
-            (_WAVE, 0.3, _BASE_STIFFNESS),
+            {"name": "neutral", "positions": _NEUTRAL, "duration": 1.0},
+            {"name": "raise_hand", "positions": _RAISED, "duration": 2.0},
+            {"name": "wave_left", "positions": _WAVE, "duration": 0.3},
+            {"name": "wave_right", "positions": _RAISED, "duration": 0.3},
+            {"name": "wave_left_again", "positions": _WAVE, "duration": 0.3},
+            {"name": "wave_right_again", "positions": _RAISED, "duration": 0.3},
+            {"name": "wave_finish", "positions": _WAVE, "duration": 0.3},
+            {"name": "return_to_neutral", "positions": _NEUTRAL, "duration": 2.0},
         ],
         "shake_hand": [
-            (_HAND_EXTENDED, 2.0, _SHAKE_STIFFNESS),
-            (_HAND_WITHDRAWN, 2.0, _SHAKE_STIFFNESS),
+            {
+                "name": "extend_right_hand",
+                "positions": _HAND_EXTENDED,
+                "duration": 2.0,
+                "hold_after_sec": 2.0,
+                "stiffness": _SHAKE_STIFFNESS,
+                "damping": _SHAKE_DAMPING,
+            },
+            {
+                "name": "withdraw_right_hand",
+                "positions": _HAND_WITHDRAWN,
+                "duration": 2.0,
+                "stiffness": _SHAKE_STIFFNESS,
+                "damping": _SHAKE_DAMPING,
+            },
         ],
     }
 
@@ -2326,7 +2424,11 @@ class GesturePlugin:
         self._lock = threading.Lock()
         self._cancel = threading.Event()
         self._thread: threading.Thread | None = None
-        self._status = {"state": "idle", "gesture": None, "step": 0, "total_steps": 0}
+        self._last_finished_at: float | None = None
+        self._status = {
+            "state": "idle", "gesture": None, "step": 0, "step_name": None,
+            "total_steps": 0, "request_id": None, "error": None,
+        }
 
     def get_tool(self) -> dict:
         return {
@@ -2337,19 +2439,21 @@ class GesturePlugin:
             "inputSchema": action_schema(
                 {
                     "list": ([], "列出内置手势及步数"),
-                    "play": (["name", "repetitions", "reset_after", "wait"], "播放内置完整手势"),
-                    "sequence": (["steps", "reset_after", "wait"], "执行自定义多步关节规划序列"),
+                    "play": (["name", "repetitions", "reset_after", "wait", "force"], "播放一次实机验证手势"),
+                    "sequence": (["steps", "reset_after", "wait", "force"], "执行经过关节限位校验的自定义序列"),
                     "stop_gesture": (["reset_after"], "取消当前步骤并停止手势"),
                     "status": ([], "查询手势、步骤和错误"),
                 },
                 {
                     "name": {"type": "string", "enum": list(self._GESTURES)},
-                    "repetitions": {"type": "integer", "minimum": 1, "maximum": 20},
+                    "repetitions": {"type": "integer", "minimum": 1, "maximum": 1,
+                                    "description": "安全限制：内置手势每次只执行一次"},
                     "reset_after": {"type": "boolean"},
                     "wait": {"type": "boolean", "description": "等待整套动作完成"},
+                    "force": {"type": "boolean", "description": "忽略 lower_body_balance 状态门禁"},
                     "steps": {
                         "type": "array",
-                        "description": "每步支持 joint_indices 或 joint_names、target_positions、duration、stiffness、damping",
+                        "description": "每步支持 joint_indices 或 joint_names、target_positions、duration、hold_after_sec、stiffness、damping",
                         "items": {"type": "object"},
                     },
                 },
@@ -2368,14 +2472,28 @@ class GesturePlugin:
             return {
                 "state": "ready",
                 "gestures": [
-                    {"name": name, "steps": len(steps), "source": "EngineAI T800 official example"}
+                    {"name": name, "steps": len(steps), "source": "T800 real-device validated trajectory"}
                     for name, steps in self._GESTURES.items()
                 ],
                 "custom_sequence": True,
+                "safety": {
+                    "required_motion_state": "lower_body_balance",
+                    "position_limit_margin_rad": self._LIMIT_MARGIN_RAD,
+                    "planner_state_synchronised": True,
+                    "cooldown_sec": self._COOLDOWN_SEC,
+                    "maximum_repetitions": 1,
+                },
             }
         if action == "status":
             with self._lock:
-                return dict(self._status)
+                result = dict(self._status)
+                if self._last_finished_at is None:
+                    result["cooldown_remaining_sec"] = 0.0
+                else:
+                    result["cooldown_remaining_sec"] = max(
+                        0.0, self._COOLDOWN_SEC - (time.monotonic() - self._last_finished_at)
+                    )
+                return result
         if action in ("stop", "stop_gesture"):
             return self._stop(reset_after=bool(args.get("reset_after", False)))
         if action == "play":
@@ -2383,20 +2501,36 @@ class GesturePlugin:
             if name not in self._GESTURES:
                 return {"error": f"unknown gesture: {name}"}
             repetitions = int(args.get("repetitions", 1))
-            if repetitions < 1 or repetitions > 20:
-                return {"error": "repetitions must be between 1 and 20"}
-            steps = []
-            for _ in range(repetitions):
-                steps.extend(self._official_steps(name))
+            if repetitions != 1:
+                return {"error": "repetitions must be 1 for thermal safety"}
+            with self._lock:
+                if (
+                    self._last_finished_at is not None
+                    and time.monotonic() - self._last_finished_at < self._COOLDOWN_SEC
+                ):
+                    return {"error": "gesture cooldown is active"}
+            steps = self._official_steps(name)
             label = name
         elif action == "sequence":
             steps = args.get("steps")
             if not isinstance(steps, list) or not steps:
                 return {"error": "steps must be a non-empty array"}
+            if any(not isinstance(step, dict) for step in steps):
+                return {"error": "every gesture step must be an object"}
             steps = [dict(step) for step in steps]
             label = "custom"
         else:
             return {"error": f"unknown gesture action: {action}"}
+        motion, _available_motions = self._joint_plan.current_motion()
+        if motion != "lower_body_balance" and not bool(args.get("force", False)):
+            return {
+                "error": "gesture requires motion state 'lower_body_balance' "
+                         f"(current: {motion or 'unknown'})"
+            }
+        try:
+            steps = self._prepare_steps(steps)
+        except (TypeError, ValueError) as exc:
+            return {"error": str(exc)}
         return self._start_sequence(
             label,
             steps,
@@ -2406,51 +2540,121 @@ class GesturePlugin:
 
     def _official_steps(self, name: str) -> list[dict]:
         steps = []
-        for positions, duration, stiffness in self._GESTURES[name]:
-            steps.append({
+        for definition in self._GESTURES[name]:
+            step = {
+                "name": definition["name"],
                 "joint_indices": list(self._INDICES),
-                "target_positions": list(positions),
-                "duration": duration,
-                "stiffness": list(stiffness),
-                "damping": list(self._BASE_DAMPING),
+                "target_positions": list(definition["positions"]),
+                "duration": definition["duration"],
+                "hold_after_sec": definition.get("hold_after_sec", 0.0),
+                "stiffness": list(definition.get("stiffness", [])),
+                "damping": list(definition.get("damping", [])),
                 "gravity_compensation": True,
-            })
+            }
+            steps.append(step)
         return steps
+
+    def _prepare_steps(self, steps: list[dict]) -> list[dict]:
+        prepared = []
+        for offset, source in enumerate(steps, start=1):
+            step = dict(source)
+            if "joint_names" in step:
+                names = step.get("joint_names")
+                if not isinstance(names, (list, tuple)) or not names:
+                    raise ValueError("joint_names must be a non-empty array")
+                unknown = [str(name) for name in names if str(name) not in T800_JOINT_INDEX]
+                if unknown:
+                    raise ValueError(f"unknown joint names: {unknown}")
+                indices = [T800_JOINT_INDEX[str(name)] for name in names]
+            else:
+                indices = step.get("joint_indices")
+            validated_indices, positions = validate_joint_positions(
+                indices,
+                step.get("target_positions"),
+                limit_margin_rad=self._LIMIT_MARGIN_RAD,
+            )
+            duration = float(step.get("duration", 2.0))
+            if not math.isfinite(duration) or not 0.05 <= duration <= 120.0:
+                raise ValueError(f"gesture step {offset} duration must be between 0.05 and 120 seconds")
+            hold_after = float(step.get("hold_after_sec", 0.0))
+            if not math.isfinite(hold_after) or not 0.0 <= hold_after <= 30.0:
+                raise ValueError(f"gesture step {offset} hold_after_sec must be between 0 and 30 seconds")
+            count = len(validated_indices)
+            step["target_positions"] = positions
+            step["duration"] = duration
+            step["hold_after_sec"] = hold_after
+            step["stiffness"] = optional_floats(step, "stiffness", count)
+            step["damping"] = optional_floats(step, "damping", count)
+            step["gravity_compensation"] = bool(step.get("gravity_compensation", True))
+            step["name"] = str(step.get("name", f"step_{offset}"))
+            if "joint_names" not in step:
+                step["joint_indices"] = validated_indices
+            prepared.append(step)
+        return prepared
 
     def _start_sequence(self, label: str, steps: list[dict], *, reset_after: bool, wait: bool) -> dict:
         with self._lock:
             if self._thread is not None and self._thread.is_alive():
                 return {"error": "another gesture sequence is already running", **self._status}
             self._cancel = threading.Event()
-            self._status = {"state": "running", "gesture": label, "step": 0,
-                            "total_steps": len(steps), "error": None}
+            self._status = {
+                "state": "running", "gesture": label, "step": 0,
+                "step_name": None, "total_steps": len(steps),
+                "request_id": None, "error": None,
+            }
 
         def run() -> None:
+            request_id = None
             try:
+                self._joint_plan.wait_until_idle(
+                    self._READY_TIMEOUT_SEC, self._cancel
+                )
                 for index, step in enumerate(steps, start=1):
                     if self._cancel.is_set():
-                        break
+                        raise RuntimeError("gesture cancelled")
                     with self._lock:
                         self._status["step"] = index
+                        self._status["step_name"] = step["name"]
                     action = "plan_named" if "joint_names" in step else "plan"
                     result = self._joint_plan.dispatch(action, step)
                     if "error" in result:
                         raise ValueError(result["error"])
+                    request_id = int(result["request_id"])
                     with self._lock:
-                        self._status["request_id"] = result.get("request_id")
-                    duration = clamp(step.get("duration", 2.0), 0.05, 120.0)
-                    if self._cancel.wait(duration):
-                        break
+                        self._status["request_id"] = request_id
+                    self._joint_plan.wait_for_request(
+                        request_id,
+                        max(self._STEP_TIMEOUT_SEC, float(step["duration"]) + 5.0),
+                        self._cancel,
+                    )
+                    hold_after = float(step.get("hold_after_sec", 0.0))
+                    if hold_after > 0 and self._cancel.wait(hold_after):
+                        raise RuntimeError("gesture cancelled")
                 if not self._cancel.is_set() and reset_after:
                     result = self._joint_plan.dispatch("reset", {})
+                    if "error" in result:
+                        raise ValueError(result["error"])
+                    request_id = int(result["request_id"])
                     with self._lock:
-                        self._status["request_id"] = result.get("request_id")
+                        self._status["request_id"] = request_id
+                        self._status["step_name"] = "reset"
+                    self._joint_plan.wait_until_idle(
+                        self._STEP_TIMEOUT_SEC,
+                        self._cancel,
+                        minimum_request_id=request_id,
+                    )
                 with self._lock:
-                    self._status["state"] = "cancelled" if self._cancel.is_set() else "completed"
+                    self._status["state"] = "completed"
             except Exception as exc:
+                cancelled = self._cancel.is_set()
+                if request_id is not None:
+                    self._joint_plan.dispatch("cancel", {"request_id": request_id})
                 with self._lock:
-                    self._status["state"] = "error"
-                    self._status["error"] = str(exc)
+                    self._status["state"] = "cancelled" if cancelled else "error"
+                    self._status["error"] = "" if cancelled else str(exc)
+            finally:
+                with self._lock:
+                    self._last_finished_at = time.monotonic()
 
         thread = threading.Thread(target=run, daemon=True, name="t800-gesture-sequence")
         with self._lock:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2434,8 +2434,8 @@ class GesturePlugin:
         schema = action_schema(
             _with_lifecycle({
                 "list": ([], "列出内置手势及步数"),
-                "play": (["name", "repetitions", "reset_after", "wait", "force"], "播放一次实机验证手势"),
-                "sequence": (["steps", "reset_after", "wait", "force"], "执行经过关节限位校验的自定义序列"),
+                "play": (["name", "repetitions", "reset_after", "force"], "异步播放一次实机验证手势"),
+                "sequence": (["steps", "reset_after", "force"], "异步执行经过关节限位校验的自定义序列"),
                 "stop_gesture": (["reset_after"], "取消当前步骤并停止手势"),
                 "status": ([], "查询手势、步骤和错误"),
             }),
@@ -2444,7 +2444,6 @@ class GesturePlugin:
                 "repetitions": {"type": "integer", "minimum": 1, "maximum": 1,
                                 "description": "安全限制：内置手势每次只执行一次"},
                 "reset_after": {"type": "boolean"},
-                "wait": {"type": "boolean", "description": "等待整套动作完成"},
                 "force": {"type": "boolean", "description": "忽略 lower_body_balance 状态门禁"},
                 "steps": {
                     "type": "array",
@@ -2504,6 +2503,11 @@ class GesturePlugin:
             return {"state": "idle"}
         if action == "stop_gesture":
             return self._stop(reset_after=bool(args.get("reset_after", False)))
+        if action in ("play", "sequence") and bool(args.get("wait", False)):
+            return {
+                "error": "wait=true is not supported for asynchronous gesture actions; "
+                         "use action_id completion or status instead"
+            }
         if action == "play":
             name = str(args.get("name", ""))
             if name not in self._GESTURES:
@@ -2543,7 +2547,6 @@ class GesturePlugin:
             label,
             steps,
             reset_after=bool(args.get("reset_after", True)),
-            wait=bool(args.get("wait", False)),
         )
 
     def _official_steps(self, name: str) -> list[dict]:
@@ -2600,17 +2603,15 @@ class GesturePlugin:
             prepared.append(step)
         return prepared
 
-    def _start_sequence(self, label: str, steps: list[dict], *, reset_after: bool, wait: bool) -> dict:
+    def _start_sequence(self, label: str, steps: list[dict], *, reset_after: bool) -> dict:
         with self._lock:
             if self._thread is not None and self._thread.is_alive():
                 current = dict(self._status)
                 current.pop("action_id", None)
                 return {**current, "error": "another gesture sequence is already running"}
-            action_id = None
-            if not wait:
-                from uuid import uuid4
+            from uuid import uuid4
 
-                action_id = f"t800_gesture_{uuid4().hex[:12]}"
+            action_id = f"t800_gesture_{uuid4().hex[:12]}"
             self._cancel = threading.Event()
             self._status = {
                 "state": "running", "gesture": label, "step": 0,
@@ -2690,10 +2691,6 @@ class GesturePlugin:
         with self._lock:
             self._thread = thread
         thread.start()
-        if wait:
-            thread.join()
-            with self._lock:
-                return dict(self._status)
         return {
             "state": "running",
             "gesture": label,
@@ -2728,20 +2725,28 @@ class GesturePlugin:
         import json as _json
         import os as _os
         import ssl as _ssl
+        import urllib.parse as _urlparse
         import urllib.request as _urllib
 
         agent_core_url = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
-        context = _ssl.create_default_context()
-        context.check_hostname = False
-        context.verify_mode = _ssl.CERT_NONE
-        payload = _json.dumps({
-            "action_id": action_id,
-            "status": status,
-            "result": result,
-            "tool": "gesture",
-            "ts": time.time(),
-        }).encode()
+        ca_cert = _os.environ.get("AGENT_CORE_CA_CERT")
         try:
+            parsed_url = _urlparse.urlparse(agent_core_url)
+            if parsed_url.scheme not in ("http", "https"):
+                raise ValueError("AGENT_CORE_URL must use http or https")
+            if (
+                parsed_url.scheme == "http"
+                and parsed_url.hostname not in ("localhost", "127.0.0.1", "::1")
+            ):
+                raise ValueError("unencrypted AGENT_CORE_URL is only allowed on loopback")
+            context = _ssl.create_default_context(cafile=ca_cert or None)
+            payload = _json.dumps({
+                "action_id": action_id,
+                "status": status,
+                "result": result,
+                "tool": "gesture",
+                "ts": time.time(),
+            }).encode()
             request = _urllib.Request(
                 f"{agent_core_url}/api/acp/complete",
                 data=payload,

--- a/engineai/t800/tests/test_control.py
+++ b/engineai/t800/tests/test_control.py
@@ -4,6 +4,7 @@ import tempfile
 import threading
 import time
 import unittest
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 
@@ -11,6 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from control import (  # noqa: E402
+    T800_JOINT_POSITION_LIMITS,
     T800_JOINT_NAMES,
     RepeatingCommand,
     action_schema,
@@ -19,6 +21,7 @@ from control import (  # noqa: E402
     joint_payload,
     sensor_tool,
     validate_joint_indices,
+    validate_joint_positions,
 )
 from native_sdk import NativeSdkManager  # noqa: E402
 
@@ -29,6 +32,7 @@ class ValidationTests(unittest.TestCase):
         self.assertEqual(25, len(set(T800_JOINT_NAMES)))
         self.assertEqual("J00_HIP_PITCH_L", T800_JOINT_NAMES[0])
         self.assertEqual("J24_HEAD_YAW", T800_JOINT_NAMES[-1])
+        self.assertEqual(25, len(T800_JOINT_POSITION_LIMITS))
 
     def test_joint_payload_uses_official_index_mapping(self):
         payload = joint_payload([0.1, 0.2], [1.0, 2.0], [3.0, 4.0], timestamp_ms=123)
@@ -66,6 +70,28 @@ class ValidationTests(unittest.TestCase):
             validate_joint_indices([25])
         with self.assertRaisesRegex(ValueError, "integers"):
             validate_joint_indices([1.5])
+
+    def test_joint_positions_enforce_urdf_limits_and_margin(self):
+        indices, positions = validate_joint_positions(
+            [13, 16], [-1.2, -1.8], limit_margin_rad=0.02
+        )
+        self.assertEqual([13, 16], indices)
+        self.assertEqual([-1.2, -1.8], positions)
+        with self.assertRaisesRegex(ValueError, "J16_ELBOW_PITCH_L"):
+            validate_joint_positions([16], [-2.28], limit_margin_rad=0.02)
+
+    def test_joint_position_limits_match_vendored_urdf(self):
+        root = ET.parse(ROOT / "resource" / "serial_t800.urdf").getroot()
+        urdf_limits = {
+            joint.attrib["name"]: (
+                float(joint.find("limit").attrib["lower"]),
+                float(joint.find("limit").attrib["upper"]),
+            )
+            for joint in root.findall("joint")
+            if joint.find("limit") is not None
+        }
+        for index, name in enumerate(T800_JOINT_NAMES):
+            self.assertEqual(urdf_limits[name], T800_JOINT_POSITION_LIMITS[index])
 
     def test_action_schema_splits_action_parameters(self):
         schema = action_schema(

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -610,6 +610,7 @@ class DevicePluginContractTests(unittest.TestCase):
         actions = set(schema["properties"]["action"]["enum"])
         self.assertTrue({"start", "info", "stop"}.issubset(actions))
         self.assertNotIn("wait", schema["properties"])
+        self.assertEqual(gesture._MAX_SEQUENCE_STEPS, schema["properties"]["steps"]["maxItems"])
         rejected = gesture.dispatch("sequence", {
             "steps": [{"joint_indices": [23], "target_positions": [0.0]}],
             "wait": True,
@@ -650,6 +651,76 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual(result["action_id"], completions[0][0])
         self.assertEqual("completed", completions[0][1])
         self.assertEqual(request_id, completions[0][2]["request_id"])
+
+    def test_gesture_reset_fails_when_exact_request_is_superseded(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        gesture = self.device.GesturePlugin(plan)
+        completions = []
+        gesture._acp_notify = lambda action_id, status, result: completions.append(
+            (action_id, status, result)
+        )
+        result = gesture.dispatch("sequence", {
+            "steps": [{"joint_indices": [23], "target_positions": [0.1], "duration": 0.05}],
+            "reset_after": True,
+            "force": True,
+        })
+
+        deadline = time.monotonic() + 1.0
+        while not plan._publisher.messages and time.monotonic() < deadline:
+            time.sleep(0.005)
+        self.assertTrue(plan._publisher.messages)
+        step_request_id = plan._publisher.messages[-1].request_id
+        plan._on_state(JointMotionPlanState(
+            step_request_id, JointMotionPlanState.EXECUTING, 0.5
+        ))
+        plan._on_state(JointMotionPlanState(
+            step_request_id, JointMotionPlanState.IDLE, 1.0
+        ))
+
+        deadline = time.monotonic() + 1.0
+        while len(plan._publisher.messages) < 2 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        self.assertGreaterEqual(len(plan._publisher.messages), 2)
+        reset_request = plan._publisher.messages[-1]
+        self.assertEqual(JointMotionPlanRequest.REQUEST_RESET, reset_request.request_type)
+        plan._on_state(JointMotionPlanState(
+            reset_request.request_id + 1, JointMotionPlanState.IDLE, 1.0
+        ))
+        gesture._thread.join(timeout=1.0)
+
+        status = gesture.dispatch("status", {})
+        self.assertEqual("error", status["state"])
+        self.assertIn("superseded", status["error"])
+        self.assertEqual(result["action_id"], completions[0][0])
+        self.assertEqual("error", completions[0][1])
+
+    def test_gesture_rejects_sequence_beyond_acp_runtime_budget(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        gesture = self.device.GesturePlugin(plan)
+        long_step = {
+            "joint_indices": [23],
+            "target_positions": [0.1],
+            "duration": 120.0,
+            "hold_after_sec": 30.0,
+        }
+        over_budget = gesture.dispatch("sequence", {
+            "steps": [long_step, long_step],
+            "reset_after": False,
+            "force": True,
+        })
+        self.assertIn("exceeds ACP completion timeout", over_budget["error"])
+        self.assertNotIn("action_id", over_budget)
+        self.assertIsNone(gesture._thread)
+
+        too_many = gesture.dispatch("sequence", {
+            "steps": [long_step] * (gesture._MAX_SEQUENCE_STEPS + 1),
+            "reset_after": False,
+            "force": True,
+        })
+        self.assertIn("cannot contain more than", too_many["error"])
+        self.assertIsNone(gesture._thread)
 
     def test_gesture_stop_preserves_cancelled_and_reports_acp(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import os
+import ssl
 import struct
 import sys
 import threading
@@ -586,16 +587,18 @@ class DevicePluginContractTests(unittest.TestCase):
         plan.wait_until_idle = lambda *_args, **_kwargs: {}
         plan.wait_for_request = lambda *_args, **_kwargs: {}
         gesture = self.device.GesturePlugin(plan)
+        gesture._acp_notify = lambda *_args: None
         listed = {item["name"]: item["steps"] for item in gesture.dispatch("list", {})["gestures"]}
         self.assertEqual(8, listed["wave_hands"])
         self.assertEqual(2, listed["shake_hand"])
         result = gesture.dispatch("sequence", {
             "steps": [{"joint_indices": [23, 24], "target_positions": [0.1, -0.1], "duration": 0.05}],
             "reset_after": False,
-            "wait": True,
             "force": True,
         })
-        self.assertEqual("completed", result["state"])
+        self.assertEqual("running", result["state"])
+        gesture._thread.join(timeout=1.0)
+        self.assertEqual("completed", gesture.dispatch("status", {})["state"])
         self.assertEqual([23, 24], plan._publisher.messages[-1].joint_indices)
 
     def test_gesture_declares_async_completion_and_lifecycle_actions(self):
@@ -606,6 +609,15 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertGreaterEqual(schema["x-completion"]["timeout"], 60)
         actions = set(schema["properties"]["action"]["enum"])
         self.assertTrue({"start", "info", "stop"}.issubset(actions))
+        self.assertNotIn("wait", schema["properties"])
+        rejected = gesture.dispatch("sequence", {
+            "steps": [{"joint_indices": [23], "target_positions": [0.0]}],
+            "wait": True,
+            "force": True,
+        })
+        self.assertIn("wait=true is not supported", rejected["error"])
+        self.assertNotIn("action_id", rejected)
+        self.assertIsNone(gesture._thread)
 
     def test_gesture_async_acp_uses_real_planner_state_transitions(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
@@ -619,7 +631,6 @@ class DevicePluginContractTests(unittest.TestCase):
         result = gesture.dispatch("sequence", {
             "steps": [{"joint_indices": [23], "target_positions": [0.1], "duration": 0.05}],
             "reset_after": False,
-            "wait": False,
             "force": True,
         })
         self.assertEqual("running", result["state"])
@@ -661,13 +672,11 @@ class DevicePluginContractTests(unittest.TestCase):
         result = gesture.dispatch("sequence", {
             "steps": [{"joint_indices": [23], "target_positions": [0.1], "duration": 0.05}],
             "reset_after": False,
-            "wait": False,
             "force": True,
         })
         self.assertTrue(entered_wait.wait(timeout=1.0))
         busy = gesture.dispatch("sequence", {
             "steps": [{"joint_indices": [23], "target_positions": [0.0]}],
-            "wait": False,
             "force": True,
         })
         self.assertIn("already running", busy["error"])
@@ -697,7 +706,6 @@ class DevicePluginContractTests(unittest.TestCase):
         result = gesture.dispatch("sequence", {
             "steps": [{"joint_indices": [23], "target_positions": [0.1], "duration": 0.05}],
             "reset_after": False,
-            "wait": False,
             "force": True,
         })
         gesture._thread.join(timeout=1.0)
@@ -723,6 +731,16 @@ class DevicePluginContractTests(unittest.TestCase):
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
         previous = os.environ.get("AGENT_CORE_URL")
+        previous_ca = os.environ.pop("AGENT_CORE_CA_CERT", None)
+        original_create_default_context = ssl.create_default_context
+        contexts = []
+
+        def create_default_context(*args, **kwargs):
+            context = original_create_default_context(*args, **kwargs)
+            contexts.append(context)
+            return context
+
+        ssl.create_default_context = create_default_context
         os.environ["AGENT_CORE_URL"] = f"http://127.0.0.1:{server.server_port}"
         try:
             self.device.GesturePlugin._acp_notify(
@@ -733,6 +751,9 @@ class DevicePluginContractTests(unittest.TestCase):
                 os.environ.pop("AGENT_CORE_URL", None)
             else:
                 os.environ["AGENT_CORE_URL"] = previous
+            if previous_ca is not None:
+                os.environ["AGENT_CORE_CA_CERT"] = previous_ca
+            ssl.create_default_context = original_create_default_context
             server.shutdown()
             server.server_close()
 
@@ -742,6 +763,8 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual("completed", payload["status"])
         self.assertEqual("gesture", payload["tool"])
         self.assertEqual("wave_hands", payload["result"]["gesture"])
+        self.assertTrue(contexts[0].check_hostname)
+        self.assertEqual(ssl.CERT_REQUIRED, contexts[0].verify_mode)
 
     def test_gesture_uses_validated_real_device_trajectories(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
@@ -750,6 +773,7 @@ class DevicePluginContractTests(unittest.TestCase):
         plan.wait_until_idle = lambda *_args, **kwargs: waits.append(("idle", kwargs)) or {}
         plan.wait_for_request = lambda request_id, *_args: waits.append(("request", request_id)) or {}
         gesture = self.device.GesturePlugin(plan)
+        gesture._acp_notify = lambda *_args: None
 
         wave = gesture._prepare_steps(gesture._official_steps("wave_hands"))
         self.assertEqual("return_to_neutral", wave[-1]["name"])
@@ -761,9 +785,11 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual(gesture._HAND_WITHDRAWN, handshake[-1]["target_positions"])
 
         result = gesture.dispatch("play", {
-            "name": "wave_hands", "wait": True, "reset_after": False, "force": True,
+            "name": "wave_hands", "reset_after": False, "force": True,
         })
-        self.assertEqual("completed", result["state"])
+        self.assertEqual("running", result["state"])
+        gesture._thread.join(timeout=1.0)
+        self.assertEqual("completed", gesture.dispatch("status", {})["state"])
         self.assertEqual(8, len([item for item in waits if item[0] == "request"]))
         self.assertEqual(gesture._NEUTRAL, plan._publisher.messages[-1].target_positions)
 

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -565,6 +565,31 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual([12, 23], sent.joint_indices)
         self.assertEqual([0.1, -0.2], sent.target_positions)
 
+    def test_joint_plan_rejects_urdf_limit_violations_on_every_plan_facade(self):
+        plugin = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plugin.start()
+        unsafe_calls = [
+            ("plan", {"joint_indices": [16], "target_positions": [-3.0]}),
+            ("plan_named", {
+                "joint_names": ["J16_ELBOW_PITCH_L"],
+                "target_positions": [-3.0],
+            }),
+            ("head_pose", {"pitch_rad": 1.0, "yaw_rad": 0.0}),
+            ("arm_pose", {
+                "side": "left",
+                "target_positions": [0.0, 0.0, 0.0, -3.0, 0.0],
+            }),
+        ]
+        for action, arguments in unsafe_calls:
+            with self.subTest(action=action):
+                with self.assertRaisesRegex(ValueError, "safe position limit"):
+                    plugin.dispatch(action, arguments)
+
+        self.state._last_joint_positions[16] = -3.0
+        with self.assertRaisesRegex(ValueError, "safe position limit"):
+            plugin.dispatch("hold_current", {})
+        self.assertEqual([], plugin._publisher.messages)
+
     def test_joint_plan_named_head_arm_and_hold_actions(self):
         plugin = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plugin.start()
@@ -609,6 +634,17 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertGreaterEqual(schema["x-completion"]["timeout"], 60)
         actions = set(schema["properties"]["action"]["enum"])
         self.assertTrue({"start", "info", "stop"}.issubset(actions))
+        action_params = schema["x-action-params"]
+        self.assertEqual(
+            ["name", "repetitions", "reset_after", "force"],
+            action_params["play"]["params"],
+        )
+        self.assertEqual(
+            ["steps", "reset_after", "force"],
+            action_params["sequence"]["params"],
+        )
+        self.assertEqual(["reset_after"], action_params["stop"]["params"])
+        self.assertEqual(["reset_after"], action_params["stop_gesture"]["params"])
         self.assertNotIn("wait", schema["properties"])
         self.assertEqual(gesture._MAX_SEQUENCE_STEPS, schema["properties"]["steps"]["maxItems"])
         rejected = gesture.dispatch("sequence", {

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1,10 +1,13 @@
 import importlib.util
+import json
+import os
 import struct
 import sys
 import threading
 import time
 import types
 import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 
@@ -594,6 +597,151 @@ class DevicePluginContractTests(unittest.TestCase):
         })
         self.assertEqual("completed", result["state"])
         self.assertEqual([23, 24], plan._publisher.messages[-1].joint_indices)
+
+    def test_gesture_declares_async_completion_and_lifecycle_actions(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        gesture = self.device.GesturePlugin(plan)
+        schema = gesture.get_tool()["inputSchema"]
+        self.assertEqual(["play", "sequence"], schema["x-completion"]["actions"])
+        self.assertGreaterEqual(schema["x-completion"]["timeout"], 60)
+        actions = set(schema["properties"]["action"]["enum"])
+        self.assertTrue({"start", "info", "stop"}.issubset(actions))
+
+    def test_gesture_async_acp_uses_real_planner_state_transitions(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        gesture = self.device.GesturePlugin(plan)
+        completions = []
+        gesture._acp_notify = lambda action_id, status, result: completions.append(
+            (action_id, status, result)
+        )
+
+        result = gesture.dispatch("sequence", {
+            "steps": [{"joint_indices": [23], "target_positions": [0.1], "duration": 0.05}],
+            "reset_after": False,
+            "wait": False,
+            "force": True,
+        })
+        self.assertEqual("running", result["state"])
+        self.assertTrue(result["action_id"].startswith("t800_gesture_"))
+
+        deadline = time.monotonic() + 1.0
+        while not plan._publisher.messages and time.monotonic() < deadline:
+            time.sleep(0.005)
+        self.assertTrue(plan._publisher.messages)
+        request_id = plan._publisher.messages[-1].request_id
+        plan._on_state(JointMotionPlanState(request_id, JointMotionPlanState.EXECUTING, 0.5))
+        plan._on_state(JointMotionPlanState(request_id, JointMotionPlanState.IDLE, 1.0))
+        gesture._thread.join(timeout=1.0)
+
+        self.assertFalse(gesture._thread.is_alive())
+        self.assertEqual("completed", gesture.dispatch("status", {})["state"])
+        self.assertEqual(result["action_id"], completions[0][0])
+        self.assertEqual("completed", completions[0][1])
+        self.assertEqual(request_id, completions[0][2]["request_id"])
+
+    def test_gesture_stop_preserves_cancelled_and_reports_acp(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        entered_wait = threading.Event()
+        release_wait = threading.Event()
+        plan.wait_until_idle = lambda *_args, **_kwargs: {}
+
+        def wait_for_request(*_args, **_kwargs):
+            entered_wait.set()
+            release_wait.wait(timeout=1.0)
+            return {}
+
+        plan.wait_for_request = wait_for_request
+        gesture = self.device.GesturePlugin(plan)
+        completions = []
+        gesture._acp_notify = lambda action_id, status, result: completions.append(
+            (action_id, status, result)
+        )
+        result = gesture.dispatch("sequence", {
+            "steps": [{"joint_indices": [23], "target_positions": [0.1], "duration": 0.05}],
+            "reset_after": False,
+            "wait": False,
+            "force": True,
+        })
+        self.assertTrue(entered_wait.wait(timeout=1.0))
+        busy = gesture.dispatch("sequence", {
+            "steps": [{"joint_indices": [23], "target_positions": [0.0]}],
+            "wait": False,
+            "force": True,
+        })
+        self.assertIn("already running", busy["error"])
+        self.assertNotIn("action_id", busy)
+        stopped = gesture.dispatch("stop_gesture", {})
+        self.assertEqual("cancelled", stopped["state"])
+        release_wait.set()
+        gesture._thread.join(timeout=1.0)
+
+        self.assertEqual("cancelled", gesture.dispatch("status", {})["state"])
+        self.assertEqual(result["action_id"], completions[0][0])
+        self.assertEqual("cancelled", completions[0][1])
+        self.assertEqual({"state": "idle"}, gesture.dispatch("stop", {}))
+
+    def test_gesture_async_error_reports_acp(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        plan.wait_until_idle = lambda *_args, **_kwargs: {}
+        plan.wait_for_request = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("planner failed")
+        )
+        gesture = self.device.GesturePlugin(plan)
+        completions = []
+        gesture._acp_notify = lambda action_id, status, result: completions.append(
+            (action_id, status, result)
+        )
+        result = gesture.dispatch("sequence", {
+            "steps": [{"joint_indices": [23], "target_positions": [0.1], "duration": 0.05}],
+            "reset_after": False,
+            "wait": False,
+            "force": True,
+        })
+        gesture._thread.join(timeout=1.0)
+
+        self.assertEqual(result["action_id"], completions[0][0])
+        self.assertEqual("error", completions[0][1])
+        self.assertIn("planner failed", completions[0][2]["error"])
+
+    def test_gesture_acp_notify_posts_completion_payload(self):
+        received = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", "0"))
+                received.append((self.path, json.loads(self.rfile.read(length))))
+                self.send_response(204)
+                self.end_headers()
+
+            def log_message(self, _format, *_args):
+                pass
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        previous = os.environ.get("AGENT_CORE_URL")
+        os.environ["AGENT_CORE_URL"] = f"http://127.0.0.1:{server.server_port}"
+        try:
+            self.device.GesturePlugin._acp_notify(
+                "t800_gesture_test", "completed", {"gesture": "wave_hands"}
+            )
+        finally:
+            if previous is None:
+                os.environ.pop("AGENT_CORE_URL", None)
+            else:
+                os.environ["AGENT_CORE_URL"] = previous
+            server.shutdown()
+            server.server_close()
+
+        self.assertEqual("/api/acp/complete", received[0][0])
+        payload = received[0][1]
+        self.assertEqual("t800_gesture_test", payload["action_id"])
+        self.assertEqual("completed", payload["status"])
+        self.assertEqual("gesture", payload["tool"])
+        self.assertEqual("wave_hands", payload["result"]["gesture"])
 
     def test_gesture_uses_validated_real_device_trajectories(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1,6 +1,7 @@
 import importlib.util
 import struct
 import sys
+import threading
 import time
 import types
 import unittest
@@ -20,6 +21,19 @@ class JointMotionPlanRequest(Message):
     REQUEST_PLAN_EXECUTE = 0
     REQUEST_CANCEL = 1
     REQUEST_RESET = 2
+
+
+class JointMotionPlanState(Message):
+    STATUS_DISABLED = 0
+    IDLE = 1
+    EXECUTING = 2
+    EXITING = 3
+
+    def __init__(self, request_id=0, status=STATUS_DISABLED, progress=0.0):
+        super().__init__()
+        self.request_id = request_id
+        self.status = status
+        self.progress = progress
 
 
 class EnableMotor:
@@ -153,12 +167,13 @@ def install_ros_stubs():
 
     protocol_msg = types.ModuleType("interface_protocol.msg")
     for name in (
-        "BodyVelCmd", "GamepadKeys", "ImuInfo", "JointCommand", "JointMotionPlanState",
+        "BodyVelCmd", "GamepadKeys", "ImuInfo", "JointCommand",
         "JointOverrideCommand", "JointState", "LedControl", "MotionState", "MotionStateRequest",
         "Heartbeat", "LinkInfo", "MotorDebug", "NodeControl", "PowerInfo", "Tts",
     ):
         setattr(protocol_msg, name, type(name, (Message,), {}))
     protocol_msg.JointMotionPlanRequest = JointMotionPlanRequest
+    protocol_msg.JointMotionPlanState = JointMotionPlanState
     protocol_srv = types.ModuleType("interface_protocol.srv")
     protocol_srv.EnableMotor = EnableMotor
     protocol = types.ModuleType("interface_protocol")
@@ -565,17 +580,73 @@ class DevicePluginContractTests(unittest.TestCase):
     def test_gesture_exposes_complete_official_sequences_and_custom_queue(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
+        plan.wait_until_idle = lambda *_args, **_kwargs: {}
+        plan.wait_for_request = lambda *_args, **_kwargs: {}
         gesture = self.device.GesturePlugin(plan)
         listed = {item["name"]: item["steps"] for item in gesture.dispatch("list", {})["gestures"]}
-        self.assertEqual(7, listed["wave_hands"])
+        self.assertEqual(8, listed["wave_hands"])
         self.assertEqual(2, listed["shake_hand"])
         result = gesture.dispatch("sequence", {
             "steps": [{"joint_indices": [23, 24], "target_positions": [0.1, -0.1], "duration": 0.05}],
             "reset_after": False,
             "wait": True,
+            "force": True,
         })
         self.assertEqual("completed", result["state"])
         self.assertEqual([23, 24], plan._publisher.messages[-1].joint_indices)
+
+    def test_gesture_uses_validated_real_device_trajectories(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        waits = []
+        plan.wait_until_idle = lambda *_args, **kwargs: waits.append(("idle", kwargs)) or {}
+        plan.wait_for_request = lambda request_id, *_args: waits.append(("request", request_id)) or {}
+        gesture = self.device.GesturePlugin(plan)
+
+        wave = gesture._prepare_steps(gesture._official_steps("wave_hands"))
+        self.assertEqual("return_to_neutral", wave[-1]["name"])
+        self.assertEqual(gesture._NEUTRAL, wave[-1]["target_positions"])
+        self.assertTrue(all(not step["stiffness"] for step in wave))
+
+        handshake = gesture._prepare_steps(gesture._official_steps("shake_hand"))
+        self.assertEqual(2.0, handshake[0]["hold_after_sec"])
+        self.assertEqual(gesture._HAND_WITHDRAWN, handshake[-1]["target_positions"])
+
+        result = gesture.dispatch("play", {
+            "name": "wave_hands", "wait": True, "reset_after": False, "force": True,
+        })
+        self.assertEqual("completed", result["state"])
+        self.assertEqual(8, len([item for item in waits if item[0] == "request"]))
+        self.assertEqual(gesture._NEUTRAL, plan._publisher.messages[-1].target_positions)
+
+    def test_gesture_rejects_unsafe_state_repetition_and_joint_target(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        gesture = self.device.GesturePlugin(plan)
+        self.assertIn(
+            "lower_body_balance",
+            gesture.dispatch("play", {"name": "wave_hands"})["error"],
+        )
+        self.assertIn(
+            "thermal safety",
+            gesture.dispatch("play", {
+                "name": "wave_hands", "repetitions": 2, "force": True,
+            })["error"],
+        )
+        result = gesture.dispatch("sequence", {
+            "steps": [{"joint_indices": [16], "target_positions": [-2.28]}],
+            "force": True,
+        })
+        self.assertIn("safe position limit", result["error"])
+
+    def test_joint_plan_waits_for_exact_executing_then_idle_request(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        plan._on_state(JointMotionPlanState(7, JointMotionPlanState.EXECUTING, 0.5))
+        plan._on_state(JointMotionPlanState(7, JointMotionPlanState.IDLE, 1.0))
+        state = plan.wait_for_request(7, 0.1, threading.Event())
+        self.assertEqual(7, state["request_id"])
+        self.assertEqual(JointMotionPlanState.IDLE, state["status"])
 
     def test_joint_override_force_path_and_release(self):
         plugin = self.device.JointOverridePlugin(CONFIG, "robot", self.ros, self.state)


### PR DESCRIPTION
## 功能说明

该 PR 优化了 EngineAI T800 的 `gesture` Actuator 卡片，将实机验证过的挥手和握手轨迹集成到标准 T800 Driver 中。手势可以直接通过卡片或 MCP 调用执行。

主要功能包括：

- 修改 `wave_hands` 挥手动作。
- 修改`shake_hand` 握手动作。
- 挥手完成后增加明确的回原位步骤，使手臂平稳放下，避免折叠悬停在空中。
- 握手时伸出右手并保持约 2 秒，然后自动收回。
- 每个动作步骤都会等待关节规划器实际进入执行状态并返回空闲状态，再继续下一步，避免连续下发导致动作重叠。
- 根据 T800 URDF 对关节目标位置进行校验，并保留安全限位余量，超出安全范围的动作会在发布前被拒绝。
- 默认要求机器人处于 `lower_body_balance` 下肢平衡状态，避免在不稳定姿态下执行上肢手势。
- 内置手势每次只允许执行一次，并在完成后进入短暂冷却，降低连续高负载动作引起电机过热的风险。
- 动作执行超时、被其他规划请求覆盖或主动停止时，会取消当前关节规划。
- 自定义 `sequence` 动作同样支持关节限位校验、规划器状态同步和停止控制。

## 内置手势

### `wave_hands`

挥手动作包含抬手、往复摆动和回原位过程。最后通过独立的 `return_to_neutral` 步骤，用约 2 秒将手臂平稳放回初始上肢姿态。

### `shake_hand`

握手动作先伸出右手，到达目标姿态后保持约 2 秒，再执行收手动作并回到自然姿态。

## 安全机制

- 执行动作前检查 `lower_body_balance` 状态。
- 按 T800 URDF 硬限位校验所有目标关节位置。
- 在硬限位基础上保留 `0.02 rad` 安全余量。
- 限制内置手势单次执行次数。
- 手势完成后设置 3 秒冷却时间。
- 每一步均与 `/motion/joint_motion_plan/state` 状态同步。
- 规划超时或状态异常时停止后续动作并取消当前请求。
- 软件停止之外，实机测试仍需由现场人员持有急停遥控器。

## 使用方式

通过 `gesture` 卡片调用：

- `list`：查看可用手势及安全信息。
- `play`：执行 `wave_hands` 或 `shake_hand`。
- `sequence`：执行经过安全校验的自定义关节动作序列。
- `status`：查询当前步骤、规划请求和执行状态。
- `stop_gesture`：取消当前手势动作。

## 测试结果

已完成关节限位、URDF 一致性、动作轨迹、回原位、握手保持、规划器状态同步、重复执行限制及卡片契约测试。相关回归测试共 30 项，全部通过。