### PR TITLE
fix(t800): add safe motion mode and on-demand motion status

### DIFF
--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -24,6 +24,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_command_feedback` | sensor | Native SDK 最近关节控制命令反馈 |
 | `gamepad` | sensor | 遥控器连接、按键和摇杆状态 |
 | `motion_state` | sensor | 当前 Native SDK motion state 和允许转换 |
+| `motion_events` | sensor | 清晰的运动摘要：两位小数速度、运动/停止、动作、控制来源、按键及当前固件状态；过滤过期速度并识别手柄与触屏动作 |
 | `driver_health` | actuator | 每次执行返回一次机器人、麦克风与 Odin2 点云/双目/深度数据流的最新健康 JSON，不持续发布 |
 | `robot_snapshot` | sensor | 运动、关节、IMU、电源和电机健康聚合快照 |
 | `fault_summary` | sensor | 电机掉线/禁用/错误/过温及电源错误摘要 |

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -33,7 +33,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `ros_graph` | sensor | 实时发现固件节点、topic、service 和尚未映射的新接口 |
 | `model` | resource | 官方 `serial_t800.urdf` |
 | `loco` | actuator | 100 Hz 速度控制；定时/持续、相对位移、转角和圆弧开环动作 |
-| `motion_mode` | actuator | 任意状态切换及 idle/passive/站立/行走/舞蹈/起身/躺下快捷动作 |
+| `motion_mode` | actuator | 5 个已验证运动状态：站立/坐下/躺下/空闲/阻力；基于固件返回的可转换列表选择目标，姿态互切时自动先起身并稳定 5 秒 |
 | `gait` | actuator | 基于 Native SDK motion state 的步态选择；自动适配 `rl_basic`/`walk` 版本差异 |
 | `dance` | actuator | 舞蹈列表、播放、停止和状态；官方基线为 `dance.mnn` + `dance.npz` |
 | `joint_plan` | actuator | 索引/名称关节轨迹、头部/单臂姿态、当前位置保持、取消、复位和预置动作 |

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -24,7 +24,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_command_feedback` | sensor | Native SDK 最近关节控制命令反馈 |
 | `gamepad` | sensor | 遥控器连接、按键和摇杆状态 |
 | `motion_state` | sensor | 当前 Native SDK motion state 和允许转换 |
-| `motion_events` | sensor | 清晰的运动摘要：两位小数速度、运动/停止、动作、控制来源、按键及当前固件状态；过滤过期速度并识别手柄与触屏动作 |
+| `motion_events` | actuator | 按需查询当前动作、运动/停止状态、两位小数速度及语义姿态；仅提供 `status`，不持续发布数据流，固件 idle/passive 会解析为 stand/sit/lie 或 unknown |
 | `driver_health` | actuator | 每次执行返回一次机器人、麦克风与 Odin2 点云/双目/深度数据流的最新健康 JSON，不持续发布 |
 | `robot_snapshot` | sensor | 运动、关节、IMU、电源和电机健康聚合快照 |
 | `fault_summary` | sensor | 电机掉线/禁用/错误/过温及电源错误摘要 |
@@ -34,7 +34,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `ros_graph` | sensor | 实时发现固件节点、topic、service 和尚未映射的新接口 |
 | `model` | resource | 官方 `serial_t800.urdf` |
 | `loco` | actuator | 100 Hz 速度控制；定时/持续、相对位移、转角和圆弧开环动作 |
-| `motion_mode` | actuator | 5 个已验证运动状态：站立/坐下/躺下/空闲/阻力；基于固件返回的可转换列表选择目标，姿态互切时自动先起身并稳定 5 秒 |
+| `safe_motion_mode` | actuator | 仅提供 stand/sit/lie 三种安全姿态；非站立姿态互切时自动经过 stand，返回完整语义转换路径 |
 | `gait` | actuator | 基于 Native SDK motion state 的步态选择；自动适配 `rl_basic`/`walk` 版本差异 |
 | `dance` | actuator | 舞蹈列表、播放、停止和状态；官方基线为 `dance.mnn` + `dance.npz` |
 | `joint_plan` | actuator | 索引/名称关节轨迹、头部/单臂姿态、当前位置保持、取消、复位和预置动作 |

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -58,7 +58,6 @@ services:
 
 diagnostics:
   command_trace_capacity: 20
-  motion_events_capacity: 100
 
 plugins:
   state:
@@ -73,7 +72,7 @@ plugins:
     enabled: true
   locomotion:
     enabled: true
-  motion_mode:
+  safe_motion_mode:
     enabled: true
   dance:
     enabled: true

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -17,6 +17,7 @@ control:
   max_vyaw: 2.0
   locomotion_prepare_duration_sec: 1.0
   mode_transition_timeout_sec: 5.0
+  mode_stand_stabilize_sec: 5.0
   motor_warning_temperature_c: 70.0
   tilt_warning_rad: 0.45
   fall_tilt_rad: 0.9

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -397,10 +397,18 @@ def _display_motion_action_from_state(
     *,
     moving: bool = False,
 ) -> str:
-    # ``available`` is retained in the interface because the firmware publishes
-    # it alongside the current state and it may be needed for future aliases.
-    del available
+    available = [str(item or "").strip().lower() for item in list(available or [])]
     action = _normalize_motion_action(name)
+    # The T800 firmware may settle on the raw state ``passive`` after a posture
+    # transition.  The recovery transition advertised at the same time is the
+    # reliable posture signal: supine/prone recovery means lying, while
+    # sitdown recovery means sitting.
+    if action in ("passive", "idle"):
+        if any("supine_to_stance" in item or "prone_to_stance" in item for item in available):
+            return "lie"
+        if any("sitdown_to_stance" in item for item in available):
+            return "sit"
+        return "unknown"
     if action == "walk":
         return "move" if moving else "stand"
     if action == "lie_down":
@@ -1525,11 +1533,11 @@ class MotionCommandTracePlugin:
         self._publisher.publish(_json_message(self._snapshot()))
 
 class MotionEventsPlugin:
-    """Read-only event timeline for T800 motion-related MCP calls and feedback."""
+    """On-demand compact T800 motion status for the embodied model."""
 
     _MOTION_TOOLS = {
         "loco",
-        "motion_mode",
+        "safe_motion_mode",
         "dance",
         "joint_plan",
         "joint_plan_state",
@@ -1546,18 +1554,9 @@ class MotionEventsPlugin:
     def __init__(self, config: dict, namespace: str, ros2):
         self._config = config
         self._ns = namespace
-        capacity = int(config.get("diagnostics", {}).get("motion_events_capacity", 100))
-        self._capacity = max(1, min(capacity, 1000))
         self._robot_node = Node("t800_motion_events_sub", context=ros2.ctx_robot)
-        self._node = Node("t800_motion_events_pub", context=ros2.ctx_core)
         ros2.executor_robot.add_node(self._robot_node)
-        ros2.executor_core.add_node(self._node)
-        self._publisher = self._node.create_publisher(
-            String, f"/{namespace}/state/motion_events", _RELIABLE
-        )
         self._lock = threading.RLock()
-        self._events = deque(maxlen=self._capacity)
-        self._sequence = 0
         self._moving = False
         self._latest_speed = 0.0
         self._latest_speed_source = "none"
@@ -1568,6 +1567,7 @@ class MotionEventsPlugin:
         self._latest_direction = "none"
         self._current_motion_state = "unknown"
         self._available_motion_states: list[str] = []
+        self._last_known_posture = "unknown"
         self._last_motion_state = "unknown"
         self._last_gamepad_signature = ""
         self._motion_start_threshold = 0.05
@@ -1606,39 +1606,22 @@ class MotionEventsPlugin:
     def get_tool(self) -> dict:
         return {
             "name": "motion_events",
-            "type": "sensor",
+            "type": "actuator",
             "multiInstance": False,
             "readOnly": True,
-            "description": "T800 motion event stream — motion state changes and motion command lifecycle events",
-            "inputSchema": action_schema(
-                _with_lifecycle({
-                    "status": ([], "返回最新事件摘要"),
-                    "debug": (["limit", "since_event_id", "source_tool", "severity"], "返回筛选后的事件时间线"),
-                }),
-                {
-                    "limit": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 200,
-                        "description": "最多返回事件条数",
-                    },
-                    "since_event_id": {
+            "description": "按需返回 T800 当前动作、运动/停止状态、速度和固件运动状态",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
                         "type": "string",
-                        "description": "只返回该事件之后的新事件",
-                    },
-                    "source_tool": {
-                        "type": "string",
-                        "description": "按来源 tool 过滤",
-                    },
-                    "severity": {
-                        "type": "string",
-                        "enum": ["debug", "info", "warning", "error"],
-                        "description": "按事件级别过滤",
+                        "enum": ["status"],
+                        "description": "查询当前运动状态",
                     },
                 },
-                "运动事件查询动作",
-            ),
-            "topic_out": [{"topic": f"/{self._ns}/state/motion_events", "format": "data/json"}],
+                "required": ["action"],
+                "additionalProperties": False,
+            },
         }
 
     def start(self) -> None:
@@ -1672,20 +1655,13 @@ class MotionEventsPlugin:
             self._robot_node.create_subscription(
                 Odometry, odometry_topic, self._on_odometry, _BEST_EFFORT
             )
-        self._node.create_timer(0.2, self._publish)
 
     def stop(self) -> None:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict:
-        if action == "info":
-            return _with_topic_out(self._summary_snapshot(), f"/{self._ns}/state/motion_events")
-        if action in ("motion_events", "status", "start"):
+        if action == "status":
             return self._summary_snapshot()
-        if action in ("debug", "list"):
-            return self._debug_snapshot(args)
-        if action == "stop":
-            return {"state": "idle"}
         return {"error": f"unknown motion events action: {action}"}
 
     def _on_velocity(self, msg) -> None:
@@ -1702,6 +1678,8 @@ class MotionEventsPlugin:
         motion_name = str(msg.target_motion_name)
         action = _normalize_motion_action(motion_name)
         with self._lock:
+            if action in ("passive", "idle"):
+                action = self._last_known_posture
             self._latest_action = action
             self._latest_control_source = "motion_request"
             self._latest_direction = "none"
@@ -1785,10 +1763,21 @@ class MotionEventsPlugin:
             if current != previous:
                 moving = self._freshly_moving()
                 raw_action = _normalize_motion_action(current)
-                if raw_action == "passive":
-                    action = "lie" if action in ("lie", "lie_down") else "passive"
+                if raw_action in ("passive", "idle"):
+                    inferred = _display_motion_action_from_state(current, available, moving=moving)
+                    if inferred in ("stand", "sit", "lie"):
+                        action = inferred
+                    else:
+                        requested_posture = "lie" if action == "lie_down" else action
+                        action = (
+                            requested_posture
+                            if requested_posture in ("stand", "sit", "lie")
+                            else self._last_known_posture
+                        )
                 else:
                     action = _display_motion_action_from_state(current, available, moving=moving)
+                if action in ("stand", "sit", "lie"):
+                    self._last_known_posture = action
                 self._latest_action = action
                 self._latest_control_source = "motion_state"
                 self._latest_direction = "none"
@@ -1888,40 +1877,27 @@ class MotionEventsPlugin:
         summary: str,
         detail: dict | None = None,
     ) -> dict:
-        with self._lock:
-            self._sequence += 1
-            event_id = f"t800-motion-{self._sequence:06d}"
-            timestamp_ms = _now_ms()
-            event = {
-                "type": event_type,
-                "timestamp": round(timestamp_ms / 1000.0, 3),
-                "event_id": event_id,
-                "timestamp_ms": timestamp_ms,
-                "source_tool": source_tool,
-                "event_type": event_type,
-                "severity": severity,
-                "phase": phase,
-                "summary": summary,
-                "detail": detail or {},
-            }
-            self._events.append(event)
-            return dict(event)
+        # Kept as a compatibility hook for the bundle dispatcher.  Events are
+        # deliberately not buffered or streamed; status is computed on demand.
+        return {
+            "source_tool": source_tool,
+            "event_type": event_type,
+            "severity": severity,
+            "phase": phase,
+            "summary": summary,
+            "detail": detail or {},
+        }
 
     def _summary_snapshot(self) -> dict:
         now = time.monotonic()
         with self._lock:
-            latest_event = dict(self._events[-1]) if self._events else None
-            events = [dict(event) for event in self._events]
-            total_recorded = self._sequence
             moving = self._moving
             latest_speed = self._latest_speed
-            latest_speed_source = self._latest_speed_source
             latest_speed_updated = self._latest_speed_updated
             latest_action = self._latest_action
-            latest_buttons = list(self._latest_buttons)
-            latest_control_source = self._latest_control_source
             current_motion_state = self._current_motion_state
             available_motion_states = list(self._available_motion_states)
+            last_known_posture = self._last_known_posture
         speed_age = None if latest_speed_updated is None else max(0.0, now - latest_speed_updated)
         fresh_moving = (
             moving
@@ -1929,74 +1905,24 @@ class MotionEventsPlugin:
             and speed_age <= _SPEED_STALE_SECONDS
         )
         display_action = latest_action
-        display_control_source = latest_control_source
         if display_action == "none" and current_motion_state not in ("", "unknown"):
             display_action = _display_motion_action_from_state(
                 current_motion_state, available_motion_states, moving=fresh_moving
             )
-            display_control_source = "motion_state"
-        if display_action == "walk" and not fresh_moving:
+        if display_action in ("passive", "idle", "none"):
+            display_action = last_known_posture if last_known_posture in ("stand", "sit", "lie") else "unknown"
+        if display_action in ("walk", "move") and not fresh_moving:
             display_action = "stand"
+        display_current_state = current_motion_state
+        if _normalize_motion_action(current_motion_state) in ("passive", "idle"):
+            display_current_state = display_action if display_action in ("stand", "sit", "lie") else "unknown"
         return {
-            "state": "running" if latest_event or latest_speed_updated is not None else "no_data",
+            "state": "running" if current_motion_state != "unknown" or latest_speed_updated is not None else "no_data",
+            "action": display_action,
             "motion_state": "moving" if fresh_moving else "stopped",
             "speed": f"{round(latest_speed, 2):.2f} m/s",
-            "speed_source": latest_speed_source,
-            "control_source": display_control_source,
-            "action": display_action,
-            "buttons": latest_buttons,
-            "current_motion_state": current_motion_state,
-            "event": None if latest_event is None else latest_event.get("type"),
-            "summary": None if latest_event is None else latest_event.get("summary"),
-            "event_id": None if latest_event is None else latest_event.get("event_id"),
-            "event_count": total_recorded,
+            "current_motion_state": display_current_state,
         }
-
-    def _debug_snapshot(self, args: dict | None = None) -> dict:
-        args = args or {}
-        limit = int(args.get("limit", 50))
-        limit = max(1, min(limit, 200))
-        since_event_id = str(args.get("since_event_id", "") or "")
-        source_tool = str(args.get("source_tool", "") or "")
-        severity = str(args.get("severity", "") or "")
-        with self._lock:
-            events = [dict(event) for event in self._events]
-            total_buffered = len(self._events)
-            latest_event_id = events[-1]["event_id"] if events else None
-            total_recorded = self._sequence
-        if since_event_id:
-            events = self._after_event(events, since_event_id)
-        if source_tool:
-            events = [event for event in events if event["source_tool"] == source_tool]
-        if severity:
-            events = [event for event in events if event["severity"] == severity]
-        events = events[-limit:]
-        warning_count = sum(1 for event in events if event["severity"] == "warning")
-        error_count = sum(1 for event in events if event["severity"] == "error")
-        return {
-            "state": "running" if events else "no_data",
-            "ok": True,
-            "robot": "t800",
-            "tool": "motion_events",
-            "events": events,
-            "summary": {
-                "capacity": self._capacity,
-                "total_recorded": total_recorded,
-                "total_buffered": total_buffered,
-                "returned": len(events),
-                "latest_event_id": latest_event_id,
-                "warning_count": warning_count,
-                "error_count": error_count,
-            },
-            "timestamp_ms": _now_ms(),
-        }
-
-    @staticmethod
-    def _after_event(events: list[dict], since_event_id: str) -> list[dict]:
-        for index, event in enumerate(events):
-            if event["event_id"] == since_event_id:
-                return events[index + 1:]
-        return events
 
     @staticmethod
     def _classify(tool_name: str, action: str, result: dict) -> tuple[str, str, str]:
@@ -2039,9 +1965,6 @@ class MotionEventsPlugin:
         if isinstance(value, (str, int, float, bool)) or value is None:
             return value
         return str(value)
-
-    def _publish(self) -> None:
-        self._publisher.publish(_json_message(self._summary_snapshot()))
 
 class NativeInterfaceProbePlugin:
     _NAME_KEYWORDS = ("engineai", "motion", "hardware")
@@ -2729,8 +2652,30 @@ def _first_available_motion(candidates, available: list[str]) -> str | None:
     return None
 
 
-class MotionModePlugin:
-    """Verified T800 posture transitions over the public ROS motion FSM."""
+def _safe_motion_mode_action(
+    name: str,
+    available: list[str] | tuple[str, ...] | None = None,
+    fallback: str | None = None,
+) -> str:
+    """Return one of the three safe semantic postures from firmware feedback."""
+    action = _motion_mode_action(name)
+    if action in ("stand", "walk", "get_up"):
+        return "stand"
+    if action == "sit":
+        return "sit"
+    if action == "lie_down":
+        return "lie"
+    if action == "passive":
+        inferred = _display_motion_action_from_state(name, available)
+        if inferred in ("sit", "lie"):
+            return inferred
+        if fallback in ("sit", "lie"):
+            return str(fallback)
+    return "unknown"
+
+
+class SafeMotionModePlugin:
+    """Safe T800 posture transitions over the public ROS motion FSM."""
 
     _ALIASES = {
         "stand": (
@@ -2745,43 +2690,35 @@ class MotionModePlugin:
         "lie": (
             "rl_mimic_stance_to_supine", "stance_to_supine", "lie_down", "liedown", "supine",
         ),
-        "idle": ("idle",),
-        "passive": ("passive",),
     }
-    _STANDING_ACTIONS = frozenset({"stand", "walk"})
-    _STAND_FIRST_TARGETS = frozenset({"stand", "sit", "lie"})
-    _MODE_ACTIONS = {
-        "stand": "stand",
-        "sit": "sit",
-        "lie": "lie_down",
-        "idle": "idle",
-        "passive": "passive",
-    }
+    _ACTIONS = ("stand", "sit", "lie")
 
     def __init__(self, config: dict, namespace: str, ros2, state: StatePlugin):
         self._config = config
         self._state = state
-        self._node = Node("t800_motion_mode", context=ros2.ctx_robot)
+        self._node = Node("t800_safe_motion_mode", context=ros2.ctx_robot)
         ros2.executor_robot.add_node(self._node)
         self._publisher = None
+        self._last_confirmed_mode: str | None = None
 
     def get_tool(self) -> dict:
         return {
-            "name": "motion_mode",
+            "name": "safe_motion_mode",
             "type": "actuator",
             "multiInstance": False,
-            "description": "T800 运动状态切换：站立/坐下/躺下/空闲/阻力；"
-                           "非站立姿态切换到其他姿态会自动先起身到站立，passive 支持 idle 切入",
-            "inputSchema": action_schema(
-                {name: (["force", "wait", "stand_stabilize_sec"], f"切换到 {name}") for name in self._ALIASES},
-                {
-                    "wait": {"type": "boolean", "description": "等待状态反馈，默认 true"},
-                    "force": {"type": "boolean", "description": "目标不在 available transitions 时仍发送（需人工确认安全）"},
-                    "timeout_sec": {"type": "number", "description": "等待状态反馈超时时间；默认使用 config.yaml"},
-                    "stand_stabilize_sec": {"type": "number", "description": "起身完成后的站立稳定等待时间；默认 5 秒"},
+            "description": "安全切换 T800 的 stand、sit、lie；非站立姿态互切会自动经过 stand",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": list(self._ACTIONS),
+                        "description": "目标安全姿态",
+                    },
                 },
-                "运动状态动作",
-            ),
+                "required": ["action"],
+                "additionalProperties": False,
+            },
         }
 
     def start(self) -> None:
@@ -2797,112 +2734,62 @@ class MotionModePlugin:
 
     def dispatch(self, action: str, args: dict) -> dict:
         mode = str(action or "")
-        if mode not in self._ALIASES:
-            return {"error": f"unknown motion mode action: {mode}"}
-        args = dict(args or {})
-        force = bool(args.get("force", False))
-        wait = bool(args.get("wait", True))
-        timeout = float(args.get("timeout_sec", self._config["control"]["mode_transition_timeout_sec"]))
-        stabilize_sec = float(args.get(
-            "stand_stabilize_sec",
-            self._config.get("control", {}).get("mode_stand_stabilize_sec", 5.0),
-        ))
+        if mode not in self._ACTIONS:
+            return {"state": "rejected", "error": f"unknown safe motion action: {mode}"}
+        del args
+        timeout = float(self._config["control"]["mode_transition_timeout_sec"])
+        stabilize_sec = float(self._config.get("control", {}).get("mode_stand_stabilize_sec", 5.0))
 
         current, available = self._state.current_motion()
-        current_action = _motion_mode_action(current)
-        steps: list[dict] = []
+        current_mode = _safe_motion_mode_action(current, available, self._last_confirmed_mode)
+        origin = current_mode
+        path = [origin] if origin in self._ACTIONS else []
 
-        if self._mode_matches_current(mode, current_action):
-            return {
-                "state": "completed",
-                "mode": mode,
-                "current": current,
-                "available": available,
-                "steps": [{"state": "completed", "target": f"already {mode}", "current": current}],
-            }
+        if current_mode not in self._ACTIONS:
+            return self._failure(
+                "rejected", mode, origin, path, current, "current posture is not safely identifiable"
+            )
+        if mode == current_mode:
+            self._last_confirmed_mode = mode
+            return self._completed(mode, origin, [mode], current, changed=False)
 
-        if mode == "idle" and current_action not in ("sit", "lie_down", "passive"):
-            return {
-                "state": "rejected",
-                "error": f"{mode} only allowed from sit, lie or passive (current: {current_action})",
-                "mode": mode,
-                "current": current,
-                "available": available,
-                "suggested_action": "switch to sit, lie or passive first",
-            }
-        if mode == "passive" and current_action not in ("sit", "lie_down", "idle"):
-            return {
-                "state": "rejected",
-                "error": f"{mode} only allowed from sit, lie or idle (current: {current_action})",
-                "mode": mode,
-                "current": current,
-                "available": available,
-                "suggested_action": "switch to sit, lie or idle first",
-            }
-
-        if mode in self._STAND_FIRST_TARGETS and current_action not in self._STANDING_ACTIONS:
-            stand_target = self._pick_target("stand", available, force, current_action=current_action)
+        if current_mode != "stand":
+            stand_target = self._pick_target("stand", available, current_mode)
             if stand_target is None:
-                return self._reject(mode, current, available, "stand")
+                return self._reject(mode, origin, path, current, available, "stand")
             step = self._request_and_wait(
                 stand_target,
-                expected=self._STANDING_ACTIONS,
-                wait=(True if mode != "stand" else wait),
+                desired_mode="stand",
                 timeout=timeout,
             )
-            steps.append(step)
+            path.append("stand")
             if step["state"] != "completed":
-                result = {
-                    "state": step["state"],
-                    "mode": mode,
-                    "target": stand_target,
-                    "current": step.get("current", current),
-                    "available": step.get("available", available),
-                    "steps": steps,
-                }
-                if step["state"] == "timeout":
-                    result["error"] = "could not stand up before " + mode
-                return result
+                return self._failure(
+                    step["state"], mode, origin, path, step.get("current", current),
+                    f"could not reach stand before {mode}",
+                )
+            self._last_confirmed_mode = "stand"
             if mode == "stand":
-                return {
-                    "state": "completed",
-                    "mode": mode,
-                    "target": stand_target,
-                    "current": step.get("current", current),
-                    "available": step.get("available", available),
-                    "steps": steps,
-                }
+                return self._completed(mode, origin, path, step.get("current", current), changed=True)
             if stabilize_sec > 0:
                 time.sleep(stabilize_sec)
             current, available = self._state.current_motion()
-            current_action = _motion_mode_action(current)
 
-        if mode == "stand" and current_action in self._STANDING_ACTIONS:
-            return {
-                "state": "completed",
-                "mode": mode,
-                "current": current,
-                "available": available,
-                "steps": [{"state": "completed", "target": "already standing", "current": current}],
-            }
-
-        target = self._pick_target(mode, available, force, current_action=current_action)
+        target = self._pick_target(mode, available, "stand")
         if target is None:
-            return self._reject(mode, current, available, mode)
-        expected = frozenset(_motion_mode_action(alias) for alias in self._ALIASES[mode])
-        final = self._request_and_wait(target, expected=expected, wait=wait, timeout=timeout)
-        steps.append(final)
-        return {
-            "state": final["state"],
-            "mode": mode,
-            "target": target,
-            "current": final.get("current", current),
-            "available": final.get("available", available),
-            "steps": steps,
-        }
+            return self._reject(mode, origin, path, current, available, mode)
+        final = self._request_and_wait(target, desired_mode=mode, timeout=timeout)
+        path.append(mode)
+        if final["state"] != "completed":
+            return self._failure(
+                final["state"], mode, origin, path, final.get("current", current),
+                f"could not reach {mode}",
+            )
+        self._last_confirmed_mode = mode
+        return self._completed(mode, origin, path, final.get("current", current), changed=True)
 
     def request_target(self, target: str, args: dict, *, expected_actions=None) -> dict:
-        """Request a raw firmware state for a dedicated facade tool."""
+        """Internal raw-state request used by the separate dance facade."""
         args = dict(args or {})
         force = bool(args.get("force", False))
         wait = bool(args.get("wait", True))
@@ -2911,33 +2798,40 @@ class MotionModePlugin:
         target = str(target or "")
         if not target:
             return {"state": "rejected", "error": "target motion is required", "current": current}
-        if not available and not force:
-            return self._reject(target, current, available, target)
-        if available and not _motion_mode_matches_any(target, available) and not force:
-            return self._reject(target, current, available, target)
+        if (not available or not _motion_mode_matches_any(target, available)) and not force:
+            return {
+                "state": "rejected",
+                "error": f"no available transition for {target} from {current}",
+                "current": current,
+            }
         expected = frozenset(expected_actions or {_motion_mode_action(target)})
-        result = self._request_and_wait(target, expected=expected, wait=wait, timeout=timeout)
+        msg = self._message_type()
+        msg.target_motion_name = target
+        self._publisher.publish(msg)
+        if not wait:
+            return {"state": "requested", "target": target, "current": current}
+        deadline = time.monotonic() + timeout
+        result = {"state": "timeout", "target": target, "current": current}
+        while time.monotonic() < deadline:
+            current, _ = self._state.current_motion()
+            if _motion_mode_action(current) in expected:
+                result = {"state": "completed", "target": target, "current": current}
+                break
+            time.sleep(0.05)
         return {
             "state": result["state"],
             "target": target,
             "current": result.get("current", current),
-            "available": result.get("available", available),
         }
 
-    def _mode_matches_current(self, mode: str, current_action: str) -> bool:
-        expected = self._MODE_ACTIONS.get(mode, mode)
+    def _target_candidates(self, mode: str, current_mode: str) -> list[str]:
         if mode == "stand":
-            return current_action in self._STANDING_ACTIONS
-        return current_action == expected
-
-    def _target_candidates(self, mode: str, current_action: str) -> list[str]:
-        if mode == "stand":
-            if current_action == "sit":
+            if current_mode == "sit":
                 return [
                     "rl_mimic_sitdown_to_stance", "sitdown_to_stance",
                     "pd_stand", "stand", "stance",
                 ]
-            if current_action in ("lie_down", "passive"):
+            if current_mode == "lie":
                 return [
                     "rl_mimic_supine_to_stance", "rl_mimic_prone_to_stance",
                     "supine_to_stance", "prone_to_stance",
@@ -2949,39 +2843,23 @@ class MotionModePlugin:
         self,
         mode: str,
         available: list[str],
-        force: bool,
-        *,
-        current_action: str,
+        current_mode: str,
     ) -> str | None:
-        candidates = self._target_candidates(mode, current_action)
-        if mode == "idle" and current_action in ("sit", "lie_down", "passive"):
-            return "idle"
-        if mode == "passive" and current_action in ("sit", "lie_down", "idle"):
-            return "passive"
-        if not available and not force:
+        candidates = self._target_candidates(mode, current_mode)
+        if not available:
             return None
-        requested = _first_available_motion(candidates, available)
-        if requested is None and force:
-            requested = candidates[0]
-        return requested
+        return _first_available_motion(candidates, available)
 
-    def _request_and_wait(self, target: str, *, expected, wait: bool, timeout: float) -> dict:
+    def _request_and_wait(self, target: str, *, desired_mode: str, timeout: float) -> dict:
         msg = self._message_type()
         msg.target_motion_name = target
         self._publisher.publish(msg)
-        result = self._wait_for_motion(target, expected=expected, wait=wait, timeout=timeout)
-        result["control_source"] = "ros_motion_request"
-        return result
-
-    def _wait_for_motion(self, target: str, *, expected, wait: bool, timeout: float) -> dict:
-        if not wait:
-            return {"state": "requested", "target": target}
         deadline = time.monotonic() + timeout
         current, available = "", []
         while time.monotonic() < deadline:
             current, available = self._state.current_motion()
-            motion = _motion_mode_action(current)
-            if motion in expected:
+            motion = _safe_motion_mode_action(current, available, desired_mode)
+            if motion == desired_mode:
                 return {
                     "state": "completed",
                     "target": target,
@@ -2992,30 +2870,59 @@ class MotionModePlugin:
             time.sleep(0.05)
         return {"state": "timeout", "target": target, "current": current, "available": available}
 
-    def _reject(self, mode: str, current: str, available: list[str], need: str) -> dict:
-        if not available:
-            return {
-                "state": "rejected",
-                "error": "no_transition_data",
-                "mode": mode,
-                "current": current,
-                "available": available,
-                "suggested_action": "wait for motion_state data or retry with force=true only after manual safety check",
-            }
+    @staticmethod
+    def _completed(mode: str, origin: str, path: list[str], firmware_state: str, *, changed: bool) -> dict:
         return {
-            "state": "rejected",
-            "error": f"no available transition for {need} from {current}",
-            "mode": mode,
-            "current": current,
-            "available": available,
-            "suggested_action": f"use one of: {', '.join(available)}",
+            "state": "completed",
+            "action": mode,
+            "from": origin,
+            "to": mode,
+            "transition_path": path,
+            "transition": f"already {mode}" if not changed else " -> ".join(path),
+            "changed": changed,
+            "current": mode,
+            "firmware_state": firmware_state,
         }
+
+    @staticmethod
+    def _failure(
+        state: str,
+        mode: str,
+        origin: str,
+        path: list[str],
+        firmware_state: str,
+        error: str,
+    ) -> dict:
+        return {
+            "state": state,
+            "action": mode,
+            "from": origin,
+            "to": mode,
+            "transition_path": path,
+            "transition": " -> ".join(path) if path else "not started",
+            "changed": False,
+            "current": _safe_motion_mode_action(firmware_state),
+            "firmware_state": firmware_state,
+            "error": error,
+        }
+
+    def _reject(
+        self,
+        mode: str,
+        origin: str,
+        path: list[str],
+        current: str,
+        available: list[str],
+        need: str,
+    ) -> dict:
+        error = "no_transition_data" if not available else f"no available transition for {need} from {current}"
+        return self._failure("rejected", mode, origin, path, current, error)
 
 
 class DancePlugin:
     """Discoverable dance facade over Native SDK motion states."""
 
-    def __init__(self, motion_mode: MotionModePlugin, state: StatePlugin):
+    def __init__(self, motion_mode: SafeMotionModePlugin, state: StatePlugin):
         self._motion_mode = motion_mode
         self._state = state
 
@@ -3065,9 +2972,9 @@ class DancePlugin:
             return {"state": "idle"}
         if action == "play":
             target = str(args.get("name", "dance"))
-            current_action = _motion_mode_action(current)
+            current_action = _safe_motion_mode_action(current, available, self._motion_mode._last_confirmed_mode)
             steps: list[dict] = []
-            if current_action not in MotionModePlugin._STANDING_ACTIONS:
+            if current_action != "stand":
                 stand = self._motion_mode.dispatch("stand", dict(args))
                 steps.append(stand)
                 if stand.get("state") != "completed":

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -274,6 +274,10 @@ _GAMEPAD_ACTIONS = {
     frozenset({"RB", "B"}): "dance",
     frozenset({"START", "CROSS_X_UP"}): "get_up",
     frozenset({"START", "CROSS_X_DOWN"}): "lie_down",
+    # Boxing punches (T800 keeps the same motion state during punches, so the
+    # action is derived from the gamepad combo only).
+    frozenset({"A", "CROSS_Y_RIGHT"}): "left_straight",
+    frozenset({"A", "CROSS_Y_LEFT"}): "right_straight",
 }
 
 
@@ -304,26 +308,104 @@ def _motion_direction(stick_x: float, stick_y: float, yaw_x: float = 0.0) -> str
     return "_".join(parts) if parts else "none"
 
 
+_SPEED_STALE_SECONDS = 0.5
+
+# T800 reports motion transitions as ``<source>_to_<target>`` (or
+# ``rl_mimic_<source>_to_<target>``). Resolve them to the stable *target* action
+# so the canvas sees a clean stand<->sit switch instead of a transient
+# intermediate state (e.g. ``rl_mimic_stance_to_sitdown`` -> sit,
+# ``rl_mimic_sitdown_to_stance`` -> stand).
+_TRANSITION_TARGETS = (
+    ("rl_mimic_stance_to_sitdown", "sit"),
+    ("stance_to_sitdown", "sit"),
+    ("rl_mimic_sitdown_to_stance", "stand"),
+    ("sitdown_to_stance", "stand"),
+    ("rl_mimic_supine_to_stance", "get_up"),
+    ("rl_mimic_prone_to_stance", "get_up"),
+    ("supine_to_stance", "get_up"),
+    ("prone_to_stance", "get_up"),
+    ("rl_mimic_stance_to_supine", "lie_down"),
+    ("stance_to_supine", "lie_down"),
+    ("rl_mimic_stance_to_kneeling", "kneel"),
+    ("rl_mimic_kneeling_to_stance", "stand"),
+)
+
+_MOTION_ALIASES = (
+    ("punch", ("punch", "boxing", "box", "fight", "fist", "打拳")),
+    ("dance", ("dance",)),
+    ("get_up", ("get_up", "getup", "supine_to_stance", "prone_to_stance")),
+    ("lie_down", ("lie_down", "liedown", "supine", "stance_to_supine")),
+    ("sit", ("sit_down", "sitdown", "pd_sitdown", "sit", "sitting", "seated", "seat", "squat")),
+    ("kneel", ("kneel", "kneeling", "knee", "跪")),
+    ("walk", ("walk", "loco", "rl_basic", "rl_terrain", "lower_body_balance", "walk_server")),
+    ("stand", ("stand", "pd_stand", "stance")),
+    ("idle", ("idle",)),
+    ("passive", ("passive", "damping")),
+)
+
+
+def _transition_target_action(name: str) -> str | None:
+    """Resolve a T800 ``*_to_*`` transition state to its stable target action."""
+    lowered = str(name or "").strip().lower()
+    if not lowered:
+        return None
+    for exact, action in _TRANSITION_TARGETS:
+        if lowered == exact:
+            return action
+    marker = "_to_"
+    if marker not in lowered:
+        return None
+    target = lowered.rsplit(marker, 1)[-1]
+    for normalized, tokens in _MOTION_ALIASES:
+        if any(token in target for token in tokens):
+            return normalized
+    return None
+
+
 def _normalize_motion_action(name: str) -> str:
     value = str(name or "").strip()
     lowered = value.lower()
     if not lowered or lowered == "unknown":
         return "unknown"
-    aliases = (
-        ("stand", ("stand", "pd_stand", "stance")),
-        ("sit", ("sit", "sitting", "seated", "seat", "squat")),
-        ("punch", ("punch", "boxing", "box", "fight", "fist", "打拳")),
-        ("dance", ("dance",)),
-        ("walk", ("walk", "loco")),
-        ("get_up", ("get_up", "getup")),
-        ("lie_down", ("lie_down", "liedown", "supine")),
-        ("idle", ("idle",)),
-        ("passive", ("passive", "damping")),
-    )
-    for normalized, tokens in aliases:
+    transition = _transition_target_action(lowered)
+    if transition:
+        return transition
+    # Match the more specific transition/screen states before broad terms such
+    # as "stance"; otherwise names like stance_to_sitdown are misclassified as
+    # stand on the canvas.
+    for normalized, tokens in _MOTION_ALIASES:
         if any(token in lowered for token in tokens):
             return normalized
     return value
+
+
+def _display_motion_action(name: str, *, moving: bool = False) -> str:
+    action = _normalize_motion_action(name)
+    # Any locomotion-capable state (rl_basic / walk_server / lower_body_balance /
+    # walk / loco / rl_terrain) describes a walking-ready pose: show "move" only
+    # while the robot is actually moving, otherwise "stand". ``moving`` must be
+    # freshness-aware so a stale speed sample never reports a stationary robot
+    # as walking.
+    if action == "walk":
+        return "move" if moving else "stand"
+    return action
+
+
+def _display_motion_action_from_state(
+    name: str,
+    available: list[str] | tuple[str, ...] | None = None,
+    *,
+    moving: bool = False,
+) -> str:
+    # ``available`` is retained in the interface because the firmware publishes
+    # it alongside the current state and it may be needed for future aliases.
+    del available
+    action = _normalize_motion_action(name)
+    if action == "walk":
+        return "move" if moving else "stand"
+    if action == "lie_down":
+        return "lie"
+    return action
 
 
 def _json_message(payload: dict) -> String:
@@ -1485,6 +1567,7 @@ class MotionEventsPlugin:
         self._latest_control_source = "none"
         self._latest_direction = "none"
         self._current_motion_state = "unknown"
+        self._available_motion_states: list[str] = []
         self._last_motion_state = "unknown"
         self._last_gamepad_signature = ""
         self._motion_start_threshold = 0.05
@@ -1495,6 +1578,20 @@ class MotionEventsPlugin:
         max_vx = abs(float(control.get("max_vx", 3.0)))
         max_vy = abs(float(control.get("max_vy", 1.0)))
         return max(1.0, math.hypot(max_vx, max_vy) * 1.5)
+
+    def _freshly_moving(self, now: float | None = None) -> bool:
+        """Whether the robot is currently moving based on a fresh speed sample.
+
+        ``_moving`` is only reset when a new sample arrives, so it can stay True
+        if the gamepad/odometry topic stops publishing. Requiring the latest
+        sample to be recent keeps a stationary robot from being reported as
+        moving (e.g. standing still in a walking-ready state).
+        """
+        now = time.monotonic() if now is None else now
+        updated = self._latest_speed_updated
+        if updated is None:
+            return False
+        return self._moving and (now - updated) <= _SPEED_STALE_SECONDS
 
     def _classify_gamepad_action(self, buttons: list[str], speed: float) -> str:
         button_set = frozenset(buttons)
@@ -1674,14 +1771,27 @@ class MotionEventsPlugin:
 
     def _on_motion_state(self, msg) -> None:
         current = str(getattr(msg, "current_motion_task", "") or "unknown")
-        action = _normalize_motion_action(current)
+        available = list(getattr(msg, "available_transition_motions", []) or [])
         with self._lock:
             previous = self._current_motion_state
             self._last_motion_state = previous
             self._current_motion_state = current
-            self._latest_action = action
-            self._latest_control_source = "motion_state"
-            self._latest_direction = "none"
+            self._available_motion_states = available
+            action = self._latest_action
+            # Refresh the displayed action only when the state actually changes.
+            # A periodic re-publish of the same state must not override a fresher
+            # gamepad action (e.g. a punch button mapped to left_straight while
+            # the robot stays in the boxing motion state).
+            if current != previous:
+                moving = self._freshly_moving()
+                raw_action = _normalize_motion_action(current)
+                if raw_action == "passive":
+                    action = "lie" if action in ("lie", "lie_down") else "passive"
+                else:
+                    action = _display_motion_action_from_state(current, available, moving=moving)
+                self._latest_action = action
+                self._latest_control_source = "motion_state"
+                self._latest_direction = "none"
         if current and current != "unknown" and current != previous:
             self.record_event(
                 source_tool="motion_state",
@@ -1689,7 +1799,7 @@ class MotionEventsPlugin:
                 severity="info",
                 phase="confirmed",
                 summary=f"motion state: {action} ({current})",
-                detail={"action": action, "previous": previous, "current": current},
+                detail={"action": action, "previous": previous, "current": current, "available": available},
             )
 
     def _on_odometry(self, msg) -> None:
@@ -1810,22 +1920,30 @@ class MotionEventsPlugin:
             latest_action = self._latest_action
             latest_buttons = list(self._latest_buttons)
             latest_control_source = self._latest_control_source
-            latest_direction = self._latest_direction
             current_motion_state = self._current_motion_state
+            available_motion_states = list(self._available_motion_states)
         speed_age = None if latest_speed_updated is None else max(0.0, now - latest_speed_updated)
+        fresh_moving = (
+            moving
+            and speed_age is not None
+            and speed_age <= _SPEED_STALE_SECONDS
+        )
         display_action = latest_action
         display_control_source = latest_control_source
         if display_action == "none" and current_motion_state not in ("", "unknown"):
-            display_action = _normalize_motion_action(current_motion_state)
+            display_action = _display_motion_action_from_state(
+                current_motion_state, available_motion_states, moving=fresh_moving
+            )
             display_control_source = "motion_state"
+        if display_action == "walk" and not fresh_moving:
+            display_action = "stand"
         return {
             "state": "running" if latest_event or latest_speed_updated is not None else "no_data",
-            "motion_state": "moving" if moving else "stopped",
+            "motion_state": "moving" if fresh_moving else "stopped",
             "speed": f"{round(latest_speed, 2):.2f} m/s",
             "speed_source": latest_speed_source,
             "control_source": display_control_source,
             "action": display_action,
-            "direction": latest_direction,
             "buttons": latest_buttons,
             "current_motion_state": current_motion_state,
             "event": None if latest_event is None else latest_event.get("type"),

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2552,16 +2552,94 @@ class LocomotionPlugin:
             self._publish_payload({"vx": 0.0, "vy": 0.0, "vyaw": 0.0})
 
 
+_MOTION_MODE_TRANSITION_TARGETS = (
+    ("rl_mimic_stance_to_sitdown", "sit"),
+    ("stance_to_sitdown", "sit"),
+    ("rl_mimic_sitdown_to_stance", "stand"),
+    ("sitdown_to_stance", "stand"),
+    ("rl_mimic_supine_to_stance", "get_up"),
+    ("rl_mimic_prone_to_stance", "get_up"),
+    ("supine_to_stance", "get_up"),
+    ("prone_to_stance", "get_up"),
+    ("rl_mimic_stance_to_supine", "lie_down"),
+    ("stance_to_supine", "lie_down"),
+)
+
+_MOTION_MODE_STATE_ALIASES = (
+    ("get_up", ("get_up", "getup", "supine_to_stance", "prone_to_stance")),
+    ("lie_down", ("lie_down", "liedown", "supine", "stance_to_supine")),
+    ("sit", ("sit_down", "sitdown", "pd_sitdown", "sit", "sitting", "seated", "seat", "squat")),
+    ("walk", ("walk", "loco", "rl_basic", "rl_terrain", "lower_body_balance", "walk_server")),
+    ("stand", ("stand", "pd_stand", "stance")),
+    ("idle", ("idle",)),
+    ("passive", ("passive", "damping")),
+)
+
+
+def _motion_mode_action(name: str) -> str:
+    """Normalize firmware-specific motion names for transition decisions."""
+    value = str(name or "").strip()
+    lowered = value.lower()
+    if not lowered or lowered == "unknown":
+        return "unknown"
+    for exact, action in _MOTION_MODE_TRANSITION_TARGETS:
+        if lowered == exact:
+            return action
+    for action, aliases in _MOTION_MODE_STATE_ALIASES:
+        if any(alias in lowered for alias in aliases):
+            return action
+    return value
+
+
+def _motion_mode_matches_any(name: str, candidates) -> bool:
+    lowered = str(name or "").strip().lower()
+    if not lowered:
+        return False
+    normalized = _motion_mode_action(lowered)
+    for candidate in candidates:
+        candidate_lowered = str(candidate or "").strip().lower()
+        if lowered == candidate_lowered or normalized == _motion_mode_action(candidate_lowered):
+            return True
+    return False
+
+
+def _first_available_motion(candidates, available: list[str]) -> str | None:
+    for candidate in candidates:
+        for item in available:
+            if _motion_mode_matches_any(item, (candidate,)):
+                return item
+    return None
+
+
 class MotionModePlugin:
-    _SHORTCUTS = {
+    """Verified T800 posture transitions over the public ROS motion FSM."""
+
+    _ALIASES = {
+        "stand": (
+            "pd_stand", "stand", "stance",
+            "rl_mimic_sitdown_to_stance", "rl_mimic_supine_to_stance",
+            "rl_mimic_prone_to_stance",
+        ),
+        "sit": (
+            "rl_mimic_stance_to_sitdown", "pd_sitdown", "sit_down", "sitdown", "sit", "sitting",
+            "seated", "seat", "squat",
+        ),
+        "lie": (
+            "rl_mimic_stance_to_supine", "stance_to_supine", "lie_down", "liedown", "supine",
+        ),
+        "idle": ("idle",),
+        "passive": ("passive",),
+    }
+    _STANDING_ACTIONS = frozenset({"stand", "walk"})
+    _STAND_FIRST_TARGETS = frozenset({"stand", "sit", "lie"})
+    _MODE_ACTIONS = {
+        "stand": "stand",
+        "sit": "sit",
+        "lie": "lie_down",
         "idle": "idle",
         "passive": "passive",
-        "stand": "pd_stand",
-        "walk": "rl_basic",
-        "dance": "dance",
-        "get_up": "rl_mimic_supine_to_stance",
-        "lie_down": "rl_mimic_stance_to_supine",
     }
+
     def __init__(self, config: dict, namespace: str, ros2, state: StatePlugin):
         self._config = config
         self._state = state
@@ -2574,17 +2652,17 @@ class MotionModePlugin:
             "name": "motion_mode",
             "type": "actuator",
             "multiInstance": False,
-            "description": "T800 运动状态机切换，包含站立、行走、舞蹈、起身、躺下及桥接模式",
+            "description": "T800 运动状态切换：站立/坐下/躺下/空闲/阻力；"
+                           "非站立姿态切换到其他姿态会自动先起身到站立，passive 支持 idle 切入",
             "inputSchema": action_schema(
-                {"switch": (["target", "force", "wait"], "请求切换到目标 Native SDK motion state"),
-                 **{name: (["force", "wait"], f"快捷切换到 {target}") for name, target in self._SHORTCUTS.items()},
-                 "status": ([], "查询当前和可转换状态")},
+                {name: (["force", "wait", "stand_stabilize_sec"], f"切换到 {name}") for name in self._ALIASES},
                 {
-                    "target": {"type": "string", "description": "目标 motion state；支持固件返回的自定义状态名"},
-                    "force": {"type": "boolean", "description": "目标不在 available transitions 时仍发送"},
                     "wait": {"type": "boolean", "description": "等待状态反馈，默认 true"},
+                    "force": {"type": "boolean", "description": "目标不在 available transitions 时仍发送（需人工确认安全）"},
+                    "timeout_sec": {"type": "number", "description": "等待状态反馈超时时间；默认使用 config.yaml"},
+                    "stand_stabilize_sec": {"type": "number", "description": "起身完成后的站立稳定等待时间；默认 5 秒"},
                 },
-                "状态机动作",
+                "运动状态动作",
             ),
         }
 
@@ -2600,34 +2678,220 @@ class MotionModePlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict:
+        mode = str(action or "")
+        if mode not in self._ALIASES:
+            return {"error": f"unknown motion mode action: {mode}"}
+        args = dict(args or {})
+        force = bool(args.get("force", False))
+        wait = bool(args.get("wait", True))
+        timeout = float(args.get("timeout_sec", self._config["control"]["mode_transition_timeout_sec"]))
+        stabilize_sec = float(args.get(
+            "stand_stabilize_sec",
+            self._config.get("control", {}).get("mode_stand_stabilize_sec", 5.0),
+        ))
+
         current, available = self._state.current_motion()
-        if action in ("start", "info", "status"):
-            return {"state": "ready", "current": current, "available": available}
-        if action == "stop":
-            return {"state": "idle"}
-        if action in self._SHORTCUTS:
-            args = dict(args)
-            args["target"] = self._SHORTCUTS[action]
-            action = "switch"
-        if action != "switch":
-            return {"error": f"unknown motion mode action: {action}"}
-        target = str(args.get("target", ""))
+        current_action = _motion_mode_action(current)
+        steps: list[dict] = []
+
+        if self._mode_matches_current(mode, current_action):
+            return {
+                "state": "completed",
+                "mode": mode,
+                "current": current,
+                "available": available,
+                "steps": [{"state": "completed", "target": f"already {mode}", "current": current}],
+            }
+
+        if mode == "idle" and current_action not in ("sit", "lie_down", "passive"):
+            return {
+                "state": "rejected",
+                "error": f"{mode} only allowed from sit, lie or passive (current: {current_action})",
+                "mode": mode,
+                "current": current,
+                "available": available,
+                "suggested_action": "switch to sit, lie or passive first",
+            }
+        if mode == "passive" and current_action not in ("sit", "lie_down", "idle"):
+            return {
+                "state": "rejected",
+                "error": f"{mode} only allowed from sit, lie or idle (current: {current_action})",
+                "mode": mode,
+                "current": current,
+                "available": available,
+                "suggested_action": "switch to sit, lie or idle first",
+            }
+
+        if mode in self._STAND_FIRST_TARGETS and current_action not in self._STANDING_ACTIONS:
+            stand_target = self._pick_target("stand", available, force, current_action=current_action)
+            if stand_target is None:
+                return self._reject(mode, current, available, "stand")
+            step = self._request_and_wait(
+                stand_target,
+                expected=self._STANDING_ACTIONS,
+                wait=(True if mode != "stand" else wait),
+                timeout=timeout,
+            )
+            steps.append(step)
+            if step["state"] != "completed":
+                result = {
+                    "state": step["state"],
+                    "mode": mode,
+                    "target": stand_target,
+                    "current": step.get("current", current),
+                    "available": step.get("available", available),
+                    "steps": steps,
+                }
+                if step["state"] == "timeout":
+                    result["error"] = "could not stand up before " + mode
+                return result
+            if mode == "stand":
+                return {
+                    "state": "completed",
+                    "mode": mode,
+                    "target": stand_target,
+                    "current": step.get("current", current),
+                    "available": step.get("available", available),
+                    "steps": steps,
+                }
+            if stabilize_sec > 0:
+                time.sleep(stabilize_sec)
+            current, available = self._state.current_motion()
+            current_action = _motion_mode_action(current)
+
+        if mode == "stand" and current_action in self._STANDING_ACTIONS:
+            return {
+                "state": "completed",
+                "mode": mode,
+                "current": current,
+                "available": available,
+                "steps": [{"state": "completed", "target": "already standing", "current": current}],
+            }
+
+        target = self._pick_target(mode, available, force, current_action=current_action)
+        if target is None:
+            return self._reject(mode, current, available, mode)
+        expected = frozenset(_motion_mode_action(alias) for alias in self._ALIASES[mode])
+        final = self._request_and_wait(target, expected=expected, wait=wait, timeout=timeout)
+        steps.append(final)
+        return {
+            "state": final["state"],
+            "mode": mode,
+            "target": target,
+            "current": final.get("current", current),
+            "available": final.get("available", available),
+            "steps": steps,
+        }
+
+    def request_target(self, target: str, args: dict, *, expected_actions=None) -> dict:
+        """Request a raw firmware state for a dedicated facade tool."""
+        args = dict(args or {})
+        force = bool(args.get("force", False))
+        wait = bool(args.get("wait", True))
+        timeout = float(args.get("timeout_sec", self._config["control"]["mode_transition_timeout_sec"]))
+        current, available = self._state.current_motion()
+        target = str(target or "")
         if not target:
-            return {"error": "target motion is required"}
-        if available and target not in available and not bool(args.get("force", False)):
-            return {"error": f"{target} is not available from {current}", "available": available}
+            return {"state": "rejected", "error": "target motion is required", "current": current}
+        if not available and not force:
+            return self._reject(target, current, available, target)
+        if available and not _motion_mode_matches_any(target, available) and not force:
+            return self._reject(target, current, available, target)
+        expected = frozenset(expected_actions or {_motion_mode_action(target)})
+        result = self._request_and_wait(target, expected=expected, wait=wait, timeout=timeout)
+        return {
+            "state": result["state"],
+            "target": target,
+            "current": result.get("current", current),
+            "available": result.get("available", available),
+        }
+
+    def _mode_matches_current(self, mode: str, current_action: str) -> bool:
+        expected = self._MODE_ACTIONS.get(mode, mode)
+        if mode == "stand":
+            return current_action in self._STANDING_ACTIONS
+        return current_action == expected
+
+    def _target_candidates(self, mode: str, current_action: str) -> list[str]:
+        if mode == "stand":
+            if current_action == "sit":
+                return [
+                    "rl_mimic_sitdown_to_stance", "sitdown_to_stance",
+                    "pd_stand", "stand", "stance",
+                ]
+            if current_action in ("lie_down", "passive"):
+                return [
+                    "rl_mimic_supine_to_stance", "rl_mimic_prone_to_stance",
+                    "supine_to_stance", "prone_to_stance",
+                    "pd_stand", "stand", "stance",
+                ]
+        return list(self._ALIASES[mode])
+
+    def _pick_target(
+        self,
+        mode: str,
+        available: list[str],
+        force: bool,
+        *,
+        current_action: str,
+    ) -> str | None:
+        candidates = self._target_candidates(mode, current_action)
+        if mode == "idle" and current_action in ("sit", "lie_down", "passive"):
+            return "idle"
+        if mode == "passive" and current_action in ("sit", "lie_down", "idle"):
+            return "passive"
+        if not available and not force:
+            return None
+        requested = _first_available_motion(candidates, available)
+        if requested is None and force:
+            requested = candidates[0]
+        return requested
+
+    def _request_and_wait(self, target: str, *, expected, wait: bool, timeout: float) -> dict:
         msg = self._message_type()
         msg.target_motion_name = target
         self._publisher.publish(msg)
-        if not bool(args.get("wait", True)):
-            return {"state": "requested", "target": target, "previous": current}
-        deadline = time.monotonic() + float(self._config["control"]["mode_transition_timeout_sec"])
+        result = self._wait_for_motion(target, expected=expected, wait=wait, timeout=timeout)
+        result["control_source"] = "ros_motion_request"
+        return result
+
+    def _wait_for_motion(self, target: str, *, expected, wait: bool, timeout: float) -> dict:
+        if not wait:
+            return {"state": "requested", "target": target}
+        deadline = time.monotonic() + timeout
+        current, available = "", []
         while time.monotonic() < deadline:
             current, available = self._state.current_motion()
-            if current == target:
-                return {"state": "completed", "current": current, "available": available}
+            motion = _motion_mode_action(current)
+            if motion in expected:
+                return {
+                    "state": "completed",
+                    "target": target,
+                    "current": current,
+                    "available": available,
+                    "motion": motion,
+                }
             time.sleep(0.05)
         return {"state": "timeout", "target": target, "current": current, "available": available}
+
+    def _reject(self, mode: str, current: str, available: list[str], need: str) -> dict:
+        if not available:
+            return {
+                "state": "rejected",
+                "error": "no_transition_data",
+                "mode": mode,
+                "current": current,
+                "available": available,
+                "suggested_action": "wait for motion_state data or retry with force=true only after manual safety check",
+            }
+        return {
+            "state": "rejected",
+            "error": f"no available transition for {need} from {current}",
+            "mode": mode,
+            "current": current,
+            "available": available,
+            "suggested_action": f"use one of: {', '.join(available)}",
+        }
 
 
 class DancePlugin:
@@ -2683,13 +2947,21 @@ class DancePlugin:
             return {"state": "idle"}
         if action == "play":
             target = str(args.get("name", "dance"))
-        elif action == "stop_dance":
-            target = str(args.get("target", "rl_basic"))
-        else:
-            return {"error": f"unknown dance action: {action}"}
-        forwarded = dict(args)
-        forwarded["target"] = target
-        return self._motion_mode.dispatch("switch", forwarded)
+            current_action = _motion_mode_action(current)
+            steps: list[dict] = []
+            if current_action not in MotionModePlugin._STANDING_ACTIONS:
+                stand = self._motion_mode.dispatch("stand", dict(args))
+                steps.append(stand)
+                if stand.get("state") != "completed":
+                    return {**stand, "dance_target": target, "steps": steps}
+            dance = self._motion_mode.request_target(target, dict(args), expected_actions={"dance"})
+            steps.append(dance)
+            return {**dance, "steps": steps}
+        if action == "stop_dance":
+            forwarded = dict(args)
+            forwarded.pop("target", None)
+            return self._motion_mode.dispatch("stand", forwarded)
+        return {"error": f"unknown dance action: {action}"}
 
 
 _JOINT_PLAN_COMPLETED_PROGRESS_MIN = 0.999

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -127,7 +127,7 @@ class DualDomainROS2:
 
 class T800DeviceBundle:
     _MOTION_OUTPUT_TOOLS = frozenset({
-        "loco", "motion_mode", "dance", "joint_plan", "gesture",
+        "loco", "safe_motion_mode", "dance", "joint_plan", "gesture",
         "joint_override", "joint_bridge", "virtual_gamepad", "gait",
         "motion_recorder", "head", "speaker",
     })
@@ -155,7 +155,7 @@ class T800DeviceBundle:
             MotionInterruptGroup,
             MotionRecorderPlugin,
             MicPlugin,
-            MotionModePlugin,
+            SafeMotionModePlugin,
             MotorPowerPlugin,
             NativeInterfaceProbePlugin,
             NativeNodeControlPlugin,
@@ -202,7 +202,7 @@ class T800DeviceBundle:
             ("motion_command_trace", MotionCommandTracePlugin, (config, namespace, ros2)),
             ("native_interface_probe", NativeInterfaceProbePlugin, (config, namespace, ros2)),
             ("locomotion", LocomotionPlugin, (config, namespace, ros2, state)),
-            ("motion_mode", MotionModePlugin, (config, namespace, ros2, state)),
+            ("safe_motion_mode", SafeMotionModePlugin, (config, namespace, ros2, state)),
             ("joint_plan", JointPlanPlugin, (config, namespace, ros2, state)),
             ("joint_override", JointOverridePlugin, (config, namespace, ros2, state)),
             ("joint_bridge", JointBridgePlugin, (config, namespace, ros2, state)),
@@ -240,8 +240,8 @@ class T800DeviceBundle:
                 "speaker", speaker.halt, speaker.motion_active
             )
 
-        if plugins.get("dance", {}).get("enabled", True) and "motion_mode" in instances:
-            instance = DancePlugin(instances["motion_mode"], state)
+        if plugins.get("dance", {}).get("enabled", True) and "safe_motion_mode" in instances:
+            instance = DancePlugin(instances["safe_motion_mode"], state)
             instances["dance"] = instance
             self._plugins.append(instance)
 
@@ -257,9 +257,9 @@ class T800DeviceBundle:
         # Gait selector — delegates to the public Native SDK motion-state API.
         if (
             plugins.get("gait", {}).get("enabled", False)
-            and "motion_mode" in instances
+            and "safe_motion_mode" in instances
         ):
-            instance = GaitPlugin(config, instances["motion_mode"], state)
+            instance = GaitPlugin(config, instances["safe_motion_mode"], state)
             instance.set_interrupt_group(motion_interrupt_group)
             motion_interrupt_group.register(
                 "gait", instance.halt, instance.motion_active
@@ -275,7 +275,7 @@ class T800DeviceBundle:
             self._plugins.append(motion_recorder)
             if "joint_plan" in instances:
                 motion_recorder.set_joint_plan(instances["joint_plan"])
-            motion_recorder.set_reset_controls(state, instances.get("motion_mode"))
+            motion_recorder.set_reset_controls(state, instances.get("safe_motion_mode"))
             motion_recorder.set_interrupt_group(motion_interrupt_group)
             motion_interrupt_group.register(
                 "motion_recorder",

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1113,20 +1113,147 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertAlmostEqual(arc["vx"], arc["vyaw"])
         plugin.dispatch("stop_move", {})
 
-    def test_motion_mode_force_path_publishes_custom_state(self):
+    def test_motion_mode_exposes_only_verified_actions(self):
+        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
+        enum = plugin.get_tool()["inputSchema"]["properties"]["action"]["enum"]
+        self.assertEqual(["stand", "sit", "lie", "idle", "passive"], enum)
+
+    def test_motion_mode_force_path_uses_default_stand_target(self):
         plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
         plugin.start()
-        result = plugin.dispatch("switch", {"target": "vendor_future_mode", "force": True, "wait": False})
+        self.state._current_motion = "unknown"
+        self.state._available_motions = []
+        result = plugin.dispatch("stand", {"force": True, "wait": False})
         self.assertEqual("requested", result["state"])
-        self.assertEqual("vendor_future_mode", plugin._publisher.messages[-1].target_motion_name)
-        plugin.dispatch("get_up", {"force": True, "wait": False})
+        self.assertEqual("pd_stand", plugin._publisher.messages[-1].target_motion_name)
+
+    def test_motion_mode_selects_firmware_transition_for_each_posture(self):
+        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
+        plugin.start()
+
+        self.state._current_motion = "sit_down"
+        self.state._available_motions = ["rl_mimic_sitdown_to_stance"]
+        result = plugin.dispatch("stand", {"wait": False})
+        self.assertEqual("requested", result["state"])
+        self.assertEqual("rl_mimic_sitdown_to_stance", plugin._publisher.messages[-1].target_motion_name)
+
+        self.state._current_motion = "rl_mimic_stance_to_supine"
+        self.state._available_motions = ["rl_mimic_supine_to_stance"]
+        result = plugin.dispatch("stand", {"wait": False})
+        self.assertEqual("requested", result["state"])
         self.assertEqual("rl_mimic_supine_to_stance", plugin._publisher.messages[-1].target_motion_name)
+
+        self.state._current_motion = "pd_stand"
+        self.state._available_motions = ["rl_mimic_stance_to_sitdown"]
+        result = plugin.dispatch("sit", {"wait": False})
+        self.assertEqual("requested", result["state"])
+        self.assertEqual("rl_mimic_stance_to_sitdown", plugin._publisher.messages[-1].target_motion_name)
+
+        self.state._available_motions = ["rl_mimic_stance_to_supine"]
+        result = plugin.dispatch("lie", {"wait": False})
+        self.assertEqual("requested", result["state"])
+        self.assertEqual("rl_mimic_stance_to_supine", plugin._publisher.messages[-1].target_motion_name)
+
+    def test_motion_mode_same_mode_is_noop(self):
+        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
+        plugin.start()
+        self.state._current_motion = "sit_down"
+        self.state._available_motions = ["rl_mimic_sitdown_to_stance"]
+        result = plugin.dispatch("sit", {"wait": False})
+        self.assertEqual("completed", result["state"])
+        self.assertEqual([], plugin._publisher.messages)
+
+    def test_motion_mode_sit_to_lie_chains_stand_first(self):
+        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
+        plugin.start()
+        self.state._current_motion = "sit_down"
+        self.state._available_motions = ["rl_mimic_sitdown_to_stance"]
+
+        def robot_executes():
+            time.sleep(0.10)
+            plugin._state._current_motion = "pd_stand"
+            plugin._state._available_motions = ["rl_mimic_stance_to_supine"]
+            time.sleep(0.10)
+            plugin._state._current_motion = "rl_mimic_stance_to_supine"
+
+        thread = threading.Thread(target=robot_executes)
+        thread.start()
+        result = plugin.dispatch("lie", {
+            "wait": True, "timeout_sec": 1.0, "stand_stabilize_sec": 0,
+        })
+        thread.join()
+        self.assertEqual("completed", result["state"])
+        targets = [msg.target_motion_name for msg in plugin._publisher.messages]
+        self.assertEqual(["rl_mimic_sitdown_to_stance", "rl_mimic_stance_to_supine"], targets)
+
+    def test_motion_mode_lie_to_sit_chains_stand_first(self):
+        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
+        plugin.start()
+        self.state._current_motion = "rl_mimic_stance_to_supine"
+        self.state._available_motions = ["rl_mimic_supine_to_stance"]
+
+        def robot_executes():
+            time.sleep(0.10)
+            plugin._state._current_motion = "pd_stand"
+            plugin._state._available_motions = ["rl_mimic_stance_to_sitdown"]
+            time.sleep(0.10)
+            plugin._state._current_motion = "rl_mimic_stance_to_sitdown"
+
+        thread = threading.Thread(target=robot_executes)
+        thread.start()
+        result = plugin.dispatch("sit", {
+            "wait": True, "timeout_sec": 1.0, "stand_stabilize_sec": 0,
+        })
+        thread.join()
+        self.assertEqual("completed", result["state"])
+        targets = [msg.target_motion_name for msg in plugin._publisher.messages]
+        self.assertEqual(["rl_mimic_supine_to_stance", "rl_mimic_stance_to_sitdown"], targets)
+
+    def test_motion_mode_rejects_missing_or_unavailable_transition(self):
+        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
+        plugin.start()
+        self.state._current_motion = "unknown"
+        self.state._available_motions = []
+        result = plugin.dispatch("stand", {"wait": False})
+        self.assertEqual("rejected", result["state"])
+        self.assertEqual("no_transition_data", result["error"])
+
+        self.state._current_motion = "pd_stand"
+        self.state._available_motions = ["rl_mimic_stance_to_supine"]
+        result = plugin.dispatch("sit", {"wait": False})
+        self.assertEqual("rejected", result["state"])
+        self.assertIn("no available transition", result["error"])
+
+    def test_motion_mode_idle_and_passive_posture_matrix(self):
+        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
+        plugin.start()
+
+        self.state._current_motion = "pd_stand"
+        self.state._available_motions = ["idle", "passive"]
+        self.assertEqual("rejected", plugin.dispatch("idle", {"wait": False})["state"])
+        self.assertEqual("rejected", plugin.dispatch("passive", {"wait": False})["state"])
+
+        allowed = (
+            ("pd_sitdown", "idle", "idle"),
+            ("rl_mimic_stance_to_supine", "passive", "passive"),
+            ("passive", "idle", "idle"),
+            ("idle", "passive", "passive"),
+        )
+        for current, action, target in allowed:
+            with self.subTest(current=current, action=action):
+                self.state._current_motion = current
+                self.state._available_motions = []
+                result = plugin.dispatch(action, {"wait": False})
+                self.assertEqual("requested", result["state"])
+                self.assertEqual(target, plugin._publisher.messages[-1].target_motion_name)
 
     def test_dance_facade_lists_and_plays_official_dance(self):
         mode = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
         mode.start()
         dance = self.device.DancePlugin(mode, self.state)
         self.assertEqual("dance.mnn", dance.dispatch("list", {})["built_in"][0]["policy"])
+        self.state._current_motion = "pd_stand"
+        self.state._available_motions = ["dance"]
         result = dance.dispatch("play", {"name": "dance", "force": True, "wait": False})
         self.assertEqual("requested", result["state"])
         self.assertEqual("dance", mode._publisher.messages[-1].target_motion_name)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -275,7 +275,7 @@ CONFIG = {
         "vision_depth": "/manifold/ODIN2/device0/depth",
     },
     "services": {"enable_motor": "/hardware/enable_motor"},
-    "diagnostics": {"command_trace_capacity": 20, "motion_events_capacity": 100},
+    "diagnostics": {"command_trace_capacity": 20},
 }
 
 
@@ -295,7 +295,7 @@ class DevicePluginContractTests(unittest.TestCase):
     def test_complete_tool_surface_is_declared(self):
         from virtual_gamepad import VirtualGamepadPlugin
 
-        motion_mode = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
+        motion_mode = self.device.SafeMotionModePlugin(CONFIG, "robot", self.ros, self.state)
         joint_plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros)
         plugins = [
             self.state,
@@ -334,7 +334,7 @@ class DevicePluginContractTests(unittest.TestCase):
              "robot_snapshot", "fault_summary", "stability", "joint_groups", "capabilities", "ros_graph",
              "mainboard", "heartbeat_status", "motion_command_trace", "motion_events",
              "native_interface_probe",
-             "loco", "motion_mode", "dance", "joint_plan", "joint_plan_state", "gesture", "head",
+             "loco", "safe_motion_mode", "dance", "joint_plan", "joint_plan_state", "gesture", "head",
              "joint_override", "joint_bridge",
              "led", "tts", "mic", "speaker", "pointcloud", "camera", "depth",
              "motor_power", "native_node_control", "virtual_gamepad", "safety", "native_sdk"},
@@ -359,7 +359,7 @@ class DevicePluginContractTests(unittest.TestCase):
     def test_latest_head_and_four_pr_cards_are_available_together(self):
         self.assertTrue(hasattr(self.device, "GaitPlugin"))
         self.assertTrue(hasattr(self.device, "MotionRecorderPlugin"))
-        motion_mode = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
+        motion_mode = self.device.SafeMotionModePlugin(CONFIG, "robot", self.ros, self.state)
         gait = self.device.GaitPlugin(CONFIG, motion_mode, self.state)
         with tempfile.TemporaryDirectory() as recordings_dir:
             config = {
@@ -421,6 +421,17 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual("waiting", direct["state"])
         self.assertEqual("0/9 路数据流正常", direct["health_summary"])
         self.assertEqual(direct["total_sources"], queried["total_sources"])
+
+    def test_motion_events_is_one_shot_status_actuator_without_topic_stream(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        tool = plugin.get_tool()
+        schema = tool["inputSchema"]
+        self.assertEqual("actuator", tool["type"])
+        self.assertNotIn("topic_out", tool)
+        self.assertEqual({"action"}, set(schema["properties"]))
+        self.assertEqual(["status"], schema["properties"]["action"]["enum"])
+        self.assertNotIn("x-action-params", schema)
+        self.assertIn("error", plugin.dispatch("debug", {}))
 
     def test_new_status_plugins_can_start_with_declared_ros_dependencies(self):
         plugins = [
@@ -503,13 +514,12 @@ class DevicePluginContractTests(unittest.TestCase):
         moving = plugin.dispatch("status", {})
         self.assertEqual("running", moving["state"])
         self.assertEqual("moving", moving["motion_state"])
-        self.assertEqual("gamepad", moving["speed_source"])
-        self.assertEqual("gamepad_analog", moving["control_source"])
         self.assertEqual("move", moving["action"])
-        self.assertNotIn("direction", moving)
-        self.assertEqual([], moving["buttons"])
         self.assertEqual("0.50 m/s", moving["speed"])
-        self.assertEqual("motion_start", moving["event"])
+        self.assertEqual(
+            {"state", "action", "motion_state", "speed", "current_motion_state"},
+            set(moving),
+        )
 
         plugin._on_gamepad(types.SimpleNamespace(
             hardware_connected=False,
@@ -519,7 +529,6 @@ class DevicePluginContractTests(unittest.TestCase):
         stopped = plugin.dispatch("status", {})
         self.assertEqual("stopped", stopped["motion_state"])
         self.assertEqual("0.00 m/s", stopped["speed"])
-        self.assertEqual("motion_stop", stopped["event"])
 
     def test_motion_events_identify_gamepad_macro_and_motion_state(self):
         plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
@@ -533,17 +542,11 @@ class DevicePluginContractTests(unittest.TestCase):
         ))
         snapshot = plugin.dispatch("status", {})
         self.assertEqual("stand", snapshot["action"])
-        self.assertEqual("gamepad_analog", snapshot["control_source"])
-        self.assertNotIn("direction", snapshot)
-        self.assertEqual(["LB", "A"], snapshot["buttons"])
-        self.assertEqual("gamepad_action", snapshot["event"])
 
         plugin._on_motion_state(types.SimpleNamespace(current_motion_task="pd_stand"))
         snapshot = plugin.dispatch("status", {})
         self.assertEqual("pd_stand", snapshot["current_motion_state"])
         self.assertEqual("stand", snapshot["action"])
-        self.assertEqual("motion_state", snapshot["control_source"])
-        self.assertEqual("motion_state_changed", snapshot["event"])
 
     def test_motion_events_normalize_screen_motion_states(self):
         plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
@@ -559,8 +562,6 @@ class DevicePluginContractTests(unittest.TestCase):
                 snapshot = plugin.dispatch("status", {})
                 self.assertEqual(raw, snapshot["current_motion_state"])
                 self.assertEqual(action, snapshot["action"])
-                self.assertEqual("motion_state", snapshot["control_source"])
-                self.assertEqual("motion_state_changed", snapshot["event"])
 
     def test_motion_events_keep_screen_state_visible_after_idle_gamepad(self):
         plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
@@ -572,7 +573,6 @@ class DevicePluginContractTests(unittest.TestCase):
         ))
         snapshot = plugin.dispatch("status", {})
         self.assertEqual("sit", snapshot["action"])
-        self.assertEqual("motion_state", snapshot["control_source"])
         self.assertEqual("sit_down", snapshot["current_motion_state"])
 
     def test_motion_events_accept_ros_array_like_gamepad_states(self):
@@ -595,7 +595,6 @@ class DevicePluginContractTests(unittest.TestCase):
         ))
         snapshot = plugin.dispatch("status", {})
         self.assertEqual("stand", snapshot["action"])
-        self.assertEqual(["LB", "A"], snapshot["buttons"])
 
     def test_motion_events_show_rl_basic_as_stand_when_stationary(self):
         plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
@@ -641,6 +640,9 @@ class DevicePluginContractTests(unittest.TestCase):
         # becomes stale and a stationary robot must not keep showing as moving.
         with plugin._lock:
             plugin._latest_speed_updated = time.monotonic() - 2.0
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("stand", snapshot["action"])
+        self.assertEqual("stopped", snapshot["motion_state"])
         plugin._on_motion_state(types.SimpleNamespace(current_motion_task="walk_server"))
         snapshot = plugin.dispatch("status", {})
         self.assertEqual("stand", snapshot["action"])
@@ -664,20 +666,17 @@ class DevicePluginContractTests(unittest.TestCase):
                 snapshot = plugin.dispatch("status", {})
                 self.assertEqual(raw, snapshot["current_motion_state"])
                 self.assertEqual(action, snapshot["action"])
-                self.assertEqual("motion_state", snapshot["control_source"])
-                self.assertEqual("motion_state_changed", snapshot["event"])
 
-    def test_motion_events_passive_request_stays_passive(self):
+    def test_motion_events_unidentifiable_passive_is_reported_as_unknown(self):
         plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
         plugin._on_motion_request(types.SimpleNamespace(target_motion_name="passive"))
         plugin._on_motion_state(types.SimpleNamespace(
             current_motion_task="passive",
-            available_transition_motions=["rl_mimic_supine_to_stance"],
+            available_transition_motions=[],
         ))
         snapshot = plugin.dispatch("status", {})
-        self.assertEqual("passive", snapshot["current_motion_state"])
-        self.assertEqual("passive", snapshot["action"])
-        self.assertEqual("motion_state", snapshot["control_source"])
+        self.assertEqual("unknown", snapshot["current_motion_state"])
+        self.assertEqual("unknown", snapshot["action"])
 
     def test_motion_events_lie_request_can_display_passive_feedback_as_lie(self):
         plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
@@ -687,9 +686,35 @@ class DevicePluginContractTests(unittest.TestCase):
             available_transition_motions=["rl_mimic_supine_to_stance"],
         ))
         snapshot = plugin.dispatch("status", {})
-        self.assertEqual("passive", snapshot["current_motion_state"])
+        self.assertEqual("lie", snapshot["current_motion_state"])
         self.assertEqual("lie", snapshot["action"])
-        self.assertEqual("motion_state", snapshot["control_source"])
+
+    def test_motion_events_sit_transition_passive_feedback_displays_sit(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        plugin._on_motion_request(types.SimpleNamespace(target_motion_name="rl_mimic_stance_to_sitdown"))
+        plugin._on_motion_state(types.SimpleNamespace(
+            current_motion_task="passive",
+            available_transition_motions=["rl_mimic_sitdown_to_stance"],
+        ))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("sit", snapshot["current_motion_state"])
+        self.assertEqual("sit", snapshot["action"])
+
+    def test_motion_events_idle_never_leaks_to_model_output(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        plugin._on_motion_state(types.SimpleNamespace(
+            current_motion_task="pd_stand",
+            available_transition_motions=[],
+        ))
+        plugin._on_motion_state(types.SimpleNamespace(
+            current_motion_task="idle",
+            available_transition_motions=[],
+        ))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("stand", snapshot["action"])
+        self.assertEqual("stand", snapshot["current_motion_state"])
+        self.assertNotIn("idle", json.dumps(snapshot))
+        self.assertNotIn("passive", json.dumps(snapshot))
 
     def test_motion_events_punch_buttons_map_to_punch_names(self):
         plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
@@ -704,8 +729,6 @@ class DevicePluginContractTests(unittest.TestCase):
         ))
         snapshot = plugin.dispatch("status", {})
         self.assertEqual("left_straight", snapshot["action"])
-        self.assertEqual("gamepad_analog", snapshot["control_source"])
-        self.assertEqual(["A", "CROSS_Y_RIGHT"], snapshot["buttons"])
 
         # 右直拳 A + CROSS_Y_LEFT
         right = [0] * 12
@@ -718,7 +741,6 @@ class DevicePluginContractTests(unittest.TestCase):
         ))
         snapshot = plugin.dispatch("status", {})
         self.assertEqual("right_straight", snapshot["action"])
-        self.assertEqual(["A", "CROSS_Y_LEFT"], snapshot["buttons"])
 
     def test_motion_events_punch_action_survives_same_motion_state_republish(self):
         plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
@@ -1267,142 +1289,130 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertAlmostEqual(arc["vx"], arc["vyaw"])
         plugin.dispatch("stop_move", {})
 
-    def test_motion_mode_exposes_only_verified_actions(self):
-        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
-        enum = plugin.get_tool()["inputSchema"]["properties"]["action"]["enum"]
-        self.assertEqual(["stand", "sit", "lie", "idle", "passive"], enum)
+    def test_safe_motion_mode_exposes_only_verified_actions(self):
+        plugin = self._safe_mode_plugin()
+        tool = plugin.get_tool()
+        schema = tool["inputSchema"]
+        self.assertEqual("safe_motion_mode", tool["name"])
+        self.assertEqual(["stand", "sit", "lie"], schema["properties"]["action"]["enum"])
+        self.assertEqual({"action"}, set(schema["properties"]))
+        self.assertNotIn("x-action-params", schema)
+        for removed in ("idle", "passive", "wait", "force", "timeout_sec", "stand_stabilize_sec"):
+            self.assertNotIn(removed, json.dumps(schema))
 
-    def test_motion_mode_force_path_uses_default_stand_target(self):
-        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
+    def _safe_mode_plugin(self):
+        config = {
+            **CONFIG,
+            "control": {
+                **CONFIG["control"],
+                "mode_transition_timeout_sec": 0.8,
+                "mode_stand_stabilize_sec": 0.0,
+            },
+        }
+        plugin = self.device.SafeMotionModePlugin(config, "robot", self.ros, self.state)
         plugin.start()
-        self.state._current_motion = "unknown"
-        self.state._available_motions = []
-        result = plugin.dispatch("stand", {"force": True, "wait": False})
-        self.assertEqual("requested", result["state"])
-        self.assertEqual("pd_stand", plugin._publisher.messages[-1].target_motion_name)
+        return plugin
 
-    def test_motion_mode_selects_firmware_transition_for_each_posture(self):
-        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
-        plugin.start()
-
-        self.state._current_motion = "sit_down"
-        self.state._available_motions = ["rl_mimic_sitdown_to_stance"]
-        result = plugin.dispatch("stand", {"wait": False})
-        self.assertEqual("requested", result["state"])
-        self.assertEqual("rl_mimic_sitdown_to_stance", plugin._publisher.messages[-1].target_motion_name)
-
-        self.state._current_motion = "rl_mimic_stance_to_supine"
+    def test_safe_motion_mode_same_mode_is_noop(self):
+        plugin = self._safe_mode_plugin()
+        self.state._current_motion = "passive"
         self.state._available_motions = ["rl_mimic_supine_to_stance"]
-        result = plugin.dispatch("stand", {"wait": False})
-        self.assertEqual("requested", result["state"])
-        self.assertEqual("rl_mimic_supine_to_stance", plugin._publisher.messages[-1].target_motion_name)
-
-        self.state._current_motion = "pd_stand"
-        self.state._available_motions = ["rl_mimic_stance_to_sitdown"]
-        result = plugin.dispatch("sit", {"wait": False})
-        self.assertEqual("requested", result["state"])
-        self.assertEqual("rl_mimic_stance_to_sitdown", plugin._publisher.messages[-1].target_motion_name)
-
-        self.state._available_motions = ["rl_mimic_stance_to_supine"]
-        result = plugin.dispatch("lie", {"wait": False})
-        self.assertEqual("requested", result["state"])
-        self.assertEqual("rl_mimic_stance_to_supine", plugin._publisher.messages[-1].target_motion_name)
-
-    def test_motion_mode_same_mode_is_noop(self):
-        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
-        plugin.start()
-        self.state._current_motion = "sit_down"
-        self.state._available_motions = ["rl_mimic_sitdown_to_stance"]
-        result = plugin.dispatch("sit", {"wait": False})
+        result = plugin.dispatch("lie", {})
         self.assertEqual("completed", result["state"])
+        self.assertEqual("already lie", result["transition"])
+        self.assertEqual(["lie"], result["transition_path"])
+        self.assertFalse(result["changed"])
         self.assertEqual([], plugin._publisher.messages)
 
-    def test_motion_mode_sit_to_lie_chains_stand_first(self):
-        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
-        plugin.start()
-        self.state._current_motion = "sit_down"
+    def test_safe_motion_mode_sit_to_lie_chains_stand_first(self):
+        plugin = self._safe_mode_plugin()
+        self.state._current_motion = "pd_sitdown"
         self.state._available_motions = ["rl_mimic_sitdown_to_stance"]
 
         def robot_executes():
-            time.sleep(0.10)
+            time.sleep(0.05)
             plugin._state._current_motion = "pd_stand"
             plugin._state._available_motions = ["rl_mimic_stance_to_supine"]
-            time.sleep(0.10)
-            plugin._state._current_motion = "rl_mimic_stance_to_supine"
+            time.sleep(0.05)
+            plugin._state._current_motion = "passive"
+            plugin._state._available_motions = ["rl_mimic_supine_to_stance"]
 
         thread = threading.Thread(target=robot_executes)
         thread.start()
-        result = plugin.dispatch("lie", {
-            "wait": True, "timeout_sec": 1.0, "stand_stabilize_sec": 0,
-        })
+        result = plugin.dispatch("lie", {})
         thread.join()
         self.assertEqual("completed", result["state"])
+        self.assertEqual("sit -> stand -> lie", result["transition"])
+        self.assertEqual(["sit", "stand", "lie"], result["transition_path"])
+        self.assertEqual("lie", result["current"])
         targets = [msg.target_motion_name for msg in plugin._publisher.messages]
         self.assertEqual(["rl_mimic_sitdown_to_stance", "rl_mimic_stance_to_supine"], targets)
 
-    def test_motion_mode_lie_to_sit_chains_stand_first(self):
-        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
-        plugin.start()
-        self.state._current_motion = "rl_mimic_stance_to_supine"
+    def test_safe_motion_mode_lie_to_sit_chains_stand_first(self):
+        plugin = self._safe_mode_plugin()
+        self.state._current_motion = "passive"
         self.state._available_motions = ["rl_mimic_supine_to_stance"]
 
         def robot_executes():
-            time.sleep(0.10)
+            time.sleep(0.05)
             plugin._state._current_motion = "pd_stand"
             plugin._state._available_motions = ["rl_mimic_stance_to_sitdown"]
-            time.sleep(0.10)
-            plugin._state._current_motion = "rl_mimic_stance_to_sitdown"
+            time.sleep(0.05)
+            plugin._state._current_motion = "passive"
+            plugin._state._available_motions = ["rl_mimic_sitdown_to_stance"]
 
         thread = threading.Thread(target=robot_executes)
         thread.start()
-        result = plugin.dispatch("sit", {
-            "wait": True, "timeout_sec": 1.0, "stand_stabilize_sec": 0,
-        })
+        result = plugin.dispatch("sit", {})
         thread.join()
         self.assertEqual("completed", result["state"])
+        self.assertEqual("lie -> stand -> sit", result["transition"])
+        self.assertEqual(["lie", "stand", "sit"], result["transition_path"])
+        self.assertEqual("sit", result["current"])
         targets = [msg.target_motion_name for msg in plugin._publisher.messages]
         self.assertEqual(["rl_mimic_supine_to_stance", "rl_mimic_stance_to_sitdown"], targets)
 
-    def test_motion_mode_rejects_missing_or_unavailable_transition(self):
-        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
-        plugin.start()
+    def test_safe_motion_mode_stand_to_lie_reports_direct_path(self):
+        plugin = self._safe_mode_plugin()
+        self.state._current_motion = "pd_stand"
+        self.state._available_motions = ["rl_mimic_stance_to_supine"]
+
+        def robot_executes():
+            time.sleep(0.05)
+            plugin._state._current_motion = "passive"
+            plugin._state._available_motions = ["rl_mimic_supine_to_stance"]
+
+        thread = threading.Thread(target=robot_executes)
+        thread.start()
+        result = plugin.dispatch("lie", {})
+        thread.join()
+        self.assertEqual("completed", result["state"])
+        self.assertEqual("stand -> lie", result["transition"])
+        self.assertEqual(["stand", "lie"], result["transition_path"])
+
+    def test_safe_motion_mode_rejects_missing_or_unavailable_transition(self):
+        plugin = self._safe_mode_plugin()
         self.state._current_motion = "unknown"
         self.state._available_motions = []
-        result = plugin.dispatch("stand", {"wait": False})
+        result = plugin.dispatch("stand", {})
         self.assertEqual("rejected", result["state"])
-        self.assertEqual("no_transition_data", result["error"])
+        self.assertIn("not safely identifiable", result["error"])
 
         self.state._current_motion = "pd_stand"
         self.state._available_motions = ["rl_mimic_stance_to_supine"]
-        result = plugin.dispatch("sit", {"wait": False})
+        result = plugin.dispatch("sit", {})
         self.assertEqual("rejected", result["state"])
         self.assertIn("no available transition", result["error"])
 
-    def test_motion_mode_idle_and_passive_posture_matrix(self):
-        plugin = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
-        plugin.start()
-
-        self.state._current_motion = "pd_stand"
-        self.state._available_motions = ["idle", "passive"]
-        self.assertEqual("rejected", plugin.dispatch("idle", {"wait": False})["state"])
-        self.assertEqual("rejected", plugin.dispatch("passive", {"wait": False})["state"])
-
-        allowed = (
-            ("pd_sitdown", "idle", "idle"),
-            ("rl_mimic_stance_to_supine", "passive", "passive"),
-            ("passive", "idle", "idle"),
-            ("idle", "passive", "passive"),
-        )
-        for current, action, target in allowed:
-            with self.subTest(current=current, action=action):
-                self.state._current_motion = current
-                self.state._available_motions = []
-                result = plugin.dispatch(action, {"wait": False})
-                self.assertEqual("requested", result["state"])
-                self.assertEqual(target, plugin._publisher.messages[-1].target_motion_name)
+    def test_safe_motion_mode_rejects_removed_modes(self):
+        plugin = self._safe_mode_plugin()
+        for action in ("idle", "passive"):
+            with self.subTest(action=action):
+                result = plugin.dispatch(action, {})
+                self.assertEqual("rejected", result["state"])
 
     def test_dance_facade_lists_and_plays_official_dance(self):
-        mode = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
+        mode = self.device.SafeMotionModePlugin(CONFIG, "robot", self.ros, self.state)
         mode.start()
         dance = self.device.DancePlugin(mode, self.state)
         self.assertEqual("dance.mnn", dance.dispatch("list", {})["built_in"][0]["policy"])

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -506,7 +506,7 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual("gamepad", moving["speed_source"])
         self.assertEqual("gamepad_analog", moving["control_source"])
         self.assertEqual("move", moving["action"])
-        self.assertEqual("forward", moving["direction"])
+        self.assertNotIn("direction", moving)
         self.assertEqual([], moving["buttons"])
         self.assertEqual("0.50 m/s", moving["speed"])
         self.assertEqual("motion_start", moving["event"])
@@ -534,7 +534,7 @@ class DevicePluginContractTests(unittest.TestCase):
         snapshot = plugin.dispatch("status", {})
         self.assertEqual("stand", snapshot["action"])
         self.assertEqual("gamepad_analog", snapshot["control_source"])
-        self.assertEqual("none", snapshot["direction"])
+        self.assertNotIn("direction", snapshot)
         self.assertEqual(["LB", "A"], snapshot["buttons"])
         self.assertEqual("gamepad_action", snapshot["event"])
 
@@ -549,6 +549,8 @@ class DevicePluginContractTests(unittest.TestCase):
         plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
         for raw, action in (
             ("sit_down", "sit"),
+            ("stance_to_sitdown", "sit"),
+            ("kneeling_pose", "kneel"),
             ("boxing_combo", "punch"),
             ("screen_punch", "punch"),
         ):
@@ -594,6 +596,158 @@ class DevicePluginContractTests(unittest.TestCase):
         snapshot = plugin.dispatch("status", {})
         self.assertEqual("stand", snapshot["action"])
         self.assertEqual(["LB", "A"], snapshot["buttons"])
+
+    def test_motion_events_show_rl_basic_as_stand_when_stationary(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        plugin._on_motion_state(types.SimpleNamespace(current_motion_task="rl_basic"))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("rl_basic", snapshot["current_motion_state"])
+        self.assertEqual("stand", snapshot["action"])
+        self.assertEqual("stopped", snapshot["motion_state"])
+
+    def test_motion_events_locomotion_states_show_stand_when_stationary(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        for raw in ("walk", "walk_server", "lower_body_balance", "loco", "rl_terrain"):
+            with self.subTest(raw=raw):
+                plugin._on_motion_state(types.SimpleNamespace(current_motion_task=raw))
+                snapshot = plugin.dispatch("status", {})
+                self.assertEqual(raw, snapshot["current_motion_state"])
+                self.assertEqual("stand", snapshot["action"])
+                self.assertEqual("stopped", snapshot["motion_state"])
+
+    def test_motion_events_locomotion_state_shows_move_while_gamepad_moving(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        plugin._on_gamepad(types.SimpleNamespace(
+            hardware_connected=True,
+            digital_states=[0] * 12,
+            analog_states=[0.0, 0.0, 0.0, 0.5, 0.0, 0.0],
+        ))
+        plugin._on_motion_state(types.SimpleNamespace(current_motion_task="rl_basic"))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("move", snapshot["action"])
+        self.assertEqual("moving", snapshot["motion_state"])
+
+    def test_motion_events_stale_speed_treated_as_stationary(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        plugin._on_gamepad(types.SimpleNamespace(
+            hardware_connected=True,
+            digital_states=[0] * 12,
+            analog_states=[0.0, 0.0, 0.0, 0.5, 0.0, 0.0],
+        ))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("move", snapshot["action"])
+        self.assertEqual("moving", snapshot["motion_state"])
+        # If the gamepad/odometry topic stops publishing, the latest speed sample
+        # becomes stale and a stationary robot must not keep showing as moving.
+        with plugin._lock:
+            plugin._latest_speed_updated = time.monotonic() - 2.0
+        plugin._on_motion_state(types.SimpleNamespace(current_motion_task="walk_server"))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("stand", snapshot["action"])
+        self.assertEqual("stopped", snapshot["motion_state"])
+
+    def test_motion_events_transitions_map_to_target(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        for raw, action in (
+            ("rl_mimic_stance_to_sitdown", "sit"),
+            ("stance_to_sitdown", "sit"),
+            ("rl_mimic_sitdown_to_stance", "stand"),
+            ("sitdown_to_stance", "stand"),
+            ("supine_to_stance", "get_up"),
+            ("rl_mimic_prone_to_stance", "get_up"),
+            ("rl_mimic_stance_to_supine", "lie"),
+            ("rl_mimic_stance_to_kneeling", "kneel"),
+            ("rl_mimic_kneeling_to_stance", "stand"),
+        ):
+            with self.subTest(raw=raw):
+                plugin._on_motion_state(types.SimpleNamespace(current_motion_task=raw))
+                snapshot = plugin.dispatch("status", {})
+                self.assertEqual(raw, snapshot["current_motion_state"])
+                self.assertEqual(action, snapshot["action"])
+                self.assertEqual("motion_state", snapshot["control_source"])
+                self.assertEqual("motion_state_changed", snapshot["event"])
+
+    def test_motion_events_passive_request_stays_passive(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        plugin._on_motion_request(types.SimpleNamespace(target_motion_name="passive"))
+        plugin._on_motion_state(types.SimpleNamespace(
+            current_motion_task="passive",
+            available_transition_motions=["rl_mimic_supine_to_stance"],
+        ))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("passive", snapshot["current_motion_state"])
+        self.assertEqual("passive", snapshot["action"])
+        self.assertEqual("motion_state", snapshot["control_source"])
+
+    def test_motion_events_lie_request_can_display_passive_feedback_as_lie(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        plugin._on_motion_request(types.SimpleNamespace(target_motion_name="rl_mimic_stance_to_supine"))
+        plugin._on_motion_state(types.SimpleNamespace(
+            current_motion_task="passive",
+            available_transition_motions=["rl_mimic_supine_to_stance"],
+        ))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("passive", snapshot["current_motion_state"])
+        self.assertEqual("lie", snapshot["action"])
+        self.assertEqual("motion_state", snapshot["control_source"])
+
+    def test_motion_events_punch_buttons_map_to_punch_names(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        # 左直拳 A + CROSS_Y_RIGHT
+        left = [0] * 12
+        left[2] = 1  # A
+        left[11] = 1  # CROSS_Y_RIGHT
+        plugin._on_gamepad(types.SimpleNamespace(
+            hardware_connected=True,
+            digital_states=left,
+            analog_states=[0.0] * 6,
+        ))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("left_straight", snapshot["action"])
+        self.assertEqual("gamepad_analog", snapshot["control_source"])
+        self.assertEqual(["A", "CROSS_Y_RIGHT"], snapshot["buttons"])
+
+        # 右直拳 A + CROSS_Y_LEFT
+        right = [0] * 12
+        right[2] = 1  # A
+        right[10] = 1  # CROSS_Y_LEFT
+        plugin._on_gamepad(types.SimpleNamespace(
+            hardware_connected=True,
+            digital_states=right,
+            analog_states=[0.0] * 6,
+        ))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("right_straight", snapshot["action"])
+        self.assertEqual(["A", "CROSS_Y_LEFT"], snapshot["buttons"])
+
+    def test_motion_events_punch_action_survives_same_motion_state_republish(self):
+        plugin = self.device.MotionEventsPlugin(CONFIG, "robot", self.ros)
+        # Enter the boxing motion state, then throw a left straight punch.
+        plugin._on_motion_state(types.SimpleNamespace(current_motion_task="rl_mimic_boxing"))
+        left = [0] * 12
+        left[2] = 1  # A
+        left[11] = 1  # CROSS_Y_RIGHT
+        plugin._on_gamepad(types.SimpleNamespace(
+            hardware_connected=True,
+            digital_states=left,
+            analog_states=[0.0] * 6,
+        ))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("left_straight", snapshot["action"])
+        # T800 keeps the same current_motion_task while punching; re-publishing the
+        # same boxing state must not override the fresher gamepad action.
+        plugin._on_motion_state(types.SimpleNamespace(current_motion_task="rl_mimic_boxing"))
+        plugin._on_motion_state(types.SimpleNamespace(current_motion_task="rl_mimic_boxing"))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("left_straight", snapshot["action"])
+        # Releasing the buttons falls back to the boxing motion state action.
+        plugin._on_gamepad(types.SimpleNamespace(
+            hardware_connected=True,
+            digital_states=[0] * 12,
+            analog_states=[0.0] * 6,
+        ))
+        snapshot = plugin.dispatch("status", {})
+        self.assertEqual("punch", snapshot["action"])
 
     def test_derived_diagnostics_and_capability_resources(self):
         self.state._set("imu", {


### PR DESCRIPTION
## Summary

- Rename the T800 posture card from `motion_mode` to `safe_motion_mode` and expose only the verified `stand`, `sit`, and `lie` actions.
- Reduce the `safe_motion_mode` input schema to the required `action` field; timing, force, and wait controls are no longer exposed to the embodied model.
- Determine the current semantic posture from `current_motion_task` and `available_transition_motions`. Firmware-internal `idle`/`passive` feedback is resolved to `stand`, `sit`, or `lie` when identifiable, otherwise it is reported as `unknown` rather than guessed.
- Sequence non-standing posture changes through a verified standing state and return an explicit result with `from`, `to`, `transition_path`, `transition`, `changed`, and the final semantic posture.
- Convert `motion_events` from a streaming sensor to a one-shot read-only actuator. It now exposes only `status`, has no `topic_out`, debug action, filter parameters, or buffered event timeline.
- Keep `motion_events.status` compact: `state`, semantic `action`, moving/stopped state, speed rounded to two decimals, and semantic/current firmware state. Raw `idle`/`passive` values are never returned to the model.

## Behavior examples

- Already lying: `transition_path=["lie"]`, `transition="already lie"`, `changed=false`.
- Standing to lying: `transition_path=["stand", "lie"]`.
- Sitting to lying: `transition_path=["sit", "stand", "lie"]`.
- Lying to sitting: `transition_path=["lie", "stand", "sit"]`.

## Validation

- Deployed and verified on a physical EngineAI T800 while preserving the existing `arm_swing` integration in the running image.
- Runtime health: 24/24 plugins and 44/44 tools active, with no startup errors.
- MCP schema verified: `safe_motion_mode` exposes only `stand`/`sit`/`lie`; `motion_events` exposes only `status` and has no output stream.
- Read-only hardware check returned `action=stand`, `motion_state=stopped`, and `speed=0.00 m/s`.
- `python3 -m unittest engineai/t800/tests/test_device_contract.py engineai/t800/tests/test_control.py engineai/t800/tests/test_virtual_gamepad.py` — 82 tests passed.
- Python compile check and `git diff --check` passed.
- Root `build.sh`, Dockerfile, and other robot drivers are unchanged.
