### PR TITLE
fix(t800): correct motion_events action for stand/sit/kneel/punch

### DIFF
--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -108,6 +108,10 @@ _GAMEPAD_ACTIONS = {
     frozenset({"RB", "B"}): "dance",
     frozenset({"START", "CROSS_X_UP"}): "get_up",
     frozenset({"START", "CROSS_X_DOWN"}): "lie_down",
+    # Boxing punches (T800 keeps the same motion state during punches, so the
+    # action is derived from the gamepad combo only).
+    frozenset({"A", "CROSS_Y_RIGHT"}): "left_straight",
+    frozenset({"A", "CROSS_Y_LEFT"}): "right_straight",
 }
 
 
@@ -138,26 +142,87 @@ def _motion_direction(stick_x: float, stick_y: float, yaw_x: float = 0.0) -> str
     return "_".join(parts) if parts else "none"
 
 
+_SPEED_STALE_SECONDS = 0.5
+
+# T800 reports motion transitions as ``<source>_to_<target>`` (or
+# ``rl_mimic_<source>_to_<target>``). Resolve them to the stable *target* action
+# so the canvas sees a clean stand<->sit switch instead of a transient
+# intermediate state (e.g. ``rl_mimic_stance_to_sitdown`` -> sit,
+# ``rl_mimic_sitdown_to_stance`` -> stand).
+_TRANSITION_TARGETS = (
+    ("rl_mimic_stance_to_sitdown", "sit"),
+    ("stance_to_sitdown", "sit"),
+    ("rl_mimic_sitdown_to_stance", "stand"),
+    ("sitdown_to_stance", "stand"),
+    ("rl_mimic_supine_to_stance", "get_up"),
+    ("rl_mimic_prone_to_stance", "get_up"),
+    ("supine_to_stance", "get_up"),
+    ("prone_to_stance", "get_up"),
+    ("rl_mimic_stance_to_supine", "lie_down"),
+    ("stance_to_supine", "lie_down"),
+    ("rl_mimic_stance_to_kneeling", "kneel"),
+    ("rl_mimic_kneeling_to_stance", "stand"),
+)
+
+_MOTION_ALIASES = (
+    ("punch", ("punch", "boxing", "box", "fight", "fist", "打拳")),
+    ("dance", ("dance",)),
+    ("get_up", ("get_up", "getup", "supine_to_stance", "prone_to_stance")),
+    ("lie_down", ("lie_down", "liedown", "supine", "stance_to_supine")),
+    ("sit", ("sit_down", "sitdown", "sit", "sitting", "seated", "seat", "squat")),
+    ("kneel", ("kneel", "kneeling", "knee", "跪")),
+    ("walk", ("walk", "loco", "rl_basic", "rl_terrain", "lower_body_balance", "walk_server")),
+    ("stand", ("stand", "pd_stand", "stance")),
+    ("idle", ("idle",)),
+    ("passive", ("passive", "damping")),
+)
+
+
+def _transition_target_action(name: str) -> str | None:
+    """Resolve a T800 ``*_to_*`` transition state to its stable target action."""
+    lowered = str(name or "").strip().lower()
+    if not lowered:
+        return None
+    for exact, action in _TRANSITION_TARGETS:
+        if lowered == exact:
+            return action
+    marker = "_to_"
+    if marker not in lowered:
+        return None
+    target = lowered.rsplit(marker, 1)[-1]
+    for normalized, tokens in _MOTION_ALIASES:
+        if any(token in target for token in tokens):
+            return normalized
+    return None
+
+
 def _normalize_motion_action(name: str) -> str:
     value = str(name or "").strip()
     lowered = value.lower()
     if not lowered or lowered == "unknown":
         return "unknown"
-    aliases = (
-        ("stand", ("stand", "pd_stand", "stance")),
-        ("sit", ("sit", "sitting", "seated", "seat", "squat")),
-        ("punch", ("punch", "boxing", "box", "fight", "fist", "打拳")),
-        ("dance", ("dance",)),
-        ("walk", ("walk", "loco")),
-        ("get_up", ("get_up", "getup")),
-        ("lie_down", ("lie_down", "liedown", "supine")),
-        ("idle", ("idle",)),
-        ("passive", ("passive", "damping")),
-    )
-    for normalized, tokens in aliases:
+    transition = _transition_target_action(lowered)
+    if transition:
+        return transition
+    # Match the more specific transition/screen states before broad terms such
+    # as "stance"; otherwise names like stance_to_sitdown are misclassified as
+    # stand on the canvas.
+    for normalized, tokens in _MOTION_ALIASES:
         if any(token in lowered for token in tokens):
             return normalized
     return value
+
+
+def _display_motion_action(name: str, *, moving: bool = False) -> str:
+    action = _normalize_motion_action(name)
+    # Any locomotion-capable state (rl_basic / walk_server / lower_body_balance /
+    # walk / loco / rl_terrain) describes a walking-ready pose: show "move" only
+    # while the robot is actually moving, otherwise "stand". ``moving`` must be
+    # freshness-aware so a stale speed sample never reports a stationary robot
+    # as walking.
+    if action == "walk":
+        return "move" if moving else "stand"
+    return action
 
 
 def _json_message(payload: dict) -> String:
@@ -1206,6 +1271,20 @@ class MotionEventsPlugin:
         max_vy = abs(float(control.get("max_vy", 1.0)))
         return max(1.0, math.hypot(max_vx, max_vy) * 1.5)
 
+    def _freshly_moving(self, now: float | None = None) -> bool:
+        """Whether the robot is currently moving based on a fresh speed sample.
+
+        ``_moving`` is only reset when a new sample arrives, so it can stay True
+        if the gamepad/odometry topic stops publishing. Requiring the latest
+        sample to be recent keeps a stationary robot from being reported as
+        moving (e.g. standing still in a walking-ready state).
+        """
+        now = time.monotonic() if now is None else now
+        updated = self._latest_speed_updated
+        if updated is None:
+            return False
+        return self._moving and (now - updated) <= _SPEED_STALE_SECONDS
+
     def _classify_gamepad_action(self, buttons: list[str], speed: float) -> str:
         button_set = frozenset(buttons)
         if button_set in _GAMEPAD_ACTIONS:
@@ -1384,14 +1463,21 @@ class MotionEventsPlugin:
 
     def _on_motion_state(self, msg) -> None:
         current = str(getattr(msg, "current_motion_task", "") or "unknown")
-        action = _normalize_motion_action(current)
         with self._lock:
             previous = self._current_motion_state
             self._last_motion_state = previous
             self._current_motion_state = current
-            self._latest_action = action
-            self._latest_control_source = "motion_state"
-            self._latest_direction = "none"
+            action = self._latest_action
+            # Refresh the displayed action only when the state actually changes.
+            # A periodic re-publish of the same state must not override a fresher
+            # gamepad action (e.g. a punch button mapped to left_straight while
+            # the robot stays in the boxing motion state).
+            if current != previous:
+                moving = self._freshly_moving()
+                action = _display_motion_action(current, moving=moving)
+                self._latest_action = action
+                self._latest_control_source = "motion_state"
+                self._latest_direction = "none"
         if current and current != "unknown" and current != previous:
             self.record_event(
                 source_tool="motion_state",
@@ -1520,22 +1606,27 @@ class MotionEventsPlugin:
             latest_action = self._latest_action
             latest_buttons = list(self._latest_buttons)
             latest_control_source = self._latest_control_source
-            latest_direction = self._latest_direction
             current_motion_state = self._current_motion_state
         speed_age = None if latest_speed_updated is None else max(0.0, now - latest_speed_updated)
+        fresh_moving = (
+            moving
+            and speed_age is not None
+            and speed_age <= _SPEED_STALE_SECONDS
+        )
         display_action = latest_action
         display_control_source = latest_control_source
         if display_action == "none" and current_motion_state not in ("", "unknown"):
-            display_action = _normalize_motion_action(current_motion_state)
+            display_action = _display_motion_action(current_motion_state, moving=fresh_moving)
             display_control_source = "motion_state"
+        if display_action == "walk" and not fresh_moving:
+            display_action = "stand"
         return {
             "state": "running" if latest_event or latest_speed_updated is not None else "no_data",
-            "motion_state": "moving" if moving else "stopped",
+            "motion_state": "moving" if fresh_moving else "stopped",
             "speed": f"{round(latest_speed, 2):.2f} m/s",
             "speed_source": latest_speed_source,
             "control_source": display_control_source,
             "action": display_action,
-            "direction": latest_direction,
             "buttons": latest_buttons,
             "current_motion_state": current_motion_state,
             "event": None if latest_event is None else latest_event.get("type"),

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -399,7 +399,7 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual("gamepad", moving["speed_source"])
         self.assertEqual("gamepad_analog", moving["control_source"])
         self.assertEqual("move", moving["action"])
-        self.assertEqual("forward", moving["direction"])
+        self.assertNotIn("direction", moving)
         self.assertEqual([], moving["buttons"])
         self.assertEqual("1.50 m/s", moving["speed"])
         self.assertEqual("motion_start", moving["event"])
@@ -427,7 +427,7 @@ class DevicePluginContractTests(unittest.TestCase):
         snapshot = plugin.dispatch("status", {})
         self.assertEqual("stand", snapshot["action"])
         self.assertEqual("gamepad_analog", snapshot["control_source"])
-        self.assertEqual("none", snapshot["direction"])
+        self.assertNotIn("direction", snapshot)
         self.assertEqual(["LB", "A"], snapshot["buttons"])
         self.assertEqual("gamepad_action", snapshot["event"])
 
@@ -442,6 +442,8 @@ class DevicePluginContractTests(unittest.TestCase):
         plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
         for raw, action in (
             ("sit_down", "sit"),
+            ("stance_to_sitdown", "sit"),
+            ("kneeling_pose", "kneel"),
             ("boxing_combo", "punch"),
             ("screen_punch", "punch"),
         ):
@@ -487,6 +489,134 @@ class DevicePluginContractTests(unittest.TestCase):
         snapshot = plugin.dispatch("status", {})
         self.assertEqual("stand", snapshot["action"])
         self.assertEqual(["LB", "A"], snapshot["buttons"])
+
+    def test_motion_events_show_rl_basic_as_stand_when_stationary(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        plugin._on_motion_state(types.SimpleNamespace(current_motion_task="rl_basic"))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("rl_basic", snapshot["current_motion_state"])
+        self.assertEqual("stand", snapshot["action"])
+        self.assertEqual("stopped", snapshot["motion_state"])
+
+    def test_motion_events_locomotion_states_show_stand_when_stationary(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        for raw in ("walk", "walk_server", "lower_body_balance", "loco", "rl_terrain"):
+            with self.subTest(raw=raw):
+                plugin._on_motion_state(types.SimpleNamespace(current_motion_task=raw))
+                snapshot = plugin.dispatch("status", {})
+                self.assertEqual(raw, snapshot["current_motion_state"])
+                self.assertEqual("stand", snapshot["action"])
+                self.assertEqual("stopped", snapshot["motion_state"])
+
+    def test_motion_events_locomotion_state_shows_move_while_gamepad_moving(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        plugin._on_gamepad(types.SimpleNamespace(
+            hardware_connected=True,
+            digital_states=[0] * 12,
+            analog_states=[0.0, 0.0, 0.0, 0.5, 0.0, 0.0],
+        ))
+        plugin._on_motion_state(types.SimpleNamespace(current_motion_task="rl_basic"))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("move", snapshot["action"])
+        self.assertEqual("moving", snapshot["motion_state"])
+
+    def test_motion_events_stale_speed_treated_as_stationary(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        plugin._on_gamepad(types.SimpleNamespace(
+            hardware_connected=True,
+            digital_states=[0] * 12,
+            analog_states=[0.0, 0.0, 0.0, 0.5, 0.0, 0.0],
+        ))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("move", snapshot["action"])
+        self.assertEqual("moving", snapshot["motion_state"])
+        # If the gamepad/odometry topic stops publishing, the latest speed sample
+        # becomes stale and a stationary robot must not keep showing as moving.
+        with plugin._lock:
+            plugin._latest_speed_updated = time.monotonic() - 2.0
+        plugin._on_motion_state(types.SimpleNamespace(current_motion_task="walk_server"))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("stand", snapshot["action"])
+        self.assertEqual("stopped", snapshot["motion_state"])
+
+    def test_motion_events_transitions_map_to_target(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        for raw, action in (
+            ("rl_mimic_stance_to_sitdown", "sit"),
+            ("stance_to_sitdown", "sit"),
+            ("rl_mimic_sitdown_to_stance", "stand"),
+            ("sitdown_to_stance", "stand"),
+            ("supine_to_stance", "get_up"),
+            ("rl_mimic_prone_to_stance", "get_up"),
+            ("rl_mimic_stance_to_supine", "lie_down"),
+            ("rl_mimic_stance_to_kneeling", "kneel"),
+            ("rl_mimic_kneeling_to_stance", "stand"),
+        ):
+            with self.subTest(raw=raw):
+                plugin._on_motion_state(types.SimpleNamespace(current_motion_task=raw))
+                snapshot = plugin.dispatch("status", {})
+                self.assertEqual(raw, snapshot["current_motion_state"])
+                self.assertEqual(action, snapshot["action"])
+                self.assertEqual("motion_state", snapshot["control_source"])
+                self.assertEqual("motion_state_changed", snapshot["event"])
+
+    def test_motion_events_punch_buttons_map_to_punch_names(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        # 左直拳 A + CROSS_Y_RIGHT
+        left = [0] * 12
+        left[2] = 1  # A
+        left[11] = 1  # CROSS_Y_RIGHT
+        plugin._on_gamepad(types.SimpleNamespace(
+            hardware_connected=True,
+            digital_states=left,
+            analog_states=[0.0] * 6,
+        ))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("left_straight", snapshot["action"])
+        self.assertEqual("gamepad_analog", snapshot["control_source"])
+        self.assertEqual(["A", "CROSS_Y_RIGHT"], snapshot["buttons"])
+
+        # 右直拳 A + CROSS_Y_LEFT
+        right = [0] * 12
+        right[2] = 1  # A
+        right[10] = 1  # CROSS_Y_LEFT
+        plugin._on_gamepad(types.SimpleNamespace(
+            hardware_connected=True,
+            digital_states=right,
+            analog_states=[0.0] * 6,
+        ))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("right_straight", snapshot["action"])
+        self.assertEqual(["A", "CROSS_Y_LEFT"], snapshot["buttons"])
+
+    def test_motion_events_punch_action_survives_same_motion_state_republish(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        # Enter the boxing motion state, then throw a left straight punch.
+        plugin._on_motion_state(types.SimpleNamespace(current_motion_task="rl_mimic_boxing"))
+        left = [0] * 12
+        left[2] = 1  # A
+        left[11] = 1  # CROSS_Y_RIGHT
+        plugin._on_gamepad(types.SimpleNamespace(
+            hardware_connected=True,
+            digital_states=left,
+            analog_states=[0.0] * 6,
+        ))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("left_straight", snapshot["action"])
+        # T800 keeps the same current_motion_task while punching; re-publishing the
+        # same boxing state must not override the fresher gamepad action.
+        plugin._on_motion_state(types.SimpleNamespace(current_motion_task="rl_mimic_boxing"))
+        plugin._on_motion_state(types.SimpleNamespace(current_motion_task="rl_mimic_boxing"))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("left_straight", snapshot["action"])
+        # Releasing the buttons falls back to the boxing motion state action.
+        plugin._on_gamepad(types.SimpleNamespace(
+            hardware_connected=True,
+            digital_states=[0] * 12,
+            analog_states=[0.0] * 6,
+        ))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("punch", snapshot["action"])
 
     def test_derived_diagnostics_and_capability_resources(self):
         self.state._set("imu", {


### PR DESCRIPTION
## Summary

Fix the T800 `motion_events` card action display based on real-machine testing feedback:

- **站立不动显示 walk → 应为 stand**：行走类状态（`rl_basic` / `walk_server` / `lower_body_balance` / `walk` / `loco` / `rl_terrain`）在静止时显示 `stand`，仅在真正移动时显示 `move`。移动判定基于新鲜速度样本（0.5s 内），避免速度话题停止发布后仍显示 moving。
- **坐下过程显示 stand → 直接 stand↔sit 切换**：过渡状态映射到目标动作（`rl_mimic_stance_to_sitdown`→`sit`，`rl_mimic_sitdown_to_stance`→`stand`），画布不再出现中间状态。
- **跪姿**：`START+B`（`rl_mimic_stance_to_kneeling`）→`kneel`，`START+Y`（`rl_mimic_kneeling_to_stance`）→`stand`。
- **出拳 action 显示按键名 → 显示拳名**：`A+CROSS_Y_RIGHT`→`left_straight`（左直拳），`A+CROSS_Y_LEFT`→`right_straight`（右直拳）；T800 出拳时 `current_motion_task` 不变，同一状态重复发布不再覆盖出拳动作。
- 从 `_summary_snapshot` 移除 `direction` 字段（画布默认字段已精简）。

## Real Machine Verification ✅ (2026-08-18)

- 部署：T800 应用单元 `10.110.10.96`，镜像 `release.260818.cd44dfe`（由本 PR 源码构建，SHA `046a3066`）
- 容器：`embodied-engineai-t800`，`/health` running，43 tools / 0 startup errors
- 真机复测全部通过：
  - 站立不动 → `action=stand`（`current_motion_state=rl_basic` 时）✅
  - 坐下 → 直接 `action=sit`（无中间 `stand`）✅
  - 跪姿 `START+B` → `kneel`；站起 `START+Y` → `stand` ✅
  - 出拳 `A+CROSS_Y_RIGHT` → `left_straight`；`A+CROSS_Y_LEFT` → `right_straight` ✅
  - 摇杆移动 → `move`，松杆静止 → `stand` ✅

## Duplicate Check

- Feishu: 待核对（依据真机测试反馈修复）
- Internal task workbench: `motion_events` 为已有卡片（内网任务 #123）
- GitHub main: `motion_events` 已在 main（PR #157 合并），本 PR 为其修复
- GitHub open PR: 无重复

## Interface

- topic: `/motion/motion_state`、`/hardware/gamepad_keys`（不变）
- message: `MotionState` / `GamepadKeys`（不变）
- 变更点: `motion_events` status 输出的 `action` 语义
- side effects: 无（只读状态卡片）

## Validation

- py_compile: OK
- unittest: `engineai/t800/tests/test_device_contract.py` 47 个用例全部通过
- git diff --check: OK
- Docker image: `release.260818.cd44dfe`
- Test container: `embodied-engineai-t800`（生产容器直接替换）
- MCP tools/list: 43 tools，`motion_events` 在列
- MCP call: `motion_events status` 正常返回
- Real T800 observation: **已真机复测通过**

## Safety

- Safety level: S0（只读状态卡片，不产生硬件动作）
- Motion involved: no
- Manual emergency stop available: not applicable
