### PR TITLE
docs: drop sensor/htmsg from the format tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ The Agent Core Web Dashboard renders live data streams based on the `format` fie
 | `sensor/lidar*` | Lidar scan | 2D/3D lidar point visualization |
 | `sensor/pointcloud` | Point cloud | 3D point cloud renderer |
 | `sensor/mapping` | 2D Map | Occupancy grid / SLAM map |
-| `sensor/htmsg` | HT message | Custom structured message |
 
 ### Skeleton Rendering (`sensor/skeleton`)
 

--- a/README_dev.md
+++ b/README_dev.md
@@ -540,7 +540,6 @@ The Agent Core Web Dashboard automatically selects a renderer based on the `form
 | `sensor/lidar*` | Lidar scan | `hint.startsWith('sensor/lidar')` |
 | `sensor/pointcloud` | 3D Point cloud | `hint === 'sensor/pointcloud'` |
 | `sensor/mapping` | 2D Occupancy map | `hint === 'sensor/mapping'` |
-| `sensor/htmsg` | HT structured message | `hint === 'sensor/htmsg'` |
 | (no hint) | Activity stream | Fallback when no format specified |
 
 ### Depth Rendering — `image/depth-z16` vs `image/depth-zlib`


### PR DESCRIPTION
## 背景

htmsg perception 插件及其 dashboard 渲染器已在 phanthymotus#129 中移除，`sensor/htmsg` 不再是合法的 `topic_out[].format`。driver 若继续声明它，会落到 activity-stream 兜底渲染器。

本仓库没有任何 driver 在用这个格式，纯文档改动。

## 改动

- `README.md:136` — 删 `sensor/htmsg` 表行
- `README_dev.md:543` — 删 `sensor/htmsg` 表行

## 相关 PR

- phanthymotus#129 — 移除 htmsg 插件、dashboard 渲染器与孤儿依赖

🤖 Generated with [Claude Code](https://claude.com/claude-code)