### PR TITLE
feat(t800): add upper body action presets

### DIFF
--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -38,6 +38,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_plan` | actuator | 索引/名称关节轨迹、头部/单臂姿态、当前位置保持、取消、复位和预置动作 |
 | `joint_plan_state` | sensor | 规划 request id、状态和进度 |
 | `gesture` | actuator | 官方完整挥手/握手多步序列及任意自定义关节动作队列 |
+| `upper_body_actions` | actuator | Driver 预设的指向、防守和热身上肢动作（非官方动作资源） |
 | `joint_override` | actuator | 指定关节 100 Hz 覆盖控制 |
 | `joint_bridge` | actuator | 全 25 关节最高 500 Hz 底层控制 |
 | `led` | actuator | 众擎协议定义的 11 种灯效 |
@@ -65,6 +66,9 @@ MCP schema 中隐藏。
 动作（挥手包含准备、举手、5 次摆动和复位；握手包含伸手、收手和复位），
 后者保留为兼容接口，只发送单个目标姿势。`gesture.sequence` 可提交任意多步
 关节动作队列。
+
+`upper_body_actions` 的异步动作通过 ACP 报告完成；`on_interrupt_motion` 和
+`on_interrupt_all` 系统 hook 会绕过 ACP barrier 直接执行 `halt`。
 
 `virtual_gamepad` 使用 Native SDK 官方通道
 `virtual_gamepad/gamepad_keys`，默认连接 `udpm://239.255.76.67:7667?ttl=1`。

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -38,7 +38,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_plan` | actuator | 索引/名称关节轨迹、头部/单臂姿态、当前位置保持、取消、复位和预置动作 |
 | `joint_plan_state` | sensor | 规划 request id、状态和进度 |
 | `gesture` | actuator | 官方完整挥手/握手多步序列及任意自定义关节动作队列 |
-| `upper_body_actions` | actuator | Driver 预设的指向、防守和热身上肢动作（非官方动作资源） |
+| `upper_body_actions` | actuator | Driver 预设的指向、近脸防守和举臂动作（非官方动作资源） |
 | `joint_override` | actuator | 指定关节 100 Hz 覆盖控制 |
 | `joint_bridge` | actuator | 全 25 关节最高 500 Hz 底层控制 |
 | `led` | actuator | 众擎协议定义的 11 种灯效 |

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -78,6 +78,8 @@ plugins:
     enabled: true
   gesture:
     enabled: true
+  upper_body_actions:
+    enabled: true
   joint_override:
     enabled: true
   joint_bridge:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2937,10 +2937,10 @@ class UpperBodyActionsPlugin:
             "left": [-0.47, -0.255, -0.161, -0.731, -0.028, 0.024, -0.081, 0.001, -0.069, 0.0],
             "right": [0.028, 0.084, -0.001, -0.066, 0.0, -0.47, 0.255, 0.161, -0.731, 0.028],
         },
-        "guard": [-0.35, 0.22, -0.15, -1.05, 0.0, -0.35, -0.22, 0.15, -1.05, 0.0],
-        "chest_open": [0.05, 0.75, 0.0, -0.25, 0.0, 0.05, -0.75, 0.0, -0.25, 0.0],
+        # Raise both upper arms and deepen the elbow bend so the hands sit
+        # closer to the face instead of hanging in front of the torso.
+        "guard": [-0.75, 0.18, -0.10, -1.35, 0.0, -0.75, -0.18, 0.10, -1.35, 0.0],
         "arm_raise": [-1.0, 0.18, 0.0, -0.2, 0.0, -1.0, -0.18, 0.0, -0.2, 0.0],
-        "side_reach": [0.0, 1.0, 0.0, -0.15, 0.0, 0.0, -1.0, 0.0, -0.15, 0.0],
     }
 
     def __init__(self, gesture: GesturePlugin):
@@ -2973,7 +2973,7 @@ class UpperBodyActionsPlugin:
             "name": "upper_body_actions",
             "type": "actuator",
             "multiInstance": False,
-            "description": "T800 Driver 预设的指向、防守和热身动作；非官方动作资源",
+            "description": "T800 Driver 预设的指向、近脸防守和举臂动作；非官方动作资源",
             "inputSchema": schema,
         }
 

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -2751,7 +2751,15 @@ class GesturePlugin:
                 f"ACP completion timeout {self._ACP_TIMEOUT_SEC:.0f}s"
             )
 
-    def _start_sequence(self, label: str, steps: list[dict], *, reset_after: bool) -> dict:
+    def _start_sequence(
+        self,
+        label: str,
+        steps: list[dict],
+        *,
+        reset_after: bool,
+        tool_name: str = "gesture",
+        action_id_prefix: str = "t800_gesture",
+    ) -> dict:
         with self._lock:
             if self._thread is not None and self._thread.is_alive():
                 current = dict(self._status)
@@ -2759,7 +2767,7 @@ class GesturePlugin:
                 return {**current, "error": "another gesture sequence is already running"}
             from uuid import uuid4
 
-            action_id = f"t800_gesture_{uuid4().hex[:12]}"
+            action_id = f"{action_id_prefix}_{uuid4().hex[:12]}"
             self._cancel = threading.Event()
             self._status = {
                 "state": "running", "gesture": label, "step": 0,
@@ -2833,7 +2841,10 @@ class GesturePlugin:
                         "error": self._status.get("error"),
                     }
                 if action_id is not None:
-                    self._acp_notify(action_id, final_status, final_result)
+                    if tool_name == "gesture":
+                        self._acp_notify(action_id, final_status, final_result)
+                    else:
+                        self._acp_notify(action_id, final_status, final_result, tool_name=tool_name)
 
         thread = threading.Thread(target=run, daemon=True, name="t800-gesture-sequence")
         with self._lock:
@@ -2868,7 +2879,13 @@ class GesturePlugin:
         return result
 
     @staticmethod
-    def _acp_notify(action_id: str, status: str, result: dict) -> None:
+    def _acp_notify(
+        action_id: str,
+        status: str,
+        result: dict,
+        *,
+        tool_name: str = "gesture",
+    ) -> None:
         """Report asynchronous gesture completion to Agent Core."""
         import json as _json
         import os as _os
@@ -2892,7 +2909,7 @@ class GesturePlugin:
                 "action_id": action_id,
                 "status": status,
                 "result": result,
-                "tool": "gesture",
+                "tool": tool_name,
                 "ts": time.time(),
             }).encode()
             request = _urllib.Request(
@@ -2908,6 +2925,134 @@ class GesturePlugin:
             )
         except Exception as exc:
             print(f"[gesture] ACP callback failed for {action_id}: {exc}", flush=True)
+
+
+class UpperBodyActionsPlugin:
+    """Driver-defined semantic upper-body poses executed by the joint planner."""
+
+    _INDICES = list(T800_JOINT_GROUPS["arms"])
+    _NEUTRAL = [0.028, 0.084, -0.001, -0.066, 0.0, 0.024, -0.081, 0.001, -0.069, 0.0]
+    _POSES = {
+        "point_forward": {
+            "left": [-0.47, -0.255, -0.161, -0.731, -0.028, 0.024, -0.081, 0.001, -0.069, 0.0],
+            "right": [0.028, 0.084, -0.001, -0.066, 0.0, -0.47, 0.255, 0.161, -0.731, 0.028],
+        },
+        "guard": [-0.35, 0.22, -0.15, -1.05, 0.0, -0.35, -0.22, 0.15, -1.05, 0.0],
+        "chest_open": [0.05, 0.75, 0.0, -0.25, 0.0, 0.05, -0.75, 0.0, -0.25, 0.0],
+        "arm_raise": [-1.0, 0.18, 0.0, -0.2, 0.0, -1.0, -0.18, 0.0, -0.2, 0.0],
+        "side_reach": [0.0, 1.0, 0.0, -0.15, 0.0, 0.0, -1.0, 0.0, -0.15, 0.0],
+    }
+
+    def __init__(self, gesture: GesturePlugin):
+        self._gesture = gesture
+
+    def get_tool(self) -> dict:
+        schema = action_schema(
+            {
+                "play": (["name", "side", "duration", "hold_sec", "return_neutral"], "执行 Driver 预设上肢动作"),
+                "return_neutral": (["duration"], "双臂回到自然姿态"),
+                "halt": ([], "请求取消当前规划；实际响应取决于固件 planner"),
+                "status": ([], "查询当前动作与规划步骤"),
+                "list": ([], "列出 Driver 预设动作及验证状态"),
+            },
+            {
+                "name": {"type": "string", "enum": list(self._POSES)},
+                "side": {"type": "string", "enum": ["left", "right"], "description": "point_forward 使用；默认 right"},
+                "duration": {"type": "number", "minimum": 0.8, "maximum": 4.0, "description": "到达姿态时间，默认 1.5 秒"},
+                "hold_sec": {"type": "number", "minimum": 0.0, "maximum": 5.0, "description": "保持时间，默认 0.5 秒"},
+                "return_neutral": {"type": "boolean", "description": "动作后回自然姿态，默认 true"},
+            },
+            "语义化上肢动作",
+        )
+        schema["x-completion"] = {"actions": ["play", "return_neutral"], "timeout": 60}
+        schema["x-hooks"] = {
+            "on_interrupt_motion": {"action": "halt"},
+            "on_interrupt_all": {"action": "halt"},
+        }
+        return {
+            "name": "upper_body_actions",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "T800 Driver 预设的指向、防守和热身动作；非官方动作资源",
+            "inputSchema": schema,
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        self._gesture._stop(reset_after=False)
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action == "list":
+            return {
+                "state": "ready",
+                "actions": [{"name": name, "source": "driver_preset", "hardware_validated": False} for name in self._POSES],
+                "required_motion_state": "lower_body_balance",
+            }
+        if action == "status":
+            status = self._gesture.dispatch("status", {})
+            return {**status, "tool": "upper_body_actions"}
+        if action == "halt":
+            return {**self._gesture._stop(reset_after=False), "cancel_is_best_effort": True}
+        if action not in ("play", "return_neutral"):
+            return {"error": f"unknown upper body action: {action}"}
+
+        motion, _ = self._gesture._joint_plan.current_motion()
+        if motion != "lower_body_balance":
+            return {"error": f"upper_body_actions requires lower_body_balance (current: {motion or 'unknown'})"}
+        try:
+            duration = float(args.get("duration", 1.5))
+            hold_sec = float(args.get("hold_sec", 0.5))
+        except (TypeError, ValueError):
+            return {"error": "duration and hold_sec must be numbers"}
+        if not math.isfinite(duration) or not 0.8 <= duration <= 4.0:
+            return {"error": "duration must be between 0.8 and 4 seconds"}
+        if not math.isfinite(hold_sec) or not 0.0 <= hold_sec <= 5.0:
+            return {"error": "hold_sec must be between 0 and 5 seconds"}
+
+        if action == "return_neutral":
+            label = "return_neutral"
+            positions = list(self._NEUTRAL)
+            steps = [self._step(label, positions, duration, 0.0)]
+        else:
+            label = str(args.get("name", ""))
+            pose = self._POSES.get(label)
+            if pose is None:
+                return {"error": f"unknown upper body preset: {label}"}
+            if isinstance(pose, dict):
+                side = str(args.get("side", "right"))
+                if side not in pose:
+                    return {"error": "side must be left or right"}
+                positions = list(pose[side])
+                label = f"{label}_{side}"
+            else:
+                positions = list(pose)
+            steps = [self._step(label, positions, duration, hold_sec)]
+            if bool(args.get("return_neutral", True)):
+                steps.append(self._step("return_neutral", list(self._NEUTRAL), duration, 0.0))
+        try:
+            prepared = self._gesture._prepare_steps(steps)
+            self._gesture._validate_completion_budget(prepared, reset_after=False)
+        except (TypeError, ValueError) as exc:
+            return {"error": str(exc)}
+        return self._gesture._start_sequence(
+            label,
+            prepared,
+            reset_after=False,
+            tool_name="upper_body_actions",
+            action_id_prefix="t800_upper_body",
+        )
+
+    def _step(self, name: str, positions: list[float], duration: float, hold_sec: float) -> dict:
+        return {
+            "name": name,
+            "joint_indices": list(self._INDICES),
+            "target_positions": positions,
+            "duration": duration,
+            "hold_after_sec": hold_sec,
+            "gravity_compensation": True,
+        }
 
 
 class _JointStreamBase:

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -125,6 +125,7 @@ class T800DeviceBundle:
             SafetyControlPlugin,
             StatePlugin,
             TtsPlugin,
+            UpperBodyActionsPlugin,
             VisionPlugin,
         )
         from virtual_gamepad import VirtualGamepadPlugin
@@ -183,6 +184,11 @@ class T800DeviceBundle:
         if plugins.get("gesture", {}).get("enabled", True) and "joint_plan" in instances:
             instance = GesturePlugin(instances["joint_plan"])
             instances["gesture"] = instance
+            self._plugins.append(instance)
+
+        if plugins.get("upper_body_actions", {}).get("enabled", True) and "gesture" in instances:
+            instance = UpperBodyActionsPlugin(instances["gesture"])
+            instances["upper_body_actions"] = instance
             self._plugins.append(instance)
 
         virtual_gamepad_config = plugins.get("virtual_gamepad", {})

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -725,7 +725,17 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual({"action": "halt"}, schema["x-hooks"]["on_interrupt_motion"])
         self.assertEqual({"action": "halt"}, schema["x-hooks"]["on_interrupt_all"])
         listed = plugin.dispatch("list", {})
+        self.assertEqual(
+            {"point_forward", "guard", "arm_raise"},
+            {item["name"] for item in listed["actions"]},
+        )
         self.assertTrue(all(not item["hardware_validated"] for item in listed["actions"]))
+        self.assertEqual(
+            [-0.75, 0.18, -0.10, -1.35, 0.0, -0.75, -0.18, 0.10, -1.35, 0.0],
+            plugin._POSES["guard"],
+        )
+        self.assertNotIn("chest_open", plugin._POSES)
+        self.assertNotIn("side_reach", plugin._POSES)
         self.assertIn("lower_body_balance", plugin.dispatch("play", {"name": "guard"})["error"])
 
     def test_gesture_declares_async_completion_and_lifecycle_actions(self):

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -238,13 +238,15 @@ class DevicePluginContractTests(unittest.TestCase):
 
         motion_mode = self.device.MotionModePlugin(CONFIG, "robot", self.ros, self.state)
         joint_plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros)
+        gesture = self.device.GesturePlugin(joint_plan)
         plugins = [
             self.state,
             self.device.LocomotionPlugin(CONFIG, "robot", self.ros, self.state),
             motion_mode,
             self.device.DancePlugin(motion_mode, self.state),
             joint_plan,
-            self.device.GesturePlugin(joint_plan),
+            gesture,
+            self.device.UpperBodyActionsPlugin(gesture),
             self.device.JointOverridePlugin(CONFIG, "robot", self.ros, self.state),
             self.device.JointBridgePlugin(CONFIG, "robot", self.ros, self.state),
             self.device.LedPlugin(CONFIG, "robot", self.ros),
@@ -273,14 +275,14 @@ class DevicePluginContractTests(unittest.TestCase):
              "robot_snapshot", "fault_summary", "stability", "joint_groups", "capabilities", "ros_graph",
              "mainboard", "heartbeat_status", "motion_command_trace", "motion_events",
              "native_interface_probe",
-             "loco", "motion_mode", "dance", "joint_plan", "joint_plan_state", "gesture",
+             "loco", "motion_mode", "dance", "joint_plan", "joint_plan_state", "gesture", "upper_body_actions",
              "joint_override", "joint_bridge",
              "led", "tts", "mic", "pointcloud", "camera", "depth",
              "motor_power", "native_node_control", "virtual_gamepad", "safety", "native_sdk"},
             names,
         )
-        self.assertEqual(41, len(names))
-        self.assertEqual(41, len(definitions), "tool names must be unique")
+        self.assertEqual(42, len(names))
+        self.assertEqual(42, len(definitions), "tool names must be unique")
         for tool in definitions:
             schema = tool.get("inputSchema")
             self.assertEqual("object", schema.get("type"), tool["name"])
@@ -696,6 +698,35 @@ class DevicePluginContractTests(unittest.TestCase):
         gesture._thread.join(timeout=1.0)
         self.assertEqual("completed", gesture.dispatch("status", {})["state"])
         self.assertEqual([23, 24], plan._publisher.messages[-1].joint_indices)
+
+    def test_upper_body_actions_use_validated_arm_only_sequences(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        plan.start()
+        plan.wait_until_idle = lambda *_args, **_kwargs: {}
+        plan.wait_for_request = lambda *_args, **_kwargs: {}
+        gesture = self.device.GesturePlugin(plan)
+        gesture._acp_notify = lambda *_args, **_kwargs: None
+        plugin = self.device.UpperBodyActionsPlugin(gesture)
+        self.state._current_motion = "lower_body_balance"
+
+        result = plugin.dispatch("play", {"name": "point_forward", "side": "right"})
+        self.assertEqual("running", result["state"])
+        self.assertTrue(result["action_id"].startswith("t800_upper_body_"))
+        gesture._thread.join(timeout=1.0)
+        self.assertEqual([13, 14, 15, 16, 17, 18, 19, 20, 21, 22], plan._publisher.messages[0].joint_indices)
+        self.assertEqual(plugin._NEUTRAL, plan._publisher.messages[-1].target_positions)
+
+    def test_upper_body_actions_gate_state_and_label_unvalidated_presets(self):
+        plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)
+        gesture = self.device.GesturePlugin(plan)
+        plugin = self.device.UpperBodyActionsPlugin(gesture)
+        schema = plugin.get_tool()["inputSchema"]
+        self.assertEqual(["play", "return_neutral"], schema["x-completion"]["actions"])
+        self.assertEqual({"action": "halt"}, schema["x-hooks"]["on_interrupt_motion"])
+        self.assertEqual({"action": "halt"}, schema["x-hooks"]["on_interrupt_all"])
+        listed = plugin.dispatch("list", {})
+        self.assertTrue(all(not item["hardware_validated"] for item in listed["actions"]))
+        self.assertIn("lower_body_balance", plugin.dispatch("play", {"name": "guard"})["error"])
 
     def test_gesture_declares_async_completion_and_lifecycle_actions(self):
         plan = self.device.JointPlanPlugin(CONFIG, "robot", self.ros, self.state)


### PR DESCRIPTION
## Summary
- add driver-defined point-forward, near-face guard, and arm-raise presets
- execute validated arm-only sequences through the existing gesture planner
- gate execution on lower_body_balance and return to a neutral arm pose by default
- expose ACP completion metadata plus barrier-bypassing motion/all interrupt hooks
- remove chest-open and side-reach after operator testing found their physical behavior redundant

## Validation
- T800 device contract suite: 44 tests passed
- pure control and targeted upper-body tests passed
- every remaining target stays within the URDF arm-joint limits
- schema/list regression tests require exactly point_forward, guard, and arm_raise
- git diff --check passed
- operator feedback from the initial hardware test was used to remove the two redundant presets; the revised guard trajectory still requires a new hardware check

## Safety boundary
- presets are explicitly labeled driver_preset and hardware_validated false
- the revised guard raises both shoulders and deepens both elbow bends conservatively to bring the hands closer to the face
- static limits and contracts are validated, but the revised guard pose is not yet claimed as physically validated
