### PR TITLE
feat(t800): 增加里程计行程统计与轨迹朝向可视化

### DIFF
--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -24,7 +24,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_command_feedback` | sensor | Native SDK 最近关节控制命令反馈 |
 | `gamepad` | sensor | 遥控器连接、按键和摇杆状态 |
 | `motion_state` | sensor | 当前 Native SDK motion state 和允许转换 |
-| `odometer` | sensor | Odin2 位置、航向、速度、累计/单次里程、静止时长及断流/跳变诊断 |
+| `odometer` | sensor | Odin2 位置、航向、速度、累计/单次里程，以及运动轨迹和朝向鸟瞰画面 |
 | `driver_health` | sensor | 各 ROS2 数据源连接与新鲜度 |
 | `robot_snapshot` | sensor | 运动、关节、IMU、电源和电机健康聚合快照 |
 | `fault_summary` | sensor | 电机掉线/禁用/错误/过温及电源错误摘要 |
@@ -61,6 +61,10 @@ MCP schema 中隐藏。
 基础运动协议没有供控制闭环使用的定位反馈，因此它们仍是开环动作并返回
 `open_loop: true`。若 Odin2 固件提供配置中的 odometry topic，
 `motion_command_trace` 会把它用于状态显示，但不会据此闭环控制动作。
+
+`odometer` 同时发布 `data/json` 状态面板和 `sensor/mapping` 鸟瞰画面。画面以
+当前单次行程起点为原点，显示运动轨迹、当前位置和朝向箭头；`reset_trip` 会
+清零单次里程并清空画面轨迹，但不会修改 Odin2 原始坐标或累计总里程。
 
 `gesture.play` 与旧的 `joint_plan.preset` 不同：前者执行官方示例里的完整多步
 动作（挥手包含准备、举手、5 次摆动和复位；握手包含伸手、收手和复位），

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -24,6 +24,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_command_feedback` | sensor | Native SDK 最近关节控制命令反馈 |
 | `gamepad` | sensor | 遥控器连接、按键和摇杆状态 |
 | `motion_state` | sensor | 当前 Native SDK motion state 和允许转换 |
+| `odometer` | sensor | Odin2 位置、航向、速度、累计/单次里程、静止时长及断流/跳变诊断 |
 | `driver_health` | sensor | 各 ROS2 数据源连接与新鲜度 |
 | `robot_snapshot` | sensor | 运动、关节、IMU、电源和电机健康聚合快照 |
 | `fault_summary` | sensor | 电机掉线/禁用/错误/过温及电源错误摘要 |

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -72,6 +72,9 @@ plugins:
     stationary_enter_m_s: 0.03
     stationary_exit_m_s: 0.05
     jump_tolerance_m: 0.25
+    trajectory_spacing_m: 0.025
+    trajectory_max_points: 4000
+    trajectory_view_extent_m: 5.0
   native_interface_probe:
     enabled: true
   locomotion:

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -66,6 +66,12 @@ plugins:
     enabled: true
   motion_command_trace:
     enabled: true
+  odometer:
+    enabled: true
+    publish_rate_hz: 5.0
+    stationary_enter_m_s: 0.03
+    stationary_exit_m_s: 0.05
+    jump_tolerance_m: 0.25
   native_interface_probe:
     enabled: true
   locomotion:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -13,9 +13,11 @@ import math
 import numbers
 import os
 import sqlite3
+import struct
 import subprocess
 import threading
 import time
+from array import array
 from collections import deque
 from dataclasses import asdict
 from pathlib import Path
@@ -23,7 +25,7 @@ from pathlib import Path
 import numpy as np
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
-from std_msgs.msg import String
+from std_msgs.msg import String, UInt8MultiArray
 
 # Open3D is optional; fall back to numpy-only PCD writing when unavailable.
 try:
@@ -1189,6 +1191,7 @@ class OdometerPlugin:
         self._config = config
         self._ns = namespace
         self._topic = f"/{namespace}/state/odometer"
+        self._visual_topic = f"/{namespace}/state/odometer/trajectory"
         plugin_config = config.get("plugins", {}).get("odometer", {})
         self._timeout = max(
             0.1,
@@ -1208,6 +1211,14 @@ class OdometerPlugin:
         self._jump_tolerance = max(
             0.0, float(plugin_config.get("jump_tolerance_m", 0.25))
         )
+        self._trajectory_spacing = max(
+            0.005, float(plugin_config.get("trajectory_spacing_m", 0.025))
+        )
+        trajectory_capacity = int(plugin_config.get("trajectory_max_points", 4000))
+        self._trajectory_capacity = max(50, min(trajectory_capacity, 20000))
+        self._visual_extent = max(
+            2.0, min(float(plugin_config.get("trajectory_view_extent_m", 5.0)), 50.0)
+        )
         self._max_speed = _max_reasonable_odometry_speed(config)
 
         self._node = Node("t800_odometer", context=ros2.ctx_robot)
@@ -1215,6 +1226,9 @@ class OdometerPlugin:
         ros2.executor_robot.add_node(self._node)
         ros2.executor_core.add_node(self._pub_node)
         self._publisher = self._pub_node.create_publisher(String, self._topic, _RELIABLE)
+        self._visual_publisher = self._pub_node.create_publisher(
+            UInt8MultiArray, self._visual_topic, _RELIABLE_ONE
+        )
 
         self._lock = threading.RLock()
         self._latest: dict | None = None
@@ -1231,12 +1245,21 @@ class OdometerPlugin:
         self._timestamp_rejected_count = 0
         self._frame_reset_count = 0
         self._last_rejection: str | None = None
+        self._visual_origin: tuple[float, float] | None = None
+        self._visual_pose: tuple[float, float, float] | None = None
+        self._trajectory = deque(maxlen=self._trajectory_capacity)
+
+    def _topic_out(self) -> list[dict]:
+        return [
+            {"topic": self._topic, "format": "data/json"},
+            {"topic": self._visual_topic, "format": "sensor/mapping"},
+        ]
 
     def get_tool(self) -> dict:
         schema = action_schema(
             _with_lifecycle({
                 "status": ([], "返回最新里程计、行程和数据健康状态"),
-                "reset_trip": ([], "清零 Driver 内部单次行程，不修改 Odin2 坐标系"),
+                "reset_trip": ([], "清零单次行程和画面轨迹，不修改 Odin2 坐标系"),
             }),
             {},
             "里程计传感器动作",
@@ -1248,9 +1271,9 @@ class OdometerPlugin:
             "type": "sensor",
             "multiInstance": False,
             "readOnly": True,
-            "description": "T800 Odin2 位置、航向、速度、累计里程、单次行程与静止状态可视化",
+            "description": "T800 Odin2 里程状态，以及机器人运动轨迹和朝向的鸟瞰可视化",
             "inputSchema": schema,
-            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+            "topic_out": self._topic_out(),
         }
 
     def start(self) -> None:
@@ -1267,12 +1290,20 @@ class OdometerPlugin:
 
     def dispatch(self, action: str, args: dict) -> dict:
         if action == "info":
-            return _with_topic_out(self._snapshot(), self._topic)
+            return {**self._snapshot(), "topic_out": self._topic_out()}
         if action in ("odometer", "status", "start"):
             return self._snapshot()
         if action == "reset_trip":
             with self._lock:
                 self._trip_distance_m = 0.0
+                if self._latest is None:
+                    self._visual_origin = None
+                    self._visual_pose = None
+                    self._trajectory.clear()
+                else:
+                    position = self._latest["position_m"]
+                    yaw = float(self._latest["orientation"]["yaw_rad"])
+                    self._reset_visual_locked(float(position["x"]), float(position["y"]), yaw)
             return {**self._snapshot(), "trip_reset": True}
         if action == "stop":
             return {"state": "idle"}
@@ -1379,6 +1410,14 @@ class OdometerPlugin:
                 "received_at": received_at,
             }
 
+            if baseline_reset or self._visual_origin is None:
+                self._reset_visual_locked(position[0], position[1], yaw)
+            else:
+                relative_x = position[0] - self._visual_origin[0]
+                relative_y = position[1] - self._visual_origin[1]
+                self._visual_pose = (relative_x, relative_y, yaw)
+                self._append_trajectory_locked(relative_x, relative_y, yaw)
+
             if self._stationary is None:
                 self._stationary = speed <= self._stationary_enter
                 self._stationary_since = received_at if self._stationary else None
@@ -1431,6 +1470,8 @@ class OdometerPlugin:
                 "frame_resets": self._frame_reset_count,
             }
             last_rejection = self._last_rejection
+            trajectory_count = len(self._trajectory)
+            visual_pose = self._visual_pose
 
         if latest is None or updated is None:
             return {
@@ -1439,6 +1480,7 @@ class OdometerPlugin:
                 "age_sec": None,
                 "distance_total_m": round(total, 6),
                 "trip_distance_m": round(trip, 6),
+                "trajectory_point_count": trajectory_count,
                 "sample_count": counts,
                 "last_rejection": last_rejection,
                 "timestamp_ms": _now_ms(),
@@ -1456,6 +1498,11 @@ class OdometerPlugin:
             **latest,
             "distance_total_m": round(total, 6),
             "trip_distance_m": round(trip, 6),
+            "trajectory_position_m": None if visual_pose is None else {
+                "x": round(visual_pose[0], 6),
+                "y": round(visual_pose[1], 6),
+            },
+            "trajectory_point_count": trajectory_count,
             "stationary_sec": round(stationary_sec, 3),
             "age_sec": round(age_sec, 3),
             "stale": stale,
@@ -1467,6 +1514,118 @@ class OdometerPlugin:
 
     def _publish(self) -> None:
         self._publisher.publish(_json_message(self._snapshot()))
+        self._publish_visual()
+
+    def _reset_visual_locked(self, x: float, y: float, yaw: float) -> None:
+        self._visual_origin = (x, y)
+        self._visual_pose = (0.0, 0.0, yaw)
+        self._trajectory.clear()
+        self._trajectory.append((0.0, 0.0, yaw))
+
+    def _append_trajectory_locked(self, x: float, y: float, yaw: float) -> None:
+        if not self._trajectory:
+            self._trajectory.append((x, y, yaw))
+            return
+        old_x, old_y, _old_yaw = self._trajectory[-1]
+        distance = math.hypot(x - old_x, y - old_y)
+        if distance < self._trajectory_spacing:
+            return
+        steps = min(
+            self._trajectory_capacity,
+            max(1, int(math.ceil(distance / self._trajectory_spacing))),
+        )
+        for index in range(1, steps + 1):
+            ratio = index / steps
+            self._trajectory.append((
+                old_x + (x - old_x) * ratio,
+                old_y + (y - old_y) * ratio,
+                yaw,
+            ))
+
+    def _visual_reference_points(self) -> list[tuple[float, float, float]]:
+        extent = self._visual_extent
+        step = 0.25
+        count = int((2.0 * extent) / step) + 1
+        points: list[tuple[float, float, float]] = []
+        for index in range(count):
+            value = -extent + index * step
+            points.append((value, 0.0, 0.0))
+            points.append((0.0, value, 0.0))
+            if index % 2 == 0:
+                points.append((value, -extent, -0.02))
+                points.append((value, extent, -0.02))
+                points.append((-extent, value, -0.02))
+                points.append((extent, value, -0.02))
+        return points
+
+    @staticmethod
+    def _heading_arrow_points(x: float, y: float, yaw: float) -> list[tuple[float, float, float]]:
+        points: list[tuple[float, float, float]] = []
+        length = 0.55
+        for index in range(24):
+            distance = length * index / 23.0
+            points.append((
+                x + math.cos(yaw) * distance,
+                y + math.sin(yaw) * distance,
+                0.28,
+            ))
+        tip_x = x + math.cos(yaw) * length
+        tip_y = y + math.sin(yaw) * length
+        for angle in (yaw + 2.55, yaw - 2.55):
+            for index in range(10):
+                distance = 0.025 * index
+                points.append((
+                    tip_x + math.cos(angle) * distance,
+                    tip_y + math.sin(angle) * distance,
+                    0.28,
+                ))
+        return points
+
+    def _visual_payload(self) -> bytes:
+        with self._lock:
+            pose = self._visual_pose
+            trajectory = list(self._trajectory)
+            frame_id = None if self._latest is None else self._latest.get("frame_id")
+            stale = self._updated is None or time.monotonic() - self._updated > self._timeout
+
+        robot_x, robot_y, robot_yaw = pose or (0.0, 0.0, 0.0)
+        points = self._visual_reference_points()
+        points.extend((x, y, 0.14) for x, y, _yaw in trajectory)
+        if pose is not None:
+            points.extend(self._heading_arrow_points(robot_x, robot_y, robot_yaw))
+        point_array = np.asarray(points, dtype=np.float32).reshape(-1, 3)
+        metadata = {
+            "version": 3,
+            "active_map": "odometer_trajectory",
+            "point_source": "odometer",
+            "frame_id": frame_id,
+            "stale": stale,
+            "trajectory_points": len(trajectory),
+            "robot": {
+                "x": robot_x,
+                "y": robot_y,
+                "yaw": robot_yaw,
+                "pose_available": pose is not None,
+            },
+            "maps": [],
+            "tags": [],
+        }
+        metadata_bytes = json.dumps(metadata, ensure_ascii=False).encode("utf-8")
+        flags = 0x03 | 0x04
+        header = struct.pack(
+            "<fffBI", robot_x, robot_y, -robot_yaw, flags, len(point_array)
+        )
+        return (
+            header
+            + point_array.tobytes()
+            + struct.pack("<I", len(metadata_bytes))
+            + metadata_bytes
+        )
+
+    def _publish_visual(self) -> None:
+        message = UInt8MultiArray()
+        message.data = array("B", self._visual_payload())
+        self._visual_publisher.publish(message)
 
 
 class MotionEventsPlugin:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -1292,7 +1292,9 @@ class OdometerPlugin:
     def dispatch(self, action: str, args: dict) -> dict:
         if action == "info":
             return {**self._snapshot(), "topic_out": self._topic_out()}
-        if action in ("odometer", "status", "start"):
+        if action == "start":
+            return {"state": "running"}
+        if action in ("odometer", "status"):
             return self._snapshot()
         if action == "reset_trip":
             with self._lock:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -93,6 +93,39 @@ def _now_ms() -> int:
     return int(time.time() * 1000)
 
 
+def _max_reasonable_odometry_speed(config: dict) -> float:
+    """Return a shared upper bound for T800 planar odometry validation."""
+    control = config.get("control", {})
+    max_vx = abs(float(control.get("max_vx", 3.0)))
+    max_vy = abs(float(control.get("max_vy", 1.0)))
+    return max(1.0, math.hypot(max_vx, max_vy) * 1.5)
+
+
+def _ros_stamp_seconds(header) -> float | None:
+    stamp = getattr(header, "stamp", None)
+    if stamp is None:
+        return None
+    try:
+        seconds = float(stamp.sec) + float(stamp.nanosec) * 1e-9
+    except (AttributeError, TypeError, ValueError, OverflowError):
+        return None
+    return seconds if math.isfinite(seconds) and seconds > 0.0 else None
+
+
+def _quaternion_yaw(x: float, y: float, z: float, w: float) -> float:
+    values = (x, y, z, w)
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError("odometry quaternion contains a non-finite value")
+    norm = math.sqrt(sum(value * value for value in values))
+    if norm <= 1e-9:
+        raise ValueError("odometry quaternion has zero length")
+    qx, qy, qz, qw = (value / norm for value in values)
+    return math.atan2(
+        2.0 * (qw * qz + qx * qy),
+        1.0 - 2.0 * (qy * qy + qz * qz),
+    )
+
+
 _GAMEPAD_BUTTON_NAMES = {
     0: "LB", 1: "RB", 2: "A", 3: "B", 4: "X", 5: "Y",
     6: "BACK", 7: "START", 8: "CROSS_X_UP", 9: "CROSS_X_DOWN",
@@ -440,11 +473,11 @@ class StatePlugin:
                 ],
                 "feedback": list(self._STREAMS) + [
                     "joint_plan_state", "heartbeat_status",
-                    "motion_command_trace", "native_interface_probe",
+                    "motion_command_trace", "odometer", "native_interface_probe",
                     "motion_events", "mainboard",
                 ],
                 "limitations": [
-                    "no odometry topic: displacement/turn/arc are time-integrated open-loop estimates",
+                    "odometry is display/statistics only; displacement/turn/arc control remains open-loop",
                     "no public dexterous-hand interface in the referenced T800 protocol",
                 ],
                 "timestamp_ms": _now_ms(),
@@ -930,12 +963,9 @@ class MotionCommandTracePlugin:
         self._odometry_updated: float | None = None
 
     def _max_reasonable_speed(self) -> float:
-        control = self._config.get("control", {})
-        max_vx = abs(float(control.get("max_vx", 3.0)))
-        max_vy = abs(float(control.get("max_vy", 1.0)))
         # Leave a small margin for measured odometry noise while still rejecting
         # ODIN2-internal values that are not robot m/s velocity on T800.
-        return max(1.0, math.hypot(max_vx, max_vy) * 1.5)
+        return _max_reasonable_odometry_speed(self._config)
 
     def _is_valid_speed(self, speed: float) -> bool:
         return math.isfinite(speed) and 0.0 <= speed <= self._max_reasonable_speed()
@@ -1150,6 +1180,294 @@ class MotionCommandTracePlugin:
 
     def _publish(self) -> None:
         self._publisher.publish(_json_message(self._snapshot()))
+
+
+class OdometerPlugin:
+    """Normalize Odin2 odometry into a dashboard-friendly trip card."""
+
+    def __init__(self, config: dict, namespace: str, ros2):
+        self._config = config
+        self._ns = namespace
+        self._topic = f"/{namespace}/state/odometer"
+        plugin_config = config.get("plugins", {}).get("odometer", {})
+        self._timeout = max(
+            0.1,
+            float(plugin_config.get(
+                "source_timeout_sec",
+                config.get("ros", {}).get("source_timeout_sec", 1.0),
+            )),
+        )
+        self._publish_rate_hz = max(0.2, float(plugin_config.get("publish_rate_hz", 5.0)))
+        self._stationary_enter = max(
+            0.0, float(plugin_config.get("stationary_enter_m_s", 0.03))
+        )
+        self._stationary_exit = max(
+            self._stationary_enter,
+            float(plugin_config.get("stationary_exit_m_s", 0.05)),
+        )
+        self._jump_tolerance = max(
+            0.0, float(plugin_config.get("jump_tolerance_m", 0.25))
+        )
+        self._max_speed = _max_reasonable_odometry_speed(config)
+
+        self._node = Node("t800_odometer", context=ros2.ctx_robot)
+        self._pub_node = Node("t800_odometer_pub", context=ros2.ctx_core)
+        ros2.executor_robot.add_node(self._node)
+        ros2.executor_core.add_node(self._pub_node)
+        self._publisher = self._pub_node.create_publisher(String, self._topic, _RELIABLE)
+
+        self._lock = threading.RLock()
+        self._latest: dict | None = None
+        self._updated: float | None = None
+        self._baseline: dict | None = None
+        self._distance_total_m = 0.0
+        self._trip_distance_m = 0.0
+        self._stationary: bool | None = None
+        self._stationary_since: float | None = None
+        self._received_count = 0
+        self._valid_count = 0
+        self._invalid_count = 0
+        self._jump_rejected_count = 0
+        self._timestamp_rejected_count = 0
+        self._frame_reset_count = 0
+        self._last_rejection: str | None = None
+
+    def get_tool(self) -> dict:
+        schema = action_schema(
+            _with_lifecycle({
+                "status": ([], "返回最新里程计、行程和数据健康状态"),
+                "reset_trip": ([], "清零 Driver 内部单次行程，不修改 Odin2 坐标系"),
+            }),
+            {},
+            "里程计传感器动作",
+        )
+        # Keep direct sensor reads compatible with Agent Core.
+        schema.pop("required", None)
+        return {
+            "name": "odometer",
+            "type": "sensor",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": "T800 Odin2 位置、航向、速度、累计里程、单次行程与静止状态可视化",
+            "inputSchema": schema,
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        from nav_msgs.msg import Odometry
+
+        source_topic = str(self._config.get("topics", {}).get("odometry", "")).strip()
+        if not source_topic:
+            raise ValueError("topics.odometry must be configured when odometer is enabled")
+        self._node.create_subscription(Odometry, source_topic, self._on_odometry, _BEST_EFFORT)
+        self._pub_node.create_timer(1.0 / self._publish_rate_hz, self._publish)
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action == "info":
+            return _with_topic_out(self._snapshot(), self._topic)
+        if action in ("odometer", "status", "start"):
+            return self._snapshot()
+        if action == "reset_trip":
+            with self._lock:
+                self._trip_distance_m = 0.0
+            return {**self._snapshot(), "trip_reset": True}
+        if action == "stop":
+            return {"state": "idle"}
+        return {"error": f"unknown odometer action: {action}"}
+
+    def _record_invalid(self, reason: str) -> None:
+        with self._lock:
+            self._received_count += 1
+            self._invalid_count += 1
+            self._last_rejection = reason
+
+    def _on_odometry(self, msg) -> None:
+        received_at = time.monotonic()
+        try:
+            pose = msg.pose.pose
+            twist = msg.twist.twist
+            position = (
+                float(pose.position.x),
+                float(pose.position.y),
+                float(pose.position.z),
+            )
+            quaternion = (
+                float(pose.orientation.x),
+                float(pose.orientation.y),
+                float(pose.orientation.z),
+                float(pose.orientation.w),
+            )
+            linear = (
+                float(twist.linear.x),
+                float(twist.linear.y),
+                float(twist.linear.z),
+            )
+            angular = (
+                float(twist.angular.x),
+                float(twist.angular.y),
+                float(twist.angular.z),
+            )
+        except (AttributeError, TypeError, ValueError, OverflowError):
+            self._record_invalid("malformed_message")
+            return
+
+        values = (*position, *linear, *angular)
+        if not all(math.isfinite(value) for value in values):
+            self._record_invalid("non_finite_value")
+            return
+        try:
+            yaw = _quaternion_yaw(*quaternion)
+        except ValueError as exc:
+            self._record_invalid(str(exc))
+            return
+
+        speed = math.hypot(linear[0], linear[1])
+        if speed > self._max_speed:
+            self._record_invalid("implausible_linear_speed")
+            return
+
+        header = getattr(msg, "header", None)
+        frame_id = str(getattr(header, "frame_id", ""))
+        child_frame_id = str(getattr(msg, "child_frame_id", ""))
+        source_stamp = _ros_stamp_seconds(header)
+        source_timestamp_ms = None if source_stamp is None else int(source_stamp * 1000.0)
+
+        with self._lock:
+            self._received_count += 1
+            baseline = self._baseline
+            jump_rejected = False
+            baseline_reset = baseline is None
+
+            if baseline is not None and frame_id != baseline["frame_id"]:
+                self._frame_reset_count += 1
+                self._last_rejection = "frame_changed"
+                baseline_reset = True
+            elif (
+                baseline is not None
+                and source_stamp is not None
+                and baseline["source_stamp"] is not None
+                and source_stamp <= baseline["source_stamp"]
+            ):
+                self._timestamp_rejected_count += 1
+                self._last_rejection = "timestamp_not_increasing"
+                return
+            elif baseline is not None:
+                delta = math.hypot(position[0] - baseline["x"], position[1] - baseline["y"])
+                if source_stamp is not None and baseline["source_stamp"] is not None:
+                    delta_time = source_stamp - baseline["source_stamp"]
+                else:
+                    delta_time = received_at - baseline["received_at"]
+                maximum_delta = self._max_speed * max(0.0, delta_time) + self._jump_tolerance
+                if delta > maximum_delta:
+                    self._jump_rejected_count += 1
+                    self._last_rejection = "position_jump"
+                    jump_rejected = True
+                    baseline_reset = True
+                else:
+                    self._distance_total_m += delta
+                    self._trip_distance_m += delta
+                    self._last_rejection = None
+
+            self._baseline = {
+                "x": position[0],
+                "y": position[1],
+                "frame_id": frame_id,
+                "source_stamp": source_stamp,
+                "received_at": received_at,
+            }
+
+            if self._stationary is None:
+                self._stationary = speed <= self._stationary_enter
+                self._stationary_since = received_at if self._stationary else None
+            elif self._stationary and speed >= self._stationary_exit:
+                self._stationary = False
+                self._stationary_since = None
+            elif not self._stationary and speed <= self._stationary_enter:
+                self._stationary = True
+                self._stationary_since = received_at
+
+            self._latest = {
+                "frame_id": frame_id,
+                "child_frame_id": child_frame_id,
+                "position_m": {"x": position[0], "y": position[1], "z": position[2]},
+                "orientation": {
+                    "quaternion_xyzw": list(quaternion),
+                    "yaw_rad": yaw,
+                    "heading_deg": math.degrees(yaw) % 360.0,
+                },
+                "linear_velocity_m_s": {
+                    "x": linear[0], "y": linear[1], "z": linear[2],
+                },
+                "angular_velocity_rad_s": {
+                    "x": angular[0], "y": angular[1], "z": angular[2],
+                },
+                "speed_m_s": speed,
+                "motion_state": "stationary" if self._stationary else "moving",
+                "stationary": bool(self._stationary),
+                "source_timestamp_ms": source_timestamp_ms,
+                "jump_rejected": jump_rejected,
+                "baseline_reset": baseline_reset,
+            }
+            self._updated = received_at
+            self._valid_count += 1
+
+    def _snapshot(self) -> dict:
+        now = time.monotonic()
+        with self._lock:
+            latest = None if self._latest is None else dict(self._latest)
+            updated = self._updated
+            total = self._distance_total_m
+            trip = self._trip_distance_m
+            stationary_since = self._stationary_since
+            counts = {
+                "received": self._received_count,
+                "valid": self._valid_count,
+                "invalid": self._invalid_count,
+                "jump_rejected": self._jump_rejected_count,
+                "timestamp_rejected": self._timestamp_rejected_count,
+                "frame_resets": self._frame_reset_count,
+            }
+            last_rejection = self._last_rejection
+
+        if latest is None or updated is None:
+            return {
+                "state": "no_data",
+                "stale": True,
+                "age_sec": None,
+                "distance_total_m": round(total, 6),
+                "trip_distance_m": round(trip, 6),
+                "sample_count": counts,
+                "last_rejection": last_rejection,
+                "timestamp_ms": _now_ms(),
+            }
+
+        age_sec = max(0.0, now - updated)
+        stale = age_sec > self._timeout
+        if latest["stationary"] and stationary_since is not None:
+            stationary_end = min(now, updated + self._timeout)
+            stationary_sec = max(0.0, stationary_end - stationary_since)
+        else:
+            stationary_sec = 0.0
+        return {
+            "state": "stale" if stale else "running",
+            **latest,
+            "distance_total_m": round(total, 6),
+            "trip_distance_m": round(trip, 6),
+            "stationary_sec": round(stationary_sec, 3),
+            "age_sec": round(age_sec, 3),
+            "stale": stale,
+            "source_topic": str(self._config.get("topics", {}).get("odometry", "")),
+            "sample_count": counts,
+            "last_rejection": last_rejection,
+            "timestamp_ms": _now_ms(),
+        }
+
+    def _publish(self) -> None:
+        self._publisher.publish(_json_message(self._snapshot()))
+
 
 class MotionEventsPlugin:
     """Read-only event timeline for T800 motion-related MCP calls and feedback."""

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -112,6 +112,7 @@ class T800DeviceBundle:
             NativeInterfaceProbePlugin,
             NativeNodeControlPlugin,
             NativeSdkPlugin,
+            OdometerPlugin,
             SafetyControlPlugin,
             StatePlugin,
             TtsPlugin,
@@ -139,6 +140,7 @@ class T800DeviceBundle:
         plugin_types = (
             ("heartbeat_status", HeartbeatStatusPlugin, (config, namespace, ros2)),
             ("motion_command_trace", MotionCommandTracePlugin, (config, namespace, ros2)),
+            ("odometer", OdometerPlugin, (config, namespace, ros2)),
             ("native_interface_probe", NativeInterfaceProbePlugin, (config, namespace, ros2)),
             ("locomotion", LocomotionPlugin, (config, namespace, ros2, state)),
             ("motion_mode", MotionModePlugin, (config, namespace, ros2, state)),

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -352,7 +352,13 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual("sensor", tool["type"])
         self.assertTrue(tool["readOnly"])
         self.assertEqual(
-            [{"topic": "/runtime_robot/state/odometer", "format": "data/json"}],
+            [
+                {"topic": "/runtime_robot/state/odometer", "format": "data/json"},
+                {
+                    "topic": "/runtime_robot/state/odometer/trajectory",
+                    "format": "sensor/mapping",
+                },
+            ],
             tool["topic_out"],
         )
         actions = tool["inputSchema"]["properties"]["action"]["enum"]
@@ -373,6 +379,8 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual({"x": 1.25, "y": -0.18, "z": 0.02}, status["position_m"])
         self.assertEqual(0.0, status["distance_total_m"])
         self.assertEqual(0.0, status["trip_distance_m"])
+        self.assertEqual({"x": 0.0, "y": 0.0}, status["trajectory_position_m"])
+        self.assertEqual(1, status["trajectory_point_count"])
         self.assertTrue(status["baseline_reset"])
 
     def test_odometer_accumulates_planar_distance_and_ignores_z(self):
@@ -391,6 +399,8 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertTrue(reset["trip_reset"])
         self.assertEqual(0.4, reset["distance_total_m"])
         self.assertEqual(0.0, reset["trip_distance_m"])
+        self.assertEqual({"x": 0.0, "y": 0.0}, reset["trajectory_position_m"])
+        self.assertEqual(1, reset["trajectory_point_count"])
         plugin._on_odometry(odometry_message(x=0.6, stamp=3.0))
         status = plugin.dispatch("status", {})
         self.assertEqual(0.6, status["distance_total_m"])
@@ -449,6 +459,7 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual(0.0, rejected["distance_total_m"])
         self.assertTrue(rejected["jump_rejected"])
         self.assertEqual(1, rejected["sample_count"]["jump_rejected"])
+        self.assertEqual({"x": 0.0, "y": 0.0}, rejected["trajectory_position_m"])
         plugin._on_odometry(odometry_message(x=20.1, stamp=3.0))
         self.assertAlmostEqual(0.1, plugin.dispatch("status", {})["distance_total_m"])
 
@@ -478,6 +489,7 @@ class DevicePluginContractTests(unittest.TestCase):
         changed = plugin.dispatch("status", {})
         self.assertEqual(0.0, changed["distance_total_m"])
         self.assertEqual(1, changed["sample_count"]["frame_resets"])
+        self.assertEqual({"x": 0.0, "y": 0.0}, changed["trajectory_position_m"])
         plugin._on_odometry(odometry_message(x=1.2, stamp=3.0, frame_id="map"))
         self.assertAlmostEqual(0.2, plugin.dispatch("status", {})["distance_total_m"])
 
@@ -496,6 +508,37 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertIn("orientation", payload)
         self.assertIn("distance_total_m", payload)
         self.assertIn("stationary_sec", payload)
+        self.assertEqual(1, len(plugin._visual_publisher.messages))
+
+    def test_odometer_mapping_payload_renders_relative_trajectory_and_heading(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(x=10.0, y=20.0, stamp=1.0))
+        half_yaw = math.pi / 4.0
+        plugin._on_odometry(odometry_message(
+            x=10.3,
+            y=20.4,
+            quaternion=(0.0, 0.0, math.sin(half_yaw), math.cos(half_yaw)),
+            stamp=2.0,
+        ))
+        raw = plugin._visual_payload()
+        robot_x, robot_y, display_yaw, flags, point_count = struct.unpack_from(
+            "<fffBI", raw, 0
+        )
+        self.assertAlmostEqual(0.3, robot_x, places=5)
+        self.assertAlmostEqual(0.4, robot_y, places=5)
+        self.assertAlmostEqual(-math.pi / 2.0, display_yaw, places=5)
+        self.assertEqual(7, flags)
+        self.assertGreater(point_count, plugin.dispatch("status", {})["trajectory_point_count"])
+
+        metadata_offset = struct.calcsize("<fffBI") + point_count * 12
+        metadata_length = struct.unpack_from("<I", raw, metadata_offset)[0]
+        metadata = json.loads(raw[
+            metadata_offset + 4:metadata_offset + 4 + metadata_length
+        ].decode("utf-8"))
+        self.assertEqual("odometer", metadata["point_source"])
+        self.assertTrue(metadata["robot"]["pose_available"])
+        self.assertGreater(metadata["trajectory_points"], 1)
+        self.assertAlmostEqual(math.pi / 2.0, metadata["robot"]["yaw"])
 
     def test_motion_trace_prefers_fresh_command_over_stale_odometry(self):
         plugin = self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -386,6 +386,8 @@ class DevicePluginContractTests(unittest.TestCase):
     def test_odometer_starts_with_configured_source_and_no_data_status(self):
         plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
         self.assertEqual("no_data", plugin.dispatch("status", {})["state"])
+        self.assertEqual({"state": "running"}, plugin.dispatch("start", {}))
+        self.assertEqual("no_data", plugin.dispatch("status", {})["state"])
         plugin.start()
         self.assertEqual(CONFIG["topics"]["odometry"], plugin._node.subscriptions[0].topic)
 

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1,10 +1,13 @@
 import importlib.util
+import json
+import math
 import struct
 import sys
 import time
 import types
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -205,6 +208,39 @@ CONFIG = {
 }
 
 
+def odometry_message(
+    *,
+    x=0.0,
+    y=0.0,
+    z=0.0,
+    quaternion=(0.0, 0.0, 0.0, 1.0),
+    linear=(0.0, 0.0, 0.0),
+    angular=(0.0, 0.0, 0.0),
+    stamp=1.0,
+    frame_id="odom",
+    child_frame_id="base_link",
+):
+    seconds = int(stamp)
+    nanoseconds = int(round((stamp - seconds) * 1_000_000_000))
+    return types.SimpleNamespace(
+        header=types.SimpleNamespace(
+            frame_id=frame_id,
+            stamp=types.SimpleNamespace(sec=seconds, nanosec=nanoseconds),
+        ),
+        child_frame_id=child_frame_id,
+        pose=types.SimpleNamespace(pose=types.SimpleNamespace(
+            position=types.SimpleNamespace(x=x, y=y, z=z),
+            orientation=types.SimpleNamespace(
+                x=quaternion[0], y=quaternion[1], z=quaternion[2], w=quaternion[3],
+            ),
+        )),
+        twist=types.SimpleNamespace(twist=types.SimpleNamespace(
+            linear=types.SimpleNamespace(x=linear[0], y=linear[1], z=linear[2]),
+            angular=types.SimpleNamespace(x=angular[0], y=angular[1], z=angular[2]),
+        )),
+    )
+
+
 class DevicePluginContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -238,6 +274,7 @@ class DevicePluginContractTests(unittest.TestCase):
             self.device.NativeSdkPlugin({"mode": "external"}, "robot", self.ros),
             self.device.HeartbeatStatusPlugin(CONFIG, "robot", self.ros),
             self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros),
+            self.device.OdometerPlugin(CONFIG, "robot", self.ros),
             self.device.MotionEventsPlugin(CONFIG, "robot", self.ros),
             self.device.NativeInterfaceProbePlugin(CONFIG, "robot", self.ros),
             VirtualGamepadPlugin({}, "robot", self.ros),
@@ -252,7 +289,7 @@ class DevicePluginContractTests(unittest.TestCase):
             {"joints", "imu", "battery", "motor_health", "motor_state", "motor_command", "joint_command_feedback",
              "gamepad", "motion_state", "driver_health", "model",
              "robot_snapshot", "fault_summary", "stability", "joint_groups", "capabilities", "ros_graph",
-             "mainboard", "heartbeat_status", "motion_command_trace", "motion_events",
+             "mainboard", "heartbeat_status", "motion_command_trace", "odometer", "motion_events",
              "native_interface_probe",
              "loco", "motion_mode", "dance", "joint_plan", "joint_plan_state", "gesture",
              "joint_override", "joint_bridge",
@@ -260,8 +297,8 @@ class DevicePluginContractTests(unittest.TestCase):
              "motor_power", "native_node_control", "virtual_gamepad", "safety", "native_sdk"},
             names,
         )
-        self.assertEqual(41, len(names))
-        self.assertEqual(41, len(definitions), "tool names must be unique")
+        self.assertEqual(42, len(names))
+        self.assertEqual(42, len(definitions), "tool names must be unique")
         for tool in definitions:
             schema = tool.get("inputSchema")
             self.assertEqual("object", schema.get("type"), tool["name"])
@@ -281,6 +318,7 @@ class DevicePluginContractTests(unittest.TestCase):
             self.state,
             self.device.HeartbeatStatusPlugin(CONFIG, "robot", self.ros),
             self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros),
+            self.device.OdometerPlugin(CONFIG, "robot", self.ros),
             self.device.MotionEventsPlugin(CONFIG, "robot", self.ros),
             self.device.NativeInterfaceProbePlugin(CONFIG, "robot", self.ros),
             self.device.VisionPlugin(CONFIG, "robot", self.ros),
@@ -300,12 +338,164 @@ class DevicePluginContractTests(unittest.TestCase):
         plugins = [
             self.device.HeartbeatStatusPlugin(CONFIG, "robot", self.ros),
             self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros),
+            self.device.OdometerPlugin(CONFIG, "robot", self.ros),
             self.device.MotionEventsPlugin(CONFIG, "robot", self.ros),
             self.device.NativeInterfaceProbePlugin(CONFIG, "robot", self.ros),
         ]
         for plugin in plugins:
             plugin.start()
             plugin.stop()
+
+    def test_odometer_declares_dashboard_topic_and_sensor_actions(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "runtime_robot", self.ros)
+        tool = plugin.get_tool()
+        self.assertEqual("sensor", tool["type"])
+        self.assertTrue(tool["readOnly"])
+        self.assertEqual(
+            [{"topic": "/runtime_robot/state/odometer", "format": "data/json"}],
+            tool["topic_out"],
+        )
+        actions = tool["inputSchema"]["properties"]["action"]["enum"]
+        self.assertTrue({"start", "info", "status", "reset_trip", "stop"}.issubset(actions))
+        self.assertNotIn("required", tool["inputSchema"])
+
+    def test_odometer_starts_with_configured_source_and_no_data_status(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        self.assertEqual("no_data", plugin.dispatch("status", {})["state"])
+        plugin.start()
+        self.assertEqual(CONFIG["topics"]["odometry"], plugin._node.subscriptions[0].topic)
+
+    def test_odometer_first_frame_sets_baseline_and_exposes_pose(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(x=1.25, y=-0.18, z=0.02, stamp=5.0))
+        status = plugin.dispatch("status", {})
+        self.assertEqual("running", status["state"])
+        self.assertEqual({"x": 1.25, "y": -0.18, "z": 0.02}, status["position_m"])
+        self.assertEqual(0.0, status["distance_total_m"])
+        self.assertEqual(0.0, status["trip_distance_m"])
+        self.assertTrue(status["baseline_reset"])
+
+    def test_odometer_accumulates_planar_distance_and_ignores_z(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(z=2.0, stamp=1.0))
+        plugin._on_odometry(odometry_message(x=0.3, y=0.4, z=20.0, stamp=2.0))
+        status = plugin.dispatch("status", {})
+        self.assertAlmostEqual(0.5, status["distance_total_m"])
+        self.assertAlmostEqual(0.5, status["trip_distance_m"])
+
+    def test_odometer_reset_trip_preserves_total_distance(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(stamp=1.0))
+        plugin._on_odometry(odometry_message(x=0.4, stamp=2.0))
+        reset = plugin.dispatch("reset_trip", {})
+        self.assertTrue(reset["trip_reset"])
+        self.assertEqual(0.4, reset["distance_total_m"])
+        self.assertEqual(0.0, reset["trip_distance_m"])
+        plugin._on_odometry(odometry_message(x=0.6, stamp=3.0))
+        status = plugin.dispatch("status", {})
+        self.assertEqual(0.6, status["distance_total_m"])
+        self.assertEqual(0.2, status["trip_distance_m"])
+
+    def test_odometer_computes_yaw_heading_and_velocities(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        half_yaw = math.pi / 4.0
+        plugin._on_odometry(odometry_message(
+            quaternion=(0.0, 0.0, math.sin(half_yaw), math.cos(half_yaw)),
+            linear=(0.3, 0.4, 0.2),
+            angular=(0.1, -0.2, 0.8),
+        ))
+        status = plugin.dispatch("status", {})
+        self.assertAlmostEqual(math.pi / 2.0, status["orientation"]["yaw_rad"])
+        self.assertAlmostEqual(90.0, status["orientation"]["heading_deg"])
+        self.assertAlmostEqual(0.5, status["speed_m_s"])
+        self.assertEqual({"x": 0.1, "y": -0.2, "z": 0.8}, status["angular_velocity_rad_s"])
+
+    def test_odometer_stationary_hysteresis_and_duration(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        with mock.patch.object(self.device.time, "monotonic", return_value=10.0):
+            plugin._on_odometry(odometry_message(linear=(0.02, 0.0, 0.0), stamp=1.0))
+        with mock.patch.object(self.device.time, "monotonic", return_value=10.5):
+            status = plugin.dispatch("status", {})
+        self.assertTrue(status["stationary"])
+        self.assertAlmostEqual(0.5, status["stationary_sec"])
+
+        with mock.patch.object(self.device.time, "monotonic", return_value=10.6):
+            plugin._on_odometry(odometry_message(linear=(0.04, 0.0, 0.0), stamp=2.0))
+        self.assertTrue(plugin.dispatch("status", {})["stationary"])
+        with mock.patch.object(self.device.time, "monotonic", return_value=10.7):
+            plugin._on_odometry(odometry_message(linear=(0.05, 0.0, 0.0), stamp=3.0))
+        self.assertFalse(plugin.dispatch("status", {})["stationary"])
+        with mock.patch.object(self.device.time, "monotonic", return_value=10.8):
+            plugin._on_odometry(odometry_message(linear=(0.04, 0.0, 0.0), stamp=4.0))
+        self.assertFalse(plugin.dispatch("status", {})["stationary"])
+        with mock.patch.object(self.device.time, "monotonic", return_value=10.9):
+            plugin._on_odometry(odometry_message(linear=(0.03, 0.0, 0.0), stamp=5.0))
+        self.assertTrue(plugin.dispatch("status", {})["stationary"])
+
+    def test_odometer_rejects_non_finite_and_zero_quaternion_samples(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(x=float("nan")))
+        plugin._on_odometry(odometry_message(linear=(float("inf"), 0.0, 0.0)))
+        plugin._on_odometry(odometry_message(quaternion=(0.0, 0.0, 0.0, 0.0)))
+        status = plugin.dispatch("status", {})
+        self.assertEqual("no_data", status["state"])
+        self.assertEqual(3, status["sample_count"]["invalid"])
+
+    def test_odometer_rejects_jump_then_recovers_from_new_baseline(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(stamp=1.0))
+        plugin._on_odometry(odometry_message(x=20.0, stamp=2.0))
+        rejected = plugin.dispatch("status", {})
+        self.assertEqual(0.0, rejected["distance_total_m"])
+        self.assertTrue(rejected["jump_rejected"])
+        self.assertEqual(1, rejected["sample_count"]["jump_rejected"])
+        plugin._on_odometry(odometry_message(x=20.1, stamp=3.0))
+        self.assertAlmostEqual(0.1, plugin.dispatch("status", {})["distance_total_m"])
+
+    def test_odometer_rejects_non_increasing_source_timestamp(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(stamp=2.0))
+        plugin._on_odometry(odometry_message(x=0.2, stamp=1.0))
+        status = plugin.dispatch("status", {})
+        self.assertEqual(0.0, status["distance_total_m"])
+        self.assertEqual(0.0, status["position_m"]["x"])
+        self.assertEqual(1, status["sample_count"]["timestamp_rejected"])
+        self.assertEqual("timestamp_not_increasing", status["last_rejection"])
+
+    def test_odometer_marks_stale_while_retaining_last_pose(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(x=1.0))
+        plugin._updated = time.monotonic() - 2.0
+        status = plugin.dispatch("status", {})
+        self.assertEqual("stale", status["state"])
+        self.assertTrue(status["stale"])
+        self.assertEqual(1.0, status["position_m"]["x"])
+
+    def test_odometer_frame_change_resets_distance_baseline(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(stamp=1.0, frame_id="odom"))
+        plugin._on_odometry(odometry_message(x=1.0, stamp=2.0, frame_id="map"))
+        changed = plugin.dispatch("status", {})
+        self.assertEqual(0.0, changed["distance_total_m"])
+        self.assertEqual(1, changed["sample_count"]["frame_resets"])
+        plugin._on_odometry(odometry_message(x=1.2, stamp=3.0, frame_id="map"))
+        self.assertAlmostEqual(0.2, plugin.dispatch("status", {})["distance_total_m"])
+
+    def test_odometer_info_stop_and_dashboard_json_contract(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        info = plugin.dispatch("info", {})
+        self.assertEqual("no_data", info["state"])
+        self.assertEqual(plugin.get_tool()["topic_out"], info["topic_out"])
+        self.assertEqual({"state": "idle"}, plugin.dispatch("stop", {}))
+
+        plugin._on_odometry(odometry_message(x=0.2, linear=(0.1, 0.0, 0.0)))
+        plugin._publish()
+        payload = json.loads(plugin._publisher.messages[-1].data)
+        self.assertEqual("running", payload["state"])
+        self.assertIn("position_m", payload)
+        self.assertIn("orientation", payload)
+        self.assertIn("distance_total_m", payload)
+        self.assertIn("stationary_sec", payload)
 
     def test_motion_trace_prefers_fresh_command_over_stale_odometry(self):
         plugin = self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros)
@@ -483,7 +673,10 @@ class DevicePluginContractTests(unittest.TestCase):
         faults = self.state.dispatch("fault_summary", {})
         self.assertEqual([1], faults["offline_joints"])
         self.assertEqual(7, faults["motor_errors"][0]["code"])
-        self.assertEqual(25, self.state.dispatch("capabilities", {})["dof"])
+        capabilities = self.state.dispatch("capabilities", {})
+        self.assertEqual(25, capabilities["dof"])
+        self.assertIn("odometer", capabilities["feedback"])
+        self.assertNotIn("no odometry topic", " ".join(capabilities["limitations"]))
         self.assertEqual([23, 24], [item["index"] for item in
                                    self.state.dispatch("joint_groups", {})["groups"]["head"]])
 


### PR DESCRIPTION
## 背景

本 PR 新增 `odometer` 传感器卡片，提供里程统计、静止判断、数据健康诊断，以及 Dashboard 鸟瞰轨迹画面，可以查看机器人的运动轨迹和朝向。

## 主要修改

### Odometer 状态卡片

订阅机器人 ROS Domain 中的：

```text
/manifold/ODIN2/device0/odometry
nav_msgs/msg/Odometry