### PR TITLE
feat(build): stamp arch facets when registering driver images

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -331,11 +331,17 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
             hw_model="${DRIVER_MODELS[$idx]:-}"
             FULL_IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/${hw_provider}/${hw_model}:${TAG}"
 
+            # 架构 facet（resource-center 据此过滤目录，见 resource-center/lib/arch.ts）。
+            # driver 是普通 ROS 容器，没有 L4T / CUDA base，所以不绑定加速器；镜像统一
+            # --platform linux/arm64 构建。将来某个 driver 真需要 Jetson，从它的
+            # driver.yaml 读一个 acc_arch 覆盖这里即可。
             payload="{
   \"imageRef\": \"${FULL_IMAGE}\",
   \"registryImage\": \"${img}\",
   \"tag\": \"${TAG}\",
   \"category\": \"${cat}\",
+  \"acc_arch\": \"agnostic\",
+  \"cpu_arch\": \"arm64\",
   \"hardware_provider\": \"${hw_provider}\",
   \"hardware_model\": \"${hw_model}\",
   \"name\": \"${name}\",


### PR DESCRIPTION
## 背景

resource-center 现在按主机的加速器 / CPU 架构过滤镜像目录（见 phanthymotus#124 与 resource-center MR `feat/arch-facet-filtering`）。构建脚本需要在注册镜像时声明这两个 facet，否则新镜像只能靠 tag 后缀兜底判定。

## 改动

`build.sh` 注册 payload 增加两个字段：

```
"acc_arch": "agnostic",
"cpu_arch": "arm64",
```

driver 是普通 ROS 容器，没有 L4T / CUDA base（`grep -rln 'jetson-base\|l4t' --include=Dockerfile .` 无命中），所以不绑定加速器；镜像统一 `--platform linux/arm64` 构建。

tag 逻辑不变 —— driver tag 保持无 facet 后缀。

## 扩展点（本次不做）

将来某个 driver 真需要 Jetson，从它的 `driver.yaml` 读一个 `acc_arch` 字段覆盖这里即可，代码里已注明。

## 验证

`bash -n build.sh` 通过；payload 用真实变量值展开后是合法 JSON，`acc_arch=agnostic` / `cpu_arch=arm64`。