### PR TITLE
feat(t800): add joint-plan arm swing card

### DIFF
--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -69,7 +69,8 @@ MCP schema 中隐藏。
 
 `arm_swing.start_swing` 支持 2–30 度摆幅；运行中再次调用会更新后续规划。
 `halt` 仅取消并停在当前位置，`return_neutral` 与 `halt_and_return` 会通过
-`joint_plan` 在可配置时间内平滑回到自然姿态。
+`joint_plan` 在可配置时间内平滑回到自然姿态。三个异步动作均通过 ACP 报告完成；
+`on_interrupt_motion` 和 `on_interrupt_all` 系统 hook 会绕过 ACP barrier 直接执行 `halt`。
 
 `virtual_gamepad` 使用 Native SDK 官方通道
 `virtual_gamepad/gamepad_keys`，默认连接 `udpm://239.255.76.67:7667?ttl=1`。

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -38,6 +38,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_plan` | actuator | 索引/名称关节轨迹、头部/单臂姿态、当前位置保持、取消、复位和预置动作 |
 | `joint_plan_state` | sensor | 规划 request id、状态和进度 |
 | `gesture` | actuator | 官方完整挥手/握手多步序列及任意自定义关节动作队列 |
+| `arm_swing` | actuator | `lower_body_balance` 下通过 `joint_plan` 持续交替摆臂，状态变化或 `halt` 时取消当前规划 |
 | `joint_override` | actuator | 指定关节 100 Hz 覆盖控制 |
 | `joint_bridge` | actuator | 全 25 关节最高 500 Hz 底层控制 |
 | `led` | actuator | 众擎协议定义的 11 种灯效 |
@@ -65,6 +66,10 @@ MCP schema 中隐藏。
 动作（挥手包含准备、举手、5 次摆动和复位；握手包含伸手、收手和复位），
 后者保留为兼容接口，只发送单个目标姿势。`gesture.sequence` 可提交任意多步
 关节动作队列。
+
+`arm_swing.start_swing` 支持 2–30 度摆幅；运行中再次调用会更新后续规划。
+`halt` 仅取消并停在当前位置，`return_neutral` 与 `halt_and_return` 会通过
+`joint_plan` 在可配置时间内平滑回到自然姿态。
 
 `virtual_gamepad` 使用 Native SDK 官方通道
 `virtual_gamepad/gamepad_keys`，默认连接 `udpm://239.255.76.67:7667?ttl=1`。

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -69,8 +69,9 @@ MCP schema 中隐藏。
 
 `arm_swing.start_swing` 支持 2–30 度摆幅；运行中再次调用会更新后续规划。
 `halt` 仅取消并停在当前位置，`return_neutral` 与 `halt_and_return` 会通过
-`joint_plan` 在可配置时间内平滑回到自然姿态。三个异步动作均通过 ACP 报告完成；
-`on_interrupt_motion` 和 `on_interrupt_all` 系统 hook 会绕过 ACP barrier 直接执行 `halt`。
+`joint_plan` 在可配置时间内平滑回到自然姿态。两个有界回正动作通过 ACP 报告完成；
+持续运行的 `start_swing` 不进入 ACP barrier，因此普通 `halt` 和运行时参数更新始终可调用。
+`on_interrupt_motion` 和 `on_interrupt_all` 系统 hook 也会直接执行 `halt`。
 
 `virtual_gamepad` 使用 Native SDK 官方通道
 `virtual_gamepad/gamepad_keys`，默认连接 `udpm://239.255.76.67:7667?ttl=1`。

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -78,6 +78,10 @@ plugins:
     enabled: true
   gesture:
     enabled: true
+  arm_swing:
+    enabled: true
+    default_amplitude_deg: 8.0
+    default_frequency_hz: 0.7
   joint_override:
     enabled: true
   joint_bridge:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -3297,6 +3297,13 @@ class ArmSwingPlugin:
             return {"error": "duration must be finite and between 0.5 and 5.0 seconds"}
         self._halt_swing(action)
         with self._lock:
+            previous_thread = self._thread
+            if previous_thread is not None and previous_thread.is_alive():
+                return {
+                    "error": "previous arm_swing action is still stopping; retry",
+                    "state": "stopping",
+                    "action_id": self._action_id,
+                }
             motion, available = self._state.current_motion()
             if motion != "lower_body_balance":
                 return {

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2229,6 +2229,7 @@ class JointPlanPlugin:
         self._request_id = 0
         self._owner_lock = threading.Lock()
         self._owner: str | None = None
+        self._owner_cancel_handlers = {}
         self._state_type = None
         self._state = state
         self._core_topic = f"/{namespace}/state/joint_plan"
@@ -2314,7 +2315,15 @@ class JointPlanPlugin:
         # Cancellation is a safety/operator escape hatch: it must remain
         # available even while an in-process plugin owns the planner.
         if action == "cancel":
-            return self._publish_request("cancel", args)
+            with self._owner_lock:
+                active_owner = self._owner
+                handler = self._owner_cancel_handlers.get(active_owner)
+                result = self._publish_request("cancel", args)
+            # Owner callbacks can acquire plugin-local locks. Invoke them only
+            # after releasing the planner ownership lock.
+            if handler is not None:
+                handler(int(result["request_id"]))
+            return result
         with self._owner_lock:
             active_owner = self._owner
             if active_owner is not None and owner != active_owner:
@@ -2385,6 +2394,10 @@ class JointPlanPlugin:
                 return False
             self._owner = owner
             return True
+
+    def register_owner_cancel_handler(self, owner: str, handler) -> None:
+        with self._owner_lock:
+            self._owner_cancel_handlers[str(owner)] = handler
 
     def release(self, owner: str) -> bool:
         with self._owner_lock:
@@ -3109,6 +3122,9 @@ class ArmSwingPlugin:
         self._action_id: str | None = None
         self._last_reason = "not_started"
         self._validate_parameters(self._amplitude_deg, self._frequency_hz)
+        self._joint_plan.register_owner_cancel_handler(
+            self._OWNER, self._on_planner_cancel
+        )
 
     def get_tool(self) -> dict:
         tool = {
@@ -3186,9 +3202,9 @@ class ArmSwingPlugin:
                     "error": "previous arm_swing action is still stopping; retry",
                     "state": "stopping",
                 }
-            self._amplitude_deg = amplitude
-            self._frequency_hz = frequency
             if running:
+                self._amplitude_deg = amplitude
+                self._frequency_hz = frequency
                 return self._status_locked()
             # Keep the idle check, motion-state gate and worker installation
             # atomic so concurrent MCP calls cannot create two workers.
@@ -3201,6 +3217,8 @@ class ArmSwingPlugin:
             if not self._joint_plan.acquire(self._OWNER):
                 return {"error": f"joint planner is owned by {self._joint_plan.owner()}"}
 
+            self._amplitude_deg = amplitude
+            self._frequency_hz = frequency
             self._halt = threading.Event()
             self._started_at = time.monotonic()
             self._publish_count = 0
@@ -3212,6 +3230,13 @@ class ArmSwingPlugin:
             self._thread = threading.Thread(target=self._run, daemon=True, name="t800-arm-swing")
             self._thread.start()
             return self._status_locked()
+
+    def _on_planner_cancel(self, request_id: int) -> None:
+        with self._lock:
+            if self._request_id is None or int(self._request_id) != int(request_id):
+                return
+            self._last_reason = "planner_cancelled"
+            self._halt.set()
 
     def _run(self) -> None:
         reason = "user_halt"

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -3181,6 +3181,11 @@ class ArmSwingPlugin:
             return {"error": str(exc)}
         with self._lock:
             running = self._thread is not None and self._thread.is_alive()
+            if running and self._halt.is_set():
+                return {
+                    "error": "previous arm_swing action is still stopping; retry",
+                    "state": "stopping",
+                }
             self._amplitude_deg = amplitude
             self._frequency_hz = frequency
             if running:
@@ -3195,13 +3200,14 @@ class ArmSwingPlugin:
                 }
             if not self._joint_plan.acquire(self._OWNER):
                 return {"error": f"joint planner is owned by {self._joint_plan.owner()}"}
-            from uuid import uuid4
 
             self._halt = threading.Event()
             self._started_at = time.monotonic()
             self._publish_count = 0
             self._request_id = None
-            self._action_id = f"t800_arm_swing_{uuid4().hex[:12]}"
+            # Continuous actions are deliberately outside x-completion and do
+            # not allocate an ACP action ID.
+            self._action_id = None
             self._last_reason = "running"
             self._thread = threading.Thread(target=self._run, daemon=True, name="t800-arm-swing")
             self._thread.start()
@@ -3264,14 +3270,6 @@ class ArmSwingPlugin:
                 request_id = self._request_id
                 self._last_reason = reason
                 self._request_id = None
-                action_id = self._action_id
-                final_status = "error" if reason.startswith("error:") else "cancelled"
-                final_result = {
-                    "reason": reason,
-                    "publish_count": self._publish_count,
-                    "request_id": request_id,
-                    "control_backend": "joint_plan",
-                }
             # A request can still be live when the worker is interrupted or
             # errors. Always cancel it before declaring the card idle.
             if request_id is not None:
@@ -3279,8 +3277,6 @@ class ArmSwingPlugin:
                     self._OWNER, "cancel", {"request_id": request_id}
                 )
             self._joint_plan.release(self._OWNER)
-            if action_id is not None:
-                self._notify_completion(action_id, final_status, final_result)
 
     def _motion_state_abort_reason(self) -> str | None:
         motion, _ = self._state.current_motion()
@@ -3317,11 +3313,13 @@ class ArmSwingPlugin:
         with self._lock:
             previous_thread = self._thread
             if previous_thread is not None and previous_thread.is_alive():
-                return {
+                result = {
                     "error": "previous arm_swing action is still stopping; retry",
                     "state": "stopping",
-                    "action_id": self._action_id,
                 }
+                if self._action_id is not None:
+                    result["action_id"] = self._action_id
+                return result
             motion, available = self._state.current_motion()
             if motion != "lower_body_balance":
                 return {
@@ -3431,18 +3429,20 @@ class ArmSwingPlugin:
 
     def _status_locked(self) -> dict:
         running = self._thread is not None and self._thread.is_alive() and not self._halt.is_set()
-        return {
+        status = {
             "state": "running" if running else "idle",
             "amplitude_deg": self._amplitude_deg,
             "frequency_hz": self._frequency_hz,
             "publish_count": self._publish_count,
             "request_id": self._request_id,
-            "action_id": self._action_id,
             "reason": self._last_reason,
             "required_motion_state": "lower_body_balance",
             "joint_indices": list(self._INDICES),
             "control_backend": "joint_plan",
         }
+        if self._action_id is not None:
+            status["action_id"] = self._action_id
+        return status
 
     @staticmethod
     def _validate_parameters(amplitude: float, frequency: float) -> None:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -4055,8 +4055,14 @@ class ArmSwingPlugin:
 
     def _notify_completion(self, action_id: str, status: str, result: dict) -> None:
         threading.Thread(
-            target=self._acp_notify,
-            args=(action_id, status, result),
+            target=_notify_acp_completion,
+            args=(
+                "arm_swing",
+                action_id,
+                status,
+                result,
+                self._ACP_CALLBACK_TIMEOUT_SEC,
+            ),
             daemon=True,
             name="t800-arm-swing-acp",
         ).start()
@@ -4088,49 +4094,6 @@ class ArmSwingPlugin:
             raise ValueError("amplitude_deg must be between 2 and 30")
         if not math.isfinite(frequency) or not 0.2 <= frequency <= 1.2:
             raise ValueError("frequency_hz must be between 0.2 and 1.2")
-
-    @staticmethod
-    def _acp_notify(action_id: str, status: str, result: dict) -> None:
-        """Report asynchronous arm-swing completion to Agent Core."""
-        import json as _json
-        import os as _os
-        import ssl as _ssl
-        import urllib.parse as _urlparse
-        import urllib.request as _urllib
-
-        agent_core_url = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
-        ca_cert = _os.environ.get("AGENT_CORE_CA_CERT")
-        try:
-            parsed_url = _urlparse.urlparse(agent_core_url)
-            if parsed_url.scheme not in ("http", "https"):
-                raise ValueError("AGENT_CORE_URL must use http or https")
-            if (
-                parsed_url.scheme == "http"
-                and parsed_url.hostname not in ("localhost", "127.0.0.1", "::1")
-            ):
-                raise ValueError("unencrypted AGENT_CORE_URL is only allowed on loopback")
-            context = _ssl.create_default_context(cafile=ca_cert or None)
-            payload = _json.dumps({
-                "action_id": action_id,
-                "status": status,
-                "result": result,
-                "tool": "arm_swing",
-                "ts": time.time(),
-            }).encode()
-            request = _urllib.Request(
-                f"{agent_core_url}/api/acp/complete",
-                data=payload,
-                headers={"Content-Type": "application/json"},
-                method="POST",
-            )
-            _urllib.urlopen(
-                request,
-                timeout=ArmSwingPlugin._ACP_CALLBACK_TIMEOUT_SEC,
-                context=context,
-            )
-        except Exception as exc:
-            print(f"[arm_swing] ACP callback failed for {action_id}: {exc}", flush=True)
-
 
 class JointBridgePlugin(_JointStreamBase):
     def __init__(self, config: dict, namespace: str, ros2, state: StatePlugin):

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -3069,6 +3069,8 @@ class ArmSwingPlugin:
     _OWNER = "arm_swing"
     _INDICES = [13, 16, 18, 21]
     _BASE = [0.028, -0.066, 0.024, -0.069]
+    _ACP_TIMEOUT_SEC = 86400.0
+    _ACP_CALLBACK_TIMEOUT_SEC = 5.0
 
     def __init__(self, config: dict, joint_plan: JointPlanPlugin, state: StatePlugin):
         cfg = config.get("plugins", {}).get("arm_swing", {})
@@ -3084,11 +3086,12 @@ class ArmSwingPlugin:
         self._started_at: float | None = None
         self._publish_count = 0
         self._request_id: int | None = None
+        self._action_id: str | None = None
         self._last_reason = "not_started"
         self._validate_parameters(self._amplitude_deg, self._frequency_hz)
 
     def get_tool(self) -> dict:
-        return {
+        tool = {
             "name": "arm_swing",
             "type": "actuator",
             "multiInstance": False,
@@ -3109,6 +3112,11 @@ class ArmSwingPlugin:
                 "持续摆臂动作",
             ),
         }
+        tool["inputSchema"]["x-completion"] = {
+            "actions": ["start_swing"],
+            "timeout": int(self._ACP_TIMEOUT_SEC),
+        }
+        return tool
 
     def start(self) -> None:
         pass
@@ -3141,17 +3149,21 @@ class ArmSwingPlugin:
             self._frequency_hz = frequency
             if running:
                 return self._status_locked()
-        motion, available = self._state.current_motion()
-        if motion != "lower_body_balance":
-            return {
-                "error": f"arm_swing requires lower_body_balance (current: {motion or 'unknown'})",
-                "available_transition_motions": available,
-            }
-        with self._lock:
+            # Keep the idle check, motion-state gate and worker installation
+            # atomic so concurrent MCP calls cannot create two workers.
+            motion, available = self._state.current_motion()
+            if motion != "lower_body_balance":
+                return {
+                    "error": f"arm_swing requires lower_body_balance (current: {motion or 'unknown'})",
+                    "available_transition_motions": available,
+                }
+            from uuid import uuid4
+
             self._halt = threading.Event()
             self._started_at = time.monotonic()
             self._publish_count = 0
             self._request_id = None
+            self._action_id = f"t800_arm_swing_{uuid4().hex[:12]}"
             self._last_reason = "running"
             self._thread = threading.Thread(target=self._run, daemon=True, name="t800-arm-swing")
             self._thread.start()
@@ -3214,10 +3226,20 @@ class ArmSwingPlugin:
                 request_id = self._request_id
                 self._last_reason = reason
                 self._request_id = None
+                action_id = self._action_id
+                final_status = "error" if reason.startswith("error:") else "cancelled"
+                final_result = {
+                    "reason": reason,
+                    "publish_count": self._publish_count,
+                    "request_id": request_id,
+                    "control_backend": "joint_plan",
+                }
             # A request can still be live when the worker is interrupted or
             # errors. Always cancel it before declaring the card idle.
             if request_id is not None:
                 self._joint_plan.dispatch("cancel", {"request_id": request_id})
+            if action_id is not None:
+                self._acp_notify(action_id, final_status, final_result)
 
     def _motion_state_abort_reason(self) -> str | None:
         motion, _ = self._state.current_motion()
@@ -3273,6 +3295,7 @@ class ArmSwingPlugin:
             "frequency_hz": self._frequency_hz,
             "publish_count": self._publish_count,
             "request_id": self._request_id,
+            "action_id": self._action_id,
             "reason": self._last_reason,
             "required_motion_state": "lower_body_balance",
             "joint_indices": list(self._INDICES),
@@ -3285,6 +3308,48 @@ class ArmSwingPlugin:
             raise ValueError("amplitude_deg must be between 2 and 30")
         if not math.isfinite(frequency) or not 0.2 <= frequency <= 1.2:
             raise ValueError("frequency_hz must be between 0.2 and 1.2")
+
+    @staticmethod
+    def _acp_notify(action_id: str, status: str, result: dict) -> None:
+        """Report asynchronous arm-swing completion to Agent Core."""
+        import json as _json
+        import os as _os
+        import ssl as _ssl
+        import urllib.parse as _urlparse
+        import urllib.request as _urllib
+
+        agent_core_url = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+        ca_cert = _os.environ.get("AGENT_CORE_CA_CERT")
+        try:
+            parsed_url = _urlparse.urlparse(agent_core_url)
+            if parsed_url.scheme not in ("http", "https"):
+                raise ValueError("AGENT_CORE_URL must use http or https")
+            if (
+                parsed_url.scheme == "http"
+                and parsed_url.hostname not in ("localhost", "127.0.0.1", "::1")
+            ):
+                raise ValueError("unencrypted AGENT_CORE_URL is only allowed on loopback")
+            context = _ssl.create_default_context(cafile=ca_cert or None)
+            payload = _json.dumps({
+                "action_id": action_id,
+                "status": status,
+                "result": result,
+                "tool": "arm_swing",
+                "ts": time.time(),
+            }).encode()
+            request = _urllib.Request(
+                f"{agent_core_url}/api/acp/complete",
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            _urllib.urlopen(
+                request,
+                timeout=ArmSwingPlugin._ACP_CALLBACK_TIMEOUT_SEC,
+                context=context,
+            )
+        except Exception as exc:
+            print(f"[arm_swing] ACP callback failed for {action_id}: {exc}", flush=True)
 
 
 class JointBridgePlugin(_JointStreamBase):

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -3113,12 +3113,6 @@ class ArmSwingPlugin:
                 "持续摆臂动作",
             ),
         }
-        tool["inputSchema"]["x-completion"] = {
-            # start_swing is continuous and must not hold Agent Core's ACP
-            # actuator barrier; halt and runtime updates need to remain callable.
-            "actions": ["return_neutral", "halt_and_return"],
-            "timeout": int(self._ACP_TIMEOUT_SEC),
-        }
         return tool
 
     def start(self) -> None:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2292,6 +2292,15 @@ class JointPlanPlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict:
+        if "_owner" in args:
+            return {"error": "_owner is reserved for internal driver use"}
+        return self._dispatch(action, args, owner=None)
+
+    def dispatch_owned(self, owner: str, action: str, args: dict) -> dict:
+        """Dispatch for an in-process plugin that already owns the planner."""
+        return self._dispatch(action, args, owner=owner)
+
+    def _dispatch(self, action: str, args: dict, *, owner: str | None) -> dict:
         if action == "start":
             return {"state": "running" if args.get("_tool_name") == "joint_plan_state" else "ready"}
         if action in ("info", "status", "joint_plan_state"):
@@ -2302,13 +2311,12 @@ class JointPlanPlugin:
             return snapshot
         if action == "stop":
             return {"state": "idle"}
-        if action == "cancel":
-            return self._publish_request("cancel", args)
-        owner = args.get("_owner")
         with self._owner_lock:
             active_owner = self._owner
         if active_owner is not None and owner != active_owner:
             return {"error": f"joint planner is owned by {active_owner}"}
+        if action == "cancel":
+            return self._publish_request("cancel", args)
         if action == "reset":
             return self._publish_request("reset", args)
         if action == "preset":
@@ -2812,7 +2820,7 @@ class GesturePlugin:
                         self._status["step"] = index
                         self._status["step_name"] = step["name"]
                     action = "plan_named" if "joint_names" in step else "plan"
-                    result = self._joint_plan.dispatch(action, {**step, "_owner": "gesture"})
+                    result = self._joint_plan.dispatch_owned("gesture", action, step)
                     if "error" in result:
                         raise ValueError(result["error"])
                     request_id = int(result["request_id"])
@@ -2827,7 +2835,7 @@ class GesturePlugin:
                     if hold_after > 0 and self._cancel.wait(hold_after):
                         raise RuntimeError("gesture cancelled")
                 if not self._cancel.is_set() and reset_after:
-                    result = self._joint_plan.dispatch("reset", {"_owner": "gesture"})
+                    result = self._joint_plan.dispatch_owned("gesture", "reset", {})
                     if "error" in result:
                         raise ValueError(result["error"])
                     request_id = int(result["request_id"])
@@ -2848,7 +2856,9 @@ class GesturePlugin:
             except Exception as exc:
                 cancelled = self._cancel.is_set()
                 if request_id is not None:
-                    self._joint_plan.dispatch("cancel", {"request_id": request_id})
+                    self._joint_plan.dispatch_owned(
+                        "gesture", "cancel", {"request_id": request_id}
+                    )
                 with self._lock:
                     self._status["state"] = "cancelled" if cancelled else "error"
                     self._status["error"] = "" if cancelled else str(exc)
@@ -2895,9 +2905,11 @@ class GesturePlugin:
                 request_id = None
             result = dict(self._status)
         if request_id is not None:
-            self._joint_plan.dispatch("cancel", {"request_id": request_id})
+            self._joint_plan.dispatch_owned(
+                "gesture", "cancel", {"request_id": request_id}
+            )
         if reset_after:
-            self._joint_plan.dispatch("reset", {"_owner": "gesture"})
+            self._joint_plan.dispatch_owned("gesture", "reset", {})
         return result
 
     @staticmethod
@@ -3185,7 +3197,7 @@ class ArmSwingPlugin:
                     # halt either wins before publication or observes the ID.
                     if self._halt.is_set():
                         break
-                    result = self._joint_plan.dispatch("plan", {
+                    result = self._joint_plan.dispatch_owned(self._OWNER, "plan", {
                         "joint_indices": self._INDICES,
                         "target_positions": [
                             self._BASE[0] + offset,
@@ -3195,7 +3207,6 @@ class ArmSwingPlugin:
                         ],
                         "duration": step_duration,
                         "gravity_compensation": True,
-                        "_owner": self._OWNER,
                     })
                     if "error" in result:
                         raise RuntimeError(str(result["error"]))
@@ -3235,7 +3246,9 @@ class ArmSwingPlugin:
             # A request can still be live when the worker is interrupted or
             # errors. Always cancel it before declaring the card idle.
             if request_id is not None:
-                self._joint_plan.dispatch("cancel", {"request_id": request_id})
+                self._joint_plan.dispatch_owned(
+                    self._OWNER, "cancel", {"request_id": request_id}
+                )
             self._joint_plan.release(self._OWNER)
             if action_id is not None:
                 self._notify_completion(action_id, final_status, final_result)
@@ -3257,16 +3270,20 @@ class ArmSwingPlugin:
             self._last_reason = reason
             self._halt.set()
         if request_id is not None:
-            self._joint_plan.dispatch("cancel", {"request_id": request_id})
+            self._joint_plan.dispatch_owned(
+                self._OWNER, "cancel", {"request_id": request_id}
+            )
         if thread is not None and thread is not threading.current_thread():
             thread.join(timeout=1.0)
         return self._status()
 
     def _return_neutral(self, args: dict, action: str) -> dict:
         try:
-            duration = clamp(args.get("duration", 1.5), 0.5, 5.0)
+            duration = float(args.get("duration", 1.5))
         except (TypeError, ValueError) as exc:
             return {"error": str(exc)}
+        if not math.isfinite(duration) or not 0.5 <= duration <= 5.0:
+            return {"error": "duration must be finite and between 0.5 and 5.0 seconds"}
         self._halt_swing(action)
         with self._lock:
             motion, available = self._state.current_motion()
@@ -3310,12 +3327,11 @@ class ArmSwingPlugin:
                 abort_reason = self._motion_state_abort_reason()
                 if abort_reason:
                     raise RuntimeError(abort_reason)
-                result = self._joint_plan.dispatch("plan", {
+                result = self._joint_plan.dispatch_owned(self._OWNER, "plan", {
                     "joint_indices": self._INDICES,
                     "target_positions": self._BASE,
                     "duration": duration,
                     "gravity_compensation": True,
-                    "_owner": self._OWNER,
                 })
                 if "error" in result:
                     raise RuntimeError(str(result["error"]))
@@ -3358,7 +3374,9 @@ class ArmSwingPlugin:
                     "control_backend": "joint_plan",
                 }
             if live_request_id is not None:
-                self._joint_plan.dispatch("cancel", {"request_id": live_request_id})
+                self._joint_plan.dispatch_owned(
+                    self._OWNER, "cancel", {"request_id": live_request_id}
+                )
             self._joint_plan.release(self._OWNER)
             if action_id is not None:
                 self._notify_completion(action_id, final_status, final_result)

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2442,12 +2442,16 @@ class JointPlanPlugin:
         target = int(request_id)
         deadline = time.monotonic() + float(timeout)
         idle = int(self._state_type.IDLE)
-        with self._state_changed:
-            while True:
-                if abort_check is not None:
-                    abort_reason = abort_check()
-                    if abort_reason:
-                        raise RuntimeError(str(abort_reason))
+        while True:
+            # abort_check may acquire plugin-local locks. Run it outside the
+            # planner condition lock to avoid lock-order inversions with halt.
+            if abort_check is not None:
+                abort_reason = abort_check()
+                if abort_reason:
+                    raise RuntimeError(str(abort_reason))
+            if cancel_event.is_set():
+                raise RuntimeError("gesture cancelled")
+            with self._state_changed:
                 if cancel_event.is_set():
                     raise RuntimeError("gesture cancelled")
                 state = dict(self._last_state)

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2926,6 +2926,8 @@ class JointOverridePlugin(_JointStreamBase):
         ros2.executor_robot.add_node(self._node)
         self._publisher = None
         self._last_indices: list[int] = []
+        self._owner_lock = threading.Lock()
+        self._owner: str | None = None
         self._stream = RepeatingCommand(
             self._publish,
             self._publish_release,
@@ -2974,6 +2976,9 @@ class JointOverridePlugin(_JointStreamBase):
             return {"state": "released" if action == "release" else "idle"}
         if action != "command":
             return {"error": f"unknown joint override action: {action}"}
+        with self._owner_lock:
+            if self._owner is not None:
+                return {"error": f"joint override is owned by {self._owner}"}
         motion, _ = self._state.current_motion()
         if motion != "lower_body_balance" and not bool(args.get("force", False)):
             return {"error": f"joint override requires lower_body_balance (current: {motion or 'unknown'})"}
@@ -2993,6 +2998,43 @@ class JointOverridePlugin(_JointStreamBase):
         self._last_indices = indices
         duration = float(args.get("duration", 1.0))
         return {"state": "running", "stream": asdict(self._stream.start(payload, duration)), "duration": duration}
+
+    def acquire(self, owner: str) -> bool:
+        with self._owner_lock:
+            if self._owner not in (None, owner):
+                return False
+            if self._stream.snapshot().active:
+                return False
+            self._owner = owner
+            return True
+
+    def publish_owned(self, owner: str, payload: dict) -> None:
+        with self._owner_lock:
+            if self._owner != owner:
+                raise RuntimeError("joint override ownership was lost")
+        indices, positions = validate_joint_positions(
+            payload.get("indices"), payload.get("position"), limit_margin_rad=0.02
+        )
+        size = len(indices)
+        self._last_indices = indices
+        self._publish({
+            "indices": indices,
+            "position": positions,
+            "velocity": optional_floats(payload, "velocity", size),
+            "feed_forward_torque": [],
+            "torque": [],
+            "stiffness": optional_floats(payload, "stiffness", size),
+            "damping": optional_floats(payload, "damping", size),
+            "weight": clamp(payload.get("weight", 0.5), 0.0, 1.0),
+        })
+
+    def release_owned(self, owner: str) -> bool:
+        with self._owner_lock:
+            if self._owner != owner:
+                return False
+            self._owner = None
+        self._publish_release()
+        return True
 
     def _publish(self, payload: dict) -> None:
         msg = self._message_type()
@@ -3014,6 +3056,198 @@ class JointOverridePlugin(_JointStreamBase):
         size = len(self._last_indices)
         self._publish({"weight": 0.0, "indices": self._last_indices, "position": [0.0] * size,
                        "velocity": [], "feed_forward_torque": [], "torque": [], "stiffness": [], "damping": []})
+
+
+class ArmSwingPlugin:
+    """Bounded alternating arm plans layered on the proven joint planner."""
+
+    _OWNER = "arm_swing"
+    _INDICES = [13, 16, 18, 21]
+    _BASE = [0.028, -0.066, 0.024, -0.069]
+
+    def __init__(self, config: dict, joint_plan: JointPlanPlugin, state: StatePlugin):
+        cfg = config.get("plugins", {}).get("arm_swing", {})
+        self._joint_plan = joint_plan
+        self._state = state
+        self._default_amplitude_deg = float(cfg.get("default_amplitude_deg", 8.0))
+        self._default_frequency_hz = float(cfg.get("default_frequency_hz", 0.7))
+        self._lock = threading.RLock()
+        self._halt = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._amplitude_deg = self._default_amplitude_deg
+        self._frequency_hz = self._default_frequency_hz
+        self._started_at: float | None = None
+        self._publish_count = 0
+        self._request_id: int | None = None
+        self._last_reason = "not_started"
+        self._validate_parameters(self._amplitude_deg, self._frequency_hz)
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "arm_swing",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "T800 lower_body_balance 下通过 joint_plan 持续交替摆臂",
+            "inputSchema": action_schema(
+                {
+                    "start_swing": (["amplitude_deg", "frequency_hz"], "开始左右交替摆臂"),
+                    "halt": ([], "取消当前规划并停止摆臂"),
+                    "return_neutral": (["duration"], "平滑回到自然姿态"),
+                    "halt_and_return": (["duration"], "取消当前规划并平滑回到自然姿态"),
+                    "status": ([], "查询摆臂状态和发布计数"),
+                },
+                {
+                    "amplitude_deg": {"type": "number", "minimum": 2.0, "maximum": 30.0, "description": "肩部摆幅，默认 8 度"},
+                    "frequency_hz": {"type": "number", "minimum": 0.2, "maximum": 1.2, "description": "摆动频率，默认 0.7 Hz"},
+                    "duration": {"type": "number", "minimum": 0.5, "maximum": 5.0, "description": "回正时间，默认 1.5 秒"},
+                },
+                "持续摆臂动作",
+            ),
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        self._halt_swing("driver_stopped")
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action == "status":
+            return self._status()
+        if action == "halt":
+            return self._halt_swing("user_halt")
+        if action in ("return_neutral", "halt_and_return"):
+            return self._return_neutral(args, action)
+        if action != "start_swing":
+            return {"error": f"unknown arm swing action: {action}"}
+        try:
+            amplitude = float(args.get("amplitude_deg", self._amplitude_deg))
+            frequency = float(args.get("frequency_hz", self._frequency_hz))
+            self._validate_parameters(amplitude, frequency)
+        except (TypeError, ValueError) as exc:
+            return {"error": str(exc)}
+        with self._lock:
+            running = self._thread is not None and self._thread.is_alive()
+            self._amplitude_deg = amplitude
+            self._frequency_hz = frequency
+            if running:
+                return self._status_locked()
+        motion, available = self._state.current_motion()
+        if motion != "lower_body_balance":
+            return {
+                "error": f"arm_swing requires lower_body_balance (current: {motion or 'unknown'})",
+                "available_transition_motions": available,
+            }
+        with self._lock:
+            self._halt = threading.Event()
+            self._started_at = time.monotonic()
+            self._publish_count = 0
+            self._request_id = None
+            self._last_reason = "running"
+            self._thread = threading.Thread(target=self._run, daemon=True, name="t800-arm-swing")
+            self._thread.start()
+            return self._status_locked()
+
+    def _run(self) -> None:
+        reason = "user_halt"
+        direction = 1.0
+        try:
+            while not self._halt.is_set():
+                motion, _ = self._state.current_motion()
+                if motion != "lower_body_balance":
+                    reason = f"motion_state_changed:{motion or 'unknown'}"
+                    break
+                with self._lock:
+                    amplitude = math.radians(self._amplitude_deg)
+                    frequency = self._frequency_hz
+                step_duration = 0.5 / frequency
+                offset = direction * amplitude
+                result = self._joint_plan.dispatch("plan", {
+                    "joint_indices": self._INDICES,
+                    "target_positions": [
+                        self._BASE[0] + offset,
+                        self._BASE[1],
+                        self._BASE[2] - offset,
+                        self._BASE[3],
+                    ],
+                    "duration": step_duration,
+                    "gravity_compensation": True,
+                })
+                if "error" in result:
+                    raise RuntimeError(str(result["error"]))
+                request_id = int(result["request_id"])
+                with self._lock:
+                    self._request_id = request_id
+                    self._publish_count += 1
+                self._joint_plan.wait_for_request(
+                    request_id,
+                    max(5.0, step_duration + 3.0),
+                    self._halt,
+                )
+                direction *= -1.0
+        except Exception as exc:
+            reason = "user_halt" if self._halt.is_set() else f"error:{exc}"
+        finally:
+            with self._lock:
+                self._last_reason = reason
+                self._request_id = None
+
+    def _halt_swing(self, reason: str) -> dict:
+        with self._lock:
+            thread = self._thread
+            request_id = self._request_id
+            self._last_reason = reason
+            self._halt.set()
+        if request_id is not None:
+            self._joint_plan.dispatch("cancel", {"request_id": request_id})
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=1.0)
+        return self._status()
+
+    def _return_neutral(self, args: dict, action: str) -> dict:
+        motion, available = self._state.current_motion()
+        if motion != "lower_body_balance":
+            return {
+                "error": f"arm_swing requires lower_body_balance (current: {motion or 'unknown'})",
+                "available_transition_motions": available,
+            }
+        try:
+            duration = clamp(args.get("duration", 1.5), 0.5, 5.0)
+        except (TypeError, ValueError) as exc:
+            return {"error": str(exc)}
+        self._halt_swing(action)
+        result = self._joint_plan.dispatch("plan", {
+            "joint_indices": self._INDICES,
+            "target_positions": self._BASE,
+            "duration": duration,
+            "gravity_compensation": True,
+        })
+        return {**result, "action": action, "duration": duration, "target": "neutral"}
+
+    def _status(self) -> dict:
+        with self._lock:
+            return self._status_locked()
+
+    def _status_locked(self) -> dict:
+        running = self._thread is not None and self._thread.is_alive() and not self._halt.is_set()
+        return {
+            "state": "running" if running else "idle",
+            "amplitude_deg": self._amplitude_deg,
+            "frequency_hz": self._frequency_hz,
+            "publish_count": self._publish_count,
+            "request_id": self._request_id,
+            "reason": self._last_reason,
+            "required_motion_state": "lower_body_balance",
+            "joint_indices": list(self._INDICES),
+            "control_backend": "joint_plan",
+        }
+
+    @staticmethod
+    def _validate_parameters(amplitude: float, frequency: float) -> None:
+        if not math.isfinite(amplitude) or not 2.0 <= amplitude <= 30.0:
+            raise ValueError("amplitude_deg must be between 2 and 30")
+        if not math.isfinite(frequency) or not 0.2 <= frequency <= 1.2:
+            raise ValueError("frequency_hz must be between 0.2 and 1.2")
 
 
 class JointBridgePlugin(_JointStreamBase):

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -3113,6 +3113,15 @@ class ArmSwingPlugin:
                 "持续摆臂动作",
             ),
         }
+        schema = tool["inputSchema"]
+        schema["x-completion"] = {
+            "actions": ["start_swing", "return_neutral", "halt_and_return"],
+            "timeout": int(self._ACP_TIMEOUT_SEC),
+        }
+        schema["x-hooks"] = {
+            "on_interrupt_motion": {"action": "halt"},
+            "on_interrupt_all": {"action": "halt"},
+        }
         return tool
 
     def start(self) -> None:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2931,8 +2931,6 @@ class JointOverridePlugin(_JointStreamBase):
         ros2.executor_robot.add_node(self._node)
         self._publisher = None
         self._last_indices: list[int] = []
-        self._owner_lock = threading.Lock()
-        self._owner: str | None = None
         self._stream = RepeatingCommand(
             self._publish,
             self._publish_release,
@@ -2981,9 +2979,6 @@ class JointOverridePlugin(_JointStreamBase):
             return {"state": "released" if action == "release" else "idle"}
         if action != "command":
             return {"error": f"unknown joint override action: {action}"}
-        with self._owner_lock:
-            if self._owner is not None:
-                return {"error": f"joint override is owned by {self._owner}"}
         motion, _ = self._state.current_motion()
         if motion != "lower_body_balance" and not bool(args.get("force", False)):
             return {"error": f"joint override requires lower_body_balance (current: {motion or 'unknown'})"}
@@ -3003,43 +2998,6 @@ class JointOverridePlugin(_JointStreamBase):
         self._last_indices = indices
         duration = float(args.get("duration", 1.0))
         return {"state": "running", "stream": asdict(self._stream.start(payload, duration)), "duration": duration}
-
-    def acquire(self, owner: str) -> bool:
-        with self._owner_lock:
-            if self._owner not in (None, owner):
-                return False
-            if self._stream.snapshot().active:
-                return False
-            self._owner = owner
-            return True
-
-    def publish_owned(self, owner: str, payload: dict) -> None:
-        with self._owner_lock:
-            if self._owner != owner:
-                raise RuntimeError("joint override ownership was lost")
-        indices, positions = validate_joint_positions(
-            payload.get("indices"), payload.get("position"), limit_margin_rad=0.02
-        )
-        size = len(indices)
-        self._last_indices = indices
-        self._publish({
-            "indices": indices,
-            "position": positions,
-            "velocity": optional_floats(payload, "velocity", size),
-            "feed_forward_torque": [],
-            "torque": [],
-            "stiffness": optional_floats(payload, "stiffness", size),
-            "damping": optional_floats(payload, "damping", size),
-            "weight": clamp(payload.get("weight", 0.5), 0.0, 1.0),
-        })
-
-    def release_owned(self, owner: str) -> bool:
-        with self._owner_lock:
-            if self._owner != owner:
-                return False
-            self._owner = None
-        self._publish_release()
-        return True
 
     def _publish(self, payload: dict) -> None:
         msg = self._message_type()
@@ -3079,6 +3037,7 @@ class ArmSwingPlugin:
         self._default_amplitude_deg = float(cfg.get("default_amplitude_deg", 8.0))
         self._default_frequency_hz = float(cfg.get("default_frequency_hz", 0.7))
         self._lock = threading.RLock()
+        self._command_lock = threading.Lock()
         self._halt = threading.Event()
         self._thread: threading.Thread | None = None
         self._amplitude_deg = self._default_amplitude_deg
@@ -3113,7 +3072,7 @@ class ArmSwingPlugin:
             ),
         }
         tool["inputSchema"]["x-completion"] = {
-            "actions": ["start_swing"],
+            "actions": ["start_swing", "return_neutral", "halt_and_return"],
             "timeout": int(self._ACP_TIMEOUT_SEC),
         }
         return tool
@@ -3122,21 +3081,29 @@ class ArmSwingPlugin:
         pass
 
     def stop(self) -> None:
-        self._halt_swing("driver_stopped")
+        with self._command_lock:
+            self._halt_swing("driver_stopped")
 
     def dispatch(self, action: str, args: dict) -> dict:
         if action in ("start", "info"):
             return {**self._status(), "state": "ready"}
         if action == "stop":
-            return self._halt_swing("lifecycle_stop")
+            with self._command_lock:
+                return self._halt_swing("lifecycle_stop")
         if action == "status":
             return self._status()
         if action == "halt":
-            return self._halt_swing("user_halt")
+            with self._command_lock:
+                return self._halt_swing("user_halt")
         if action in ("return_neutral", "halt_and_return"):
-            return self._return_neutral(args, action)
+            with self._command_lock:
+                return self._return_neutral(args, action)
         if action != "start_swing":
             return {"error": f"unknown arm swing action: {action}"}
+        with self._command_lock:
+            return self._start_swing(args)
+
+    def _start_swing(self, args: dict) -> dict:
         try:
             amplitude = float(args.get("amplitude_deg", self._amplitude_deg))
             frequency = float(args.get("frequency_hz", self._frequency_hz))
@@ -3239,7 +3206,7 @@ class ArmSwingPlugin:
             if request_id is not None:
                 self._joint_plan.dispatch("cancel", {"request_id": request_id})
             if action_id is not None:
-                self._acp_notify(action_id, final_status, final_result)
+                self._notify_completion(action_id, final_status, final_result)
 
     def _motion_state_abort_reason(self) -> str | None:
         motion, _ = self._state.current_motion()
@@ -3264,24 +3231,109 @@ class ArmSwingPlugin:
         return self._status()
 
     def _return_neutral(self, args: dict, action: str) -> dict:
-        motion, available = self._state.current_motion()
-        if motion != "lower_body_balance":
-            return {
-                "error": f"arm_swing requires lower_body_balance (current: {motion or 'unknown'})",
-                "available_transition_motions": available,
-            }
         try:
             duration = clamp(args.get("duration", 1.5), 0.5, 5.0)
         except (TypeError, ValueError) as exc:
             return {"error": str(exc)}
         self._halt_swing(action)
-        result = self._joint_plan.dispatch("plan", {
-            "joint_indices": self._INDICES,
-            "target_positions": self._BASE,
-            "duration": duration,
-            "gravity_compensation": True,
-        })
-        return {**result, "action": action, "duration": duration, "target": "neutral"}
+        with self._lock:
+            motion, available = self._state.current_motion()
+            if motion != "lower_body_balance":
+                return {
+                    "error": f"arm_swing requires lower_body_balance (current: {motion or 'unknown'})",
+                    "available_transition_motions": available,
+                }
+            from uuid import uuid4
+
+            self._halt = threading.Event()
+            self._started_at = time.monotonic()
+            self._publish_count = 0
+            self._request_id = None
+            self._action_id = f"t800_arm_swing_{uuid4().hex[:12]}"
+            self._last_reason = "running"
+            self._thread = threading.Thread(
+                target=self._run_neutral,
+                args=(duration, action),
+                daemon=True,
+                name="t800-arm-swing-neutral",
+            )
+            self._thread.start()
+            return {
+                "state": "running",
+                "action": action,
+                "action_id": self._action_id,
+                "duration": duration,
+                "target": "neutral",
+            }
+
+    def _run_neutral(self, duration: float, action: str) -> None:
+        reason = "completed"
+        request_id = None
+        try:
+            with self._lock:
+                if self._halt.is_set():
+                    raise RuntimeError("neutral return cancelled")
+                abort_reason = self._motion_state_abort_reason()
+                if abort_reason:
+                    raise RuntimeError(abort_reason)
+                result = self._joint_plan.dispatch("plan", {
+                    "joint_indices": self._INDICES,
+                    "target_positions": self._BASE,
+                    "duration": duration,
+                    "gravity_compensation": True,
+                })
+                if "error" in result:
+                    raise RuntimeError(str(result["error"]))
+                request_id = int(result["request_id"])
+                self._request_id = request_id
+                self._publish_count += 1
+            self._joint_plan.wait_for_request(
+                request_id,
+                max(5.0, duration + 3.0),
+                self._halt,
+                abort_check=self._motion_state_abort_reason,
+            )
+            with self._lock:
+                if self._request_id == request_id:
+                    self._request_id = None
+            request_id = None
+        except Exception as exc:
+            message = str(exc)
+            if message.startswith("motion_state_changed:"):
+                reason = message
+            else:
+                reason = self._last_reason if self._halt.is_set() else f"error:{exc}"
+        finally:
+            with self._lock:
+                live_request_id = self._request_id if self._request_id is not None else request_id
+                self._request_id = None
+                self._last_reason = reason
+                action_id = self._action_id
+                final_status = (
+                    "completed" if reason == "completed"
+                    else "error" if reason.startswith("error:")
+                    else "cancelled"
+                )
+                final_result = {
+                    "action": action,
+                    "target": "neutral",
+                    "duration": duration,
+                    "reason": reason,
+                    "request_id": live_request_id,
+                    "control_backend": "joint_plan",
+                }
+            if live_request_id is not None:
+                self._joint_plan.dispatch("cancel", {"request_id": live_request_id})
+            if action_id is not None:
+                self._notify_completion(action_id, final_status, final_result)
+
+    def _notify_completion(self, action_id: str, status: str, result: dict) -> None:
+        threading.Thread(
+            target=self._acp_notify,
+            args=(action_id, status, result),
+            daemon=True,
+            name="t800-arm-swing-acp",
+        ).start()
 
     def _status(self) -> dict:
         with self._lock:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2311,12 +2311,14 @@ class JointPlanPlugin:
             return snapshot
         if action == "stop":
             return {"state": "idle"}
+        # Cancellation is a safety/operator escape hatch: it must remain
+        # available even while an in-process plugin owns the planner.
+        if action == "cancel":
+            return self._publish_request("cancel", args)
         with self._owner_lock:
             active_owner = self._owner
         if active_owner is not None and owner != active_owner:
             return {"error": f"joint planner is owned by {active_owner}"}
-        if action == "cancel":
-            return self._publish_request("cancel", args)
         if action == "reset":
             return self._publish_request("reset", args)
         if action == "preset":
@@ -3112,7 +3114,9 @@ class ArmSwingPlugin:
             ),
         }
         tool["inputSchema"]["x-completion"] = {
-            "actions": ["start_swing", "return_neutral", "halt_and_return"],
+            # start_swing is continuous and must not hold Agent Core's ACP
+            # actuator barrier; halt and runtime updates need to remain callable.
+            "actions": ["return_neutral", "halt_and_return"],
             "timeout": int(self._ACP_TIMEOUT_SEC),
         }
         return tool

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -3119,7 +3119,10 @@ class ArmSwingPlugin:
         }
         schema = tool["inputSchema"]
         schema["x-completion"] = {
-            "actions": ["start_swing", "return_neutral", "halt_and_return"],
+            # start_swing is intentionally continuous. Registering it here
+            # would hold Agent Core's actuator barrier and make its ordinary
+            # halt and runtime parameter updates unreachable.
+            "actions": ["return_neutral", "halt_and_return"],
             "timeout": int(self._ACP_TIMEOUT_SEC),
         }
         schema["x-hooks"] = {

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2399,6 +2399,7 @@ class JointPlanPlugin:
         request_id: int,
         timeout: float,
         cancel_event: threading.Event,
+        abort_check=None,
     ) -> dict:
         """Require the planner to execute and finish the exact request."""
         if self._state_type is None:
@@ -2408,6 +2409,10 @@ class JointPlanPlugin:
         idle = int(self._state_type.IDLE)
         with self._state_changed:
             while True:
+                if abort_check is not None:
+                    abort_reason = abort_check()
+                    if abort_reason:
+                        raise RuntimeError(str(abort_reason))
                 if cancel_event.is_set():
                     raise RuntimeError("gesture cancelled")
                 state = dict(self._last_state)
@@ -3089,13 +3094,13 @@ class ArmSwingPlugin:
             "multiInstance": False,
             "description": "T800 lower_body_balance 下通过 joint_plan 持续交替摆臂",
             "inputSchema": action_schema(
-                {
+                _with_lifecycle({
                     "start_swing": (["amplitude_deg", "frequency_hz"], "开始左右交替摆臂"),
                     "halt": ([], "取消当前规划并停止摆臂"),
                     "return_neutral": (["duration"], "平滑回到自然姿态"),
                     "halt_and_return": (["duration"], "取消当前规划并平滑回到自然姿态"),
                     "status": ([], "查询摆臂状态和发布计数"),
-                },
+                }),
                 {
                     "amplitude_deg": {"type": "number", "minimum": 2.0, "maximum": 30.0, "description": "肩部摆幅，默认 8 度"},
                     "frequency_hz": {"type": "number", "minimum": 0.2, "maximum": 1.2, "description": "摆动频率，默认 0.7 Hz"},
@@ -3112,6 +3117,10 @@ class ArmSwingPlugin:
         self._halt_swing("driver_stopped")
 
     def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("start", "info"):
+            return {**self._status(), "state": "ready"}
+        if action == "stop":
+            return self._halt_swing("lifecycle_stop")
         if action == "status":
             return self._status()
         if action == "halt":
@@ -3162,35 +3171,63 @@ class ArmSwingPlugin:
                     frequency = self._frequency_hz
                 step_duration = 0.5 / frequency
                 offset = direction * amplitude
-                result = self._joint_plan.dispatch("plan", {
-                    "joint_indices": self._INDICES,
-                    "target_positions": [
-                        self._BASE[0] + offset,
-                        self._BASE[1],
-                        self._BASE[2] - offset,
-                        self._BASE[3],
-                    ],
-                    "duration": step_duration,
-                    "gravity_compensation": True,
-                })
-                if "error" in result:
-                    raise RuntimeError(str(result["error"]))
-                request_id = int(result["request_id"])
                 with self._lock:
+                    # Keep publication and ID storage in one critical section.
+                    # halt either wins before publication or observes the ID.
+                    if self._halt.is_set():
+                        break
+                    result = self._joint_plan.dispatch("plan", {
+                        "joint_indices": self._INDICES,
+                        "target_positions": [
+                            self._BASE[0] + offset,
+                            self._BASE[1],
+                            self._BASE[2] - offset,
+                            self._BASE[3],
+                        ],
+                        "duration": step_duration,
+                        "gravity_compensation": True,
+                    })
+                    if "error" in result:
+                        raise RuntimeError(str(result["error"]))
+                    request_id = int(result["request_id"])
                     self._request_id = request_id
                     self._publish_count += 1
                 self._joint_plan.wait_for_request(
                     request_id,
                     max(5.0, step_duration + 3.0),
                     self._halt,
+                    abort_check=self._motion_state_abort_reason,
                 )
+                with self._lock:
+                    if self._request_id == request_id:
+                        self._request_id = None
                 direction *= -1.0
         except Exception as exc:
-            reason = "user_halt" if self._halt.is_set() else f"error:{exc}"
+            message = str(exc)
+            if message.startswith("motion_state_changed:"):
+                reason = message
+            else:
+                reason = self._last_reason if self._halt.is_set() else f"error:{exc}"
         finally:
+            request_id = None
             with self._lock:
+                request_id = self._request_id
                 self._last_reason = reason
                 self._request_id = None
+            # A request can still be live when the worker is interrupted or
+            # errors. Always cancel it before declaring the card idle.
+            if request_id is not None:
+                self._joint_plan.dispatch("cancel", {"request_id": request_id})
+
+    def _motion_state_abort_reason(self) -> str | None:
+        motion, _ = self._state.current_motion()
+        if motion == "lower_body_balance":
+            return None
+        reason = f"motion_state_changed:{motion or 'unknown'}"
+        with self._lock:
+            self._last_reason = reason
+            self._halt.set()
+        return reason
 
     def _halt_swing(self, reason: str) -> dict:
         with self._lock:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2227,6 +2227,8 @@ class JointPlanPlugin:
         self._last_state = {"state": "no_data"}
         self._executing_requests: set[int] = set()
         self._request_id = 0
+        self._owner_lock = threading.Lock()
+        self._owner: str | None = None
         self._state_type = None
         self._state = state
         self._core_topic = f"/{namespace}/state/joint_plan"
@@ -2300,10 +2302,15 @@ class JointPlanPlugin:
             return snapshot
         if action == "stop":
             return {"state": "idle"}
-        if action == "reset":
-            return self._publish_request("reset", {})
         if action == "cancel":
             return self._publish_request("cancel", args)
+        owner = args.get("_owner")
+        with self._owner_lock:
+            active_owner = self._owner
+        if active_owner is not None and owner != active_owner:
+            return {"error": f"joint planner is owned by {active_owner}"}
+        if action == "reset":
+            return self._publish_request("reset", args)
         if action == "preset":
             preset = self._PRESETS.get(str(args.get("preset", "")))
             if preset is None:
@@ -2354,6 +2361,24 @@ class JointPlanPlugin:
         if action == "plan":
             return self._publish_request("plan", args)
         return {"error": f"unknown joint plan action: {action}"}
+
+    def acquire(self, owner: str) -> bool:
+        with self._owner_lock:
+            if self._owner not in (None, owner):
+                return False
+            self._owner = owner
+            return True
+
+    def release(self, owner: str) -> bool:
+        with self._owner_lock:
+            if self._owner != owner:
+                return False
+            self._owner = None
+            return True
+
+    def owner(self) -> str | None:
+        with self._owner_lock:
+            return self._owner
 
     def current_motion(self) -> tuple[str, list[str]]:
         if self._state is None:
@@ -2762,6 +2787,8 @@ class GesturePlugin:
                 current = dict(self._status)
                 current.pop("action_id", None)
                 return {**current, "error": "another gesture sequence is already running"}
+            if not self._joint_plan.acquire("gesture"):
+                return {"error": f"joint planner is owned by {self._joint_plan.owner()}"}
             from uuid import uuid4
 
             action_id = f"t800_gesture_{uuid4().hex[:12]}"
@@ -2785,7 +2812,7 @@ class GesturePlugin:
                         self._status["step"] = index
                         self._status["step_name"] = step["name"]
                     action = "plan_named" if "joint_names" in step else "plan"
-                    result = self._joint_plan.dispatch(action, step)
+                    result = self._joint_plan.dispatch(action, {**step, "_owner": "gesture"})
                     if "error" in result:
                         raise ValueError(result["error"])
                     request_id = int(result["request_id"])
@@ -2800,7 +2827,7 @@ class GesturePlugin:
                     if hold_after > 0 and self._cancel.wait(hold_after):
                         raise RuntimeError("gesture cancelled")
                 if not self._cancel.is_set() and reset_after:
-                    result = self._joint_plan.dispatch("reset", {})
+                    result = self._joint_plan.dispatch("reset", {"_owner": "gesture"})
                     if "error" in result:
                         raise ValueError(result["error"])
                     request_id = int(result["request_id"])
@@ -2837,6 +2864,7 @@ class GesturePlugin:
                         "request_id": self._status.get("request_id"),
                         "error": self._status.get("error"),
                     }
+                self._joint_plan.release("gesture")
                 if action_id is not None:
                     self._acp_notify(action_id, final_status, final_result)
 
@@ -2869,7 +2897,7 @@ class GesturePlugin:
         if request_id is not None:
             self._joint_plan.dispatch("cancel", {"request_id": request_id})
         if reset_after:
-            self._joint_plan.dispatch("reset", {})
+            self._joint_plan.dispatch("reset", {"_owner": "gesture"})
         return result
 
     @staticmethod
@@ -3124,6 +3152,8 @@ class ArmSwingPlugin:
                     "error": f"arm_swing requires lower_body_balance (current: {motion or 'unknown'})",
                     "available_transition_motions": available,
                 }
+            if not self._joint_plan.acquire(self._OWNER):
+                return {"error": f"joint planner is owned by {self._joint_plan.owner()}"}
             from uuid import uuid4
 
             self._halt = threading.Event()
@@ -3165,6 +3195,7 @@ class ArmSwingPlugin:
                         ],
                         "duration": step_duration,
                         "gravity_compensation": True,
+                        "_owner": self._OWNER,
                     })
                     if "error" in result:
                         raise RuntimeError(str(result["error"]))
@@ -3205,6 +3236,7 @@ class ArmSwingPlugin:
             # errors. Always cancel it before declaring the card idle.
             if request_id is not None:
                 self._joint_plan.dispatch("cancel", {"request_id": request_id})
+            self._joint_plan.release(self._OWNER)
             if action_id is not None:
                 self._notify_completion(action_id, final_status, final_result)
 
@@ -3243,6 +3275,8 @@ class ArmSwingPlugin:
                     "error": f"arm_swing requires lower_body_balance (current: {motion or 'unknown'})",
                     "available_transition_motions": available,
                 }
+            if not self._joint_plan.acquire(self._OWNER):
+                return {"error": f"joint planner is owned by {self._joint_plan.owner()}"}
             from uuid import uuid4
 
             self._halt = threading.Event()
@@ -3281,6 +3315,7 @@ class ArmSwingPlugin:
                     "target_positions": self._BASE,
                     "duration": duration,
                     "gravity_compensation": True,
+                    "_owner": self._OWNER,
                 })
                 if "error" in result:
                     raise RuntimeError(str(result["error"]))
@@ -3324,6 +3359,7 @@ class ArmSwingPlugin:
                 }
             if live_request_id is not None:
                 self._joint_plan.dispatch("cancel", {"request_id": live_request_id})
+            self._joint_plan.release(self._OWNER)
             if action_id is not None:
                 self._notify_completion(action_id, final_status, final_result)
 

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2317,8 +2317,15 @@ class JointPlanPlugin:
             return self._publish_request("cancel", args)
         with self._owner_lock:
             active_owner = self._owner
-        if active_owner is not None and owner != active_owner:
-            return {"error": f"joint planner is owned by {active_owner}"}
+            if active_owner is not None and owner != active_owner:
+                return {"error": f"joint planner is owned by {active_owner}"}
+            # Keep arbitration and publication in the same critical section.
+            # Otherwise an owner can be acquired after this check but before a
+            # public request is allocated and published.
+            return self._dispatch_exclusive(action, args)
+
+    def _dispatch_exclusive(self, action: str, args: dict) -> dict:
+        """Publish a non-cancel request while the ownership lock is held."""
         if action == "reset":
             return self._publish_request("reset", args)
         if action == "preset":
@@ -3073,8 +3080,16 @@ class ArmSwingPlugin:
     _OWNER = "arm_swing"
     _INDICES = [13, 16, 18, 21]
     _BASE = [0.028, -0.066, 0.024, -0.069]
-    _ACP_TIMEOUT_SEC = 86400.0
+    _MAX_NEUTRAL_DURATION_SEC = 5.0
+    _NEUTRAL_WAIT_MARGIN_SEC = 3.0
     _ACP_CALLBACK_TIMEOUT_SEC = 5.0
+    _ACP_SAFETY_MARGIN_SEC = 2.0
+    _ACP_TIMEOUT_SEC = (
+        _MAX_NEUTRAL_DURATION_SEC
+        + _NEUTRAL_WAIT_MARGIN_SEC
+        + _ACP_CALLBACK_TIMEOUT_SEC
+        + _ACP_SAFETY_MARGIN_SEC
+    )
 
     def __init__(self, config: dict, joint_plan: JointPlanPlugin, state: StatePlugin):
         cfg = config.get("plugins", {}).get("arm_swing", {})
@@ -3296,7 +3311,7 @@ class ArmSwingPlugin:
             duration = float(args.get("duration", 1.5))
         except (TypeError, ValueError) as exc:
             return {"error": str(exc)}
-        if not math.isfinite(duration) or not 0.5 <= duration <= 5.0:
+        if not math.isfinite(duration) or not 0.5 <= duration <= self._MAX_NEUTRAL_DURATION_SEC:
             return {"error": "duration must be finite and between 0.5 and 5.0 seconds"}
         self._halt_swing(action)
         with self._lock:
@@ -3361,7 +3376,7 @@ class ArmSwingPlugin:
                 self._publish_count += 1
             self._joint_plan.wait_for_request(
                 request_id,
-                max(5.0, duration + 3.0),
+                max(5.0, duration + self._NEUTRAL_WAIT_MARGIN_SEC),
                 self._halt,
                 abort_check=self._motion_state_abort_reason,
             )

--- a/engineai/t800/driver.yaml
+++ b/engineai/t800/driver.yaml
@@ -6,6 +6,6 @@ hardware_model: "t800"
 image_name: engineai-t800
 port: 15708
 mcp_url: "http://localhost:15708/mcp"
-description: "EngineAI T800 开发版 — ROS2/Native SDK、全身状态、舞蹈/手势、虚拟手柄、高低层运动、LED 与语音控制"
+description: "EngineAI T800 开发版 — ROS2/Native SDK、全身状态、舞蹈/手势/摆臂、虚拟手柄、高低层运动、LED 与语音控制"
 build_context_extras:
   - ../../common

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -106,6 +106,7 @@ class T800DeviceBundle:
     def __init__(self, config: dict, namespace: str, ros2: DualDomainROS2):
         from device import (
             DancePlugin,
+            ArmSwingPlugin,
             GesturePlugin,
             JointBridgePlugin,
             JointOverridePlugin,
@@ -185,6 +186,11 @@ class T800DeviceBundle:
             instances["gesture"] = instance
             self._plugins.append(instance)
 
+        if plugins.get("arm_swing", {}).get("enabled", True) and "joint_plan" in instances:
+            instance = ArmSwingPlugin(config, instances["joint_plan"], state)
+            instances["arm_swing"] = instance
+            self._plugins.append(instance)
+
         virtual_gamepad_config = plugins.get("virtual_gamepad", {})
         if virtual_gamepad_config.get("enabled", False):
             instance = VirtualGamepadPlugin(virtual_gamepad_config, namespace, ros2)
@@ -213,7 +219,7 @@ class T800DeviceBundle:
             instances["safety"].set_controls(
                 [
                     instances[key]
-                    for key in ("locomotion", "joint_override", "joint_bridge", "virtual_gamepad", "gesture")
+                    for key in ("locomotion", "joint_override", "joint_bridge", "virtual_gamepad", "gesture", "arm_swing")
                     if key in instances
                 ]
             )

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1225,6 +1225,46 @@ class DevicePluginContractTests(unittest.TestCase):
                    if msg.request_type == plan._request_type.REQUEST_CANCEL]
         self.assertTrue(any(msg.request_id == request_id for msg in cancels))
 
+    def test_arm_swing_rejects_neutral_replacement_while_worker_is_stopping(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        original_dispatch_owned = plan.dispatch_owned
+        published = threading.Event()
+        allow_return = threading.Event()
+
+        def delayed_dispatch_owned(owner, action, args):
+            result = original_dispatch_owned(owner, action, args)
+            if action == "plan":
+                published.set()
+                allow_return.wait(timeout=2.0)
+            return result
+
+        plan.dispatch_owned = delayed_dispatch_owned
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        swing._notify_completion = lambda *_args: None
+        self.state._current_motion = "lower_body_balance"
+        started = swing.dispatch("start_swing", {})
+        self.assertTrue(published.wait(timeout=1.0))
+        worker = swing._thread
+        original_join = worker.join
+        worker.join = lambda timeout=None: None
+        try:
+            result = swing.dispatch("return_neutral", {"duration": 1.5})
+            self.assertEqual("stopping", result["state"])
+            self.assertIn("still stopping", result["error"])
+            self.assertEqual(started["action_id"], result["action_id"])
+            plans = [msg for msg in plan._publisher.messages
+                     if msg.request_type == plan._request_type.REQUEST_PLAN_EXECUTE]
+            self.assertEqual(1, len(plans))
+            self.assertIs(worker, swing._thread)
+            self.assertEqual("arm_swing", plan.owner())
+        finally:
+            worker.join = original_join
+            allow_return.set()
+            original_join(timeout=1.0)
+        self.assertFalse(worker.is_alive())
+        self.assertIsNone(plan.owner())
+
     def test_arm_swing_concurrent_start_creates_one_worker(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1172,6 +1172,31 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual(plan._request_type.REQUEST_CANCEL, plan._publisher.messages[-1].request_type)
         self.assertEqual([], completions)
 
+    def test_arm_swing_completion_reuses_shared_acp_notifier(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        calls = []
+        notified = threading.Event()
+
+        def notify(*args):
+            calls.append(args)
+            notified.set()
+
+        self.device._notify_acp_completion = notify
+        swing._notify_completion("t800_arm_swing_test", "completed", {"action": "return_neutral"})
+
+        self.assertTrue(notified.wait(1.0))
+        self.assertEqual(
+            (
+                "arm_swing",
+                "t800_arm_swing_test",
+                "completed",
+                {"action": "return_neutral"},
+                swing._ACP_CALLBACK_TIMEOUT_SEC,
+            ),
+            calls[0],
+        )
+
     def test_arm_swing_gates_state_and_parameters(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1042,9 +1042,10 @@ class DevicePluginContractTests(unittest.TestCase):
         actions = swing.get_tool()["inputSchema"]["properties"]["action"]["enum"]
         completion = swing.get_tool()["inputSchema"]["x-completion"]
         self.assertEqual(
-            ["start_swing", "return_neutral", "halt_and_return"],
+            ["return_neutral", "halt_and_return"],
             completion["actions"],
         )
+        self.assertNotIn("start_swing", completion["actions"])
         self.assertGreater(completion["timeout"], 3)
         self.assertTrue({"start", "info", "stop"}.issubset(actions))
         self.assertNotIn("set_parameters", actions)
@@ -1271,6 +1272,20 @@ class DevicePluginContractTests(unittest.TestCase):
             result = plan.dispatch(action, {**args, "_owner": "arm_swing"})
             self.assertIn("reserved for internal driver use", result["error"])
         self.assertEqual([], plan._publisher.messages)
+
+    def test_joint_plan_public_cancel_bypasses_active_owner(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        self.assertTrue(plan.acquire("arm_swing"))
+        blocked = plan.dispatch("reset", {})
+        self.assertIn("owned by arm_swing", blocked["error"])
+        self.assertEqual([], plan._publisher.messages)
+        result = plan.dispatch("cancel", {"request_id": 12})
+        self.assertEqual("requested", result["state"])
+        sent = plan._publisher.messages[-1]
+        self.assertEqual(plan._request_type.REQUEST_CANCEL, sent.request_type)
+        self.assertEqual(12, sent.request_id)
+        self.assertEqual("arm_swing", plan.owner())
 
     def test_gesture_rejects_start_while_arm_swing_owns_planner(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1062,9 +1062,11 @@ class DevicePluginContractTests(unittest.TestCase):
         schema = swing.get_tool()["inputSchema"]
         actions = schema["properties"]["action"]["enum"]
         self.assertEqual(
-            ["start_swing", "return_neutral", "halt_and_return"],
+            ["return_neutral", "halt_and_return"],
             schema["x-completion"]["actions"],
         )
+        self.assertNotIn("start_swing", schema["x-completion"]["actions"])
+        self.assertNotIn("halt", schema["x-completion"]["actions"])
         self.assertGreater(schema["x-completion"]["timeout"], 3)
         self.assertEqual(
             {"action": "halt"},

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1033,9 +1033,13 @@ class DevicePluginContractTests(unittest.TestCase):
         self.state._current_motion = "lower_body_balance"
         self.assertIn("between 2 and 30", swing.dispatch("start_swing", {"amplitude_deg": 31})["error"])
         actions = swing.get_tool()["inputSchema"]["properties"]["action"]["enum"]
+        self.assertTrue({"start", "info", "stop"}.issubset(actions))
         self.assertNotIn("set_parameters", actions)
         self.assertIn("return_neutral", actions)
         self.assertIn("halt_and_return", actions)
+        self.assertEqual("ready", swing.dispatch("start", {})["state"])
+        self.assertEqual("ready", swing.dispatch("info", {})["state"])
+        self.assertEqual("idle", swing.dispatch("stop", {})["state"])
 
     def test_arm_swing_return_neutral_uses_joint_plan(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
@@ -1053,16 +1057,57 @@ class DevicePluginContractTests(unittest.TestCase):
     def test_arm_swing_cancels_when_motion_state_changes(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
-        plan.wait_for_request = lambda *_args, **_kwargs: time.sleep(0.03)
         swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
         self.state._current_motion = "lower_body_balance"
         swing.dispatch("start_swing", {})
-        time.sleep(0.01)
+        deadline = time.monotonic() + 1.0
+        while not plan._publisher.messages and time.monotonic() < deadline:
+            time.sleep(0.01)
+        request_id = plan._publisher.messages[0].request_id
         self.state._current_motion = "rl_basic"
         swing._thread.join(timeout=1.0)
         status = swing.dispatch("status", {})
         self.assertEqual("idle", status["state"])
         self.assertIn("motion_state_changed", status["reason"])
+        cancels = [msg for msg in plan._publisher.messages
+                   if msg.request_type == plan._request_type.REQUEST_CANCEL]
+        self.assertTrue(any(msg.request_id == request_id for msg in cancels))
+
+    def test_arm_swing_halt_cancels_request_published_before_id_storage(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        original_dispatch = plan.dispatch
+        published = threading.Event()
+        allow_return = threading.Event()
+
+        def delayed_dispatch(action, args):
+            result = original_dispatch(action, args)
+            if action == "plan":
+                published.set()
+                allow_return.wait(timeout=1.0)
+            return result
+
+        plan.dispatch = delayed_dispatch
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        self.state._current_motion = "lower_body_balance"
+        swing.dispatch("start_swing", {})
+        self.assertTrue(published.wait(timeout=1.0))
+        halted = {}
+
+        def halt():
+            halted.update(swing.dispatch("halt", {}))
+
+        halt_thread = threading.Thread(target=halt)
+        halt_thread.start()
+        time.sleep(0.02)
+        allow_return.set()
+        halt_thread.join(timeout=1.0)
+        self.assertEqual("idle", halted["state"])
+        request_id = next(msg.request_id for msg in plan._publisher.messages
+                          if msg.request_type == plan._request_type.REQUEST_PLAN_EXECUTE)
+        cancels = [msg for msg in plan._publisher.messages
+                   if msg.request_type == plan._request_type.REQUEST_CANCEL]
+        self.assertTrue(any(msg.request_id == request_id for msg in cancels))
 
     def test_joint_bridge_force_path_and_damping_stop(self):
         plugin = self.device.JointBridgePlugin(CONFIG, "robot", self.ros, self.state)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -238,6 +238,7 @@ class DevicePluginContractTests(unittest.TestCase):
 
         motion_mode = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
         joint_plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros)
+        joint_override = self.device.JointOverridePlugin(CONFIG, "robot", self.ros, self.state)
         plugins = [
             self.state,
             self.device.LocomotionPlugin(CONFIG, "robot", self.ros, self.state),
@@ -245,7 +246,8 @@ class DevicePluginContractTests(unittest.TestCase):
             self.device.DancePlugin(motion_mode, self.state),
             joint_plan,
             self.device.GesturePlugin(joint_plan),
-            self.device.JointOverridePlugin(CONFIG, "robot", self.ros, self.state),
+            joint_override,
+            self.device.ArmSwingPlugin(CONFIG, joint_plan, self.state),
             self.device.JointBridgePlugin(CONFIG, "robot", self.ros, self.state),
             self.device.LedPlugin(CONFIG, "robot", self.ros),
             self.device.TtsPlugin(CONFIG, "robot", self.ros),
@@ -274,13 +276,13 @@ class DevicePluginContractTests(unittest.TestCase):
              "mainboard", "heartbeat_status", "motion_command_trace", "motion_events",
              "native_interface_probe",
              "loco", "motion_mode", "dance", "joint_plan", "joint_plan_state", "gesture",
-             "joint_override", "joint_bridge",
+             "joint_override", "arm_swing", "joint_bridge",
              "led", "tts", "mic", "pointcloud", "camera", "depth",
              "motor_power", "native_node_control", "virtual_gamepad", "safety", "native_sdk"},
             names,
         )
-        self.assertEqual(41, len(names))
-        self.assertEqual(41, len(definitions), "tool names must be unique")
+        self.assertEqual(42, len(names))
+        self.assertEqual(42, len(definitions), "tool names must be unique")
         for tool in definitions:
             schema = tool.get("inputSchema")
             self.assertEqual("object", schema.get("type"), tool["name"])
@@ -1007,6 +1009,60 @@ class DevicePluginContractTests(unittest.TestCase):
         time.sleep(0.03)
         plugin.dispatch("release", {})
         self.assertEqual(0.0, plugin._publisher.messages[-1].weight)
+
+    def test_arm_swing_plans_bounded_shoulders_and_halts_with_cancel(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        self.state._current_motion = "lower_body_balance"
+        result = swing.dispatch("start_swing", {"amplitude_deg": 6, "frequency_hz": 0.5})
+        self.assertEqual("running", result["state"])
+        time.sleep(0.06)
+        halted = swing.dispatch("halt", {})
+        self.assertEqual("idle", halted["state"])
+        self.assertGreater(halted["publish_count"], 0)
+        self.assertEqual("joint_plan", halted["control_backend"])
+        self.assertEqual([13, 16, 18, 21], plan._publisher.messages[0].joint_indices)
+        self.assertEqual(plan._request_type.REQUEST_CANCEL, plan._publisher.messages[-1].request_type)
+
+    def test_arm_swing_gates_state_and_parameters(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        self.assertIn("lower_body_balance", swing.dispatch("start_swing", {})["error"])
+        self.state._current_motion = "lower_body_balance"
+        self.assertIn("between 2 and 30", swing.dispatch("start_swing", {"amplitude_deg": 31})["error"])
+        actions = swing.get_tool()["inputSchema"]["properties"]["action"]["enum"]
+        self.assertNotIn("set_parameters", actions)
+        self.assertIn("return_neutral", actions)
+        self.assertIn("halt_and_return", actions)
+
+    def test_arm_swing_return_neutral_uses_joint_plan(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        self.state._current_motion = "lower_body_balance"
+        result = swing.dispatch("return_neutral", {"duration": 2.0})
+        self.assertEqual("requested", result["state"])
+        self.assertEqual("neutral", result["target"])
+        message = plan._publisher.messages[-1]
+        self.assertEqual([13, 16, 18, 21], message.joint_indices)
+        self.assertEqual(list(swing._BASE), message.target_positions)
+        self.assertEqual(2.0, message.execution_time)
+
+    def test_arm_swing_cancels_when_motion_state_changes(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        plan.wait_for_request = lambda *_args, **_kwargs: time.sleep(0.03)
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        self.state._current_motion = "lower_body_balance"
+        swing.dispatch("start_swing", {})
+        time.sleep(0.01)
+        self.state._current_motion = "rl_basic"
+        swing._thread.join(timeout=1.0)
+        status = swing.dispatch("status", {})
+        self.assertEqual("idle", status["state"])
+        self.assertIn("motion_state_changed", status["reason"])
 
     def test_joint_bridge_force_path_and_damping_stop(self):
         plugin = self.device.JointBridgePlugin(CONFIG, "robot", self.ros, self.state)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1067,7 +1067,7 @@ class DevicePluginContractTests(unittest.TestCase):
         )
         self.assertNotIn("start_swing", schema["x-completion"]["actions"])
         self.assertNotIn("halt", schema["x-completion"]["actions"])
-        self.assertGreater(schema["x-completion"]["timeout"], 3)
+        self.assertEqual(15, schema["x-completion"]["timeout"])
         self.assertEqual(
             {"action": "halt"},
             schema["x-hooks"]["on_interrupt_motion"],
@@ -1342,6 +1342,47 @@ class DevicePluginContractTests(unittest.TestCase):
             result = plan.dispatch(action, {**args, "_owner": "arm_swing"})
             self.assertIn("reserved for internal driver use", result["error"])
         self.assertEqual([], plan._publisher.messages)
+
+    def test_joint_plan_owner_acquire_waits_for_public_plan_publication(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        original_publish_request = plan._publish_request
+        publication_entered = threading.Event()
+        allow_publication = threading.Event()
+        owner_acquired = threading.Event()
+        plan_results = []
+        acquire_results = []
+
+        def delayed_publish_request(action, args):
+            if action == "plan":
+                publication_entered.set()
+                allow_publication.wait(timeout=1.0)
+            return original_publish_request(action, args)
+
+        plan._publish_request = delayed_publish_request
+        direct = threading.Thread(target=lambda: plan_results.append(plan.dispatch("plan", {
+            "joint_indices": [23],
+            "target_positions": [0.1],
+            "duration": 1.0,
+        })))
+
+        def acquire_owner():
+            acquire_results.append(plan.acquire("arm_swing"))
+            owner_acquired.set()
+
+        owner = threading.Thread(target=acquire_owner)
+        direct.start()
+        self.assertTrue(publication_entered.wait(timeout=1.0))
+        owner.start()
+        self.assertFalse(owner_acquired.wait(timeout=0.05))
+        allow_publication.set()
+        direct.join(timeout=1.0)
+        owner.join(timeout=1.0)
+        self.assertFalse(direct.is_alive())
+        self.assertFalse(owner.is_alive())
+        self.assertEqual("requested", plan_results[0]["state"])
+        self.assertEqual([True], acquire_results)
+        self.assertTrue(plan.release("arm_swing"))
 
     def test_joint_plan_public_cancel_bypasses_active_owner(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1055,9 +1055,24 @@ class DevicePluginContractTests(unittest.TestCase):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
         swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
-        self.assertIn("lower_body_balance", swing.dispatch("start_swing", {})["error"])
+        rejected_state = swing.dispatch("start_swing", {
+            "amplitude_deg": 20.0,
+            "frequency_hz": 1.0,
+        })
+        self.assertIn("lower_body_balance", rejected_state["error"])
+        self.assertEqual(8.0, swing._amplitude_deg)
+        self.assertEqual(0.7, swing._frequency_hz)
         self.state._current_motion = "lower_body_balance"
         self.assertIn("between 2 and 30", swing.dispatch("start_swing", {"amplitude_deg": 31})["error"])
+        self.assertTrue(plan.acquire("gesture"))
+        rejected_owner = swing.dispatch("start_swing", {
+            "amplitude_deg": 18.0,
+            "frequency_hz": 0.9,
+        })
+        self.assertIn("owned by gesture", rejected_owner["error"])
+        self.assertEqual(8.0, swing._amplitude_deg)
+        self.assertEqual(0.7, swing._frequency_hz)
+        self.assertTrue(plan.release("gesture"))
         schema = swing.get_tool()["inputSchema"]
         actions = schema["properties"]["action"]["enum"]
         self.assertEqual(
@@ -1224,6 +1239,31 @@ class DevicePluginContractTests(unittest.TestCase):
         cancels = [msg for msg in plan._publisher.messages
                    if msg.request_type == plan._request_type.REQUEST_CANCEL]
         self.assertTrue(any(msg.request_id == request_id for msg in cancels))
+
+    def test_public_joint_plan_cancel_stops_active_arm_swing_worker(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        swing._notify_completion = lambda *_args: None
+        self.state._current_motion = "lower_body_balance"
+        started = swing.dispatch("start_swing", {})
+        self.assertEqual("running", started["state"])
+        deadline = time.monotonic() + 1.0
+        while swing._request_id is None and time.monotonic() < deadline:
+            time.sleep(0.01)
+        request_id = swing._request_id
+        self.assertIsNotNone(request_id)
+
+        cancelled = plan.dispatch("cancel", {"request_id": request_id})
+        self.assertEqual("requested", cancelled["state"])
+        swing._thread.join(timeout=1.0)
+        self.assertFalse(swing._thread.is_alive())
+        self.assertTrue(swing._halt.is_set())
+        self.assertEqual("planner_cancelled", swing._last_reason)
+        execute_requests = [msg for msg in plan._publisher.messages
+                            if msg.request_type == plan._request_type.REQUEST_PLAN_EXECUTE]
+        self.assertEqual(1, len(execute_requests))
+        self.assertIsNone(plan.owner())
 
     def test_arm_swing_rejects_neutral_replacement_while_worker_is_stopping(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1039,14 +1039,9 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertIn("lower_body_balance", swing.dispatch("start_swing", {})["error"])
         self.state._current_motion = "lower_body_balance"
         self.assertIn("between 2 and 30", swing.dispatch("start_swing", {"amplitude_deg": 31})["error"])
-        actions = swing.get_tool()["inputSchema"]["properties"]["action"]["enum"]
-        completion = swing.get_tool()["inputSchema"]["x-completion"]
-        self.assertEqual(
-            ["return_neutral", "halt_and_return"],
-            completion["actions"],
-        )
-        self.assertNotIn("start_swing", completion["actions"])
-        self.assertGreater(completion["timeout"], 3)
+        schema = swing.get_tool()["inputSchema"]
+        actions = schema["properties"]["action"]["enum"]
+        self.assertNotIn("x-completion", schema)
         self.assertTrue({"start", "info", "stop"}.issubset(actions))
         self.assertNotIn("set_parameters", actions)
         self.assertIn("return_neutral", actions)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1041,7 +1041,7 @@ class DevicePluginContractTests(unittest.TestCase):
         self.state._current_motion = "lower_body_balance"
         result = swing.dispatch("start_swing", {"amplitude_deg": 6, "frequency_hz": 0.5})
         self.assertEqual("running", result["state"])
-        self.assertTrue(result["action_id"].startswith("t800_arm_swing_"))
+        self.assertNotIn("action_id", result)
         time.sleep(0.06)
         halted = swing.dispatch("halt", {})
         self.assertEqual("idle", halted["state"])
@@ -1049,8 +1049,7 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual("joint_plan", halted["control_backend"])
         self.assertEqual([13, 16, 18, 21], plan._publisher.messages[0].joint_indices)
         self.assertEqual(plan._request_type.REQUEST_CANCEL, plan._publisher.messages[-1].request_type)
-        self.assertEqual(result["action_id"], completions[0][0])
-        self.assertEqual("cancelled", completions[0][1])
+        self.assertEqual([], completions)
 
     def test_arm_swing_gates_state_and_parameters(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
@@ -1186,9 +1185,8 @@ class DevicePluginContractTests(unittest.TestCase):
         cancels = [msg for msg in plan._publisher.messages
                    if msg.request_type == plan._request_type.REQUEST_CANCEL]
         self.assertTrue(any(msg.request_id == request_id for msg in cancels))
-        self.assertEqual(started["action_id"], completions[0][0])
-        self.assertEqual("cancelled", completions[0][1])
-        self.assertIn("motion_state_changed", completions[0][2]["reason"])
+        self.assertNotIn("action_id", started)
+        self.assertEqual([], completions)
 
     def test_arm_swing_halt_cancels_request_published_before_id_storage(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
@@ -1254,7 +1252,8 @@ class DevicePluginContractTests(unittest.TestCase):
             result = swing.dispatch("return_neutral", {"duration": 1.5})
             self.assertEqual("stopping", result["state"])
             self.assertIn("still stopping", result["error"])
-            self.assertEqual(started["action_id"], result["action_id"])
+            self.assertNotIn("action_id", started)
+            self.assertNotIn("action_id", result)
             plans = [msg for msg in plan._publisher.messages
                      if msg.request_type == plan._request_type.REQUEST_PLAN_EXECUTE]
             self.assertEqual(1, len(plans))
@@ -1265,6 +1264,53 @@ class DevicePluginContractTests(unittest.TestCase):
             allow_return.set()
             original_join(timeout=1.0)
         self.assertFalse(worker.is_alive())
+        self.assertIsNone(plan.owner())
+
+    def test_arm_swing_rejects_restart_while_halted_worker_is_stopping(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        original_wait_for_request = plan.wait_for_request
+        wait_entered = threading.Event()
+        allow_return = threading.Event()
+
+        def delayed_wait_for_request(*args, **kwargs):
+            wait_entered.set()
+            allow_return.wait(timeout=2.0)
+            return original_wait_for_request(*args, **kwargs)
+
+        plan.wait_for_request = delayed_wait_for_request
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        completions = []
+        swing._notify_completion = lambda *args: completions.append(args)
+        self.state._current_motion = "lower_body_balance"
+        started = swing.dispatch("start_swing", {
+            "amplitude_deg": 6.0,
+            "frequency_hz": 0.5,
+        })
+        self.assertTrue(wait_entered.wait(timeout=1.0))
+        worker = swing._thread
+        original_join = worker.join
+        worker.join = lambda timeout=None: None
+        try:
+            halted = swing.dispatch("halt", {})
+            self.assertEqual("idle", halted["state"])
+            restarted = swing.dispatch("start_swing", {
+                "amplitude_deg": 12.0,
+                "frequency_hz": 1.0,
+            })
+            self.assertEqual("stopping", restarted["state"])
+            self.assertIn("still stopping", restarted["error"])
+            self.assertNotIn("action_id", started)
+            self.assertNotIn("action_id", restarted)
+            self.assertEqual(6.0, swing._amplitude_deg)
+            self.assertEqual(0.5, swing._frequency_hz)
+            self.assertIs(worker, swing._thread)
+        finally:
+            worker.join = original_join
+            allow_return.set()
+            original_join(timeout=1.0)
+        self.assertFalse(worker.is_alive())
+        self.assertEqual([], completions)
         self.assertIsNone(plan.owner())
 
     def test_arm_swing_concurrent_start_creates_one_worker(self):
@@ -1298,7 +1344,7 @@ class DevicePluginContractTests(unittest.TestCase):
         while not plan._publisher.messages and time.monotonic() < deadline:
             time.sleep(0.01)
         self.assertEqual(2, len(results))
-        self.assertEqual(1, len({result["action_id"] for result in results}))
+        self.assertTrue(all("action_id" not in result for result in results))
         execute_requests = [msg for msg in plan._publisher.messages
                             if msg.request_type == plan._request_type.REQUEST_PLAN_EXECUTE]
         self.assertEqual(1, len(execute_requests))

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1223,6 +1223,56 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual(1, len(execute_requests))
         swing.dispatch("halt", {})
 
+    def test_arm_swing_rejects_start_while_gesture_owns_planner(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        gesture = self.device.GesturePlugin(plan)
+        gesture._acp_notify = lambda *_args: None
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        swing._notify_completion = lambda *_args: None
+        self.state._current_motion = "lower_body_balance"
+        started = gesture.dispatch("sequence", {
+            "steps": [{"joint_indices": [23], "target_positions": [0.1], "duration": 1.0}],
+            "reset_after": False,
+        })
+        self.assertEqual("running", started["state"])
+        deadline = time.monotonic() + 1.0
+        while not plan._publisher.messages and time.monotonic() < deadline:
+            time.sleep(0.01)
+        request_count = len(plan._publisher.messages)
+        blocked = swing.dispatch("start_swing", {})
+        self.assertIn("owned by gesture", blocked["error"])
+        direct = plan.dispatch("head_pose", {"pitch_rad": 0.0, "yaw_rad": 0.0})
+        self.assertIn("owned by gesture", direct["error"])
+        self.assertEqual(request_count, len(plan._publisher.messages))
+        gesture.dispatch("stop_gesture", {})
+        gesture._thread.join(timeout=1.0)
+        self.assertIsNone(plan.owner())
+
+    def test_gesture_rejects_start_while_arm_swing_owns_planner(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        swing._notify_completion = lambda *_args: None
+        gesture = self.device.GesturePlugin(plan)
+        gesture._acp_notify = lambda *_args: None
+        self.state._current_motion = "lower_body_balance"
+        started = swing.dispatch("start_swing", {})
+        self.assertEqual("running", started["state"])
+        deadline = time.monotonic() + 1.0
+        while not plan._publisher.messages and time.monotonic() < deadline:
+            time.sleep(0.01)
+        request_count = len(plan._publisher.messages)
+        blocked = gesture.dispatch("sequence", {
+            "steps": [{"joint_indices": [23], "target_positions": [0.1], "duration": 1.0}],
+            "reset_after": False,
+        })
+        self.assertIn("owned by arm_swing", blocked["error"])
+        self.assertNotIn("action_id", blocked)
+        self.assertEqual(request_count, len(plan._publisher.messages))
+        swing.dispatch("halt", {})
+        self.assertIsNone(plan.owner())
+
     def test_joint_bridge_force_path_and_damping_stop(self):
         plugin = self.device.JointBridgePlugin(CONFIG, "robot", self.ros, self.state)
         plugin.start()

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1041,7 +1041,19 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertIn("between 2 and 30", swing.dispatch("start_swing", {"amplitude_deg": 31})["error"])
         schema = swing.get_tool()["inputSchema"]
         actions = schema["properties"]["action"]["enum"]
-        self.assertNotIn("x-completion", schema)
+        self.assertEqual(
+            ["start_swing", "return_neutral", "halt_and_return"],
+            schema["x-completion"]["actions"],
+        )
+        self.assertGreater(schema["x-completion"]["timeout"], 3)
+        self.assertEqual(
+            {"action": "halt"},
+            schema["x-hooks"]["on_interrupt_motion"],
+        )
+        self.assertEqual(
+            {"action": "halt"},
+            schema["x-hooks"]["on_interrupt_all"],
+        )
         self.assertTrue({"start", "info", "stop"}.issubset(actions))
         self.assertNotIn("set_parameters", actions)
         self.assertIn("return_neutral", actions)
@@ -1089,7 +1101,7 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual(result["action_id"], completions[0][0])
         self.assertEqual("completed", completions[0][1])
 
-    def test_arm_swing_stop_cancels_monitored_neutral_return(self):
+    def test_arm_swing_interrupt_hook_cancels_monitored_neutral_return(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
         swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
@@ -1103,7 +1115,8 @@ class DevicePluginContractTests(unittest.TestCase):
         while not plan._publisher.messages and time.monotonic() < deadline:
             time.sleep(0.01)
         request_id = plan._publisher.messages[0].request_id
-        stopped = swing.dispatch("stop", {})
+        hook = swing.get_tool()["inputSchema"]["x-hooks"]["on_interrupt_motion"]
+        stopped = swing.dispatch(hook["action"], {})
         self.assertEqual("idle", stopped["state"])
         cancels = [msg for msg in plan._publisher.messages
                    if msg.request_type == plan._request_type.REQUEST_CANCEL]

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1002,6 +1002,26 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual(7, state["request_id"])
         self.assertEqual(JointMotionPlanState.IDLE, state["status"])
 
+    def test_joint_plan_runs_abort_check_outside_state_lock(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+
+        def abort_check():
+            acquired = threading.Event()
+
+            def acquire_state_lock():
+                with plan._state_lock:
+                    acquired.set()
+
+            contender = threading.Thread(target=acquire_state_lock, daemon=True)
+            contender.start()
+            self.assertTrue(acquired.wait(0.2), "abort_check ran under planner state lock")
+            contender.join(timeout=0.2)
+            return "motion_state_changed:test"
+
+        with self.assertRaisesRegex(RuntimeError, "motion_state_changed:test"):
+            plan.wait_for_request(7, 0.5, threading.Event(), abort_check=abort_check)
+
     def test_joint_override_force_path_and_release(self):
         plugin = self.device.JointOverridePlugin(CONFIG, "robot", self.ros, self.state)
         plugin.start()

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1014,9 +1014,14 @@ class DevicePluginContractTests(unittest.TestCase):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
         swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        completions = []
+        swing._acp_notify = lambda action_id, status, result: completions.append(
+            (action_id, status, result)
+        )
         self.state._current_motion = "lower_body_balance"
         result = swing.dispatch("start_swing", {"amplitude_deg": 6, "frequency_hz": 0.5})
         self.assertEqual("running", result["state"])
+        self.assertTrue(result["action_id"].startswith("t800_arm_swing_"))
         time.sleep(0.06)
         halted = swing.dispatch("halt", {})
         self.assertEqual("idle", halted["state"])
@@ -1024,6 +1029,8 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual("joint_plan", halted["control_backend"])
         self.assertEqual([13, 16, 18, 21], plan._publisher.messages[0].joint_indices)
         self.assertEqual(plan._request_type.REQUEST_CANCEL, plan._publisher.messages[-1].request_type)
+        self.assertEqual(result["action_id"], completions[0][0])
+        self.assertEqual("cancelled", completions[0][1])
 
     def test_arm_swing_gates_state_and_parameters(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
@@ -1033,6 +1040,9 @@ class DevicePluginContractTests(unittest.TestCase):
         self.state._current_motion = "lower_body_balance"
         self.assertIn("between 2 and 30", swing.dispatch("start_swing", {"amplitude_deg": 31})["error"])
         actions = swing.get_tool()["inputSchema"]["properties"]["action"]["enum"]
+        completion = swing.get_tool()["inputSchema"]["x-completion"]
+        self.assertEqual(["start_swing"], completion["actions"])
+        self.assertGreater(completion["timeout"], 3)
         self.assertTrue({"start", "info", "stop"}.issubset(actions))
         self.assertNotIn("set_parameters", actions)
         self.assertIn("return_neutral", actions)
@@ -1045,6 +1055,7 @@ class DevicePluginContractTests(unittest.TestCase):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
         swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        swing._acp_notify = lambda *_args: None
         self.state._current_motion = "lower_body_balance"
         result = swing.dispatch("return_neutral", {"duration": 2.0})
         self.assertEqual("requested", result["state"])
@@ -1058,8 +1069,12 @@ class DevicePluginContractTests(unittest.TestCase):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
         swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        completions = []
+        swing._acp_notify = lambda action_id, status, result: completions.append(
+            (action_id, status, result)
+        )
         self.state._current_motion = "lower_body_balance"
-        swing.dispatch("start_swing", {})
+        started = swing.dispatch("start_swing", {})
         deadline = time.monotonic() + 1.0
         while not plan._publisher.messages and time.monotonic() < deadline:
             time.sleep(0.01)
@@ -1072,6 +1087,9 @@ class DevicePluginContractTests(unittest.TestCase):
         cancels = [msg for msg in plan._publisher.messages
                    if msg.request_type == plan._request_type.REQUEST_CANCEL]
         self.assertTrue(any(msg.request_id == request_id for msg in cancels))
+        self.assertEqual(started["action_id"], completions[0][0])
+        self.assertEqual("cancelled", completions[0][1])
+        self.assertIn("motion_state_changed", completions[0][2]["reason"])
 
     def test_arm_swing_halt_cancels_request_published_before_id_storage(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
@@ -1089,6 +1107,7 @@ class DevicePluginContractTests(unittest.TestCase):
 
         plan.dispatch = delayed_dispatch
         swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        swing._acp_notify = lambda *_args: None
         self.state._current_motion = "lower_body_balance"
         swing.dispatch("start_swing", {})
         self.assertTrue(published.wait(timeout=1.0))
@@ -1108,6 +1127,43 @@ class DevicePluginContractTests(unittest.TestCase):
         cancels = [msg for msg in plan._publisher.messages
                    if msg.request_type == plan._request_type.REQUEST_CANCEL]
         self.assertTrue(any(msg.request_id == request_id for msg in cancels))
+
+    def test_arm_swing_concurrent_start_creates_one_worker(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        swing._acp_notify = lambda *_args: None
+        self.state._current_motion = "lower_body_balance"
+        original_current_motion = self.state.current_motion
+        entered_gate = threading.Event()
+        release_gate = threading.Event()
+
+        def delayed_current_motion():
+            if not entered_gate.is_set():
+                entered_gate.set()
+                release_gate.wait(timeout=1.0)
+            return original_current_motion()
+
+        self.state.current_motion = delayed_current_motion
+        results = []
+        first = threading.Thread(target=lambda: results.append(swing.dispatch("start_swing", {})))
+        second = threading.Thread(target=lambda: results.append(swing.dispatch("start_swing", {})))
+        first.start()
+        self.assertTrue(entered_gate.wait(timeout=1.0))
+        second.start()
+        time.sleep(0.02)
+        release_gate.set()
+        first.join(timeout=1.0)
+        second.join(timeout=1.0)
+        deadline = time.monotonic() + 1.0
+        while not plan._publisher.messages and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertEqual(2, len(results))
+        self.assertEqual(1, len({result["action_id"] for result in results}))
+        execute_requests = [msg for msg in plan._publisher.messages
+                            if msg.request_type == plan._request_type.REQUEST_PLAN_EXECUTE]
+        self.assertEqual(1, len(execute_requests))
+        swing.dispatch("halt", {})
 
     def test_joint_bridge_force_path_and_damping_stop(self):
         plugin = self.device.JointBridgePlugin(CONFIG, "robot", self.ros, self.state)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1054,6 +1054,16 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual("ready", swing.dispatch("info", {})["state"])
         self.assertEqual("idle", swing.dispatch("stop", {})["state"])
 
+    def test_arm_swing_rejects_invalid_neutral_return_duration(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        self.state._current_motion = "lower_body_balance"
+        for duration in (0.01, 100, float("inf"), float("nan")):
+            result = swing.dispatch("return_neutral", {"duration": duration})
+            self.assertIn("duration must be finite", result["error"])
+        self.assertEqual([], plan._publisher.messages)
+
     def test_arm_swing_return_neutral_uses_joint_plan(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
@@ -1152,18 +1162,18 @@ class DevicePluginContractTests(unittest.TestCase):
     def test_arm_swing_halt_cancels_request_published_before_id_storage(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
-        original_dispatch = plan.dispatch
+        original_dispatch_owned = plan.dispatch_owned
         published = threading.Event()
         allow_return = threading.Event()
 
-        def delayed_dispatch(action, args):
-            result = original_dispatch(action, args)
+        def delayed_dispatch_owned(owner, action, args):
+            result = original_dispatch_owned(owner, action, args)
             if action == "plan":
                 published.set()
                 allow_return.wait(timeout=1.0)
             return result
 
-        plan.dispatch = delayed_dispatch
+        plan.dispatch_owned = delayed_dispatch_owned
         swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
         swing._notify_completion = lambda *_args: None
         self.state._current_motion = "lower_body_balance"
@@ -1248,6 +1258,19 @@ class DevicePluginContractTests(unittest.TestCase):
         gesture.dispatch("stop_gesture", {})
         gesture._thread.join(timeout=1.0)
         self.assertIsNone(plan.owner())
+
+    def test_joint_plan_rejects_forged_owner_from_public_dispatch(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        self.assertTrue(plan.acquire("arm_swing"))
+        for action, args in (
+            ("head_pose", {"pitch_rad": 0.0, "yaw_rad": 0.0}),
+            ("reset", {}),
+            ("cancel", {"request_id": 12}),
+        ):
+            result = plan.dispatch(action, {**args, "_owner": "arm_swing"})
+            self.assertIn("reserved for internal driver use", result["error"])
+        self.assertEqual([], plan._publisher.messages)
 
     def test_gesture_rejects_start_while_arm_swing_owns_planner(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1015,7 +1015,7 @@ class DevicePluginContractTests(unittest.TestCase):
         plan.start()
         swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
         completions = []
-        swing._acp_notify = lambda action_id, status, result: completions.append(
+        swing._notify_completion = lambda action_id, status, result: completions.append(
             (action_id, status, result)
         )
         self.state._current_motion = "lower_body_balance"
@@ -1041,7 +1041,10 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertIn("between 2 and 30", swing.dispatch("start_swing", {"amplitude_deg": 31})["error"])
         actions = swing.get_tool()["inputSchema"]["properties"]["action"]["enum"]
         completion = swing.get_tool()["inputSchema"]["x-completion"]
-        self.assertEqual(["start_swing"], completion["actions"])
+        self.assertEqual(
+            ["start_swing", "return_neutral", "halt_and_return"],
+            completion["actions"],
+        )
         self.assertGreater(completion["timeout"], 3)
         self.assertTrue({"start", "info", "stop"}.issubset(actions))
         self.assertNotIn("set_parameters", actions)
@@ -1055,22 +1058,77 @@ class DevicePluginContractTests(unittest.TestCase):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
         swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
-        swing._acp_notify = lambda *_args: None
+        completions = []
+        swing._notify_completion = lambda action_id, status, result: completions.append(
+            (action_id, status, result)
+        )
         self.state._current_motion = "lower_body_balance"
         result = swing.dispatch("return_neutral", {"duration": 2.0})
-        self.assertEqual("requested", result["state"])
+        self.assertEqual("running", result["state"])
         self.assertEqual("neutral", result["target"])
-        message = plan._publisher.messages[-1]
+        deadline = time.monotonic() + 1.0
+        while not plan._publisher.messages and time.monotonic() < deadline:
+            time.sleep(0.01)
+        message = plan._publisher.messages[0]
         self.assertEqual([13, 16, 18, 21], message.joint_indices)
         self.assertEqual(list(swing._BASE), message.target_positions)
         self.assertEqual(2.0, message.execution_time)
+        plan._on_state(JointMotionPlanState(
+            message.request_id, JointMotionPlanState.EXECUTING, 0.5,
+        ))
+        plan._on_state(JointMotionPlanState(
+            message.request_id, JointMotionPlanState.IDLE, 1.0,
+        ))
+        swing._thread.join(timeout=1.0)
+        self.assertEqual(result["action_id"], completions[0][0])
+        self.assertEqual("completed", completions[0][1])
+
+    def test_arm_swing_stop_cancels_monitored_neutral_return(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        completions = []
+        swing._notify_completion = lambda action_id, status, result: completions.append(
+            (action_id, status, result)
+        )
+        self.state._current_motion = "lower_body_balance"
+        started = swing.dispatch("halt_and_return", {"duration": 5.0})
+        deadline = time.monotonic() + 1.0
+        while not plan._publisher.messages and time.monotonic() < deadline:
+            time.sleep(0.01)
+        request_id = plan._publisher.messages[0].request_id
+        stopped = swing.dispatch("stop", {})
+        self.assertEqual("idle", stopped["state"])
+        cancels = [msg for msg in plan._publisher.messages
+                   if msg.request_type == plan._request_type.REQUEST_CANCEL]
+        self.assertTrue(any(msg.request_id == request_id for msg in cancels))
+        self.assertEqual(started["action_id"], completions[0][0])
+        self.assertEqual("cancelled", completions[0][1])
+
+    def test_arm_swing_motion_exit_cancels_monitored_neutral_return(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
+        swing._notify_completion = lambda *_args: None
+        self.state._current_motion = "lower_body_balance"
+        swing.dispatch("return_neutral", {"duration": 5.0})
+        deadline = time.monotonic() + 1.0
+        while not plan._publisher.messages and time.monotonic() < deadline:
+            time.sleep(0.01)
+        request_id = plan._publisher.messages[0].request_id
+        self.state._current_motion = "rl_basic"
+        swing._thread.join(timeout=1.0)
+        cancels = [msg for msg in plan._publisher.messages
+                   if msg.request_type == plan._request_type.REQUEST_CANCEL]
+        self.assertTrue(any(msg.request_id == request_id for msg in cancels))
+        self.assertIn("motion_state_changed", swing.dispatch("status", {})["reason"])
 
     def test_arm_swing_cancels_when_motion_state_changes(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
         swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
         completions = []
-        swing._acp_notify = lambda action_id, status, result: completions.append(
+        swing._notify_completion = lambda action_id, status, result: completions.append(
             (action_id, status, result)
         )
         self.state._current_motion = "lower_body_balance"
@@ -1107,7 +1165,7 @@ class DevicePluginContractTests(unittest.TestCase):
 
         plan.dispatch = delayed_dispatch
         swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
-        swing._acp_notify = lambda *_args: None
+        swing._notify_completion = lambda *_args: None
         self.state._current_motion = "lower_body_balance"
         swing.dispatch("start_swing", {})
         self.assertTrue(published.wait(timeout=1.0))
@@ -1132,7 +1190,7 @@ class DevicePluginContractTests(unittest.TestCase):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
         swing = self.device.ArmSwingPlugin(CONFIG, plan, self.state)
-        swing._acp_notify = lambda *_args: None
+        swing._notify_completion = lambda *_args: None
         self.state._current_motion = "lower_body_balance"
         original_current_motion = self.state.current_motion
         entered_gate = threading.Event()


### PR DESCRIPTION
## Summary
- add an `arm_swing` actuator card for bounded alternating arm motion in `lower_body_balance`
- execute each swing step through the proven `joint_plan` request/state path
- support 2-30 degree amplitude, runtime updates via repeated `start_swing`, `halt`, `return_neutral`, `halt_and_return`, and `status`
- cancel the active planner request on halt or motion-state exit
- register the card with T800 safety controls and document its behavior

## Validation
- `docker run --rm --network none -v /private/tmp/phanthymotus-t800-arm-swing/engineai/t800:/src:ro -w /src --entrypoint python3 engineai-t800:arm-swing-joint-plan-test -m unittest discover -s tests -p "test_*.py"`
- 82 tests passed
- ARM64 image built and deployed to T800 application host
- Driver health: 24/24 plugins, 44/44 tools, no startup errors, restart count 0
- MCP schema verified on-device: actions and amplitude maximum 30
- final physical swing behavior remains to be confirmed by the on-site operator

## Safety
- requires `lower_body_balance`
- URDF joint limits are validated before planner publication
- `halt` cancels the current request and leaves the current pose
- neutral return is explicit and uses a bounded-duration `joint_plan` request