### PR TITLE
feat(m20): add standalone mapping view

### DIFF
--- a/deep_robotics/lynx_m20/README.md
+++ b/deep_robotics/lynx_m20/README.md
@@ -30,14 +30,16 @@ Dockerfile 会在解压和编译前再次校验 SHA256。归档内保留上游 `
 - 选配自主充电：开始、退出和异常强制复位。
 - 设备与状态：前后灯、常规/导航/辅助模式、休眠与自动休眠、16 关节反馈、双电池、温度和错误列表。
 - 双路相机：返回官方 H.265 RTSP 地址 `video1`/`video2`；文档明确相机不发布 ROS 2/DDS 话题。
-- M20 Pro：将 `model_variant` 改为 `pro` 后，额外开放里程计、定位初始化、单点导航、取消和状态查询。
+- M20 Pro：默认开放里程计、定位初始化、单点导航、取消、状态查询，以及 `mapping_view` 建图视图。建图期间将 `/grid_map_3d` 的 `base_link` 点云通过 `/SLAM_ODOM` 转换并累积到 `map` 坐标，停止后切换到最终 `/GRID_MAP`。
 
 ## 型号边界
 
-默认 `model_variant: standard`。供应商文档明确建图、定位和内置导航仅 M20 Pro 支持，因此标准版不会注册导航工具。建图由 Pro 机载 `drmap` 命令管理，不通过本 Driver 远程执行高权限 shell。
+默认 `model_variant: pro`，用于当前 M20 Pro 的 Web Console 无外部配置部署。供应商文档明确建图、定位和内置导航仅 M20 Pro 支持；部署到标准版时必须将该值改为 `standard`，标准版不会注册这些工具。
+
+`mapping_view` 是不依赖 SSH 的只读 Sensor，仅在 M20 Pro 上注册。启动卡片后，它将 `/grid_map_3d` 的 `base_link` 点云通过 `/SLAM_ODOM` 转换并累积到 `map` 坐标；停止卡片后，如果收到过 `/GRID_MAP`，则切换到最终占据栅格视图。实时点云按 `voxel_size` 去重、受 `max_buffer_points` 约束，并按 `publish_hz` 和 `max_points` 限制 Canvas 负载。数据包元数据和 `mapping_view.info` 会公布状态、数据源、坐标系、更新时间、更新次数及点数。最终二维地图只发布占据值大于等于 `occupied_threshold` 的栅格中心点。本 Driver 不负责启动、停止或保存 NOS 建图任务。
 
 供应商文档未提供舞蹈、自定义特技或关节位置控制接口，本 Driver 不虚构这些能力。
 
 ## 验证状态
 
-机器人目前还没到位。协议编解码、能力契约、配置和 Python 语法已在开发机验证；Fast DDS 发现、真实状态机、速度方向、选配件存在性、充电及 Pro 导航仍需真机验真。首次联调前请确认系统版本为 V1.1.8、外接主机接入 `10.21.31.x` 或 `10.21.33.x` 网段，并确保没有与 `planner` 或 `charge_manager` 并发发布 `/NAV_CMD`。
+已在 M20 Pro 真机确认 `/grid_map_3d` 与 `/SLAM_ODOM` 均约 10 Hz，并确认 `/grid_map_3d` 为 `base_link` 坐标、XYZ float32、16 字节点步长，`/SLAM_ODOM` 为 `map` 坐标。实时坐标转换、点云累积、最终栅格编码和 Canvas 生命周期契约已通过开发机测试；仍需用本分支镜像在 Agent Core/Canvas 上复测独立启停和最终地图切换。速度方向、选配件存在性、充电及 Pro 导航仍未完成真机验证。首次联调前请确认系统版本为 V1.1.8、外接主机接入 `10.21.31.x` 或 `10.21.33.x` 网段，并确保没有与 `planner` 或 `charge_manager` 并发发布 `/NAV_CMD`。

--- a/deep_robotics/lynx_m20/README.md
+++ b/deep_robotics/lynx_m20/README.md
@@ -42,4 +42,4 @@ Dockerfile 会在解压和编译前再次校验 SHA256。归档内保留上游 `
 
 ## 验证状态
 
-已在 M20 Pro 真机确认 `/grid_map_3d` 与 `/SLAM_ODOM` 均约 10 Hz，并确认 `/grid_map_3d` 为 `base_link` 坐标、XYZ float32、16 字节点步长，`/SLAM_ODOM` 为 `map` 坐标。实时坐标转换、点云累积、最终栅格编码和 Canvas 生命周期契约已通过开发机测试；仍需用本分支镜像在 Agent Core/Canvas 上复测独立启停和最终地图切换。速度方向、选配件存在性、充电及 Pro 导航仍未完成真机验证。首次联调前请确认系统版本为 V1.1.8、外接主机接入 `10.21.31.x` 或 `10.21.33.x` 网段，并确保没有与 `planner` 或 `charge_manager` 并发发布 `/NAV_CMD`。
+已在 M20 Pro 真机确认 `/grid_map_3d` 与 `/SLAM_ODOM` 均约 10 Hz，并确认 `/grid_map_3d` 为 `base_link` 坐标、XYZ float32、16 字节点步长，`/SLAM_ODOM` 为 `map` 坐标。通过 103 手动 SSH 启动 106 的 `mapping.service` 后，已确认 Agent Core/Canvas 中 `mapping_view` 可显示实时建图；最终 `/GRID_MAP` 切换仍需单独验真。实时坐标转换、点云累积、最终栅格编码和 Canvas 生命周期契约已通过开发机测试。速度方向、选配件存在性、充电及 Pro 导航仍未完成真机验证。首次联调前请确认系统版本为 V1.1.8、外接主机接入 `10.21.31.x` 或 `10.21.33.x` 网段，并确保没有与 `planner` 或 `charge_manager` 并发发布 `/NAV_CMD`。

--- a/deep_robotics/lynx_m20/config.yaml
+++ b/deep_robotics/lynx_m20/config.yaml
@@ -1,7 +1,7 @@
 mcp_port: 15716
 ros_namespace: ""
 name: "云深处山猫 M20"
-model_variant: "standard"
+model_variant: "pro"
 velocity_command_timeout: 0.5
 ros:
   robot_domain_id: 0
@@ -13,6 +13,12 @@ basic_server:
   udp_port: 30000
   tcp_port: 30001
   timeout: 1.5
+mapping_visualization:
+  occupied_threshold: 50
+  max_points: 50000
+  max_buffer_points: 200000
+  voxel_size: 0.08
+  publish_hz: 2.0
 topics:
   motion_info: "/MOTION_INFO"
   motion_state: "/MOTION_STATE"
@@ -27,3 +33,6 @@ topics:
   gps: "/GPS"
   joints: "/JOINTS_DATA"
   odometry: "/ODOM"
+  grid_map: "/GRID_MAP"
+  grid_map_3d: "/grid_map_3d"
+  slam_odometry: "/SLAM_ODOM"

--- a/deep_robotics/lynx_m20/device.py
+++ b/deep_robotics/lynx_m20/device.py
@@ -86,13 +86,18 @@ def _transform_point(point, pose):
     )
 
 
-def encode_occupancy_grid(msg, pose=None, *, occupied_threshold=50, max_points=50000, metadata=None) -> bytes:
-    """Convert nav_msgs/OccupancyGrid into the Canvas sensor/mapping packet."""
+def _validate_occupancy_grid(msg):
     width = int(msg.info.width)
     height = int(msg.info.height)
     resolution = float(msg.info.resolution)
     if width <= 0 or height <= 0 or resolution <= 0 or len(msg.data) < width * height:
         raise ValueError("invalid occupancy grid dimensions")
+    return width, height, resolution
+
+
+def encode_occupancy_grid(msg, pose=None, *, occupied_threshold=50, max_points=50000, metadata=None) -> bytes:
+    """Convert nav_msgs/OccupancyGrid into the Canvas sensor/mapping packet."""
+    width, height, resolution = _validate_occupancy_grid(msg)
 
     if not 0 <= occupied_threshold <= 100:
         raise ValueError("occupied_threshold must be between 0 and 100")
@@ -381,7 +386,9 @@ class M20Nodes:
         def callback(msg):
             try:
                 config = self.config.get("mapping_visualization", {})
+                _validate_occupancy_grid(msg)
                 with self._mapping_lock:
+                    self._mapping_last_grid_msg = msg
                     if self._mapping_runtime["state"] in ("starting", "live_mapping"):
                         return
                     pose = dict(self._mapping_pose) if self._mapping_pose else None
@@ -394,7 +401,6 @@ class M20Nodes:
                         "last_update_time": time.time(),
                     })
                     metadata = self._mapping_metadata_locked()
-                    self._mapping_last_grid_msg = msg
                 payload = encode_occupancy_grid(
                     msg,
                     pose,

--- a/deep_robotics/lynx_m20/device.py
+++ b/deep_robotics/lynx_m20/device.py
@@ -4,8 +4,12 @@
 from __future__ import annotations
 
 import json
+import math
+import os
+import struct
 import threading
 import time
+from array import array
 
 from basic_server import BasicServerClient
 from common.vendor_runtime import action_schema, jsonable, tool
@@ -15,12 +19,118 @@ GAITS = {"basic": 0x1001, "standard_stairs": 0x1003, "agile_flat": 0x3002, "agil
 MOTION_STATES = {"idle": 0, "stand": 1, "soft_estop": 2, "damping": 3, "lie": 4, "rl_control": 17}
 
 
+def _yaw_from_quaternion(quaternion) -> float:
+    x = float(getattr(quaternion, "x", 0.0))
+    y = float(getattr(quaternion, "y", 0.0))
+    z = float(getattr(quaternion, "z", 0.0))
+    w = float(getattr(quaternion, "w", 1.0))
+    return math.atan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z))
+
+
+def _mapping_packet(points, pose=None, metadata=None) -> bytes:
+    values = array("f")
+    for point in points:
+        values.extend((float(point[0]), float(point[1]), float(point[2])))
+    if values.itemsize != 4:
+        raise RuntimeError("sensor/mapping requires 32-bit floats")
+    if os.sys.byteorder != "little":
+        values.byteswap()
+    robot_x = float((pose or {}).get("x", 0.0))
+    robot_y = float((pose or {}).get("y", 0.0))
+    robot_yaw = -float((pose or {}).get("yaw", 0.0))
+    meta_bytes = b"" if metadata is None else json.dumps(metadata, ensure_ascii=False).encode("utf-8")
+    flags = 0x03 | (0x04 if meta_bytes else 0)
+    payload = struct.pack("<fffBI", robot_x, robot_y, robot_yaw, flags, len(values) // 3)
+    payload += values.tobytes()
+    if meta_bytes:
+        payload += struct.pack("<I", len(meta_bytes)) + meta_bytes
+    return payload
+
+
+def _pointcloud_xyz(msg):
+    """Extract finite XYZ float32 points from a standard PointCloud2 message."""
+    fields = {field.name: field for field in msg.fields}
+    if any(name not in fields for name in ("x", "y", "z")):
+        raise ValueError("PointCloud2 requires x/y/z fields")
+    if any(int(fields[name].datatype) != 7 or int(fields[name].count) != 1 for name in ("x", "y", "z")):
+        raise ValueError("PointCloud2 x/y/z fields must be FLOAT32 scalars")
+    point_step = int(msg.point_step)
+    if point_step <= 0:
+        raise ValueError("PointCloud2 point_step must be positive")
+    offsets = [int(fields[name].offset) for name in ("x", "y", "z")]
+    if any(offset < 0 or offset + 4 > point_step for offset in offsets):
+        raise ValueError("PointCloud2 field offset exceeds point_step")
+    raw = bytes(msg.data)
+    point_count = min(int(msg.width) * int(msg.height), len(raw) // point_step)
+    endian = ">" if bool(msg.is_bigendian) else "<"
+    points = []
+    for index in range(point_count):
+        base = index * point_step
+        point = tuple(struct.unpack_from(f"{endian}f", raw, base + offset)[0] for offset in offsets)
+        if all(math.isfinite(value) for value in point):
+            points.append(point)
+    return points
+
+
+def _transform_point(point, pose):
+    """Transform a base_link point into map coordinates using SLAM odometry."""
+    x, y, z = point
+    qx, qy, qz, qw = (float(pose[key]) for key in ("qx", "qy", "qz", "qw"))
+    xx, yy, zz = qx * qx, qy * qy, qz * qz
+    xy, xz, yz = qx * qy, qx * qz, qy * qz
+    wx, wy, wz = qw * qx, qw * qy, qw * qz
+    return (
+        float(pose["x"]) + (1 - 2 * (yy + zz)) * x + 2 * (xy - wz) * y + 2 * (xz + wy) * z,
+        float(pose["y"]) + 2 * (xy + wz) * x + (1 - 2 * (xx + zz)) * y + 2 * (yz - wx) * z,
+        float(pose.get("z", 0.0)) + 2 * (xz - wy) * x + 2 * (yz + wx) * y + (1 - 2 * (xx + yy)) * z,
+    )
+
+
+def encode_occupancy_grid(msg, pose=None, *, occupied_threshold=50, max_points=50000, metadata=None) -> bytes:
+    """Convert nav_msgs/OccupancyGrid into the Canvas sensor/mapping packet."""
+    width = int(msg.info.width)
+    height = int(msg.info.height)
+    resolution = float(msg.info.resolution)
+    if width <= 0 or height <= 0 or resolution <= 0 or len(msg.data) < width * height:
+        raise ValueError("invalid occupancy grid dimensions")
+
+    if not 0 <= occupied_threshold <= 100:
+        raise ValueError("occupied_threshold must be between 0 and 100")
+    if max_points <= 0:
+        raise ValueError("max_points must be positive")
+    cell_count = width * height
+    occupied_count = sum(1 for value in msg.data[:cell_count] if int(value) >= occupied_threshold)
+    stride = max(1, math.ceil(occupied_count / max_points))
+    origin = msg.info.origin
+    origin_yaw = _yaw_from_quaternion(origin.orientation)
+    cos_yaw, sin_yaw = math.cos(origin_yaw), math.sin(origin_yaw)
+    points = []
+    occupied_index = 0
+    for index, value in enumerate(msg.data[:cell_count]):
+        if int(value) < occupied_threshold:
+            continue
+        selected = occupied_index % stride == 0
+        occupied_index += 1
+        if not selected:
+            continue
+        column, row = index % width, index // width
+        local_x = (column + 0.5) * resolution
+        local_y = (row + 0.5) * resolution
+        points.append((
+            float(origin.position.x) + cos_yaw * local_x - sin_yaw * local_y,
+            float(origin.position.y) + sin_yaw * local_x + cos_yaw * local_y,
+            0.0,
+        ))
+    return _mapping_packet(points, pose, metadata)
+
+
 class M20Nodes:
     def __init__(self, config, namespace, ros2):
         from drdds.msg import Gait, JointsData, MotionInfo, MotionState, NavCmd, NavSat, StdMsgInt32, StdStatus
-        from nav_msgs.msg import Odometry
+        from nav_msgs.msg import OccupancyGrid, Odometry
+        from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
         from sensor_msgs.msg import Imu, PointCloud2
-        from std_msgs.msg import String
+        from std_msgs.msg import String, UInt8MultiArray
         from rclpy.node import Node
 
         self.config = config
@@ -41,6 +151,25 @@ class M20Nodes:
         self._header_lock = threading.Lock()
         self.values = {}
         self.streams = {}
+        self._mapping_pose = None
+        self._mapping_lock = threading.Lock()
+        self._mapping_voxels = {}
+        self._mapping_last_points = []
+        self._mapping_last_grid_msg = None
+        self._mapping_uint8_type = None
+        self._mapping_last_publish = 0.0
+        self._mapping_runtime = {
+            "state": "idle",
+            "requested_map": None,
+            "active_map": None,
+            "source": None,
+            "source_frame": None,
+            "target_frame": "map",
+            "update_count": 0,
+            "point_count": 0,
+            "buffer_point_count": 0,
+            "last_update_time": None,
+        }
         self.frame_id = 0
         self.native_velocity_command = 25
         self._motion_condition = threading.Condition(threading.Lock())
@@ -88,6 +217,47 @@ class M20Nodes:
                 depth,
             )
             self.streams[key] = {"robot_topic": robot_topic, "topic": core_topic, "format": fmt}
+        if self.is_pro:
+            self.mapping_topic = f"/{namespace}/lynx_m20/mapping_view"
+            self.mapping_pub = self.core.create_publisher(UInt8MultiArray, self.mapping_topic, 1)
+            self._mapping_uint8_type = UInt8MultiArray
+            final_map_callback = self._final_mapping_callback(UInt8MultiArray)
+            live_qos = QoSProfile(
+                reliability=ReliabilityPolicy.BEST_EFFORT,
+                durability=DurabilityPolicy.VOLATILE,
+                history=HistoryPolicy.KEEP_LAST,
+                depth=1,
+            )
+            latched_qos = QoSProfile(
+                reliability=ReliabilityPolicy.RELIABLE,
+                durability=DurabilityPolicy.TRANSIENT_LOCAL,
+                history=HistoryPolicy.KEEP_LAST,
+                depth=1,
+            )
+            self.robot.create_subscription(
+                OccupancyGrid,
+                topics.get("grid_map", "/GRID_MAP"),
+                final_map_callback,
+                live_qos,
+            )
+            self.robot.create_subscription(
+                OccupancyGrid,
+                topics.get("grid_map", "/GRID_MAP"),
+                final_map_callback,
+                latched_qos,
+            )
+            self.robot.create_subscription(
+                PointCloud2,
+                topics.get("grid_map_3d", "/grid_map_3d"),
+                self._live_mapping_callback(UInt8MultiArray),
+                live_qos,
+            )
+            self.robot.create_subscription(
+                Odometry,
+                topics.get("slam_odometry", "/SLAM_ODOM"),
+                self._slam_odometry_callback,
+                live_qos,
+            )
 
     def _callback(self, key, publisher, *, as_json=False, string_type=None):
         def callback(msg):
@@ -119,6 +289,165 @@ class M20Nodes:
                     self._last_gait = gait
                     self.publish_motion_event("gait_changed", previous=previous, current=gait, confirmed=True)
         return callback
+
+    def _slam_odometry_callback(self, msg):
+        pose = msg.pose.pose
+        frame_id = str(getattr(msg.header, "frame_id", ""))
+        if frame_id and frame_id != "map":
+            print(f"[mapping_view] ignored SLAM pose in unexpected frame: {frame_id}", flush=True)
+            return
+        quaternion = pose.orientation
+        value = {
+            "x": float(pose.position.x),
+            "y": float(pose.position.y),
+            "z": float(pose.position.z),
+            "qx": float(quaternion.x),
+            "qy": float(quaternion.y),
+            "qz": float(quaternion.z),
+            "qw": float(quaternion.w),
+            "yaw": _yaw_from_quaternion(quaternion),
+        }
+        with self._mapping_lock:
+            self._mapping_pose = value
+
+    def _mapping_metadata_locked(self):
+        return {"version": 3, **self._mapping_runtime}
+
+    def _publish_mapping_payload(self, uint8_type, points, pose, metadata):
+        payload = _mapping_packet(points, pose, metadata)
+        output = uint8_type()
+        try:
+            output.data = array("B", payload)
+        except TypeError:
+            output.data = list(payload)
+        self.mapping_pub.publish(output)
+
+    def _live_mapping_callback(self, uint8_type):
+        def callback(msg):
+            try:
+                config = self.config.get("mapping_visualization", {})
+                with self._mapping_lock:
+                    if self._mapping_runtime["state"] not in ("starting", "live_mapping", "saving"):
+                        return
+                    pose = dict(self._mapping_pose) if self._mapping_pose else None
+                if pose is None:
+                    return
+                frame_id = str(getattr(msg.header, "frame_id", ""))
+                if frame_id != "base_link":
+                    raise ValueError(f"expected grid_map_3d frame base_link, got {frame_id or 'empty'}")
+                local_points = _pointcloud_xyz(msg)
+                voxel_size = float(config.get("voxel_size", 0.08))
+                max_buffer_points = int(config.get("max_buffer_points", 200000))
+                max_points = int(config.get("max_points", 50000))
+                publish_interval = 1.0 / max(0.1, float(config.get("publish_hz", 2.0)))
+                if voxel_size <= 0 or max_buffer_points <= 0 or max_points <= 0:
+                    raise ValueError("mapping visualization limits must be positive")
+                transformed = [_transform_point(point, pose) for point in local_points]
+                now = time.monotonic()
+                with self._mapping_lock:
+                    for point in transformed:
+                        voxel = tuple(math.floor(value / voxel_size) for value in point)
+                        self._mapping_voxels[voxel] = point
+                    excess = len(self._mapping_voxels) - max_buffer_points
+                    if excess > 0:
+                        for voxel in list(self._mapping_voxels)[:excess]:
+                            self._mapping_voxels.pop(voxel, None)
+                    self._mapping_runtime.update({
+                        "state": "live_mapping" if self._mapping_runtime["state"] == "starting" else self._mapping_runtime["state"],
+                        "source": "grid_map_3d",
+                        "source_frame": frame_id,
+                        "target_frame": "map",
+                        "update_count": self._mapping_runtime["update_count"] + 1,
+                        "buffer_point_count": len(self._mapping_voxels),
+                        "last_update_time": time.time(),
+                    })
+                    if now - self._mapping_last_publish < publish_interval:
+                        return
+                    all_points = list(self._mapping_voxels.values())
+                    stride = max(1, math.ceil(len(all_points) / max_points))
+                    points = all_points[::stride]
+                    self._mapping_runtime["point_count"] = len(points)
+                    self._mapping_last_points = points
+                    self._mapping_last_publish = now
+                    metadata = self._mapping_metadata_locked()
+                self._publish_mapping_payload(uint8_type, points, pose, metadata)
+                with self.lock:
+                    self.values["mapping_view"] = dict(metadata)
+            except Exception as exc:
+                print(f"[mapping_view] skipped invalid live cloud: {exc}", flush=True)
+        return callback
+
+    def _final_mapping_callback(self, uint8_type):
+        def callback(msg):
+            try:
+                config = self.config.get("mapping_visualization", {})
+                with self._mapping_lock:
+                    if self._mapping_runtime["state"] in ("starting", "live_mapping"):
+                        return
+                    pose = dict(self._mapping_pose) if self._mapping_pose else None
+                    self._mapping_runtime.update({
+                        "state": "saved_map",
+                        "source": "GRID_MAP",
+                        "source_frame": str(getattr(msg.header, "frame_id", "map")) or "map",
+                        "target_frame": "map",
+                        "update_count": self._mapping_runtime["update_count"] + 1,
+                        "last_update_time": time.time(),
+                    })
+                    metadata = self._mapping_metadata_locked()
+                    self._mapping_last_grid_msg = msg
+                payload = encode_occupancy_grid(
+                    msg,
+                    pose,
+                    occupied_threshold=int(config.get("occupied_threshold", 50)),
+                    max_points=int(config.get("max_points", 50000)),
+                    metadata=metadata,
+                )
+                point_count = struct.unpack_from("<I", payload, 13)[0]
+                with self._mapping_lock:
+                    self._mapping_runtime["point_count"] = point_count
+                    metadata = self._mapping_metadata_locked()
+                payload = encode_occupancy_grid(
+                    msg,
+                    pose,
+                    occupied_threshold=int(config.get("occupied_threshold", 50)),
+                    max_points=int(config.get("max_points", 50000)),
+                    metadata=metadata,
+                )
+                output = uint8_type()
+                try:
+                    output.data = array("B", payload)
+                except TypeError:
+                    output.data = list(payload)
+                self.mapping_pub.publish(output)
+                with self.lock:
+                    self.values["mapping_view"] = dict(metadata)
+            except Exception as exc:
+                print(f"[mapping_view] skipped invalid final grid: {exc}", flush=True)
+        return callback
+
+    def start_mapping_view(self):
+        with self._mapping_lock:
+            self._mapping_voxels.clear()
+            self._mapping_last_points = []
+            self._mapping_last_publish = 0.0
+            self._mapping_runtime.update({
+                "state": "live_mapping", "requested_map": None, "active_map": None,
+                "source": "grid_map_3d", "source_frame": "base_link", "target_frame": "map",
+                "update_count": 0, "point_count": 0, "last_update_time": None,
+                "buffer_point_count": 0,
+            })
+
+    def stop_mapping_view(self):
+        with self._mapping_lock:
+            self._mapping_runtime["state"] = "idle"
+            final_grid = self._mapping_last_grid_msg
+            uint8_type = self._mapping_uint8_type
+        if final_grid is not None and uint8_type is not None:
+            self._final_mapping_callback(uint8_type)(final_grid)
+
+    def mapping_view_snapshot(self):
+        with self._mapping_lock:
+            return dict(self._mapping_runtime)
 
     def publish_motion_event(self, event: str, **data) -> dict:
         from std_msgs.msg import String
@@ -546,8 +875,45 @@ class M20ProNavigationPlugin:
         return self.nodes.native.request(1003, 1, items)
 
 
+class M20MappingViewPlugin:
+    def __init__(self, nodes):
+        self.nodes = nodes
+        self.topic_out = [{"topic": nodes.mapping_topic, "format": "sensor/mapping"}]
+
+    def get_tool(self):
+        return tool(
+            "mapping_view",
+            "sensor",
+            "仅 M20 Pro：实时累积 /grid_map_3d 并通过 /SLAM_ODOM 转换到 map 坐标；停止后显示最终 /GRID_MAP",
+            topic_out=self.topic_out,
+        )
+
+    def start(self): pass
+    def stop(self): pass
+
+    def dispatch(self, action, args):
+        if action == "stop":
+            self.nodes.stop_mapping_view()
+            return {"state": "idle"}
+        if action == "start":
+            self.nodes.start_mapping_view()
+            snapshot = getattr(self.nodes, "mapping_view_snapshot", lambda: {"state": "ready"})()
+            return {
+                **snapshot,
+                "state": "running",
+                "mapping_state": snapshot.get("state", "ready"),
+                "topic_out": self.topic_out,
+            }
+        if action == "info":
+            snapshot = getattr(self.nodes, "mapping_view_snapshot", lambda: {"state": "ready"})()
+            return {**snapshot, "topic_out": self.topic_out}
+        raise ValueError(f"unsupported mapping_view action: {action}")
+
+
 def build_plugins(config, namespace, ros2):
     nodes = M20Nodes(config, namespace, ros2)
     plugins = [M20StatePlugin(nodes), M20MotionPlugin(nodes), M20MotionEventsPlugin(nodes), M20ChargePlugin(nodes), M20DevicePlugin(nodes)]
-    if nodes.is_pro: plugins.append(M20ProNavigationPlugin(nodes))
+    if nodes.is_pro:
+        plugins.append(M20ProNavigationPlugin(nodes))
+        plugins.append(M20MappingViewPlugin(nodes))
     return plugins

--- a/tests/test_lynx_m20_driver.py
+++ b/tests/test_lynx_m20_driver.py
@@ -198,6 +198,32 @@ class LynxM20ContractTests(unittest.TestCase):
             metadata["state"], metadata["requested_map"], metadata["source"],
         ))
 
+        quaternion = SimpleNamespace(x=0.0, y=0.0, z=0.0, w=1.0)
+        grid = SimpleNamespace(
+            header=SimpleNamespace(frame_id="map"),
+            info=SimpleNamespace(
+                width=2, height=1, resolution=0.5,
+                origin=SimpleNamespace(
+                    position=SimpleNamespace(x=0.0, y=0.0),
+                    orientation=quaternion,
+                ),
+            ),
+            data=[100, 0],
+        )
+        nodes._final_mapping_callback(FakeUInt8)(grid)
+        self.assertIs(grid, nodes._mapping_last_grid_msg)
+        self.assertEqual(1, len(nodes.mapping_pub.messages))
+
+        nodes.stop_mapping_view()
+        self.assertEqual(2, len(nodes.mapping_pub.messages))
+        packet = bytes(nodes.mapping_pub.messages[-1].data)
+        _, _, _, flags, count = struct.unpack_from("<fffBI", packet)
+        self.assertEqual((0x07, 1), (flags, count))
+        metadata_offset = 17 + count * 12
+        metadata_size = struct.unpack_from("<I", packet, metadata_offset)[0]
+        metadata = json.loads(packet[metadata_offset + 4:metadata_offset + 4 + metadata_size])
+        self.assertEqual(("saved_map", "GRID_MAP"), (metadata["state"], metadata["source"]))
+
     def test_mapping_view_encodes_supported_canvas_packet(self):
         quaternion = SimpleNamespace(x=0.0, y=0.0, z=0.0, w=1.0)
         origin = SimpleNamespace(position=SimpleNamespace(x=-1.0, y=2.0), orientation=quaternion)

--- a/tests/test_lynx_m20_driver.py
+++ b/tests/test_lynx_m20_driver.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import struct
 import sys
 import threading
 import time
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -58,6 +60,8 @@ class FakeNodes:
         self.last_velocity = ("stopped", reason)
         self.publish_motion_event("motion_stopped", reason=reason)
     def motion_summary(self): return {"state": 17}
+    def start_mapping_view(self): pass
+    def stop_mapping_view(self): pass
 
 
 class LynxM20ContractTests(unittest.TestCase):
@@ -92,6 +96,160 @@ class LynxM20ContractTests(unittest.TestCase):
         self.assertEqual((2, 23), (body["Type"], body["Command"]))
         self.assertEqual(0x3002, body["Items"]["GaitParam"])
         self.assertEqual(protocol.SYNC, frame[:4])
+
+    def test_live_mapping_pointcloud_layout_and_map_transform(self):
+        fields = [
+            SimpleNamespace(name="x", offset=0, datatype=7, count=1),
+            SimpleNamespace(name="y", offset=4, datatype=7, count=1),
+            SimpleNamespace(name="z", offset=8, datatype=7, count=1),
+        ]
+        raw = struct.pack("<fffIfffI", 1.0, 2.0, 3.0, 99, -1.0, 0.5, 0.0, 42)
+        cloud = SimpleNamespace(
+            fields=fields, point_step=16, width=2, height=1,
+            is_bigendian=False, data=raw,
+        )
+        self.assertEqual([(1.0, 2.0, 3.0), (-1.0, 0.5, 0.0)], m20._pointcloud_xyz(cloud))
+
+        half = 2 ** -0.5
+        pose = {"x": 10.0, "y": 20.0, "z": 0.0, "qx": 0.0, "qy": 0.0, "qz": half, "qw": half}
+        transformed = m20._transform_point((1.0, 0.0, 0.0), pose)
+        self.assertAlmostEqual(10.0, transformed[0], places=6)
+        self.assertAlmostEqual(21.0, transformed[1], places=6)
+        self.assertAlmostEqual(0.0, transformed[2], places=6)
+
+    def test_mapping_packet_carries_map_name_and_runtime_metadata(self):
+        metadata = {
+            "version": 3,
+            "state": "live_mapping",
+            "requested_map": "floor_1",
+            "active_map": None,
+        }
+        packet = m20._mapping_packet([(1, 2, 3)], {"x": 4, "y": 5, "yaw": 0.25}, metadata)
+        _, _, _, flags, point_count = struct.unpack_from("<fffBI", packet)
+        self.assertEqual((0x07, 1), (flags, point_count))
+        metadata_offset = 17 + point_count * 12
+        metadata_size = struct.unpack_from("<I", packet, metadata_offset)[0]
+        decoded = json.loads(packet[metadata_offset + 4:metadata_offset + 4 + metadata_size])
+        self.assertEqual("floor_1", decoded["requested_map"])
+        self.assertEqual("live_mapping", decoded["state"])
+
+    def test_live_mapping_callback_accumulates_transformed_points(self):
+        class FakePublisher:
+            def __init__(self): self.messages = []
+            def publish(self, message): self.messages.append(message)
+
+        class FakeUInt8:
+            def __init__(self): self.data = []
+
+        nodes = object.__new__(m20.M20Nodes)
+        nodes.config = {"mapping_visualization": {
+            "voxel_size": 0.08, "max_buffer_points": 100, "max_points": 100, "publish_hz": 100,
+        }}
+        nodes.lock = threading.Lock()
+        nodes.values = {}
+        nodes._mapping_lock = threading.Lock()
+        nodes._mapping_pose = None
+        nodes._mapping_voxels = {}
+        nodes._mapping_last_points = []
+        nodes._mapping_last_grid_msg = None
+        nodes._mapping_uint8_type = FakeUInt8
+        nodes._mapping_last_publish = 0.0
+        nodes._mapping_runtime = {
+            "state": "idle", "requested_map": None, "active_map": None,
+            "source": None, "source_frame": None, "target_frame": "map",
+            "update_count": 0, "point_count": 0, "buffer_point_count": 0,
+            "last_update_time": None,
+        }
+        nodes.mapping_pub = FakePublisher()
+        nodes.start_mapping_view()
+
+        quaternion = SimpleNamespace(x=0.0, y=0.0, z=0.0, w=1.0)
+        pose = SimpleNamespace(
+            position=SimpleNamespace(x=10.0, y=20.0, z=0.0),
+            orientation=quaternion,
+        )
+        odometry = SimpleNamespace(
+            header=SimpleNamespace(frame_id="map"),
+            pose=SimpleNamespace(pose=pose),
+        )
+        nodes._slam_odometry_callback(odometry)
+
+        fields = [
+            SimpleNamespace(name="x", offset=0, datatype=7, count=1),
+            SimpleNamespace(name="y", offset=4, datatype=7, count=1),
+            SimpleNamespace(name="z", offset=8, datatype=7, count=1),
+        ]
+        cloud = SimpleNamespace(
+            header=SimpleNamespace(frame_id="base_link"), fields=fields,
+            point_step=16, width=1, height=1, is_bigendian=False,
+            data=struct.pack("<fffI", 1.0, 2.0, 3.0, 0),
+        )
+        nodes._live_mapping_callback(FakeUInt8)(cloud)
+
+        self.assertEqual(1, len(nodes.mapping_pub.messages))
+        packet = bytes(nodes.mapping_pub.messages[0].data)
+        _, _, _, flags, count = struct.unpack_from("<fffBI", packet)
+        self.assertEqual((0x07, 1), (flags, count))
+        self.assertEqual((11.0, 22.0, 3.0), struct.unpack_from("<fff", packet, 17))
+        metadata_offset = 17 + count * 12
+        metadata_size = struct.unpack_from("<I", packet, metadata_offset)[0]
+        metadata = json.loads(packet[metadata_offset + 4:metadata_offset + 4 + metadata_size])
+        self.assertEqual(("live_mapping", None, "grid_map_3d"), (
+            metadata["state"], metadata["requested_map"], metadata["source"],
+        ))
+
+    def test_mapping_view_encodes_supported_canvas_packet(self):
+        quaternion = SimpleNamespace(x=0.0, y=0.0, z=0.0, w=1.0)
+        origin = SimpleNamespace(position=SimpleNamespace(x=-1.0, y=2.0), orientation=quaternion)
+        grid = SimpleNamespace(
+            info=SimpleNamespace(width=3, height=2, resolution=0.5, origin=origin),
+            data=[0, 50, -1, 100, 49, 80],
+        )
+        packet = m20.encode_occupancy_grid(grid, {"x": 1, "y": 2, "yaw": 0.25})
+        robot_x, robot_y, robot_yaw, flags, count = m20.struct.unpack_from("<fffBI", packet)
+        self.assertEqual((1.0, 2.0, -0.25, 0x03, 3), (robot_x, robot_y, robot_yaw, flags, count))
+        points = m20.struct.unpack_from("<9f", packet, 17)
+        self.assertEqual((-0.25, 2.25, 0.0), points[:3])
+        self.assertEqual((-0.75, 2.75, 0.0), points[3:6])
+        self.assertEqual((0.25, 2.75, 0.0), points[6:9])
+
+    def test_mapping_view_static_and_dynamic_contract_match(self):
+        nodes = FakeNodes()
+        nodes.mapping_topic = "/host/lynx_m20/mapping_view"
+        nodes.mapping_view_snapshot = lambda: {
+            "state": "live_mapping", "requested_map": "floor_1", "point_count": 123,
+        }
+        plugin = m20.M20MappingViewPlugin(nodes)
+        expected = [{"topic": nodes.mapping_topic, "format": "sensor/mapping"}]
+        self.assertEqual(expected, plugin.get_tool()["topic_out"])
+        started = plugin.dispatch("start", {})
+        self.assertEqual(expected, started["topic_out"])
+        self.assertEqual(
+            ("running", "live_mapping", "floor_1", 123),
+            (started["state"], started["mapping_state"], started["requested_map"], started["point_count"]),
+        )
+        info = plugin.dispatch("info", {})
+        self.assertEqual(expected, info["topic_out"])
+        self.assertEqual(("live_mapping", "floor_1", 123), (info["state"], info["requested_map"], info["point_count"]))
+        self.assertEqual({"state": "idle"}, plugin.dispatch("stop", {}))
+
+    def test_mapping_view_start_reports_running_when_mapping_is_idle(self):
+        nodes = FakeNodes()
+        nodes.mapping_topic = "/host/lynx_m20/mapping_view"
+        nodes.mapping_view_snapshot = lambda: {
+            "state": "idle", "requested_map": None, "point_count": 0,
+        }
+        started = m20.M20MappingViewPlugin(nodes).dispatch("start", {})
+        self.assertEqual("running", started["state"])
+        self.assertEqual("idle", started["mapping_state"])
+        self.assertEqual(0, started["point_count"])
+
+    def test_mapping_view_supports_live_and_latched_grid_publishers(self):
+        source = (DRIVER / "device.py").read_text()
+        self.assertIn("DurabilityPolicy.VOLATILE", source)
+        self.assertIn("DurabilityPolicy.TRANSIENT_LOCAL", source)
+        self.assertIn("ReliabilityPolicy.BEST_EFFORT", source)
+        self.assertIn("ReliabilityPolicy.RELIABLE", source)
 
     def test_tcp_stream_decoder_handles_fragmented_and_concatenated_frames(self):
         first = protocol.encode_frame(1, 100, 100)
@@ -303,8 +461,10 @@ class LynxM20ContractTests(unittest.TestCase):
         config = (DRIVER / "config.yaml").read_text()
         source = (DRIVER / "device.py").read_text()
         readme = (DRIVER / "README.md").read_text()
-        self.assertIn('model_variant: "standard"', config)
+        self.assertIn('model_variant: "pro"', config)
         self.assertIn("if nodes.is_pro", source)
+        self.assertNotIn("M20ProMappingPlugin", source)
+        self.assertNotIn("nos_mapping", source)
         self.assertIn("仅 M20 Pro", readme)
         self.assertIn("未提供舞蹈", readme)
 


### PR DESCRIPTION
## 变更内容

- 新增仅 M20 Pro 注册的 `mapping_view` Sensor，输出 Canvas 支持的 `sensor/mapping` 数据流。
- 将 `/grid_map_3d` 点云通过 `/SLAM_ODOM` 转换并累积到 `map` 坐标系，支持限频、体素去重和点数上限。
- 支持读取实时及 transient-local 的 `/GRID_MAP`，编码最终占据栅格视图。
- `mapping_view` 自己管理 start/stop 生命周期，不再依赖 `mapping` 控制卡触发内部状态。
- 默认配置改为 M20 Pro，保证 Web Console 未挂载外部配置时能够发现该卡片。

## 边界

- 本 PR 仅提供只读可视化，不包含 `mapping` 控制卡。
- 不包含 SSH、私钥、NOS helper、OpenSSH 包或构建基础设施改动。
- Driver 不负责启动、停止或保存 NOS 建图任务。

## 验证

- `python3 tests/test_lynx_m20_driver.py`：29 tests passed。
- `git diff --check upstream/main...HEAD`：通过。
- 已在 M20 Pro 确认 `/grid_map_3d` 和 `/SLAM_ODOM` 均约 10 Hz；独立卡片启停与最终地图切换仍需使用本分支镜像进行 Canvas 真机复测。
