### PR TITLE
feat: x-sensitive 敏感配置字段约定 + review 清单

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,22 @@ Tool naming convention: `{device}_{action}` (e.g., `loco_move`, `mic_start`, `ar
 3. Test the driver locally with a running Agent Core instance
 4. Submit a PR with a clear description
 
+### Review Checklist
+
+Reviewers should confirm each of these before approving a driver change:
+
+- [ ] **Sensitive config fields are declared.** Every `configSchema` property holding
+      a credential, token, license key, private endpoint or personal identifier
+      declares `"format": "password"` or `"x-sensitive": true`. Canvas config is
+      packaged into shareable Solutions and uploaded to the Resource Center;
+      packaging can only blank what the tool declares, so an unmarked secret is
+      published in clear text. See [README_dev.md](README_dev.md#marking-sensitive-fields-x-sensitive).
+- [ ] `dispatch()` returns a plain dict, never a pre-wrapped `[{"type": "text", ...}]`
+- [ ] Per-instance state is guarded per the concurrency rules (`tools/call` runs on
+      its own thread); `stop` can cancel a concurrent `start`
+- [ ] `topic_out[].format` matches the intended dashboard renderer
+- [ ] Actuator tools are actuator-typed, so Agent Core's safety confirmation applies
+
 ## Code Style
 
 - Python: Follow PEP 8, use type hints where practical

--- a/README_dev.md
+++ b/README_dev.md
@@ -102,6 +102,37 @@ For `multiInstance: true` tools, `scope` determines whether a config field is se
 }
 ```
 
+#### Marking sensitive fields (`x-sensitive`)
+
+Canvas configuration is packaged into shareable **Solutions** (Agent Core's
+`/api/solutions/pack`), which are uploaded to the Resource Center marketplace.
+Packaging blanks out sensitive values, but it can only do that for fields the
+tool **declares** as sensitive — there is no field-name blocklist, because a
+guessing heuristic would both miss real secrets and wrongly clear innocent
+fields. A field counts as sensitive when either holds:
+
+| Declaration | Also does |
+|-------------|-----------|
+| `"format": "password"` | Frontend renders a masked password input |
+| `"x-sensitive": true`  | Nothing visually — use when the field must stay visible while typing |
+
+```python
+"configSchema": {
+    "type": "object",
+    "properties": {
+        "api_key":     {"type": "string", "format": "password"},        # masked + never packaged
+        "device_token":{"type": "string", "x-sensitive": True},         # visible + never packaged
+        "endpoint":    {"type": "string"},                             # packaged as-is
+    },
+}
+```
+
+Anything you don't mark is packaged verbatim and becomes readable by everyone
+who downloads the solution. Mark every credential, token, license key, private
+endpoint and personal identifier. Fields that were blanked are reported to the
+loading user as "needs configuration", so marking a field does not break the
+solution — it just makes the recipient fill in their own value.
+
 ---
 
 ## x-action-params Specification

--- a/README_dev.md
+++ b/README_dev.md
@@ -133,6 +133,10 @@ endpoint and personal identifier. Fields that were blanked are reported to the
 loading user as "needs configuration", so marking a field does not break the
 solution — it just makes the recipient fill in their own value.
 
+Two formats are cleared automatically and need no marking, because their values
+only mean something on the machine they were set on: `channel-select` (a local
+channel id) and `audio-input-device` (a local sound-card device).
+
 ---
 
 ## x-action-params Specification

--- a/README_dev.md
+++ b/README_dev.md
@@ -115,6 +115,7 @@ fields. A field counts as sensitive when either holds:
 |-------------|-----------|
 | `"format": "password"` | Frontend renders a masked password input |
 | `"x-sensitive": true`  | Nothing visually — use when the field must stay visible while typing |
+| `"x-sensitive": false` | Opts **out** of packaging redaction even though `format: password` masks it |
 
 ```python
 "configSchema": {
@@ -122,10 +123,18 @@ fields. A field counts as sensitive when either holds:
     "properties": {
         "api_key":     {"type": "string", "format": "password"},        # masked + never packaged
         "device_token":{"type": "string", "x-sensitive": True},         # visible + never packaged
+        # Fixed factory password — masked in the UI, but not a user secret. Blanking it
+        # would only make the recipient retype the same default.
+        "ssh_pass":    {"type": "string", "format": "password", "x-sensitive": False},
         "endpoint":    {"type": "string"},                             # packaged as-is
     },
 }
 ```
+
+`format: password` defaults to sensitive on purpose — an unmarked password box is
+assumed to be a real secret, so drivers written before this convention stay safe.
+Use `"x-sensitive": false` only when the value is a fixed, publicly documented
+default; if an operator can put a real credential in that field, leave it sensitive.
 
 Anything you don't mark is packaged verbatim and becomes readable by everyone
 who downloads the solution. Mark every credential, token, license key, private

--- a/x-humanoid/tianyi2.0/controlled_spatial.py
+++ b/x-humanoid/tianyi2.0/controlled_spatial.py
@@ -247,6 +247,9 @@ class ControlledSpatialPlugin:
                         "description": "受保护操作（建图、删除、增删虚拟墙/轨道/区域/POI等）所需的密码，初始密码为 123456",
                         "default": "123456",
                         "format": "password",
+                        # 底盘的固定初始密码，不是用户秘密：打包成解决方案时保留，
+                        # 清空只会让载入方重新敲一遍同一个默认值。
+                        "x-sensitive": False,
                         "scope": "shared",
                     },
                 },

--- a/x-humanoid/tianyi2.0/ext_devices.py
+++ b/x-humanoid/tianyi2.0/ext_devices.py
@@ -1091,6 +1091,9 @@ class ExtMicPlugin:
                 "ssh_pass": {
                     "type": "string",
                     "format": "password",
+                    "x-sensitive": False,   # 固定的出厂密码，不是用户秘密：打包成
+                                            # 解决方案时不需要清空（清了只会让载入
+                                            # 方重新敲一遍同一个默认值）
                     "description": "SSH password",
                     "default": "123",
                 },


### PR DESCRIPTION
> 取代 #194（分支从 `docs/` 改名成 `feat/` 后 GitHub 自动关掉了原 PR，内容不变 + 新增豁免声明）

## 背景

Agent Core 新增了**解决方案**功能（phanthymotus#127）：把画布拓扑 + 卡片配置 + 技能 + prompt + 任务打包成一个包，上传到 Resource Center 供别人一键载入。

卡片配置里有真凭证（API key、鉴权 token、私有 endpoint）。打包时会清空敏感字段，但**只能清空工具自己声明过的** —— 不做字段名黑名单，因为按名字猜既会漏掉真密钥（`app_secret`、`license`、各家驱动自己的叫法），也会误清无害字段。

## 改了什么

### 1. 约定文档（README_dev.md）

configSchema 章节补一节 "Marking sensitive fields"，判定是三态的：

| 声明 | 结果 | 附带效果 |
|------|------|----------|
| `"x-sensitive": true` | 敏感 | 不改渲染，用于需明文可见但不该外传的字段 |
| `"x-sensitive": false` | 豁免 | 即使 `format` 是 password 也不清空 |
| 未声明 | 回落到 `format: password` | 前端渲染成密码框（driver 侧早就在用） |

`format: password` 默认按敏感处理是**安全默认**：写在这条约定之前的驱动没机会加标记，如果只认 `x-sensitive: true`，已有的密钥字段会原样进包体。

另外说明：`channel-select` 与 `audio-input-device` 由 Agent Core 自动清空（值只对本机有效），驱动作者不需要额外标记。

### 2. 天翼两个固定密码标为豁免

- `x-humanoid/tianyi2.0/ext_devices.py` 的 `ssh_pass`（固定出厂密码 `123`）
- `x-humanoid/tianyi2.0/controlled_spatial.py` 的 `password`（Slamtec 底盘初始密码 `123456`）

这两个是公开的固定默认值，不是用户秘密；清空只会让载入方重新敲一遍同一个值。输入框照旧打码。

⚠️ 边界：只有值固定且公开时才该豁免。如果以后允许运维在这两个字段填现场真密码，就要把豁免撤掉。

### 3. CONTRIBUTING.md 加 Review Checklist

"敏感字段必须声明"放第一条，顺带把几个已知易错点一起列上（`dispatch()` 必须返回 plain dict、插件并发规则、`topic_out[].format` 与渲染器对应、actuator 工具的安全确认）。

## 验证

Agent Core 侧对三态判定做了单测（`api/solutions._sensitive_props`）：`format: password` → 敏感、`x-sensitive: true` → 敏感、`x-sensitive: false` + password → 豁免、非布尔值不算声明。并确认本仓库这两个字段改动后确实被豁免且仍保留打码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)