### PR TITLE
feat(bumi): add motion events card

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,14 +51,17 @@ select_mirror() {
     case "${MIRROR}" in
         tencent)
             PYPI_MIRROR="https://mirrors.tencentyun.com/pypi/simple/"
+            UBUNTU_MIRROR="http://mirrors.tencentyun.com/ubuntu-ports"
             BINFMT_IMAGE="mirror.ccs.tencentyun.com/tonistiigi/binfmt"
             ;;
         tuna)
             PYPI_MIRROR="https://pypi.tuna.tsinghua.edu.cn/simple/"
+            UBUNTU_MIRROR="https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports"
             BINFMT_IMAGE="docker.io/tonistiigi/binfmt"
             ;;
         none|*)
             PYPI_MIRROR="https://pypi.org/simple/"
+            UBUNTU_MIRROR="https://ports.ubuntu.com/ubuntu-ports"
             BINFMT_IMAGE="docker.io/tonistiigi/binfmt"
             ;;
     esac
@@ -291,6 +294,7 @@ for idx in "${SELECTED_INDICES[@]}"; do
         --platform linux/arm64 \
         ${NO_CACHE} \
         --build-arg "PYPI_MIRROR=${PYPI_MIRROR}" \
+        --build-arg "UBUNTU_MIRROR=${UBUNTU_MIRROR}" \
         --file "${dir}Dockerfile" \
         --tag "${FULL_IMAGE}" \
         $(${PUSH_ENABLED} && echo "--push" || echo "--output=type=docker") \

--- a/noetix/bumi/Dockerfile
+++ b/noetix/bumi/Dockerfile
@@ -1,11 +1,15 @@
 ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base:latest
 ARG PYPI_MIRROR=https://pypi.org/simple/
+ARG UBUNTU_MIRROR=https://ports.ubuntu.com/ubuntu-ports
 FROM ${ROS_BASE_IMAGE}
 ARG PYPI_MIRROR
+ARG UBUNTU_MIRROR
 
 WORKDIR /work
 
-RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
+RUN find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) \
+        -exec sed -i -E "s#https?://[^/]+/ubuntu-ports#${UBUNTU_MIRROR}#g" {} + && \
+    apt-get -o Acquire::AllowInsecureRepositories=true update && \
     apt-get install -y --no-install-recommends --allow-unauthenticated \
         python3-pip \
         python3-dev \

--- a/noetix/bumi/config.yaml
+++ b/noetix/bumi/config.yaml
@@ -18,3 +18,11 @@ plugins:
     poll_interval_s: 0.5
     # Activity classification only; this is not a motor safety or command limit.
     activity_velocity_threshold: 0.15
+  motion_events:
+    enabled: true
+    # Detect state transitions at 2 Hz; this is observation, not motor safety control.
+    poll_interval_s: 0.5
+    # Recent events are kept in memory only and cleared when the driver restarts.
+    history_size: 100
+    # Must match motion_state so both cards classify joint activity consistently.
+    activity_velocity_threshold: 0.15

--- a/noetix/bumi/device.py
+++ b/noetix/bumi/device.py
@@ -9,7 +9,13 @@ drivers/noetix/bumi/device.py — Noetix Bumi-EDU 设备插件实现。
   - SpeakerPlugin: audio playback via MediaController
   - CameraPlugin: Realsense D435i color + depth
   - MotionStatePlugin: combined whole-body motion state
+  - MotionEventsPlugin: workmode, protection, motor-fault and link events
 """
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime, timezone
 
 import json
 import math
@@ -1373,6 +1379,14 @@ def _finite_number(value: Any, field: str) -> float:
     return result
 
 
+def _utc_timestamp() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
 def _quaternion_xyzw_to_rpy(quaternion: list[float]) -> list[float] | None:
     """Convert the SDK's documented [x, y, z, w] quaternion to roll/pitch/yaw."""
     norm = math.sqrt(sum(value * value for value in quaternion))
@@ -1559,4 +1573,413 @@ class MotionStatePlugin:
             return {"state": "running"}
         if action == "stop":
             return {"state": "idle"}
+        return None
+
+
+def _read_motion_event_snapshot(
+    high_ctrl,
+    activity_velocity_threshold: float,
+) -> tuple[int, dict[int, dict], dict]:
+    mode = int(high_ctrl.get_mode())
+    raw_joint_state = high_ctrl.get_joint_state()
+    if len(raw_joint_state) != len(_JOINT_NAMES_BY_ID):
+        raise RuntimeError(
+            f"HighController returned {len(raw_joint_state)} joints, "
+            f"expected {len(_JOINT_NAMES_BY_ID)}"
+        )
+
+    faults = {}
+    joint_velocities = []
+    for index, joint in enumerate(raw_joint_state):
+        velocity = float(getattr(joint, "vel", 0.0))
+        if not math.isfinite(velocity):
+            raise RuntimeError(
+                f"HighController returned a non-finite velocity for "
+                f"{_JOINT_NAMES_BY_ID[index]}"
+            )
+        joint_velocities.append(abs(velocity))
+
+        error = int(getattr(joint, "error", 0))
+        if error not in _MOTOR_ERROR_NAMES:
+            continue
+
+        motor_id = int(getattr(joint, "motor_id", index))
+        faults[motor_id] = {
+            "motor_id": motor_id,
+            "joint": _JOINT_NAMES_BY_ID[index],
+            "error": error,
+            "error_name": _MOTOR_ERROR_NAMES[error],
+            "temperature": int(getattr(joint, "temperature", 0)),
+        }
+
+    moving_indices = [
+        index
+        for index, velocity in enumerate(joint_velocities)
+        if velocity >= activity_velocity_threshold
+    ]
+    activity = {
+        "active": bool(moving_indices),
+        "velocity_threshold": activity_velocity_threshold,
+        "moving_joint_count": len(moving_indices),
+        "moving_joints": [_JOINT_NAMES_BY_ID[index] for index in moving_indices],
+        "max_abs_velocity": round(max(joint_velocities), 6),
+    }
+
+    return mode, faults, activity
+
+
+class _MotionEventTracker:
+    def __init__(self, history_size: int):
+        if history_size < 1:
+            raise ValueError("history_size must be at least 1")
+        self._history = deque(maxlen=history_size)
+        self._next_id = 1
+        self._dropped_events = 0
+        self._previous_mode: int | None = None
+        self._previous_faults: dict[int, dict] | None = None
+        self._previous_activity: dict | None = None
+        self._fresh: bool | None = None
+        self._lock = threading.RLock()
+
+    @property
+    def cursor(self) -> int:
+        with self._lock:
+            return self._next_id - 1
+
+    @property
+    def history(self) -> list[dict]:
+        with self._lock:
+            return list(self._history)
+
+    @property
+    def dropped_events(self) -> int:
+        with self._lock:
+            return self._dropped_events
+
+    @property
+    def fresh(self) -> bool | None:
+        with self._lock:
+            return self._fresh
+
+    @property
+    def snapshot(self) -> dict:
+        with self._lock:
+            return {
+                "fresh": self._fresh,
+                "cursor": self._next_id - 1,
+                "events": list(self._history),
+                "dropped_events": self._dropped_events,
+            }
+
+    def _record(self, event_type: str, **details) -> dict:
+        with self._lock:
+            event = {
+                "id": self._next_id,
+                "timestamp": _utc_timestamp(),
+                "type": event_type,
+                "source": "Noetix HighController/CycloneDDS",
+                **details,
+            }
+            self._next_id += 1
+            if len(self._history) == self._history.maxlen:
+                self._dropped_events += 1
+            self._history.append(event)
+        return event
+
+    def mark_stale(self, reason: str) -> list[dict]:
+        with self._lock:
+            if self._fresh is False:
+                return []
+            self._fresh = False
+            return [self._record("state_data_stale", reason=reason)]
+
+    def mark_fresh(self) -> list[dict]:
+        with self._lock:
+            if self._fresh is None:
+                self._fresh = True
+                return []
+            if self._fresh is False:
+                self._fresh = True
+                return [self._record("state_data_recovered")]
+            return []
+
+    def observe_mode(self, mode: int) -> list[dict]:
+        with self._lock:
+            if self._previous_mode is None:
+                self._previous_mode = mode
+                return []
+
+            previous_mode = self._previous_mode
+            self._previous_mode = mode
+
+            if mode == previous_mode:
+                return []
+
+            transition = {
+                "from": {
+                    "code": previous_mode,
+                    "name": _WORKMODE_NAMES.get(previous_mode, "unknown"),
+                },
+                "to": {
+                    "code": mode,
+                    "name": _WORKMODE_NAMES.get(mode, "unknown"),
+                },
+            }
+            events = [
+                self._record("workmode_changed", workmode=transition)
+            ]
+
+            if mode == 26:
+                events.append(
+                    self._record("protection_entered", workmode=transition)
+                )
+            elif previous_mode == 26:
+                events.append(
+                    self._record("protection_cleared", workmode=transition)
+                )
+
+            return events
+
+    def observe_faults(self, faults: dict[int, dict]) -> list[dict]:
+        with self._lock:
+            current_faults = {
+                motor_id: dict(fault)
+                for motor_id, fault in faults.items()
+            }
+
+            if self._previous_faults is None:
+                self._previous_faults = current_faults
+                return []
+
+            previous_faults = self._previous_faults
+            self._previous_faults = current_faults
+            events = []
+
+            motor_ids = sorted(set(previous_faults) | set(current_faults))
+            for motor_id in motor_ids:
+                previous = previous_faults.get(motor_id)
+                current = current_faults.get(motor_id)
+
+                if previous is None and current is not None:
+                    events.append(
+                        self._record("motor_fault_appeared", fault=current)
+                    )
+                elif previous is not None and current is None:
+                    events.append(
+                        self._record("motor_fault_cleared", fault=previous)
+                    )
+                elif (
+                    previous is not None
+                    and current is not None
+                    and previous["error"] != current["error"]
+                ):
+                    events.append(
+                        self._record(
+                            "motor_fault_changed",
+                            previous_fault=previous,
+                            current_fault=current,
+                        )
+                    )
+
+            return events
+
+    def observe_activity(self, activity: dict) -> list[dict]:
+        with self._lock:
+            current_activity = dict(activity)
+            if self._previous_activity is None:
+                self._previous_activity = current_activity
+                return []
+
+            previous_activity = self._previous_activity
+            self._previous_activity = current_activity
+            if current_activity["active"] == previous_activity["active"]:
+                return []
+
+            event_type = (
+                "joint_activity_started"
+                if current_activity["active"]
+                else "joint_activity_stopped"
+            )
+            return [
+                self._record(
+                    event_type,
+                    previous_activity=previous_activity,
+                    current_activity=current_activity,
+                )
+            ]
+
+
+class _MotionEventsNode(Node):
+    def __init__(self, namespace: str, high_ctrl, interval_s: float,
+                 history_size: int, activity_velocity_threshold: float):
+        super().__init__("bumi_motion_events")
+        self._high_ctrl = high_ctrl
+        self._topic = f"/{namespace}/motion/events"
+        self._pub = self.create_publisher(String, self._topic, 10)
+        self._interval_s = interval_s
+        self._activity_velocity_threshold = activity_velocity_threshold
+        self._tracker = _MotionEventTracker(history_size)
+        self._running = False
+        self._thread: threading.Thread | None = None
+
+    @property
+    def topic(self) -> str:
+        return self._topic
+
+    @property
+    def status(self) -> dict:
+        snapshot = self._tracker.snapshot
+        return {
+            "running": self._running,
+            "fresh": snapshot["fresh"],
+            "cursor": snapshot["cursor"],
+            "history_count": len(snapshot["events"]),
+            "dropped_events": snapshot["dropped_events"],
+        }
+
+    @property
+    def report(self) -> dict:
+        snapshot = self._tracker.snapshot
+        return {
+            "state": "completed",
+            "running": self._running,
+            "fresh": snapshot["fresh"],
+            "cursor": snapshot["cursor"],
+            "history_count": len(snapshot["events"]),
+            "dropped_events": snapshot["dropped_events"],
+            "events": snapshot["events"],
+        }
+
+    def start_polling(self):
+        if self._running:
+            return
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._loop,
+            daemon=True,
+            name="bumi_motion_events",
+        )
+        self._thread.start()
+
+    def stop_polling(self):
+        self._running = False
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=max(1.0, self._interval_s + 0.5))
+
+    def _publish_event(self, event: dict):
+        snapshot = self._tracker.snapshot
+        payload = {
+            "state": "completed",
+            "event": event,
+            "cursor": event["id"],
+            "history_count": len(snapshot["events"]),
+            "dropped_events": snapshot["dropped_events"],
+        }
+        msg = String()
+        msg.data = json.dumps(payload, ensure_ascii=False)
+        self._pub.publish(msg)
+
+    def _poll_once(self) -> list[dict]:
+        try:
+            mode, faults, activity = _read_motion_event_snapshot(
+                self._high_ctrl,
+                self._activity_velocity_threshold,
+            )
+            events = []
+            events.extend(self._tracker.mark_fresh())
+            events.extend(self._tracker.observe_mode(mode))
+            events.extend(self._tracker.observe_faults(faults))
+            events.extend(self._tracker.observe_activity(activity))
+        except Exception as exc:
+            events = self._tracker.mark_stale(str(exc))
+            if events:
+                self.get_logger().warn(f"Motion event state read failed: {exc}")
+
+        for event in events:
+            self._publish_event(event)
+        return events
+
+    def _loop(self):
+        while self._running:
+            started_at = time.monotonic()
+            try:
+                self._poll_once()
+            except Exception as exc:
+                self.get_logger().error(f"Motion event publish failed: {exc}")
+            elapsed = time.monotonic() - started_at
+            time.sleep(max(0.0, self._interval_s - elapsed))
+
+
+class MotionEventsPlugin:
+    PREFIX = "motion_events"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, high_ctrl):
+        interval = _finite_number(
+            plugin_config.get("poll_interval_s", 0.5),
+            "poll_interval_s",
+        )
+        if not 0.02 <= interval <= 2.0:
+            raise ValueError("poll_interval_s must be in [0.02, 2.0]")
+
+        history_size = plugin_config.get("history_size", 100)
+        if isinstance(history_size, bool) or not isinstance(history_size, int):
+            raise ValueError("history_size must be an integer")
+        if not 1 <= history_size <= 1000:
+            raise ValueError("history_size must be in [1, 1000]")
+
+        activity_threshold = _finite_number(
+            plugin_config.get("activity_velocity_threshold", 0.15),
+            "activity_velocity_threshold",
+        )
+        if not 0.001 <= activity_threshold <= 10.0:
+            raise ValueError(
+                "activity_velocity_threshold must be in [0.001, 10.0]"
+            )
+
+        self._node = _MotionEventsNode(
+            namespace,
+            high_ctrl,
+            interval,
+            history_size,
+            activity_threshold,
+        )
+        executor.add_node(self._node)
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "motion_events",
+            "type": "sensor",
+            "multiInstance": False,
+            "description": (
+                "Bumi 只读运动事件监测：记录工作模式变化、进入或退出保护、"
+                "关节运动开始/停止、已确认电机故障的出现/变化/恢复，以及 "
+                "HighController 数据中断/恢复。"
+                "用于动作测试和事后分析；不控制机器人，不证明物理动作已完成。"
+            ),
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [
+                {"topic": self._node.topic, "format": "data/json"}
+            ],
+        }
+
+    def start(self):
+        self._node.start_polling()
+
+    def stop(self):
+        self._node.stop_polling()
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        topic_out = [{"topic": self._node.topic, "format": "data/json"}]
+        if action == "start":
+            self._node.start_polling()
+            return {"state": "running", "topic_out": topic_out, **self._node.status}
+        if action == "stop":
+            self._node.stop_polling()
+            return {"state": "idle", "topic_out": topic_out, **self._node.status}
+        if action == "info":
+            status = self._node.status
+            state = "running" if status["running"] else "idle"
+            return {"state": state, "topic_out": topic_out, **status}
+        if action == "motion_events":
+            return self._node.report
         return None

--- a/noetix/bumi/main.py
+++ b/noetix/bumi/main.py
@@ -12,6 +12,8 @@ drivers/noetix/bumi/main.py — Noetix Bumi-EDU 设备 bundle 统一入口。
     CONFIG_PATH — config.yaml 路径（默认同目录下）
 """
 
+from __future__ import annotations
+
 # Make every log line one atomic, control-character-free write, so concurrent
 # writers cannot tear a Docker log record. Must run before anything prints.
 try:
@@ -91,6 +93,11 @@ class BumiDeviceBundle:
             self._plugins.append(MotionStatePlugin(
                 plugins_cfg["motion_state"], namespace, executor, high_ctrl))
             print("[bundle] MotionStatePlugin loaded")
+        if plugins_cfg.get("motion_events", {}).get("enabled", False) and high_ctrl is not None:
+            from device import MotionEventsPlugin
+            self._plugins.append(MotionEventsPlugin(
+                plugins_cfg["motion_events"], namespace, executor, high_ctrl))
+            print("[bundle] MotionEventsPlugin loaded")
 
     def start_all(self) -> None:
         for i, p in enumerate(self._plugins):

--- a/noetix/bumi/tests/test_motion_events.py
+++ b/noetix/bumi/tests/test_motion_events.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import time
+import types
+import unittest
+from pathlib import Path
+
+
+class _Message:
+    def __init__(self):
+        self.data = ""
+
+
+class _Publisher:
+    def __init__(self):
+        self.messages: list[dict] = []
+
+    def publish(self, message):
+        self.messages.append(json.loads(message.data))
+
+
+class _Logger:
+    def __init__(self):
+        self.warnings: list[str] = []
+        self.errors: list[str] = []
+
+    def warn(self, message):
+        self.warnings.append(message)
+
+    def error(self, message):
+        self.errors.append(message)
+
+
+class _Node:
+    def __init__(self, name):
+        self.node_name = name
+        self.publisher = _Publisher()
+        self.logger = _Logger()
+
+    def create_publisher(self, *_args):
+        return self.publisher
+
+    def get_logger(self):
+        return self.logger
+
+
+class _QoSProfile:
+    def __init__(self, **kwargs):
+        self.options = kwargs
+
+
+def _install_ros_stubs():
+    rclpy = types.ModuleType("rclpy")
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_qos = types.ModuleType("rclpy.qos")
+    rclpy_executors = types.ModuleType("rclpy.executors")
+    rclpy_node.Node = _Node
+    rclpy_qos.QoSProfile = _QoSProfile
+    rclpy_qos.ReliabilityPolicy = type(
+        "ReliabilityPolicy", (), {"BEST_EFFORT": "best_effort"}
+    )
+    rclpy_qos.HistoryPolicy = type(
+        "HistoryPolicy", (), {"KEEP_LAST": "keep_last"}
+    )
+    rclpy_qos.DurabilityPolicy = type(
+        "DurabilityPolicy", (), {"VOLATILE": "volatile"}
+    )
+    rclpy.executors = rclpy_executors
+
+    std_msgs = types.ModuleType("std_msgs")
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    std_msgs_msg.String = _Message
+
+    audio_msgs = types.ModuleType("audio_msgs")
+    audio_msgs_msg = types.ModuleType("audio_msgs.msg")
+    audio_msgs_msg.AudioChunk = _Message
+
+    sensor_msgs = types.ModuleType("sensor_msgs")
+    sensor_msgs_msg = types.ModuleType("sensor_msgs.msg")
+    sensor_msgs_msg.CompressedImage = _Message
+    sensor_msgs_msg.Image = _Message
+
+    sys.modules.update({
+        "rclpy": rclpy,
+        "rclpy.node": rclpy_node,
+        "rclpy.qos": rclpy_qos,
+        "rclpy.executors": rclpy_executors,
+        "std_msgs": std_msgs,
+        "std_msgs.msg": std_msgs_msg,
+        "audio_msgs": audio_msgs,
+        "audio_msgs.msg": audio_msgs_msg,
+        "sensor_msgs": sensor_msgs,
+        "sensor_msgs.msg": sensor_msgs_msg,
+    })
+
+
+def _load_device_module():
+    _install_ros_stubs()
+    path = Path(__file__).resolve().parents[1] / "device.py"
+    spec = importlib.util.spec_from_file_location("bumi_device_for_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+DEVICE = _load_device_module()
+
+
+def _load_main_module():
+    _install_ros_stubs()
+    sys.modules["device"] = DEVICE
+    path = Path(__file__).resolve().parents[1] / "main.py"
+    spec = importlib.util.spec_from_file_location("bumi_main_for_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+MAIN = _load_main_module()
+
+
+class _Joint:
+    def __init__(
+        self,
+        motor_id: int,
+        error: int = 0,
+        temperature: int = 30,
+        velocity: float = 0.0,
+    ):
+        self.motor_id = motor_id
+        self.error = error
+        self.temperature = temperature
+        self.vel = velocity
+
+
+class _Controller:
+    def __init__(self):
+        self.mode = 2
+        self.joints = [_Joint(index) for index in range(21)]
+        self.fail = False
+
+    def get_mode(self):
+        if self.fail:
+            raise RuntimeError("dds timeout")
+        return self.mode
+
+    def get_joint_state(self):
+        return self.joints
+
+
+class _Executor:
+    def __init__(self):
+        self.nodes = []
+
+    def add_node(self, node):
+        self.nodes.append(node)
+
+
+class MotionEventTrackerTest(unittest.TestCase):
+    def test_mode_and_protection_transitions_are_deduplicated(self):
+        tracker = DEVICE._MotionEventTracker(20)
+
+        self.assertEqual(tracker.observe_mode(2), [])
+        self.assertEqual(tracker.observe_mode(2), [])
+        self.assertEqual(
+            [event["type"] for event in tracker.observe_mode(5)],
+            ["workmode_changed"],
+        )
+        self.assertEqual(
+            [event["type"] for event in tracker.observe_mode(26)],
+            ["workmode_changed", "protection_entered"],
+        )
+        self.assertEqual(
+            [event["type"] for event in tracker.observe_mode(2)],
+            ["workmode_changed", "protection_cleared"],
+        )
+
+    def test_fault_appeared_changed_and_cleared(self):
+        tracker = DEVICE._MotionEventTracker(20)
+        fault_a = {
+            "motor_id": 4,
+            "joint": "l_leg_pitch_joint",
+            "error": 0x0D,
+            "error_name": "communication_lost",
+            "temperature": 40,
+        }
+        fault_b = {**fault_a, "error": 0x0E, "error_name": "overload"}
+
+        self.assertEqual(tracker.observe_faults({}), [])
+        self.assertEqual(
+            [event["type"] for event in tracker.observe_faults({4: fault_a})],
+            ["motor_fault_appeared"],
+        )
+        self.assertEqual(tracker.observe_faults({4: fault_a}), [])
+        self.assertEqual(
+            [event["type"] for event in tracker.observe_faults({4: fault_b})],
+            ["motor_fault_changed"],
+        )
+        self.assertEqual(
+            [event["type"] for event in tracker.observe_faults({})],
+            ["motor_fault_cleared"],
+        )
+
+    def test_freshness_and_bounded_history(self):
+        tracker = DEVICE._MotionEventTracker(2)
+
+        self.assertEqual(tracker.mark_fresh(), [])
+        self.assertEqual(
+            [event["type"] for event in tracker.mark_stale("timeout")],
+            ["state_data_stale"],
+        )
+        self.assertEqual(tracker.mark_stale("timeout again"), [])
+        self.assertEqual(
+            [event["type"] for event in tracker.mark_fresh()],
+            ["state_data_recovered"],
+        )
+        tracker.observe_mode(2)
+        tracker.observe_mode(5)
+
+        self.assertEqual(len(tracker.history), 2)
+        self.assertEqual(tracker.dropped_events, 1)
+        self.assertEqual(tracker.cursor, 3)
+        self.assertTrue(all(event["timestamp"].endswith("Z") for event in tracker.history))
+        self.assertEqual(
+            tracker.snapshot,
+            {
+                "fresh": True,
+                "cursor": 3,
+                "events": tracker.history,
+                "dropped_events": 1,
+            },
+        )
+
+    def test_joint_activity_transitions_are_deduplicated(self):
+        tracker = DEVICE._MotionEventTracker(10)
+        stopped = {
+            "active": False,
+            "velocity_threshold": 0.15,
+            "moving_joint_count": 0,
+            "moving_joints": [],
+            "max_abs_velocity": 0.01,
+        }
+        moving = {
+            "active": True,
+            "velocity_threshold": 0.15,
+            "moving_joint_count": 1,
+            "moving_joints": ["l_arm_pitch_joint"],
+            "max_abs_velocity": 0.2,
+        }
+
+        self.assertEqual(tracker.observe_activity(stopped), [])
+        self.assertEqual(
+            [event["type"] for event in tracker.observe_activity(moving)],
+            ["joint_activity_started"],
+        )
+        self.assertEqual(tracker.observe_activity(moving), [])
+        self.assertEqual(
+            [event["type"] for event in tracker.observe_activity(stopped)],
+            ["joint_activity_stopped"],
+        )
+
+
+class MotionEventSnapshotTest(unittest.TestCase):
+    def test_snapshot_reports_only_documented_faults(self):
+        controller = _Controller()
+        controller.mode = 26
+        controller.joints[4] = _Joint(104, error=0x0D, temperature=47)
+        controller.joints[5] = _Joint(105, error=0x55, temperature=48)
+
+        controller.joints[0].vel = 0.2
+        mode, faults, activity = DEVICE._read_motion_event_snapshot(
+            controller, 0.15
+        )
+
+        self.assertEqual(mode, 26)
+        self.assertEqual(set(faults), {104})
+        self.assertEqual(faults[104]["joint"], "l_leg_pitch_joint")
+        self.assertEqual(faults[104]["error_name"], "communication_lost")
+        self.assertTrue(activity["active"])
+        self.assertEqual(activity["moving_joints"], ["l_arm_pitch_joint"])
+
+    def test_snapshot_rejects_wrong_joint_count(self):
+        controller = _Controller()
+        controller.joints.pop()
+
+        with self.assertRaisesRegex(RuntimeError, "returned 20 joints, expected 21"):
+            DEVICE._read_motion_event_snapshot(controller, 0.15)
+
+
+class MotionEventsPluginTest(unittest.TestCase):
+    def test_bundle_registers_enabled_motion_events_tool(self):
+        controller = _Controller()
+        executor = _Executor()
+        bundle = MAIN.BumiDeviceBundle(
+            {
+                "plugins": {
+                    "motion_events": {
+                        "enabled": True,
+                        "poll_interval_s": 0.5,
+                        "history_size": 10,
+                        "activity_velocity_threshold": 0.15,
+                    }
+                }
+            },
+            "bumi_test",
+            executor,
+            controller,
+            None,
+        )
+
+        self.assertEqual(
+            [tool["name"] for tool in bundle.get_all_tools()],
+            ["motion_events"],
+        )
+
+    def test_tool_contract_and_event_publication(self):
+        controller = _Controller()
+        executor = _Executor()
+        plugin = DEVICE.MotionEventsPlugin(
+            {"poll_interval_s": 0.5, "history_size": 10},
+            "bumi_test",
+            executor,
+            controller,
+        )
+        node = executor.nodes[0]
+
+        tool = plugin.get_tool()
+        self.assertEqual(tool["name"], "motion_events")
+        self.assertEqual(tool["type"], "sensor")
+        self.assertEqual(
+            tool["topic_out"],
+            [{"topic": "/bumi_test/motion/events", "format": "data/json"}],
+        )
+
+        self.assertEqual(node._poll_once(), [])
+        controller.mode = 5
+        self.assertEqual(
+            [event["type"] for event in node._poll_once()],
+            ["workmode_changed"],
+        )
+        controller.joints[4].error = 0x0D
+        self.assertEqual(
+            [event["type"] for event in node._poll_once()],
+            ["motor_fault_appeared"],
+        )
+        controller.joints[0].vel = 0.2
+        self.assertEqual(
+            [event["type"] for event in node._poll_once()],
+            ["joint_activity_started"],
+        )
+
+        info = plugin.dispatch("info", {})
+        self.assertEqual(info["state"], "idle")
+        self.assertEqual(info["cursor"], 3)
+        self.assertEqual(info["history_count"], 3)
+        report = plugin.dispatch("motion_events", {})
+        self.assertEqual(len(report["events"]), 3)
+        self.assertEqual(report["history_count"], 3)
+        self.assertEqual(node.publisher.messages[-1]["cursor"], 3)
+
+    def test_link_failure_and_recovery(self):
+        controller = _Controller()
+        executor = _Executor()
+        plugin = DEVICE.MotionEventsPlugin({}, "bumi_test", executor, controller)
+        node = executor.nodes[0]
+        node._poll_once()
+
+        controller.fail = True
+        self.assertEqual(
+            [event["type"] for event in node._poll_once()],
+            ["state_data_stale"],
+        )
+        self.assertEqual(node._poll_once(), [])
+        controller.fail = False
+        self.assertEqual(
+            [event["type"] for event in node._poll_once()],
+            ["state_data_recovered"],
+        )
+        self.assertEqual(len(node.logger.warnings), 1)
+
+    def test_configuration_validation(self):
+        controller = _Controller()
+        executor = _Executor()
+
+        with self.assertRaisesRegex(ValueError, "poll_interval_s"):
+            DEVICE.MotionEventsPlugin(
+                {"poll_interval_s": 0.001}, "bumi", executor, controller
+            )
+        with self.assertRaisesRegex(ValueError, "history_size must be an integer"):
+            DEVICE.MotionEventsPlugin(
+                {"history_size": True}, "bumi", executor, controller
+            )
+        with self.assertRaisesRegex(ValueError, "history_size must be in"):
+            DEVICE.MotionEventsPlugin(
+                {"history_size": 1001}, "bumi", executor, controller
+            )
+        with self.assertRaisesRegex(ValueError, "activity_velocity_threshold"):
+            DEVICE.MotionEventsPlugin(
+                {"activity_velocity_threshold": 0}, "bumi", executor, controller
+            )
+
+    def test_start_and_stop_are_idempotent(self):
+        controller = _Controller()
+        executor = _Executor()
+        plugin = DEVICE.MotionEventsPlugin(
+            {"poll_interval_s": 0.02}, "bumi_test", executor, controller
+        )
+
+        first = plugin.dispatch("start", {})
+        second = plugin.dispatch("start", {})
+        self.assertTrue(first["running"])
+        self.assertTrue(second["running"])
+        time.sleep(0.03)
+        stopped = plugin.dispatch("stop", {})
+        self.assertFalse(stopped["running"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add the Bumi motion_events sensor card.
- Detect joint activity, work mode, protection, motor fault, and DDS link transitions.
- Publish motion events through MCP and ROS2 topic /{namespace}/motion/events.
- Add unit tests and configuration validation.

## Verification

- 11 unit tests passed.
- ARM64 image built successfully on Bumi.
- Verified motion_events through MCP.
- Verified real joint activity events from HighController/CycloneDDS.
- Verified ROS2 topic and PhanthyMotus data stream.