### PR TITLE
feat(engineai/t800): loco 卡片 — 官方状态对齐 + 安全增强（精简版，无导航集成）

### DIFF
--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -12,14 +12,15 @@ control:
   velocity_rate_hz: 100.0
   low_level_rate_hz: 500.0
   override_rate_hz: 100.0
-  max_vx: 3.0
+  max_vx: 1.0
   max_vy: 1.0
-  max_vyaw: 3.141592653589793
+  max_vyaw: 1.0
   mode_transition_timeout_sec: 5.0
   motor_warning_temperature_c: 70.0
   tilt_warning_rad: 0.45
   fall_tilt_rad: 0.9
   fall_angular_speed_rad_s: 3.0
+  stream_watchdog_period_sec: 0.5
 
 topics:
   joint_state: "/hardware/joint_state"

--- a/engineai/t800/control.py
+++ b/engineai/t800/control.py
@@ -93,14 +93,23 @@ MOTION_STATES = (
     "idle",
     "passive",
     "pd_stand",
-    "walk",
-    "dance",
-    "supine_to_stance",
-    "stance_to_supine",
-    "joint_bridge",
+    "rl_basic",
     "lower_body_balance",
+    "joint_bridge",
+    "pd_sitground",
+    "walk_server",
+    "rl_mimic_supine_to_stance",
+    "rl_mimic_stance_to_supine",
+    "rl_mimic_left_to_right",
+    "rl_mimic_right_to_left",
+    "rl_amp",
     "rl_terrain",
+    "rl_recover_prone",
+    "rl_floor_sitting",
+    "dance",
 )
+
+WALK_MOTION_STATES = ("rl_basic", "lower_body_balance")
 
 LED_MODES = {
     "blink_red": 0x1,
@@ -350,8 +359,10 @@ def action_schema(
     actions: dict[str, tuple[list[str], str]],
     properties: dict,
     description: str,
+    *,
+    completion: tuple[list[str], int] | None = None,
 ) -> dict:
-    return {
+    schema = {
         "type": "object",
         "properties": {
             "action": {
@@ -367,6 +378,12 @@ def action_schema(
             for name, (params, action_description) in actions.items()
         },
     }
+    if completion is not None:
+        schema["x-completion"] = {
+            "actions": completion[0],
+            "timeout": completion[1],
+        }
+    return schema
 
 
 def sensor_action_schema() -> dict:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -1804,22 +1804,29 @@ class NativeInterfaceProbePlugin:
         return "low"
 
 class LocomotionPlugin:
+    STOP_PRIORITY = 0
+
     def __init__(self, config: dict, namespace: str, ros2, state: StatePlugin):
         self._config = config
         self._state = state
         self._node = Node("t800_locomotion", context=ros2.ctx_robot)
         ros2.executor_robot.add_node(self._node)
         self._publisher = None
-        limits = config["control"]
+        self._watchdog_timer = None
+        limits = config.get("control", {})
         self._limits = (
-            float(limits["max_vx"]),
-            float(limits["max_vy"]),
-            float(limits["max_vyaw"]),
+            abs(float(limits.get("max_vx", 1.0))),
+            abs(float(limits.get("max_vy", 1.0))),
+            abs(float(limits.get("max_vyaw", 1.0))),
         )
         self._stream = RepeatingCommand(
             self._publish_payload,
             self._publish_zero,
-            rate_hz=float(limits["velocity_rate_hz"]),
+            rate_hz=float(limits.get("velocity_rate_hz", 100)),
+        )
+        self._watchdog_period = float(limits.get("stream_watchdog_period_sec", 0.5))
+        self._stream_gap_limit_sec = max(
+            5.0 / float(limits.get("velocity_rate_hz", 100)), 0.5
         )
 
     def get_tool(self) -> dict:
@@ -1852,6 +1859,7 @@ class LocomotionPlugin:
                     "linear_speed_m_s": {"type": "number", "description": "圆弧线速度，m/s；负数为后退"},
                 },
                 "运动动作",
+                completion=(["move"], 60),
             ),
         }
 
@@ -1862,11 +1870,31 @@ class LocomotionPlugin:
         self._publisher = self._node.create_publisher(
             BodyVelCmd, self._config["topics"]["body_velocity"], _RELIABLE
         )
+        self._watchdog_timer = self._node.create_timer(
+            self._watchdog_period, self._stream_health_check
+        )
+
+    def _stream_health_check(self):
+        """流发布看门狗：active 且超过 gap 上限无发布 → 停流归零"""
+        s = self._stream.snapshot()
+        if s.active and s.last_publish_at is not None:
+            gap = time.monotonic() - s.last_publish_at
+            if gap > self._stream_gap_limit_sec:
+                self._stream.stop()
+                self._publish_zero()
 
     def stop(self) -> None:
         self._stream.stop()
 
     def dispatch(self, action: str, args: dict) -> dict:
+        try:
+            return self._dispatch(action, args)
+        except Exception:
+            self._stream.stop()
+            self._publish_zero()
+            raise
+
+    def _dispatch(self, action: str, args: dict) -> dict:
         if action == "start":
             return {"state": "ready"}
         if action == "stop":
@@ -1949,10 +1977,10 @@ class MotionModePlugin:
         "idle": "idle",
         "passive": "passive",
         "stand": "pd_stand",
-        "walk": "walk",
+        "walk": "rl_basic",
         "dance": "dance",
-        "get_up": "supine_to_stance",
-        "lie_down": "stance_to_supine",
+        "get_up": "rl_mimic_supine_to_stance",
+        "lie_down": "rl_mimic_stance_to_supine",
     }
     def __init__(self, config: dict, namespace: str, ros2, state: StatePlugin):
         self._config = config
@@ -2076,7 +2104,7 @@ class DancePlugin:
         if action == "play":
             target = str(args.get("name", "dance"))
         elif action == "stop_dance":
-            target = str(args.get("target", "walk"))
+            target = str(args.get("target", "rl_basic"))
         else:
             return {"error": f"unknown dance action: {action}"}
         forwarded = dict(args)

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -231,7 +231,8 @@ class T800DeviceBundle:
     def stop_all(self) -> None:
         if not self._started:
             return
-        for plugin in reversed(self._active_plugins):
+        for plugin in sorted(self._active_plugins,
+                             key=lambda p: getattr(p, "STOP_PRIORITY", 100)):
             try:
                 plugin.stop()
             except Exception as exc:

--- a/engineai/t800/tests/test_control.py
+++ b/engineai/t800/tests/test_control.py
@@ -12,6 +12,8 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from control import (  # noqa: E402
+    MOTION_STATES,
+    WALK_MOTION_STATES,
     T800_JOINT_POSITION_LIMITS,
     T800_JOINT_NAMES,
     RepeatingCommand,
@@ -107,6 +109,34 @@ class ValidationTests(unittest.TestCase):
         self.assertTrue(tool["readOnly"])
         self.assertEqual("sensor", tool["type"])
         self.assertEqual("/robot/state/imu", tool["topic_out"][0]["topic"])
+
+    def test_action_schema_with_completion(self):
+        schema = action_schema(
+            {"move": (["vx"], "move"), "stop": ([], "stop")},
+            {"vx": {"type": "number"}},
+            "action",
+            completion=(["move"], 60),
+        )
+        self.assertEqual(["move"], schema["x-completion"]["actions"])
+        self.assertEqual(60, schema["x-completion"]["timeout"])
+
+    def test_action_schema_without_completion_omits_key(self):
+        schema = action_schema(
+            {"move": (["vx"], "move")},
+            {"vx": {"type": "number"}},
+            "action",
+        )
+        self.assertNotIn("x-completion", schema)
+
+    def test_motion_states_has_17_official_values(self):
+        self.assertEqual(17, len(MOTION_STATES))
+        self.assertIn("rl_basic", MOTION_STATES)
+        self.assertIn("lower_body_balance", MOTION_STATES)
+        self.assertIn("rl_mimic_supine_to_stance", MOTION_STATES)
+        self.assertIn("rl_mimic_stance_to_supine", MOTION_STATES)
+
+    def test_walk_motion_states_matches_official_walking_modes(self):
+        self.assertEqual(("rl_basic", "lower_body_balance"), WALK_MOTION_STATES)
 
 
 class RepeatingCommandTests(unittest.TestCase):

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -199,7 +199,8 @@ def load_device():
 CONFIG = {
     "ros": {"robot_domain_id": 69, "core_domain_id": 42, "source_timeout_sec": 1.0},
     "control": {"velocity_rate_hz": 100.0, "low_level_rate_hz": 200.0, "override_rate_hz": 100.0,
-                "max_vx": 3.0, "max_vy": 1.0, "max_vyaw": 3.14, "mode_transition_timeout_sec": 0.1},
+                "max_vx": 1.0, "max_vy": 1.0, "max_vyaw": 1.0, "mode_transition_timeout_sec": 0.1,
+                "stream_watchdog_period_sec": 0.5},
     "topics": {
         "joint_state": "/hardware/joint_state", "imu": "/hardware/imu_info",
         "gamepad": "/hardware/gamepad_keys", "motor_debug": "/hardware/motor_debug",
@@ -374,7 +375,7 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual("gamepad_analog", snapshot["source"])
         self.assertEqual("moving", snapshot["motion_state"])
         self.assertEqual("forward_left", snapshot["direction"])
-        self.assertEqual("0.98 m/s", snapshot["speed"])
+        self.assertEqual("0.50 m/s", snapshot["speed"])
 
     def test_motion_events_ignore_implausible_odin_odometry(self):
         plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
@@ -401,7 +402,7 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual("move", moving["action"])
         self.assertEqual("forward", moving["direction"])
         self.assertEqual([], moving["buttons"])
-        self.assertEqual("1.50 m/s", moving["speed"])
+        self.assertEqual("0.50 m/s", moving["speed"])
         self.assertEqual("motion_start", moving["event"])
 
         plugin._on_gamepad(types.SimpleNamespace(
@@ -510,7 +511,7 @@ class DevicePluginContractTests(unittest.TestCase):
         plugin = self.device.LocomotionPlugin(CONFIG, "robot", self.ros, self.state)
         plugin.start()
         result = plugin.dispatch("move", {"vx": 9, "vy": -9, "vyaw": 9, "duration": 0.03, "force": True})
-        self.assertEqual(3.0, result["vx"])
+        self.assertEqual(1.0, result["vx"])
         self.assertEqual(-1.0, result["vy"])
         time.sleep(0.08)
         self.assertGreaterEqual(len(plugin._publisher.messages), 2)
@@ -544,7 +545,7 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual("requested", result["state"])
         self.assertEqual("vendor_future_mode", plugin._publisher.messages[-1].target_motion_name)
         plugin.dispatch("get_up", {"force": True, "wait": False})
-        self.assertEqual("supine_to_stance", plugin._publisher.messages[-1].target_motion_name)
+        self.assertEqual("rl_mimic_supine_to_stance", plugin._publisher.messages[-1].target_motion_name)
 
     def test_dance_facade_lists_and_plays_official_dance(self):
         mode = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)


### PR DESCRIPTION
## loco 卡片的作用

**loco = locomotion（运动控制）。** 画布（Canvas）通过这个卡片下发速度指令控制机器人行走。

对外接口：

| action | 参数 | 作用 |
|--------|------|------|
| move | vx, vy, vyaw, duration | 按速度移动，duration 到期自停 |
| move_displacement | x_m, y_m, speed_m_s | 开环位移估算 |
| turn_angle | angle_rad, angular_speed_rad_s | 开环原地转角 |
| arc | radius_m, angle_rad, linear_speed_m_s | 开环圆弧运动 |
| stop_move | — | 立即停止 |
| status | — | 查询当前速度控制状态 |

内部通过 100Hz BodyVelCmd 发布流（Domain 69）驱动机器人，限幅到官方 ±1，仅行走模式下可接收速度指令，异常自动归零，发布线程超时 0.5s 自动停流。

## 与仓库现有 loco 卡片的区别

仓库现有 loco 卡片（宇树 G1/Go2/R1、noetix bumi、pnpbotics adam）均依赖各自平台 SDK 的运动控制 API（body_rotate RPC、SmartMotion 子进程等）。T800（众擎）没有等效 SDK——它只提供底层 BodyVelCmd 话题（Domain 69, 100Hz 速度指令流）。因此 T800 loco 卡片需自行管理完整的发布流、限幅、状态门禁和安全增强。

此外，本卡片对现有 T800 LocomotionPlugin 实现做了以下合规对齐和加固：

| 改动 | 说明 |
|------|------|
| 17 官方状态全集 | 旧 10 状态含非官方名 "walk"；改为 rl_basic / rl_mimic_* 等官方名 |
| 步行模式白名单 | 官方仅 rl_basic 和 lower_body_balance 两个行走模式 |
| 快捷方式修正 | walk→rl_basic，get_up→rl_mimic_supine_to_stance（固件不认旧名） |
| 限幅缺键回退 1.0 | 对齐官方文档 ±1（旧 3.0） |
| fail-closed dispatch | 异常→停流归零+re-raise |
| 流发布看门狗 0.5s | 发布线程死/卡住→自动归零 |
| STOP_PRIORITY=0 | bundle 关停时 loco 最先归零 |
| x-completion | 画布知道 move 是定时完成动作 |