### PR TITLE
fix(t800): extend driver health media status

### DIFF
--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -24,7 +24,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_command_feedback` | sensor | Native SDK 最近关节控制命令反馈 |
 | `gamepad` | sensor | 遥控器连接、按键和摇杆状态 |
 | `motion_state` | sensor | 当前 Native SDK motion state 和允许转换 |
-| `driver_health` | sensor | 各 ROS2 数据源连接与新鲜度 |
+| `driver_health` | sensor | 机器人、麦克风与 Odin2 点云/双目/深度数据流的连接、新鲜度和分组健康摘要 |
 | `robot_snapshot` | sensor | 运动、关节、IMU、电源和电机健康聚合快照 |
 | `fault_summary` | sensor | 电机掉线/禁用/错误/过温及电源错误摘要 |
 | `stability` | sensor | 基于 IMU 的倾斜和跌倒风险估计 |

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -24,7 +24,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_command_feedback` | sensor | Native SDK 最近关节控制命令反馈 |
 | `gamepad` | sensor | 遥控器连接、按键和摇杆状态 |
 | `motion_state` | sensor | 当前 Native SDK motion state 和允许转换 |
-| `driver_health` | sensor | 机器人、麦克风与 Odin2 点云/双目/深度数据流的连接、新鲜度和分组健康摘要 |
+| `driver_health` | actuator | 每次执行返回一次机器人、麦克风与 Odin2 点云/双目/深度数据流的最新健康 JSON，不持续发布 |
 | `robot_snapshot` | sensor | 运动、关节、IMU、电源和电机健康聚合快照 |
 | `fault_summary` | sensor | 电机掉线/禁用/错误/过温及电源错误摘要 |
 | `stability` | sensor | 基于 IMU 的倾斜和跌倒风险估计 |

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -208,7 +208,6 @@ class StatePlugin:
         "joint_command_feedback": ("state/joint_command_feedback", "data/json", "T800 Native SDK 最近关节控制命令反馈"),
         "gamepad": ("state/gamepad", "data/json", "T800 遥控器连接、按键和摇杆状态"),
         "motion_state": ("state/motion", "data/json", "T800 当前运动状态和允许转换状态"),
-        "driver_health": ("state/driver_health", "data/json", "T800 driver 各数据源连接与新鲜度"),
     }
     _DERIVED_STREAMS = {
         "robot_snapshot": ("state/robot_snapshot", "T800 运动、关节、IMU、电源和电机状态聚合快照"),
@@ -270,6 +269,19 @@ class StatePlugin:
             sensor_tool(name, description, f"/{self._ns}/{relative}", fmt)
             for name, (relative, fmt, description) in self._STREAMS.items()
         ]
+        tools.append(
+            {
+                "name": "driver_health",
+                "type": "actuator",
+                "multiInstance": False,
+                "description": "执行一次并返回 T800 机器人、麦克风与 Odin2 数据流的最新健康 JSON",
+                "inputSchema": action_schema(
+                    {"status": ([], "获取一次最新 Driver Health JSON")},
+                    {},
+                    "一次性健康检查动作",
+                ),
+            }
+        )
         tools.append(
             {
                 "name": "model",
@@ -351,10 +363,14 @@ class StatePlugin:
                 return {"error": "T800 URDF not found"}
         if action_or_tool in self._DERIVED_STREAMS:
             return self._derived_snapshot(action_or_tool)
+        if action_or_tool == "driver_health":
+            return self._health()
         if action_or_tool in self._STREAMS:
             return self._snapshot(action_or_tool)
         if action_or_tool == "status":
             name = args.get("_tool_name", "driver_health")
+            if name == "driver_health":
+                return self._health()
             if name in self._DERIVED_STREAMS:
                 return self._derived_snapshot(name)
             if name in self._STREAMS:
@@ -645,8 +661,6 @@ class StatePlugin:
             self._updated[name] = time.monotonic()
 
     def _snapshot(self, name: str) -> dict:
-        if name == "driver_health":
-            return self._health()
         with self._lock:
             payload = dict(self._cache.get(name, {"state": "no_data"}))
             updated = self._updated.get(name)
@@ -665,7 +679,6 @@ class StatePlugin:
                     "label": self._SOURCE_LABELS.get(name, name),
                 }
                 for name in self._STREAMS
-                if name != "driver_health"
             }
             providers = dict(self._health_providers)
         for value in sources.values():
@@ -881,12 +894,11 @@ class StatePlugin:
             "motor_command": 4,
             "joint_command_feedback": 4,
             "battery": 20,
-            "driver_health": 20,
         }
         for name, divisor in schedules.items():
             if tick % divisor:
                 continue
-            if name != "driver_health" and name not in self._cache:
+            if name not in self._cache:
                 continue
             self._publishers[name].publish(_json_message(self._snapshot(name)))
         if tick % 20 == 0:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -221,6 +221,17 @@ class StatePlugin:
     }
     _MAINBOARD_KEYWORDS = ("mainboard", "main_board", "board", "thermal", "temperature", "fan", "diagnostic")
     _MAINBOARD_STRONG_KEYWORDS = ("mainboard", "main_board", "board")
+    _SOURCE_LABELS = {
+        "joints": "关节状态",
+        "imu": "机身 IMU",
+        "battery": "电池",
+        "motor_health": "电机健康",
+        "motor_state": "电机状态",
+        "motor_command": "电机命令",
+        "joint_command_feedback": "关节命令反馈",
+        "gamepad": "遥控器",
+        "motion_state": "运动状态",
+    }
 
     def __init__(self, config: dict, namespace: str, ros2, motion_events=None):
         self._config = config
@@ -236,6 +247,7 @@ class StatePlugin:
         self._last_joint_positions = [0.0] * len(T800_JOINT_NAMES)
         self._current_motion = ""
         self._available_motions: list[str] = []
+        self._health_providers: dict[str, object] = {}
 
         self._sub_node = Node("t800_state_sub", context=ros2.ctx_robot)
         self._pub_node = Node("t800_state_pub", context=ros2.ctx_core)
@@ -325,6 +337,11 @@ class StatePlugin:
     def joint_positions(self) -> list[float]:
         with self._lock:
             return list(self._last_joint_positions)
+
+    def register_health_provider(self, name: str, callback) -> None:
+        """Add non-StatePlugin streams to the driver_health aggregation."""
+        with self._lock:
+            self._health_providers[str(name)] = callback
 
     def dispatch(self, action_or_tool: str, args: dict) -> dict:
         if action_or_tool == "model":
@@ -644,24 +661,109 @@ class StatePlugin:
                 name: {
                     "connected": name in self._updated,
                     "age_sec": None if name not in self._updated else max(0.0, now - self._updated[name]),
+                    "category": "robot",
+                    "label": self._SOURCE_LABELS.get(name, name),
                 }
                 for name in self._STREAMS
                 if name != "driver_health"
             }
+            providers = dict(self._health_providers)
         for value in sources.values():
             value["stale"] = value["age_sec"] is None or value["age_sec"] > self._timeout
+            value["state"] = (
+                "running" if value["connected"] and not value["stale"]
+                else "stale" if value["connected"]
+                else "waiting"
+            )
+        for provider_name, callback in providers.items():
+            try:
+                provided = callback()
+                if not isinstance(provided, dict):
+                    raise TypeError("health provider must return an object")
+                for source_name, value in provided.items():
+                    if isinstance(value, dict):
+                        sources[str(source_name)] = dict(value)
+            except Exception as exc:
+                sources[provider_name] = {
+                    "connected": False,
+                    "age_sec": None,
+                    "stale": True,
+                    "state": "error",
+                    "category": "internal",
+                    "label": provider_name,
+                    "error": str(exc),
+                }
+        for value in sources.values():
+            value.setdefault("connected", False)
+            value.setdefault("age_sec", None)
+            value.setdefault(
+                "stale", value["age_sec"] is None or float(value["age_sec"]) > self._timeout
+            )
+            value.setdefault("state", "running" if value["connected"] and not value["stale"] else "waiting")
+            value.setdefault("category", "other")
+            value.setdefault("label", "未命名数据流")
+            if value["age_sec"] is not None:
+                value["age_sec"] = round(float(value["age_sec"]), 3)
         connected = sum(1 for value in sources.values() if value["connected"])
         fresh = sum(1 for value in sources.values() if value["connected"] and not value["stale"])
-        if fresh:
+        total = len(sources)
+        if total and fresh == total:
             state = "running"
-        elif connected:
+        elif connected or fresh:
             state = "degraded"
         else:
             state = "waiting"
+        groups = {}
+        for category in ("robot", "audio", "odin2", "internal", "other"):
+            names = [name for name, value in sources.items() if value["category"] == category]
+            if not names:
+                continue
+            group_connected = sum(1 for name in names if sources[name]["connected"])
+            group_fresh = sum(
+                1 for name in names if sources[name]["connected"] and not sources[name]["stale"]
+            )
+            if group_fresh == len(names):
+                group_state = "running"
+            elif group_connected or group_fresh:
+                group_state = "degraded"
+            else:
+                states = {sources[name]["state"] for name in names}
+                group_state = "error" if "error" in states else "waiting"
+            groups[category] = {
+                "state": group_state,
+                "connected": group_connected,
+                "fresh": group_fresh,
+                "total": len(names),
+                "sources": names,
+            }
+        issues = [
+            f"{value['label']}: {value['state']}"
+            for value in sources.values()
+            if value["state"] != "running"
+        ]
+        group_summary = {
+            category: f"{group['state']} · {group['fresh']}/{group['total']} 路正常"
+            for category, group in groups.items()
+        }
         return {
             "state": state,
+            "health_summary": f"{fresh}/{total} 路数据流正常",
+            "robot_summary": group_summary.get("robot", "unavailable"),
+            "audio_summary": group_summary.get("audio", "unavailable"),
+            "odin2_summary": group_summary.get("odin2", "unavailable"),
+            "microphone_state": sources.get("microphone", {}).get("state", "unavailable"),
+            "odin2_pointcloud_state": sources.get("odin2_pointcloud", {}).get("state", "unavailable"),
+            "odin2_camera_left_state": sources.get("odin2_camera_left", {}).get("state", "unavailable"),
+            "odin2_camera_right_state": sources.get("odin2_camera_right", {}).get("state", "unavailable"),
+            "odin2_depth_state": sources.get("odin2_depth", {}).get("state", "unavailable"),
             "connected_sources": connected,
             "fresh_sources": fresh,
+            "total_sources": total,
+            "robot_state": groups.get("robot", {}).get("state", "unavailable"),
+            "audio_state": groups.get("audio", {}).get("state", "unavailable"),
+            "odin2_state": groups.get("odin2", {}).get("state", "unavailable"),
+            "issues": issues,
+            "groups": groups,
             "sources": sources,
             "robot_domain_id": self._config["ros"]["robot_domain_id"],
             "core_domain_id": self._config["ros"]["core_domain_id"],
@@ -3353,7 +3455,12 @@ class MicPlugin:
         self._process = None
         self._thread = None
         self._samples_published = 0
+        self._chunks_published = 0
+        self._last_chunk_at: float | None = None
         self._last_error = ""
+        self._stop_requested = False
+        self._timeout = float(config["ros"].get("source_timeout_sec", 1.0))
+        self._lock = threading.RLock()
 
     def get_tool(self) -> dict:
         return sensor_tool(
@@ -3384,7 +3491,11 @@ class MicPlugin:
             self._last_error = f"parec exited with code {self._process.returncode}"
             self._process = None
             raise RuntimeError(self._last_error)
-        self._running = True
+        with self._lock:
+            self._running = True
+            self._last_chunk_at = None
+            self._last_error = ""
+            self._stop_requested = False
         self._thread = threading.Thread(target=self._capture_loop, daemon=True, name="t800-mic")
         self._thread.start()
 
@@ -3401,7 +3512,9 @@ class MicPlugin:
         subprocess.run(["pactl", "info"], capture_output=True, text=True, timeout=3, check=True)
 
     def stop(self) -> None:
-        self._running = False
+        with self._lock:
+            self._running = False
+            self._stop_requested = True
         process = self._process
         self._process = None
         if process is not None and process.poll() is None:
@@ -3430,7 +3543,9 @@ class MicPlugin:
                     self._publish_chunk(bytes(pending))
                     pending.clear()
         except Exception as exc:  # noqa: BLE001
-            self._last_error = str(exc)
+            with self._lock:
+                self._last_error = str(exc)
+                self._running = False
         finally:
             if self._running and process is not None and process.poll() is not None:
                 self._last_error = f"parec exited with code {process.returncode}"
@@ -3443,7 +3558,49 @@ class MicPlugin:
         msg.format = "audio/pcm-16k"
         msg.data = list(chunk)
         self._publisher.publish(msg)
-        self._samples_published += len(chunk) // 2
+        with self._lock:
+            self._samples_published += len(chunk) // 2
+            self._chunks_published += 1
+            self._last_chunk_at = time.monotonic()
+
+    def health_sources(self) -> dict:
+        now = time.monotonic()
+        with self._lock:
+            running = self._running
+            updated = self._last_chunk_at
+            samples = self._samples_published
+            chunks = self._chunks_published
+            error = self._last_error
+            stop_requested = self._stop_requested
+        age = None if updated is None else max(0.0, now - updated)
+        connected = updated is not None
+        stale = (not running) or age is None or age > self._timeout
+        if error and not running and not stop_requested:
+            state = "error"
+        elif not running:
+            state = "idle"
+        elif not connected:
+            state = "waiting"
+        elif stale:
+            state = "stale"
+        else:
+            state = "running"
+        return {
+            "microphone": {
+                "category": "audio",
+                "label": "麦克风音频",
+                "state": state,
+                "connected": connected,
+                "age_sec": age,
+                "stale": stale,
+                "process_running": running,
+                "samples_published": samples,
+                "chunks_published": chunks,
+                "topic": self._topic,
+                "format": "audio/pcm-16k",
+                "error": error or None,
+            }
+        }
 
     def dispatch(self, action: str, args: dict) -> dict:
         if action == "start":
@@ -3460,9 +3617,9 @@ class MicPlugin:
             self.stop()
             return {"state": "idle"}
         if action in ("info", "status"):
-            return {"state": "running" if self._running else "idle",
+            source = self.health_sources()["microphone"]
+            return {**source,
                     "topic_out": [{"topic": self._topic, "format": "audio/pcm-16k"}],
-                    "samples_published": self._samples_published,
                     "last_error": self._last_error}
         return {"error": f"unknown mic action: {action}"}
 
@@ -3505,6 +3662,8 @@ class VisionPlugin:
         self._enabled_tools: set[str] = set()
         self._lock = threading.RLock()
         self._frames = {"pointcloud": 0, "camera_left": 0, "camera_right": 0, "depth": 0}
+        self._updated: dict[str, float] = {}
+        self._timeout = float(config["ros"].get("source_timeout_sec", 1.0))
 
     def get_tools(self) -> list[dict]:
         return [self._cloud_tool(), self._camera_tool(), self._depth_tool()]
@@ -3617,19 +3776,19 @@ class VisionPlugin:
         out = self._multi_type()
         out.data = self._array.array("B", buf)
         self._cloud_pub.publish(out)
-        self._frames["pointcloud"] += 1
+        self._record_frame("pointcloud")
 
     def _on_camera_left(self, msg) -> None:
         if not self._running or "camera" not in self._enabled_tools:
             return
         self._cam_left_pub.publish(msg)
-        self._frames["camera_left"] += 1
+        self._record_frame("camera_left")
 
     def _on_camera_right(self, msg) -> None:
         if not self._running or "camera" not in self._enabled_tools:
             return
         self._cam_right_pub.publish(msg)
-        self._frames["camera_right"] += 1
+        self._record_frame("camera_right")
 
     def _on_depth(self, msg) -> None:
         if not self._running or "depth" not in self._enabled_tools:
@@ -3697,7 +3856,80 @@ class VisionPlugin:
         out.step = target_width * 2
         out.data = depth_mm.tobytes(order="C")
         self._depth_pub.publish(out)
-        self._frames["depth"] += 1
+        self._record_frame("depth")
+
+    def _record_frame(self, name: str) -> None:
+        with self._lock:
+            self._frames[name] += 1
+            self._updated[name] = time.monotonic()
+
+    def health_sources(self) -> dict:
+        now = time.monotonic()
+        with self._lock:
+            running = self._running
+            enabled_tools = set(self._enabled_tools)
+            frames = dict(self._frames)
+            updated = dict(self._updated)
+            source = self._source
+        definitions = {
+            "odin2_pointcloud": {
+                "frame_key": "pointcloud",
+                "tool": "pointcloud",
+                "label": f"Odin2 {source.upper()} 点云",
+                "topic": self._topics[f"vision_cloud_{source}"],
+                "format": "sensor/pointcloud",
+            },
+            "odin2_camera_left": {
+                "frame_key": "camera_left",
+                "tool": "camera",
+                "label": "Odin2 左相机",
+                "topic": self._topics["vision_camera_left"],
+                "format": "image/jpeg",
+            },
+            "odin2_camera_right": {
+                "frame_key": "camera_right",
+                "tool": "camera",
+                "label": "Odin2 右相机",
+                "topic": self._topics["vision_camera_right"],
+                "format": "image/jpeg",
+            },
+            "odin2_depth": {
+                "frame_key": "depth",
+                "tool": "depth",
+                "label": "Odin2 深度图",
+                "topic": self._topics["vision_depth"],
+                "format": "image/depth-z16",
+            },
+        }
+        health = {}
+        for name, definition in definitions.items():
+            frame_key = definition["frame_key"]
+            enabled = running and definition["tool"] in enabled_tools
+            last_update = updated.get(frame_key)
+            age = None if last_update is None else max(0.0, now - last_update)
+            connected = last_update is not None
+            stale = (not enabled) or age is None or age > self._timeout
+            if not enabled:
+                state = "idle"
+            elif not connected:
+                state = "waiting"
+            elif stale:
+                state = "stale"
+            else:
+                state = "running"
+            health[name] = {
+                "category": "odin2",
+                "label": definition["label"],
+                "state": state,
+                "connected": connected,
+                "age_sec": age,
+                "stale": stale,
+                "bridge_running": enabled,
+                "frames": frames[frame_key],
+                "topic": definition["topic"],
+                "format": definition["format"],
+            }
+        return health
 
     def dispatch(self, action: str, args: dict) -> dict:
         tool_name = str(args.get("_tool_name", ""))
@@ -3742,13 +3974,15 @@ class VisionPlugin:
             return {"state": "running" if is_running else "idle",
                     "source": self._source,
                     "topic_out": topic_out,
-                    "frames": dict(self._frames)}
+                    "frames": dict(self._frames),
+                    "health": self.health_sources()}
         if action == "select_source":
             source = str(args.get("source", "")).strip()
             if source not in self._SOURCES:
                 raise ValueError(f"invalid pointcloud source: {source}; expected {'|'.join(self._SOURCES)}")
             with self._lock:
                 self._source = source
+                self._updated.pop("pointcloud", None)
             return {"state": "running" if self._running else "idle", "source": source}
         return {"error": f"unknown vision action: {action}"}
 

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -160,6 +160,11 @@ class T800DeviceBundle:
                 instances[key] = instance
                 self._plugins.append(instance)
 
+        for key in ("mic", "vision"):
+            provider = instances.get(key)
+            if provider is not None and hasattr(provider, "health_sources"):
+                state.register_health_provider(key, provider.health_sources)
+
         if plugins.get("dance", {}).get("enabled", True) and "motion_mode" in instances:
             instance = DancePlugin(instances["motion_mode"], state)
             instances["dance"] = instance

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -506,6 +506,61 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual([23, 24], [item["index"] for item in
                                    self.state.dispatch("joint_groups", {})["groups"]["head"]])
 
+    def test_driver_health_aggregates_audio_and_odin2_stream_freshness(self):
+        mic = self.device.MicPlugin(CONFIG, "robot", self.ros)
+        vision = self.device.VisionPlugin(CONFIG, "robot", self.ros)
+        now = time.monotonic()
+        mic._running = True
+        mic._last_chunk_at = now
+        mic._samples_published = 512
+        mic._chunks_published = 1
+        vision._running = True
+        vision._enabled_tools.update(vision._TOOL_NAMES)
+        vision._updated = {
+            "pointcloud": now,
+            "camera_left": now,
+            "camera_right": now,
+            "depth": now,
+        }
+        vision._frames = {
+            "pointcloud": 3,
+            "camera_left": 4,
+            "camera_right": 4,
+            "depth": 2,
+        }
+        self.state.register_health_provider("mic", mic.health_sources)
+        self.state.register_health_provider("vision", vision.health_sources)
+        for name in self.state._STREAMS:
+            if name != "driver_health":
+                self.state._set(name, {})
+
+        health = self.state.dispatch("driver_health", {})
+        self.assertEqual("running", health["state"])
+        self.assertEqual((14, 14, 14), (
+            health["connected_sources"], health["fresh_sources"], health["total_sources"],
+        ))
+        self.assertEqual("running", health["robot_state"])
+        self.assertEqual("running", health["audio_state"])
+        self.assertEqual("running", health["odin2_state"])
+        self.assertEqual("14/14 路数据流正常", health["health_summary"])
+        self.assertEqual("running · 9/9 路正常", health["robot_summary"])
+        self.assertEqual("running · 1/1 路正常", health["audio_summary"])
+        self.assertEqual("running · 4/4 路正常", health["odin2_summary"])
+        self.assertEqual("running", health["microphone_state"])
+        self.assertEqual("running", health["odin2_camera_right_state"])
+        self.assertEqual([], health["issues"])
+        self.assertEqual(512, health["sources"]["microphone"]["samples_published"])
+        self.assertEqual(3, health["sources"]["odin2_pointcloud"]["frames"])
+
+        vision._updated["camera_right"] = time.monotonic() - 2.0
+        degraded = self.state.dispatch("driver_health", {})
+        self.assertEqual("degraded", degraded["state"])
+        self.assertEqual("degraded", degraded["odin2_state"])
+        self.assertEqual("stale", degraded["odin2_camera_right_state"])
+        self.assertEqual("degraded · 3/4 路正常", degraded["odin2_summary"])
+        self.assertEqual("stale", degraded["sources"]["odin2_camera_right"]["state"])
+        self.assertIn("Odin2 右相机: stale", degraded["issues"])
+
     def test_locomotion_force_path_publishes_and_stops(self):
         plugin = self.device.LocomotionPlugin(CONFIG, "robot", self.ros, self.state)
         plugin.start()
@@ -974,7 +1029,7 @@ class DevicePluginContractTests(unittest.TestCase):
                 self.reads = [b"\x01\x00" * 512, b""]
 
             def read(self, _size):
-                return self.reads.pop(0)
+                return self.reads.pop(0) if self.reads else b""
 
         class FakeProcess:
             def __init__(self):
@@ -1002,7 +1057,14 @@ class DevicePluginContractTests(unittest.TestCase):
             time.sleep(0.01)
         self.assertEqual("audio/pcm-16k", plugin._publisher.messages[0].format)
         self.assertEqual(1024, len(plugin._publisher.messages[0].data))
+        health = plugin.health_sources()["microphone"]
+        self.assertEqual("running", health["state"])
+        self.assertFalse(health["stale"])
+        self.assertEqual(1, health["chunks_published"])
         self.assertEqual("idle", plugin.dispatch("stop", {})["state"])
+        stopped_health = plugin.health_sources()["microphone"]
+        self.assertEqual("idle", stopped_health["state"])
+        self.assertTrue(stopped_health["stale"])
 
     def test_native_node_control_and_composed_safety(self):
         native = self.device.NativeNodeControlPlugin(CONFIG, "robot", self.ros)
@@ -1041,6 +1103,9 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual(struct.pack("<II", 16, 4), bytes(out.data[:8]))
         self.assertEqual(bytes(range(64)), bytes(out.data[8:]))
         self.assertEqual(1, plugin._frames["pointcloud"])
+        health = plugin.health_sources()["odin2_pointcloud"]
+        self.assertEqual("running", health["state"])
+        self.assertFalse(health["stale"])
 
     def test_vision_select_source_switches_cloud(self):
         plugin = self.device.VisionPlugin(CONFIG, "robot", self.ros)
@@ -1069,9 +1134,12 @@ class DevicePluginContractTests(unittest.TestCase):
             info = plugin.dispatch("info", {"_tool_name": tool_name})
             self.assertEqual(tool["topic_out"], info["topic_out"], tool_name)
 
+        plugin._updated["depth"] = time.monotonic()
         stopped = plugin.dispatch("stop", {"_tool_name": "depth"})
         camera = plugin.dispatch("info", {"_tool_name": "camera"})
         self.assertEqual("idle", stopped["state"])
+        self.assertEqual("idle", stopped["health"]["odin2_depth"]["state"])
+        self.assertTrue(stopped["health"]["odin2_depth"]["stale"])
         self.assertEqual("running", camera["state"])
         self.assertTrue(plugin._running)
         self.assertNotIn("depth", plugin._enabled_tools)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -315,6 +315,22 @@ class DevicePluginContractTests(unittest.TestCase):
                 info = plugin.dispatch("info", {"_tool_name": tool["name"]})
                 self.assertTrue(info.get("topic_out"), tool["name"])
 
+    def test_driver_health_is_one_shot_actuator_without_topic_stream(self):
+        tool = {item["name"]: item for item in self.state.get_tools()}["driver_health"]
+        self.assertEqual("actuator", tool["type"])
+        self.assertNotIn("topic_out", tool)
+        self.assertEqual(
+            ["status"], tool["inputSchema"]["properties"]["action"]["enum"]
+        )
+        self.assertEqual(["action"], tool["inputSchema"]["required"])
+        self.assertNotIn("driver_health", self.state._publishers)
+
+        direct = self.state.dispatch("driver_health", {})
+        queried = self.state.dispatch("status", {"_tool_name": "driver_health"})
+        self.assertEqual("waiting", direct["state"])
+        self.assertEqual("0/9 路数据流正常", direct["health_summary"])
+        self.assertEqual(direct["total_sources"], queried["total_sources"])
+
     def test_new_status_plugins_can_start_with_declared_ros_dependencies(self):
         plugins = [
             self.device.HeartbeatStatusPlugin(CONFIG, "robot", self.ros),


### PR DESCRIPTION
**背景**
原有 driver_health 卡片仅展示 9 路机器人基础 ROS2 数据源，缺少麦克风及 Odin2 点云、双目相机、深度图的健康状态。同时数据主要集中在嵌套的 sources 字段中，dashboard 上不便快速判断异常来源。
**主要改动**
在现有 driver_health 卡片中增加以下健康数据源：
  1.   - 麦克风音频
  2.   - Odin2 点云
  3.   - Odin2 左相机
  4.   - Odin2 右相机
  5.   - Odin2 深度图

- 健康检查由原来的 9 路扩展为 14 路。
- 增加机器人、音频和 Odin2 三组健康摘要。
- 增加 dashboard 可直接展示的顶层状态字段：
  1. robot_summary
  2. audio_summary
  3. odin2_summary
  4. microphone_state
  5. odin2_pointcloud_state
  6. odin2_camera_left_state
  7. odin2_camera_right_state
  8. odin2_depth_state

- 支持区分 running、waiting、stale、idle、error 和 degraded。

- 当任意数据流未连接或超时，整体状态会显示为 degraded，避免部分数据正常时误报为完全健康。

- age_sec 保留三位小数，改善 dashboard 可读性。

- 保留原有 connected_sources、fresh_sources 和 sources 字段，兼容现有调用方。

- 修复麦克风主动停止与异常退出状态无法区分的问题。