### PR TITLE
feat(t800): add conservative waist control

### DIFF
--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -38,6 +38,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_plan` | actuator | 索引/名称关节轨迹、头部/单臂姿态、当前位置保持、取消、复位和预置动作 |
 | `joint_plan_state` | sensor | 规划 request id、状态和进度 |
 | `gesture` | actuator | 官方完整挥手/握手多步序列及任意自定义关节动作队列 |
+| `waist` | actuator | J12 腰部绝对偏航控制、回正和状态查询；卡片限制为 ±30° |
 | `joint_override` | actuator | 指定关节 100 Hz 覆盖控制 |
 | `joint_bridge` | actuator | 全 25 关节最高 500 Hz 底层控制 |
 | `led` | actuator | 众擎协议定义的 11 种灯效 |

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -67,6 +67,9 @@ MCP schema 中隐藏。
 后者保留为兼容接口，只发送单个目标姿势。`gesture.sequence` 可提交任意多步
 关节动作队列。
 
+`waist.set_angle` 和 `waist.center` 通过 ACP 跟踪对应的 planner request 直到完成；
+`waist.stop` 会取消活动 request，并已接入 `safety` 的 emergency/idle 停止链路。
+
 `virtual_gamepad` 使用 Native SDK 官方通道
 `virtual_gamepad/gamepad_keys`，默认连接 `udpm://239.255.76.67:7667?ttl=1`。
 除了原始按键/摇杆外，提供 idle、passive、stand、walk、dance、get_up、

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -78,6 +78,10 @@ plugins:
     enabled: true
   gesture:
     enabled: true
+  waist:
+    enabled: true
+    max_abs_angle_deg: 30.0
+    default_duration: 1.5
   joint_override:
     enabled: true
   joint_bridge:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2433,6 +2433,41 @@ class JointPlanPlugin:
                     raise TimeoutError(f"joint planner did not complete request {target}")
                 self._state_changed.wait(timeout=min(remaining, 0.2))
 
+    def wait_for_terminal_request(
+        self,
+        request_id: int,
+        timeout: float,
+        cancel_event: threading.Event,
+    ) -> dict:
+        """Wait for an exact request's terminal IDLE state.
+
+        Unlike gesture sequencing, bounded one-shot actions do not require an
+        observed EXECUTING sample. The planner-state subscription is best
+        effort, so a matching terminal IDLE is authoritative even when the
+        intermediate EXECUTING sample was dropped.
+        """
+        if self._state_type is None:
+            raise RuntimeError("joint planner is not started")
+        target = int(request_id)
+        deadline = time.monotonic() + float(timeout)
+        idle = int(self._state_type.IDLE)
+        with self._state_changed:
+            while True:
+                if cancel_event.is_set():
+                    raise RuntimeError(f"joint planner request {target} cancelled")
+                state = dict(self._last_state)
+                current_id = state.get("request_id")
+                status = int(state.get("status", -1))
+                if current_id is not None and int(current_id) == target and status == idle:
+                    self._executing_requests.discard(target)
+                    return state
+                if current_id is not None and int(current_id) > target:
+                    raise RuntimeError(f"joint planner request {target} was superseded")
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(f"joint planner did not complete request {target}")
+                self._state_changed.wait(timeout=min(remaining, 0.2))
+
     def _next_request_id(self) -> int:
         with self._state_lock:
             self._request_id += 1
@@ -2582,16 +2617,32 @@ class WaistPlugin:
             motion, available = self._joint_plan.current_motion()
             positions = self._joint_plan.joint_positions()
             angle_rad = positions[self._JOINT_INDEX] if positions is not None else None
-            return {
+            with self._lock:
+                active = (
+                    self._thread is not None
+                    and self._thread.is_alive()
+                    and self._action_id is not None
+                )
+                action_id = self._action_id
+                request_id = self._request_id
+            status = {
                 **self._metadata(),
-                "state": "ready" if motion == self._REQUIRED_MOTION else "unavailable",
+                "state": (
+                    "running" if active
+                    else "ready" if motion == self._REQUIRED_MOTION
+                    else "unavailable"
+                ),
                 "current_motion": motion,
                 "available_transition_motions": available,
                 "angle_rad": angle_rad,
                 "angle_deg": math.degrees(angle_rad) if angle_rad is not None else None,
             }
+            if active:
+                status["action_id"] = action_id
+                status["request_id"] = request_id
+            return status
         if action not in ("set_angle", "center"):
-            return {"error": f"unknown waist action: {action}"}
+            return None
 
         with self._command_lock:
             return self._start_motion(action, args)
@@ -2661,7 +2712,7 @@ class WaistPlugin:
         status = "completed"
         error = ""
         try:
-            self._joint_plan.wait_for_request(
+            self._joint_plan.wait_for_terminal_request(
                 request_id,
                 duration + self._WAIT_MARGIN_SEC,
                 self._cancel,

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2546,6 +2546,10 @@ class WaistPlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("start", "info"):
+            return {**self._metadata(), "state": "ready"}
+        if action == "stop":
+            return {"state": "idle"}
         if action == "list":
             return self._metadata()
         if action == "status":

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2497,10 +2497,26 @@ class WaistPlugin:
     _JOINT_INDEX = T800_JOINT_INDEX["J12_TORSO_YAW"]
     _JOINT_NAME = "J12_TORSO_YAW"
     _REQUIRED_MOTION = "lower_body_balance"
+    _MAX_DURATION_SEC = 5.0
+    _WAIT_MARGIN_SEC = 3.0
+    _ACP_CALLBACK_TIMEOUT_SEC = 5.0
+    _ACP_SAFETY_MARGIN_SEC = 2.0
+    _ACP_TIMEOUT_SEC = (
+        _MAX_DURATION_SEC
+        + _WAIT_MARGIN_SEC
+        + _ACP_CALLBACK_TIMEOUT_SEC
+        + _ACP_SAFETY_MARGIN_SEC
+    )
 
     def __init__(self, config: dict, joint_plan: JointPlanPlugin):
         waist_config = config.get("plugins", {}).get("waist", {})
         self._joint_plan = joint_plan
+        self._lock = threading.RLock()
+        self._command_lock = threading.Lock()
+        self._cancel = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._request_id: int | None = None
+        self._action_id: str | None = None
         self._max_abs_angle_deg = float(waist_config.get("max_abs_angle_deg", 30.0))
         self._default_duration = float(waist_config.get("default_duration", 1.5))
         if not math.isfinite(self._max_abs_angle_deg) or not 0 < self._max_abs_angle_deg <= 30.0:
@@ -2509,7 +2525,7 @@ class WaistPlugin:
             raise ValueError("waist.default_duration must be between 0.5 and 5 seconds")
 
     def get_tool(self) -> dict:
-        return {
+        tool = {
             "name": "waist",
             "type": "actuator",
             "multiInstance": False,
@@ -2538,18 +2554,28 @@ class WaistPlugin:
                 "腰部控制动作",
             ),
         }
+        tool["inputSchema"]["x-completion"] = {
+            "actions": ["set_angle", "center"],
+            "timeout": int(self._ACP_TIMEOUT_SEC),
+        }
+        tool["inputSchema"]["x-hooks"] = {
+            "on_interrupt_motion": {"action": "stop"},
+            "on_interrupt_all": {"action": "stop"},
+        }
+        return tool
 
     def start(self) -> None:
         pass
 
-    def stop(self) -> None:
-        pass
+    def stop(self) -> dict:
+        with self._command_lock:
+            return self._stop_motion()
 
     def dispatch(self, action: str, args: dict) -> dict:
         if action in ("start", "info"):
             return {**self._metadata(), "state": "ready"}
         if action == "stop":
-            return {"state": "idle"}
+            return self.stop()
         if action == "list":
             return self._metadata()
         if action == "status":
@@ -2567,6 +2593,10 @@ class WaistPlugin:
         if action not in ("set_angle", "center"):
             return {"error": f"unknown waist action: {action}"}
 
+        with self._command_lock:
+            return self._start_motion(action, args)
+
+    def _start_motion(self, action: str, args: dict) -> dict:
         motion, available = self._joint_plan.current_motion()
         if motion != self._REQUIRED_MOTION:
             return {
@@ -2579,24 +2609,99 @@ class WaistPlugin:
         if abs(angle_deg) > self._max_abs_angle_deg:
             return {"error": f"angle_deg must be between {-self._max_abs_angle_deg:g} and {self._max_abs_angle_deg:g}"}
         duration = self._finite_number(args.get("duration", self._default_duration), "duration")
-        if not 0.5 <= duration <= 5.0:
+        if not 0.5 <= duration <= self._MAX_DURATION_SEC:
             return {"error": "duration must be between 0.5 and 5 seconds"}
 
         angle_rad = math.radians(angle_deg)
-        result = self._joint_plan.dispatch("plan", {
-            "joint_indices": [self._JOINT_INDEX],
-            "target_positions": [angle_rad],
-            "duration": duration,
-            "gravity_compensation": True,
-        })
+        with self._lock:
+            if self._thread is not None and self._thread.is_alive():
+                return {"error": "another waist action is already running"}
+            result = self._joint_plan.dispatch("plan", {
+                "joint_indices": [self._JOINT_INDEX],
+                "target_positions": [angle_rad],
+                "duration": duration,
+                "gravity_compensation": True,
+            })
+            if "error" in result:
+                return result
+            from uuid import uuid4
+
+            request_id = int(result["request_id"])
+            action_id = f"t800_waist_{uuid4().hex[:12]}"
+            self._cancel = threading.Event()
+            self._request_id = request_id
+            self._action_id = action_id
+            self._thread = threading.Thread(
+                target=self._monitor_motion,
+                args=(action_id, request_id, action, angle_deg, angle_rad, duration),
+                daemon=True,
+                name="t800-waist-motion",
+            )
+            self._thread.start()
         return {
             **result,
+            "state": "running",
+            "action_id": action_id,
             "joint_index": self._JOINT_INDEX,
             "joint_name": self._JOINT_NAME,
             "target_angle_deg": angle_deg,
             "target_angle_rad": angle_rad,
             "duration": duration,
         }
+
+    def _monitor_motion(
+        self,
+        action_id: str,
+        request_id: int,
+        action: str,
+        angle_deg: float,
+        angle_rad: float,
+        duration: float,
+    ) -> None:
+        status = "completed"
+        error = ""
+        try:
+            self._joint_plan.wait_for_request(
+                request_id,
+                duration + self._WAIT_MARGIN_SEC,
+                self._cancel,
+            )
+        except Exception as exc:
+            status = "cancelled" if self._cancel.is_set() else "error"
+            error = "" if status == "cancelled" else str(exc)
+            if status == "error":
+                self._joint_plan.dispatch("cancel", {"request_id": request_id})
+        finally:
+            with self._lock:
+                if self._action_id == action_id:
+                    self._request_id = None
+                    self._action_id = None
+            self._notify_completion(action_id, status, {
+                "action": action,
+                "request_id": request_id,
+                "target_angle_deg": angle_deg,
+                "target_angle_rad": angle_rad,
+                "duration": duration,
+                "error": error,
+            })
+
+    def _stop_motion(self) -> dict:
+        with self._lock:
+            self._cancel.set()
+            request_id = self._request_id
+            thread = self._thread
+        if request_id is not None:
+            self._joint_plan.dispatch("cancel", {"request_id": request_id})
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=1.0)
+        result = {"state": "idle"}
+        if request_id is not None:
+            result["request_id"] = request_id
+        return result
+
+    @staticmethod
+    def _notify_completion(action_id: str, status: str, result: dict) -> None:
+        GesturePlugin._acp_notify(action_id, status, result, tool="waist")
 
     def _metadata(self) -> dict:
         return {
@@ -3001,7 +3106,7 @@ class GesturePlugin:
         return result
 
     @staticmethod
-    def _acp_notify(action_id: str, status: str, result: dict) -> None:
+    def _acp_notify(action_id: str, status: str, result: dict, tool: str = "gesture") -> None:
         """Report asynchronous gesture completion to Agent Core."""
         import json as _json
         import os as _os
@@ -3025,7 +3130,7 @@ class GesturePlugin:
                 "action_id": action_id,
                 "status": status,
                 "result": result,
-                "tool": "gesture",
+                "tool": tool,
                 "ts": time.time(),
             }).encode()
             request = _urllib.Request(
@@ -3040,7 +3145,7 @@ class GesturePlugin:
                 context=context,
             )
         except Exception as exc:
-            print(f"[gesture] ACP callback failed for {action_id}: {exc}", flush=True)
+            print(f"[{tool}] ACP callback failed for {action_id}: {exc}", flush=True)
 
 
 class _JointStreamBase:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2360,6 +2360,11 @@ class JointPlanPlugin:
             return "", []
         return self._state.current_motion()
 
+    def joint_positions(self) -> list[float] | None:
+        if self._state is None:
+            return None
+        return self._state.joint_positions()
+
     def wait_until_idle(
         self,
         timeout: float,
@@ -2484,6 +2489,130 @@ class JointPlanPlugin:
                 self._executing_requests.add(int(msg.request_id))
             self._state_changed.notify_all()
         self._core_pub.publish(_json_message(payload))
+
+
+class WaistPlugin:
+    """Conservative absolute-yaw facade for the T800 torso joint."""
+
+    _JOINT_INDEX = T800_JOINT_INDEX["J12_TORSO_YAW"]
+    _JOINT_NAME = "J12_TORSO_YAW"
+    _REQUIRED_MOTION = "lower_body_balance"
+
+    def __init__(self, config: dict, joint_plan: JointPlanPlugin):
+        waist_config = config.get("plugins", {}).get("waist", {})
+        self._joint_plan = joint_plan
+        self._max_abs_angle_deg = float(waist_config.get("max_abs_angle_deg", 30.0))
+        self._default_duration = float(waist_config.get("default_duration", 1.5))
+        if not math.isfinite(self._max_abs_angle_deg) or not 0 < self._max_abs_angle_deg <= 30.0:
+            raise ValueError("waist.max_abs_angle_deg must be between 0 and 30")
+        if not math.isfinite(self._default_duration) or not 0.5 <= self._default_duration <= 5.0:
+            raise ValueError("waist.default_duration must be between 0.5 and 5 seconds")
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "waist",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "安全控制 T800 腰部 J12 偏航；使用绝对角度并限制在正负 30 度内",
+            "inputSchema": action_schema(
+                {
+                    "set_angle": (["angle_deg", "duration"], "设置腰部绝对偏航角度"),
+                    "center": (["duration"], "将腰部回正到 0 度"),
+                    "status": ([], "读取当前腰部角度和运动状态"),
+                    "list": ([], "查看控制范围、关节和状态要求"),
+                },
+                {
+                    "angle_deg": {
+                        "type": "number",
+                        "minimum": -self._max_abs_angle_deg,
+                        "maximum": self._max_abs_angle_deg,
+                        "description": "J12 绝对目标角度；正负方向以机器人坐标系为准",
+                    },
+                    "duration": {
+                        "type": "number",
+                        "minimum": 0.5,
+                        "maximum": 5.0,
+                        "description": "执行时间，秒；默认 1.5",
+                    },
+                },
+                "腰部控制动作",
+            ),
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action == "list":
+            return self._metadata()
+        if action == "status":
+            motion, available = self._joint_plan.current_motion()
+            positions = self._joint_plan.joint_positions()
+            angle_rad = positions[self._JOINT_INDEX] if positions is not None else None
+            return {
+                **self._metadata(),
+                "state": "ready" if motion == self._REQUIRED_MOTION else "unavailable",
+                "current_motion": motion,
+                "available_transition_motions": available,
+                "angle_rad": angle_rad,
+                "angle_deg": math.degrees(angle_rad) if angle_rad is not None else None,
+            }
+        if action not in ("set_angle", "center"):
+            return {"error": f"unknown waist action: {action}"}
+
+        motion, available = self._joint_plan.current_motion()
+        if motion != self._REQUIRED_MOTION:
+            return {
+                "error": f"waist requires motion state '{self._REQUIRED_MOTION}' (current: {motion or 'unknown'})",
+                "current_motion": motion,
+                "available_transition_motions": available,
+            }
+
+        angle_deg = 0.0 if action == "center" else self._finite_number(args.get("angle_deg"), "angle_deg")
+        if abs(angle_deg) > self._max_abs_angle_deg:
+            return {"error": f"angle_deg must be between {-self._max_abs_angle_deg:g} and {self._max_abs_angle_deg:g}"}
+        duration = self._finite_number(args.get("duration", self._default_duration), "duration")
+        if not 0.5 <= duration <= 5.0:
+            return {"error": "duration must be between 0.5 and 5 seconds"}
+
+        angle_rad = math.radians(angle_deg)
+        result = self._joint_plan.dispatch("plan", {
+            "joint_indices": [self._JOINT_INDEX],
+            "target_positions": [angle_rad],
+            "duration": duration,
+            "gravity_compensation": True,
+        })
+        return {
+            **result,
+            "joint_index": self._JOINT_INDEX,
+            "joint_name": self._JOINT_NAME,
+            "target_angle_deg": angle_deg,
+            "target_angle_rad": angle_rad,
+            "duration": duration,
+        }
+
+    def _metadata(self) -> dict:
+        return {
+            "joint_index": self._JOINT_INDEX,
+            "joint_name": self._JOINT_NAME,
+            "control_mode": "absolute",
+            "min_angle_deg": -self._max_abs_angle_deg,
+            "max_angle_deg": self._max_abs_angle_deg,
+            "required_motion_state": self._REQUIRED_MOTION,
+            "default_duration": self._default_duration,
+        }
+
+    @staticmethod
+    def _finite_number(value, name: str) -> float:
+        if isinstance(value, bool) or not isinstance(value, numbers.Real):
+            raise ValueError(f"{name} must be a finite number")
+        converted = float(value)
+        if not math.isfinite(converted):
+            raise ValueError(f"{name} must be a finite number")
+        return converted
 
 
 class GesturePlugin:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2566,12 +2566,12 @@ class WaistPlugin:
             "multiInstance": False,
             "description": "安全控制 T800 腰部 J12 偏航；使用绝对角度并限制在正负 30 度内",
             "inputSchema": action_schema(
-                {
+                _with_lifecycle({
                     "set_angle": (["angle_deg", "duration"], "设置腰部绝对偏航角度"),
                     "center": (["duration"], "将腰部回正到 0 度"),
                     "status": ([], "读取当前腰部角度和运动状态"),
                     "list": ([], "查看控制范围、关节和状态要求"),
-                },
+                }),
                 {
                     "angle_deg": {
                         "type": "number",

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2227,6 +2227,9 @@ class JointPlanPlugin:
         self._last_state = {"state": "no_data"}
         self._executing_requests: set[int] = set()
         self._request_id = 0
+        self._pending_request_id: int | None = None
+        self._owner_lock = threading.Lock()
+        self._owner: str | None = None
         self._state_type = None
         self._state = state
         self._core_topic = f"/{namespace}/state/joint_plan"
@@ -2290,6 +2293,14 @@ class JointPlanPlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict:
+        if "_owner" in args:
+            return {"error": "_owner is reserved for internal driver use"}
+        return self._dispatch(action, args, owner=None)
+
+    def dispatch_owned(self, owner: str, action: str, args: dict) -> dict:
+        return self._dispatch(action, args, owner=owner)
+
+    def _dispatch(self, action: str, args: dict, *, owner: str | None) -> dict:
         if action == "start":
             return {"state": "running" if args.get("_tool_name") == "joint_plan_state" else "ready"}
         if action in ("info", "status", "joint_plan_state"):
@@ -2300,10 +2311,21 @@ class JointPlanPlugin:
             return snapshot
         if action == "stop":
             return {"state": "idle"}
-        if action == "reset":
-            return self._publish_request("reset", {})
+        # Cancellation remains an owner-independent safety/operator path.
         if action == "cancel":
             return self._publish_request("cancel", args)
+        with self._owner_lock:
+            active_owner = self._owner
+            if owner is not None and active_owner != owner:
+                return {"error": f"joint planner is owned by {active_owner or 'nobody'}"}
+            if owner is None and active_owner is not None:
+                return {"error": f"joint planner is owned by {active_owner}"}
+            return self._dispatch_exclusive(action, args)
+
+    def _dispatch_exclusive(self, action: str, args: dict) -> dict:
+        """Allocate and publish while the planner ownership lock is held."""
+        if action == "reset":
+            return self._publish_request("reset", {})
         if action == "preset":
             preset = self._PRESETS.get(str(args.get("preset", "")))
             if preset is None:
@@ -2354,6 +2376,29 @@ class JointPlanPlugin:
         if action == "plan":
             return self._publish_request("plan", args)
         return {"error": f"unknown joint plan action: {action}"}
+
+    def acquire(self, owner: str) -> bool:
+        with self._owner_lock:
+            if self._owner == owner:
+                return True
+            if self._owner is not None:
+                return False
+            with self._state_lock:
+                if self._pending_request_id is not None:
+                    return False
+            self._owner = owner
+            return True
+
+    def release(self, owner: str) -> bool:
+        with self._owner_lock:
+            if self._owner != owner:
+                return False
+            self._owner = None
+            return True
+
+    def owner(self) -> str | None:
+        with self._owner_lock:
+            return self._owner
 
     def current_motion(self) -> tuple[str, list[str]]:
         if self._state is None:
@@ -2508,6 +2553,12 @@ class JointPlanPlugin:
             msg.stiffness = []
             msg.damping = []
         self._publisher.publish(msg)
+        with self._state_lock:
+            if action == "cancel":
+                if self._pending_request_id == int(msg.request_id):
+                    self._pending_request_id = None
+            else:
+                self._pending_request_id = int(msg.request_id)
         return {"state": "requested", "request_id": msg.request_id, "request_type": int(msg.request_type)}
 
     def _on_state(self, msg) -> None:
@@ -2522,6 +2573,12 @@ class JointPlanPlugin:
             self._last_state = payload
             if self._state_type is not None and int(msg.status) == int(self._state_type.EXECUTING):
                 self._executing_requests.add(int(msg.request_id))
+            if (
+                self._state_type is not None
+                and int(msg.status) == int(self._state_type.IDLE)
+                and self._pending_request_id == int(msg.request_id)
+            ):
+                self._pending_request_id = None
             self._state_changed.notify_all()
         self._core_pub.publish(_json_message(payload))
 
@@ -2667,13 +2724,17 @@ class WaistPlugin:
         with self._lock:
             if self._thread is not None and self._thread.is_alive():
                 return {"error": "another waist action is already running"}
-            result = self._joint_plan.dispatch("plan", {
+            if not self._joint_plan.acquire("waist"):
+                owner = self._joint_plan.owner()
+                return {"error": f"joint planner is busy{f' (owned by {owner})' if owner else ''}"}
+            result = self._joint_plan.dispatch_owned("waist", "plan", {
                 "joint_indices": [self._JOINT_INDEX],
                 "target_positions": [angle_rad],
                 "duration": duration,
                 "gravity_compensation": True,
             })
             if "error" in result:
+                self._joint_plan.release("waist")
                 return result
             from uuid import uuid4
 
@@ -2721,12 +2782,13 @@ class WaistPlugin:
             status = "cancelled" if self._cancel.is_set() else "error"
             error = "" if status == "cancelled" else str(exc)
             if status == "error":
-                self._joint_plan.dispatch("cancel", {"request_id": request_id})
+                self._joint_plan.dispatch_owned("waist", "cancel", {"request_id": request_id})
         finally:
             with self._lock:
                 if self._action_id == action_id:
                     self._request_id = None
                     self._action_id = None
+            self._joint_plan.release("waist")
             self._notify_completion(action_id, status, {
                 "action": action,
                 "request_id": request_id,
@@ -2742,7 +2804,7 @@ class WaistPlugin:
             request_id = self._request_id
             thread = self._thread
         if request_id is not None:
-            self._joint_plan.dispatch("cancel", {"request_id": request_id})
+            self._joint_plan.dispatch_owned("waist", "cancel", {"request_id": request_id})
         if thread is not None and thread is not threading.current_thread():
             thread.join(timeout=1.0)
         result = {"state": "idle"}
@@ -3046,6 +3108,9 @@ class GesturePlugin:
                 current = dict(self._status)
                 current.pop("action_id", None)
                 return {**current, "error": "another gesture sequence is already running"}
+            if not self._joint_plan.acquire("gesture"):
+                owner = self._joint_plan.owner()
+                return {"error": f"joint planner is busy{f' (owned by {owner})' if owner else ''}"}
             from uuid import uuid4
 
             action_id = f"t800_gesture_{uuid4().hex[:12]}"
@@ -3069,7 +3134,7 @@ class GesturePlugin:
                         self._status["step"] = index
                         self._status["step_name"] = step["name"]
                     action = "plan_named" if "joint_names" in step else "plan"
-                    result = self._joint_plan.dispatch(action, step)
+                    result = self._joint_plan.dispatch_owned("gesture", action, step)
                     if "error" in result:
                         raise ValueError(result["error"])
                     request_id = int(result["request_id"])
@@ -3084,7 +3149,7 @@ class GesturePlugin:
                     if hold_after > 0 and self._cancel.wait(hold_after):
                         raise RuntimeError("gesture cancelled")
                 if not self._cancel.is_set() and reset_after:
-                    result = self._joint_plan.dispatch("reset", {})
+                    result = self._joint_plan.dispatch_owned("gesture", "reset", {})
                     if "error" in result:
                         raise ValueError(result["error"])
                     request_id = int(result["request_id"])
@@ -3105,11 +3170,12 @@ class GesturePlugin:
             except Exception as exc:
                 cancelled = self._cancel.is_set()
                 if request_id is not None:
-                    self._joint_plan.dispatch("cancel", {"request_id": request_id})
+                    self._joint_plan.dispatch_owned("gesture", "cancel", {"request_id": request_id})
                 with self._lock:
                     self._status["state"] = "cancelled" if cancelled else "error"
                     self._status["error"] = "" if cancelled else str(exc)
             finally:
+                self._joint_plan.release("gesture")
                 with self._lock:
                     self._last_finished_at = time.monotonic()
                     final_status = str(self._status.get("state", "error"))
@@ -3151,9 +3217,9 @@ class GesturePlugin:
                 request_id = None
             result = dict(self._status)
         if request_id is not None:
-            self._joint_plan.dispatch("cancel", {"request_id": request_id})
+            self._joint_plan.dispatch_owned("gesture", "cancel", {"request_id": request_id})
         if reset_after:
-            self._joint_plan.dispatch("reset", {})
+            self._joint_plan.dispatch_owned("gesture", "reset", {})
         return result
 
     @staticmethod

--- a/engineai/t800/driver.yaml
+++ b/engineai/t800/driver.yaml
@@ -6,6 +6,6 @@ hardware_model: "t800"
 image_name: engineai-t800
 port: 15708
 mcp_url: "http://localhost:15708/mcp"
-description: "EngineAI T800 开发版 — ROS2/Native SDK、全身状态、舞蹈/手势、虚拟手柄、高低层运动、LED 与语音控制"
+description: "EngineAI T800 开发版 — ROS2/Native SDK、全身状态、舞蹈/手势/腰部、虚拟手柄、高低层运动、LED 与语音控制"
 build_context_extras:
   - ../../common

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -126,6 +126,7 @@ class T800DeviceBundle:
             StatePlugin,
             TtsPlugin,
             VisionPlugin,
+            WaistPlugin,
         )
         from virtual_gamepad import VirtualGamepadPlugin
 
@@ -183,6 +184,11 @@ class T800DeviceBundle:
         if plugins.get("gesture", {}).get("enabled", True) and "joint_plan" in instances:
             instance = GesturePlugin(instances["joint_plan"])
             instances["gesture"] = instance
+            self._plugins.append(instance)
+
+        if plugins.get("waist", {}).get("enabled", True) and "joint_plan" in instances:
+            instance = WaistPlugin(config, instances["joint_plan"])
+            instances["waist"] = instance
             self._plugins.append(instance)
 
         virtual_gamepad_config = plugins.get("virtual_gamepad", {})

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -219,7 +219,7 @@ class T800DeviceBundle:
             instances["safety"].set_controls(
                 [
                     instances[key]
-                    for key in ("locomotion", "joint_override", "joint_bridge", "virtual_gamepad", "gesture")
+                    for key in ("locomotion", "joint_override", "joint_bridge", "virtual_gamepad", "gesture", "waist")
                     if key in instances
                 ]
             )

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -682,7 +682,9 @@ class DevicePluginContractTests(unittest.TestCase):
     def test_waist_controls_only_j12_with_conservative_absolute_angle(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
-        plan.wait_for_terminal_request = lambda *_args, **_kwargs: {}
+        plan.wait_for_terminal_request = lambda request_id, *_args, **_kwargs: plan._on_state(
+            JointMotionPlanState(request_id=request_id, status=JointMotionPlanState.IDLE, progress=1.0)
+        )
         waist = self.device.WaistPlugin(CONFIG, plan)
         completions = []
         waist._notify_completion = lambda *args: completions.append(args)
@@ -765,6 +767,104 @@ class DevicePluginContractTests(unittest.TestCase):
         cancels = [msg for msg in plan._publisher.messages
                    if msg.request_type == plan._request_type.REQUEST_CANCEL]
         self.assertTrue(any(msg.request_id == request_id for msg in cancels))
+
+    def test_waist_rejects_while_gesture_owns_shared_planner(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        gate = threading.Event()
+        plan.wait_until_idle = lambda *_args, **_kwargs: gate.wait(timeout=1.0)
+        gesture = self.device.GesturePlugin(plan)
+        gesture._acp_notify = lambda *_args, **_kwargs: None
+        waist = self.device.WaistPlugin(CONFIG, plan)
+        self.state._current_motion = "lower_body_balance"
+
+        started = gesture.dispatch("sequence", {
+            "steps": [{
+                "joint_indices": [23],
+                "target_positions": [0.1],
+                "duration": 0.05,
+            }],
+            "reset_after": False,
+        })
+        self.assertEqual("running", started["state"])
+        self.assertEqual("gesture", plan.owner())
+        blocked = waist.dispatch("set_angle", {"angle_deg": 5.0})
+        self.assertIn("owned by gesture", blocked["error"])
+        self.assertEqual([], plan._publisher.messages)
+
+        gesture.dispatch("stop_gesture", {"reset_after": False})
+        gate.set()
+        gesture._thread.join(timeout=1.0)
+        self.assertFalse(gesture._thread.is_alive())
+        self.assertIsNone(plan.owner())
+
+    def test_waist_loses_race_to_atomic_direct_plan_publication(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        waist = self.device.WaistPlugin(CONFIG, plan)
+        waist._notify_completion = lambda *_args: None
+        self.state._current_motion = "lower_body_balance"
+        original_publish_request = plan._publish_request
+        publication_entered = threading.Event()
+        allow_publication = threading.Event()
+        direct_results = []
+        waist_results = []
+
+        def delayed_publish_request(action, args):
+            if action == "plan" and not publication_entered.is_set():
+                publication_entered.set()
+                allow_publication.wait(timeout=1.0)
+            return original_publish_request(action, args)
+
+        plan._publish_request = delayed_publish_request
+        direct = threading.Thread(target=lambda: direct_results.append(plan.dispatch("plan", {
+            "joint_indices": [23],
+            "target_positions": [0.1],
+            "duration": 1.0,
+        })))
+        competing_waist = threading.Thread(target=lambda: waist_results.append(
+            waist.dispatch("set_angle", {"angle_deg": 5.0})
+        ))
+        direct.start()
+        self.assertTrue(publication_entered.wait(timeout=1.0))
+        competing_waist.start()
+        self.assertTrue(competing_waist.is_alive())
+        allow_publication.set()
+        direct.join(timeout=1.0)
+        competing_waist.join(timeout=1.0)
+
+        self.assertEqual("requested", direct_results[0]["state"])
+        self.assertIn("joint planner is busy", waist_results[0]["error"])
+        execute_requests = [msg for msg in plan._publisher.messages
+                            if msg.request_type == plan._request_type.REQUEST_PLAN_EXECUTE]
+        self.assertEqual(1, len(execute_requests))
+        plan.dispatch("cancel", {"request_id": direct_results[0]["request_id"]})
+
+    def test_waist_owner_blocks_new_public_plans_but_not_public_cancel(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        waist = self.device.WaistPlugin(CONFIG, plan)
+        waist._notify_completion = lambda *_args: None
+        self.state._current_motion = "lower_body_balance"
+        started = waist.dispatch("set_angle", {"angle_deg": 5.0, "duration": 5.0})
+        self.assertEqual("waist", plan.owner())
+
+        blocked = plan.dispatch("plan", {
+            "joint_indices": [23],
+            "target_positions": [0.1],
+            "duration": 1.0,
+        })
+        self.assertIn("owned by waist", blocked["error"])
+        forged = plan.dispatch("reset", {"_owner": "waist"})
+        self.assertIn("reserved", forged["error"])
+        cancelled = plan.dispatch("cancel", {"request_id": started["request_id"]})
+        self.assertEqual("requested", cancelled["state"])
+        self.assertEqual("waist", plan.owner())
+
+        waist.stop()
+        waist._thread.join(timeout=1.0)
+        self.assertFalse(waist._thread.is_alive())
+        self.assertIsNone(plan.owner())
 
     def test_waist_completes_from_matching_idle_when_executing_sample_is_dropped(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -696,6 +696,18 @@ class DevicePluginContractTests(unittest.TestCase):
         waist.dispatch("center", {})
         self.assertEqual([0.0], plan._publisher.messages[-1].target_positions)
 
+    def test_waist_dispatch_handles_actuator_lifecycle_actions(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        waist = self.device.WaistPlugin(CONFIG, plan)
+
+        started = waist.dispatch("start", {})
+        self.assertEqual("ready", started["state"])
+        self.assertEqual("J12_TORSO_YAW", started["joint_name"])
+        self.assertEqual("ready", waist.dispatch("info", {})["state"])
+        self.assertEqual({"state": "idle"}, waist.dispatch("stop", {}))
+        self.assertEqual([], plan._publisher.messages)
+
     def test_waist_rejects_unsafe_state_angle_and_duration(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -718,6 +718,10 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertIsNone(waist.dispatch("unsupported", {}))
         self.assertEqual([], plan._publisher.messages)
         schema = waist.get_tool()["inputSchema"]
+        lifecycle = {"start", "info", "stop"}
+        self.assertTrue(lifecycle.issubset(schema["properties"]["action"]["enum"]))
+        self.assertTrue(lifecycle.issubset(schema["x-action-params"]))
+        self.assertEqual([], schema["x-action-params"]["stop"]["params"])
         self.assertEqual(["set_angle", "center"], schema["x-completion"]["actions"])
         self.assertEqual(15, schema["x-completion"]["timeout"])
         self.assertEqual({"action": "stop"}, schema["x-hooks"]["on_interrupt_all"])

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -682,7 +682,7 @@ class DevicePluginContractTests(unittest.TestCase):
     def test_waist_controls_only_j12_with_conservative_absolute_angle(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
-        plan.wait_for_request = lambda *_args, **_kwargs: {}
+        plan.wait_for_terminal_request = lambda *_args, **_kwargs: {}
         waist = self.device.WaistPlugin(CONFIG, plan)
         completions = []
         waist._notify_completion = lambda *args: completions.append(args)
@@ -715,6 +715,7 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual("J12_TORSO_YAW", started["joint_name"])
         self.assertEqual("ready", waist.dispatch("info", {})["state"])
         self.assertEqual({"state": "idle"}, waist.dispatch("stop", {}))
+        self.assertIsNone(waist.dispatch("unsupported", {}))
         self.assertEqual([], plan._publisher.messages)
         schema = waist.get_tool()["inputSchema"]
         self.assertEqual(["set_angle", "center"], schema["x-completion"]["actions"])
@@ -760,6 +761,38 @@ class DevicePluginContractTests(unittest.TestCase):
         cancels = [msg for msg in plan._publisher.messages
                    if msg.request_type == plan._request_type.REQUEST_CANCEL]
         self.assertTrue(any(msg.request_id == request_id for msg in cancels))
+
+    def test_waist_completes_from_matching_idle_when_executing_sample_is_dropped(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        waist = self.device.WaistPlugin(CONFIG, plan)
+        completions = []
+        waist._notify_completion = lambda *args: completions.append(args)
+        self.state._current_motion = "lower_body_balance"
+
+        started = waist.dispatch("set_angle", {"angle_deg": 5.0, "duration": 1.0})
+        active = waist.dispatch("status", {})
+        self.assertEqual("running", active["state"])
+        self.assertEqual(started["action_id"], active["action_id"])
+        self.assertEqual(started["request_id"], active["request_id"])
+
+        # Deliver only the exact terminal state. No EXECUTING sample is sent.
+        plan._on_state(JointMotionPlanState(
+            request_id=started["request_id"],
+            status=JointMotionPlanState.IDLE,
+            progress=1.0,
+        ))
+        waist._thread.join(timeout=1.0)
+        self.assertFalse(waist._thread.is_alive())
+        self.assertEqual("completed", completions[0][1])
+        self.assertEqual(started["request_id"], completions[0][2]["request_id"])
+        cancels = [msg for msg in plan._publisher.messages
+                   if msg.request_type == plan._request_type.REQUEST_CANCEL]
+        self.assertEqual([], cancels)
+        ready = waist.dispatch("status", {})
+        self.assertEqual("ready", ready["state"])
+        self.assertNotIn("action_id", ready)
+        self.assertNotIn("request_id", ready)
 
     def test_waist_status_reports_current_j12_without_publishing(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -682,18 +682,27 @@ class DevicePluginContractTests(unittest.TestCase):
     def test_waist_controls_only_j12_with_conservative_absolute_angle(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
         plan.start()
+        plan.wait_for_request = lambda *_args, **_kwargs: {}
         waist = self.device.WaistPlugin(CONFIG, plan)
+        completions = []
+        waist._notify_completion = lambda *args: completions.append(args)
         self.state._current_motion = "lower_body_balance"
 
         result = waist.dispatch("set_angle", {"angle_deg": 30, "duration": 2.0})
+        waist._thread.join(timeout=1.0)
         sent = plan._publisher.messages[-1]
-        self.assertEqual("requested", result["state"])
+        self.assertEqual("running", result["state"])
+        self.assertTrue(result["action_id"].startswith("t800_waist_"))
         self.assertEqual([12], sent.joint_indices)
         self.assertAlmostEqual(math.pi / 6, sent.target_positions[0])
         self.assertEqual(2.0, sent.execution_time)
         self.assertTrue(sent.use_gravity_compensation)
+        self.assertEqual(result["action_id"], completions[0][0])
+        self.assertEqual("completed", completions[0][1])
 
-        waist.dispatch("center", {})
+        centered = waist.dispatch("center", {})
+        waist._thread.join(timeout=1.0)
+        self.assertEqual("running", centered["state"])
         self.assertEqual([0.0], plan._publisher.messages[-1].target_positions)
 
     def test_waist_dispatch_handles_actuator_lifecycle_actions(self):
@@ -707,6 +716,10 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual("ready", waist.dispatch("info", {})["state"])
         self.assertEqual({"state": "idle"}, waist.dispatch("stop", {}))
         self.assertEqual([], plan._publisher.messages)
+        schema = waist.get_tool()["inputSchema"]
+        self.assertEqual(["set_angle", "center"], schema["x-completion"]["actions"])
+        self.assertEqual(15, schema["x-completion"]["timeout"])
+        self.assertEqual({"action": "stop"}, schema["x-hooks"]["on_interrupt_all"])
 
     def test_waist_rejects_unsafe_state_angle_and_duration(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
@@ -722,7 +735,31 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertIn("between 0.5 and 5", waist.dispatch("set_angle", {"angle_deg": 0, "duration": 0.1})["error"])
         with self.assertRaisesRegex(ValueError, "finite number"):
             waist.dispatch("set_angle", {"angle_deg": float("nan")})
+        with self.assertRaisesRegex(ValueError, "finite number"):
+            waist.dispatch("set_angle", {"angle_deg": True})
+        with self.assertRaisesRegex(ValueError, "finite number"):
+            waist.dispatch("set_angle", {"angle_deg": 0, "duration": float("nan")})
         self.assertEqual([], plan._publisher.messages)
+
+    def test_safety_emergency_cancels_active_waist_request(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        waist = self.device.WaistPlugin(CONFIG, plan)
+        waist._notify_completion = lambda *_args: None
+        self.state._current_motion = "lower_body_balance"
+        started = waist.dispatch("set_angle", {"angle_deg": 5.0, "duration": 5.0})
+        request_id = started["request_id"]
+
+        safety = self.device.SafetyControlPlugin(CONFIG, "robot", self.ros, self.state)
+        safety.set_controls([waist])
+        safety.start()
+        result = safety.dispatch("emergency_passive", {})
+        self.assertIn("WaistPlugin", result["stopped_streams"])
+        waist._thread.join(timeout=1.0)
+        self.assertFalse(waist._thread.is_alive())
+        cancels = [msg for msg in plan._publisher.messages
+                   if msg.request_type == plan._request_type.REQUEST_CANCEL]
+        self.assertTrue(any(msg.request_id == request_id for msg in cancels))
 
     def test_waist_status_reports_current_j12_without_publishing(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import math
 import os
 import ssl
 import struct
@@ -245,6 +246,7 @@ class DevicePluginContractTests(unittest.TestCase):
             self.device.DancePlugin(motion_mode, self.state),
             joint_plan,
             self.device.GesturePlugin(joint_plan),
+            self.device.WaistPlugin(CONFIG, joint_plan),
             self.device.JointOverridePlugin(CONFIG, "robot", self.ros, self.state),
             self.device.JointBridgePlugin(CONFIG, "robot", self.ros, self.state),
             self.device.LedPlugin(CONFIG, "robot", self.ros),
@@ -273,14 +275,14 @@ class DevicePluginContractTests(unittest.TestCase):
              "robot_snapshot", "fault_summary", "stability", "joint_groups", "capabilities", "ros_graph",
              "mainboard", "heartbeat_status", "motion_command_trace", "motion_events",
              "native_interface_probe",
-             "loco", "motion_mode", "dance", "joint_plan", "joint_plan_state", "gesture",
+             "loco", "motion_mode", "dance", "joint_plan", "joint_plan_state", "gesture", "waist",
              "joint_override", "joint_bridge",
              "led", "tts", "mic", "pointcloud", "camera", "depth",
              "motor_power", "native_node_control", "virtual_gamepad", "safety", "native_sdk"},
             names,
         )
-        self.assertEqual(41, len(names))
-        self.assertEqual(41, len(definitions), "tool names must be unique")
+        self.assertEqual(42, len(names))
+        self.assertEqual(42, len(definitions), "tool names must be unique")
         for tool in definitions:
             schema = tool.get("inputSchema")
             self.assertEqual("object", schema.get("type"), tool["name"])
@@ -676,6 +678,53 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual([13, 14, 15, 16, 17], plugin._publisher.messages[-1].joint_indices)
         plugin.dispatch("hold_current", {})
         self.assertEqual(list(range(25)), plugin._publisher.messages[-1].joint_indices)
+
+    def test_waist_controls_only_j12_with_conservative_absolute_angle(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        waist = self.device.WaistPlugin(CONFIG, plan)
+        self.state._current_motion = "lower_body_balance"
+
+        result = waist.dispatch("set_angle", {"angle_deg": 30, "duration": 2.0})
+        sent = plan._publisher.messages[-1]
+        self.assertEqual("requested", result["state"])
+        self.assertEqual([12], sent.joint_indices)
+        self.assertAlmostEqual(math.pi / 6, sent.target_positions[0])
+        self.assertEqual(2.0, sent.execution_time)
+        self.assertTrue(sent.use_gravity_compensation)
+
+        waist.dispatch("center", {})
+        self.assertEqual([0.0], plan._publisher.messages[-1].target_positions)
+
+    def test_waist_rejects_unsafe_state_angle_and_duration(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        waist = self.device.WaistPlugin(CONFIG, plan)
+
+        blocked = waist.dispatch("set_angle", {"angle_deg": 10})
+        self.assertIn("lower_body_balance", blocked["error"])
+        self.assertEqual([], plan._publisher.messages)
+
+        self.state._current_motion = "lower_body_balance"
+        self.assertIn("between -30 and 30", waist.dispatch("set_angle", {"angle_deg": 31})["error"])
+        self.assertIn("between 0.5 and 5", waist.dispatch("set_angle", {"angle_deg": 0, "duration": 0.1})["error"])
+        with self.assertRaisesRegex(ValueError, "finite number"):
+            waist.dispatch("set_angle", {"angle_deg": float("nan")})
+        self.assertEqual([], plan._publisher.messages)
+
+    def test_waist_status_reports_current_j12_without_publishing(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        waist = self.device.WaistPlugin(CONFIG, plan)
+        self.state._current_motion = "lower_body_balance"
+        self.state._last_joint_positions[12] = 0.25
+
+        status = waist.dispatch("status", {})
+        self.assertEqual("ready", status["state"])
+        self.assertEqual("J12_TORSO_YAW", status["joint_name"])
+        self.assertAlmostEqual(0.25, status["angle_rad"])
+        self.assertAlmostEqual(math.degrees(0.25), status["angle_deg"])
+        self.assertEqual([], plan._publisher.messages)
 
     def test_gesture_exposes_complete_official_sequences_and_custom_queue(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)


### PR DESCRIPTION
## Summary
- add a dedicated waist actuator for absolute J12 torso-yaw control
- gate commands on lower_body_balance and cap targets to +/-30 degrees
- expose lifecycle/status metadata and reject non-finite or out-of-range inputs
- implement bounded ACP completion for set_angle/center
- tolerate a dropped best-effort EXECUTING sample by accepting the exact request's terminal IDLE state
- cancel active waist planner requests from stop and the managed safety path
- register the card in configuration and T800 catalog metadata

## Validation
- T800 device contract suite: 48 tests passed
- ACP schema, unique action IDs, exact terminal request monitoring, and terminal completion are covered
- regression test completes from matching IDLE without an EXECUTING sample and verifies no spurious cancel
- active status reports action_id/request_id and returns to ready after completion
- active waist command followed by emergency_passive cancels the matching planner request
- lifecycle and unknown-action None contracts are covered
- invalid NaN duration and boolean angle inputs are covered
- git diff --check passed
- 2026-08-26: commit `1ea3701` was built as `engineai-t800:waist-1ea3701` on the T800 host and its waist card test was reported passing by the operator
- fixes through `485e47f` are code-tested but require a new image build before they are present on that host

## Safety boundary
- controls only J12_TORSO_YAW through the existing joint planner
- requires `lower_body_balance`, rejects non-finite/out-of-range targets, and limits absolute yaw to +/-30 degrees
- set_angle/center use a 15-second ACP fallback derived from the 5-second maximum motion plus wait/callback margins
- stop and safety emergency/idle cancel the active waist planner request
- the driver.yaml change only advertises the capability and does not alter Dockerfile, build context, or image contents
- hardware validation is limited to the operator-confirmed deployment/test above; no broader motion or endurance validation is claimed
