### PR TITLE
Go2：适配导航速度提案与 LiDAR/IMU Driver 卡片

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ python main.py
 4. Tools become available to the LLM agent and appear in the Web Dashboard
 5. The LLM agent can invoke tools via MCP `tools/call`
 
+### Go2 Nav2 Driver Inputs
+
+The Go2 Driver reuses the same lease-bound
+`phanthy.navigation.velocity_proposal.v1` contract on
+`/ubuntu/navigation/nav2/velocity_proposal`. The subscription and execution
+queue are both latest-only. Valid velocities are forwarded to
+`SportClient.Move` in m/s and rad/s; terminal or expired proposals use
+`StopMove` and require a fresh zero `loco/state` sample before the lease is
+released or held for recovery. Direct `loco`, gait, gesture, or acrobatics
+actions revoke Nav2 authority and require a confirmed stop before issuing their
+RPC.
+
+The read-only `navigation_lidar` and `navigation_imu` cards convert Go2's
+native `rt/utlidar/cloud` and `rt/utlidar/imu` DDS streams into the
+same standard `/ubuntu/navigation/lidar` `PointCloud2` and
+`/ubuntu/navigation/imu` `Imu` contracts. Go2 uses the configured identity
+mounting rotation; the isolated worker, source-clock normalization, fail-closed
+readiness checks, and shared card lifecycle match the G1 navigation sensor
+path.
+
 ## Writing a New Driver
 
 Want to add support for new hardware? See the **[Driver Development Guide](README_dev.md)** for the full specification, including:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,11 @@ all covariances. Go2 defaults to the identity rotation because the MID360 cloud
 and IMU axes are parallel and the installed sensor is REP-103 aligned. Per
 REP-145, a stationary upward sensor Z axis reports `+g`; this is not a frame
 inversion. Raw per-point `time` is in seconds and is converted to a strictly
-increasing FLOAT64 absolute nanosecond timestamp. The isolated worker,
+increasing FLOAT64 absolute nanosecond timestamp. Because one Go2 raw DDS
+message is only a partial near-field-heavy packet, the Driver combines two
+consecutive packets, rejects gaps over 120 ms, and removes returns below 0.5 m
+before publishing one navigation scan; `ring` and source `time` remain attached
+to every retained point. The isolated worker,
 source-clock normalization, fail-closed readiness checks, and shared card
 lifecycle match the G1 navigation sensor path. The same worker publishes the
 configured `base_link -> utlidar_lidar` mount through ROS 2's static transform

--- a/README.md
+++ b/README.md
@@ -95,7 +95,11 @@ REP-145, a stationary upward sensor Z axis reports `+g`; this is not a frame
 inversion. Raw per-point `time` is in seconds and is converted to a strictly
 increasing FLOAT64 absolute nanosecond timestamp. The isolated worker,
 source-clock normalization, fail-closed readiness checks, and shared card
-lifecycle match the G1 navigation sensor path.
+lifecycle match the G1 navigation sensor path. The same worker publishes the
+configured `base_link -> utlidar_lidar` mount through ROS 2's static transform
+broadcaster. Go2 defaults to Unitree's [factory `radar_joint` transform](https://github.com/unitreerobotics/unitree_ros/blob/master/robots/go2_description/urdf/go2_description.urdf)
+(`xyz=[0.28945, 0,-0.046825]`, `rpy=[0,2.8782,0]`); missing or invalid
+extrinsics fail worker startup instead of falling back to identity.
 
 ## Writing a New Driver
 

--- a/README.md
+++ b/README.md
@@ -86,10 +86,16 @@ RPC.
 The read-only `navigation_lidar` and `navigation_imu` cards convert Go2's
 native `rt/utlidar/cloud` and `rt/utlidar/imu` DDS streams into the
 same standard `/ubuntu/navigation/lidar` `PointCloud2` and
-`/ubuntu/navigation/imu` `Imu` contracts. Go2 uses the configured identity
-mounting rotation; the isolated worker, source-clock normalization, fail-closed
-readiness checks, and shared card lifecycle match the G1 navigation sensor
-path.
+`/ubuntu/navigation/imu` `Imu` contracts. Both outputs use the same non-empty
+REP-103 `sensor_frame`. The configured device-to-sensor rotation is applied to
+cloud xyz and to IMU orientation, angular velocity, linear acceleration, and
+all covariances. Go2 defaults to the identity rotation because the MID360 cloud
+and IMU axes are parallel and the installed sensor is REP-103 aligned. Per
+REP-145, a stationary upward sensor Z axis reports `+g`; this is not a frame
+inversion. Raw per-point `time` is in seconds and is converted to a strictly
+increasing FLOAT64 absolute nanosecond timestamp. The isolated worker,
+source-clock normalization, fail-closed readiness checks, and shared card
+lifecycle match the G1 navigation sensor path.
 
 ## Writing a New Driver
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -76,8 +76,13 @@ latest-only；合法速度以 m/s 和 rad/s 原样交给 `SportClient.Move`。
 只读 `navigation_lidar` 和 `navigation_imu` 卡片把 Go2 原生
 `rt/utlidar/cloud` 与 `rt/utlidar/imu` DDS 流转换为同样的
 `/ubuntu/navigation/lidar` `PointCloud2` 和 `/ubuntu/navigation/imu` `Imu`
-合同。Go2 使用配置中的单位安装旋转；隔离 worker、源时钟归一化、fail-closed
-就绪检查和两张卡共享生命周期与 G1 导航传感器路径一致。
+合同。两路输出使用同一个非空 REP-103 `sensor_frame`；Driver 将配置的
+设备到传感器旋转同时应用于点云 xyz，以及 IMU 的姿态、角速度、线加速度和
+全部协方差。MID360 点云与 IMU 三轴平行，Go2 安装轴已对齐 REP-103，因此
+默认使用单位旋转。按 REP-145，静止且 Z 轴向上的 IMU 应输出 `+g`，这不是坐标翻转。
+原始逐点 `time` 的单位为秒，Driver 将其转为帧内严格递增的 FLOAT64
+绝对纳秒时间戳。隔离 worker、源时钟归一化、fail-closed 就绪检查和两张卡共享生命周期
+与 G1 导航传感器路径一致。
 
 ## 开发新驱动
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -82,7 +82,10 @@ latest-only；合法速度以 m/s 和 rad/s 原样交给 `SportClient.Move`。
 默认使用单位旋转。按 REP-145，静止且 Z 轴向上的 IMU 应输出 `+g`，这不是坐标翻转。
 原始逐点 `time` 的单位为秒，Driver 将其转为帧内严格递增的 FLOAT64
 绝对纳秒时间戳。隔离 worker、源时钟归一化、fail-closed 就绪检查和两张卡共享生命周期
-与 G1 导航传感器路径一致。
+与 G1 导航传感器路径一致。同一 worker 还通过 ROS 2 静态变换广播器发布配置的
+`base_link -> utlidar_lidar` 安装外参。Go2 默认采用[宇树出厂 `radar_joint` 变换](https://github.com/unitreerobotics/unitree_ros/blob/master/robots/go2_description/urdf/go2_description.urdf)
+（`xyz=[0.28945, 0, -0.046825]`，`rpy=[0, 2.8782, 0]`）；外参缺失或非法时
+worker 启动失败，不使用单位变换兜底。
 
 ## 开发新驱动
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -81,7 +81,9 @@ latest-only；合法速度以 m/s 和 rad/s 原样交给 `SportClient.Move`。
 全部协方差。MID360 点云与 IMU 三轴平行，Go2 安装轴已对齐 REP-103，因此
 默认使用单位旋转。按 REP-145，静止且 Z 轴向上的 IMU 应输出 `+g`，这不是坐标翻转。
 原始逐点 `time` 的单位为秒，Driver 将其转为帧内严格递增的 FLOAT64
-绝对纳秒时间戳。隔离 worker、源时钟归一化、fail-closed 就绪检查和两张卡共享生命周期
+绝对纳秒时间戳。Go2 的单条 raw DDS 消息只是近场点占比很高的部分包，因此 Driver
+默认连续聚合两个包，拒绝间隔超过 120 ms 的跨缺口拼接，并过滤 0.5 m 内本体回波后
+再发布一帧导航点云；所有保留点仍携带原始 `ring` 和 `time`。隔离 worker、源时钟归一化、fail-closed 就绪检查和两张卡共享生命周期
 与 G1 导航传感器路径一致。同一 worker 还通过 ROS 2 静态变换广播器发布配置的
 `base_link -> utlidar_lidar` 安装外参。Go2 默认采用[宇树出厂 `radar_joint` 变换](https://github.com/unitreerobotics/unitree_ros/blob/master/robots/go2_description/urdf/go2_description.urdf)
 （`xyz=[0.28945, 0, -0.046825]`，`rpy=[0, 2.8782, 0]`）；外参缺失或非法时

--- a/README_zh.md
+++ b/README_zh.md
@@ -63,6 +63,22 @@ python main.py
 4. 工具对 LLM Agent 可用，并显示在 Web Dashboard 中
 5. LLM Agent 通过 MCP `tools/call` 调用工具
 
+### Go2 Nav2 Driver 输入
+
+Go2 Driver 复用同一套 lease 约束的
+`phanthy.navigation.velocity_proposal.v1` 合同，固定订阅
+`/ubuntu/navigation/nav2/velocity_proposal`。ROS 订阅和执行队列均为
+latest-only；合法速度以 m/s 和 rad/s 原样交给 `SportClient.Move`。
+终态或 TTL 超时调用 `StopMove`，并用调用后新的零速 `loco/state` 样本确认
+停车后才释放任务或保留可恢复 lease。直接调用 loco、步态、动作或特技时，
+会先撤销 Nav2 控制权，并在确认停车后才执行对应 RPC。
+
+只读 `navigation_lidar` 和 `navigation_imu` 卡片把 Go2 原生
+`rt/utlidar/cloud` 与 `rt/utlidar/imu` DDS 流转换为同样的
+`/ubuntu/navigation/lidar` `PointCloud2` 和 `/ubuntu/navigation/imu` `Imu`
+合同。Go2 使用配置中的单位安装旋转；隔离 worker、源时钟归一化、fail-closed
+就绪检查和两张卡共享生命周期与 G1 导航传感器路径一致。
+
 ## 开发新驱动
 
 想要为新硬件添加驱动？请参阅 **[驱动开发指南](README_dev.md)** 获取完整规范，包括：

--- a/unitree/go2/Dockerfile
+++ b/unitree/go2/Dockerfile
@@ -1,11 +1,20 @@
 ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base:latest
-ARG PYPI_MIRROR=https://pypi.org/simple/
+ARG UBUNTU_PORTS_MIRROR=https://mirrors.aliyun.com/ubuntu-ports
+ARG PYPI_MIRROR=https://mirrors.aliyun.com/pypi/simple/
 FROM ${ROS_BASE_IMAGE}
+ARG UBUNTU_PORTS_MIRROR
 ARG PYPI_MIRROR
 
 WORKDIR /work
 
-RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
+RUN find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) \
+        -exec sed -i \
+            -e "s|http://mirrors.tencentyun.com/ubuntu-ports|${UBUNTU_PORTS_MIRROR}|g" \
+            -e "s|https://mirrors.tencentyun.com/ubuntu-ports|${UBUNTU_PORTS_MIRROR}|g" \
+            -e "s|http://ports.ubuntu.com/ubuntu-ports|${UBUNTU_PORTS_MIRROR}|g" \
+            -e "s|https://ports.ubuntu.com/ubuntu-ports|${UBUNTU_PORTS_MIRROR}|g" \
+            {} + && \
+    apt-get -o Acquire::AllowInsecureRepositories=true update && \
     apt-get install -y --no-install-recommends --allow-unauthenticated \
         python3-pip \
         python3-colcon-common-extensions \
@@ -72,6 +81,12 @@ COPY global_registration.py /work/global_registration.py
 COPY ext_devices.py /work/ext_devices.py
 COPY lidar.py /work/lidar.py
 COPY pointcloud_utils.py /work/pointcloud_utils.py
+COPY velocity_proposal.py /work/velocity_proposal.py
+COPY proposal_controller.py /work/proposal_controller.py
+COPY navigation_pointcloud.py /work/navigation_pointcloud.py
+COPY navigation_time.py /work/navigation_time.py
+COPY navigation_sensor_bridge.py /work/navigation_sensor_bridge.py
+COPY navigation_sensor_bridge_main.py /work/navigation_sensor_bridge_main.py
 COPY config.yaml /work/config.yaml
 COPY deploy/     /deploy/
 

--- a/unitree/go2/config.yaml
+++ b/unitree/go2/config.yaml
@@ -11,6 +11,16 @@ plugins:
     enabled: true
   loco:
     enabled: true
+    velocity_proposal_topic: /ubuntu/navigation/nav2/velocity_proposal
+    velocity_proposal_max_ttl_ms: 250
+    velocity_proposal_min_x: -1.0
+    velocity_proposal_max_x: 1.0
+    velocity_proposal_max_abs_y: 1.0
+    velocity_proposal_max_abs_yaw: 2.0
+    velocity_proposal_max_planar_speed: 1.4142135623730951
+    velocity_proposal_stop_confirm_timeout: 1.0
+    velocity_proposal_stop_linear_epsilon: 0.04
+    velocity_proposal_stop_yaw_epsilon: 0.08
   obstacles_avoid:
     enabled: true
   camera:
@@ -24,6 +34,19 @@ plugins:
     enabled: true
   lidar:
     enabled: true
+  navigation_sensors:
+    enabled: true
+    raw_cloud_topic: rt/utlidar/cloud
+    raw_imu_topic: rt/utlidar/imu
+    cloud_topic: /ubuntu/navigation/lidar
+    imu_topic: /ubuntu/navigation/imu
+    lidar_frame: utlidar_lidar
+    imu_frame: utlidar_imu
+    sensor_rotation_matrix: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+    clock_warmup_samples: 32
+    clock_window_samples: 400
+    clock_reset_threshold_ms: 1000
+    clock_reset_confirm_samples: 8
   controlled_spatial:
     enabled: false
     native_slam_pcd_dir: /home/unitree/maps

--- a/unitree/go2/config.yaml
+++ b/unitree/go2/config.yaml
@@ -40,9 +40,8 @@ plugins:
     raw_imu_topic: rt/utlidar/imu
     cloud_topic: /ubuntu/navigation/lidar
     imu_topic: /ubuntu/navigation/imu
-    lidar_frame: utlidar_lidar
-    imu_frame: utlidar_imu
-    sensor_rotation_matrix: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+    sensor_frame: utlidar_lidar
+    device_to_sensor_rotation_matrix: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
     clock_warmup_samples: 32
     clock_window_samples: 400
     clock_reset_threshold_ms: 1000

--- a/unitree/go2/config.yaml
+++ b/unitree/go2/config.yaml
@@ -40,7 +40,11 @@ plugins:
     raw_imu_topic: rt/utlidar/imu
     cloud_topic: /ubuntu/navigation/lidar
     imu_topic: /ubuntu/navigation/imu
+    base_frame: base_link
     sensor_frame: utlidar_lidar
+    # Unitree Go2 radar_joint factory mount, expressed as base_link -> sensor.
+    base_to_sensor_translation_m: [0.28945, 0.0, -0.046825]
+    base_to_sensor_rotation_rpy_rad: [0.0, 2.8782, 0.0]
     device_to_sensor_rotation_matrix: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
     clock_warmup_samples: 32
     clock_window_samples: 400

--- a/unitree/go2/config.yaml
+++ b/unitree/go2/config.yaml
@@ -46,6 +46,9 @@ plugins:
     base_to_sensor_translation_m: [0.28945, 0.0, -0.046825]
     base_to_sensor_rotation_rpy_rad: [0.0, 2.8782, 0.0]
     device_to_sensor_rotation_matrix: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+    cloud_packets_per_scan: 2
+    cloud_min_range_m: 0.5
+    cloud_max_packet_gap_ms: 120
     clock_warmup_samples: 32
     clock_window_samples: 400
     clock_reset_threshold_ms: 1000

--- a/unitree/go2/device.py
+++ b/unitree/go2/device.py
@@ -37,6 +37,13 @@ from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPo
 from std_msgs.msg import String
 from audio_msgs.msg import AudioChunk
 
+from proposal_controller import Go2VelocityProposalController
+from velocity_proposal import (
+    resolve_input_topic,
+    resolve_optional_expected_nav_id,
+    velocity_proposal_port,
+)
+
 # ── 常量 ──────────────────────────────────────────────────────────────────────
 
 MIC_GROUP_IP = "239.168.123.161"
@@ -543,11 +550,18 @@ _GO2_STATE_CODES = {
 class LocoPlugin:
     """Go2 locomotion control via SportClient RPC — exposes 4 tools."""
     PREFIX = "loco"
+    STOP_PRIORITY = 0
 
     def __init__(self, plugin_config: dict, namespace: str, executor, rpc_proxy):
         self._proxy = rpc_proxy
+        self._executor = executor
         self._continuous_move_lock = threading.Lock()
         self._continuous_move_stop: threading.Event | None = None
+        self._proposal = Go2VelocityProposalController(
+            plugin_config, namespace, rpc_proxy
+        )
+        executor.add_node(self._proposal)
+        self._closed = False
 
     def get_tools(self) -> list:
         return [self._loco_tool(), self._switch_gait_tool(), self._gesture_tool(), self._acrobatics_tool()]
@@ -594,6 +608,7 @@ class LocoPlugin:
                     "auto_recovery_get": {"params": [],                       "description": "Query auto-recovery status"},
                 },
             },
+            "topic_in": [velocity_proposal_port(self._proposal.topic)],
         }
 
     def _switch_gait_tool(self) -> dict:
@@ -694,11 +709,49 @@ class LocoPlugin:
         }
 
     def start(self) -> None:
+        # Driver startup remains disarmed. Canvas start owns the subscription.
         pass
 
     def stop(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
         self._stop_continuous_move()
-        self._proxy.StopMove()
+        self._proposal.close()
+        try:
+            self._executor.remove_node(self._proposal)
+            self._proposal.destroy_node()
+        except Exception:
+            pass
+
+    def _connect_velocity_proposal(self, args: dict) -> dict:
+        try:
+            topic = resolve_input_topic(args, self._proposal.topic)
+            expected_nav_id = resolve_optional_expected_nav_id(args)
+        except ValueError as exc:
+            self._proxy.StopMove()
+            return {
+                "state": "error",
+                "connected": False,
+                "error": str(exc),
+                "topic_in": [velocity_proposal_port(self._proposal.topic)],
+            }
+        result = self._proposal.connect(topic, expected_nav_id)
+        connected = bool(
+            result.get("connected")
+            and (result.get("armed") or result.get("awaiting_nav_id"))
+        )
+        return {
+            **result,
+            "state": "ready" if connected else "error",
+            "topic_in": [velocity_proposal_port(self._proposal.topic)],
+        }
+
+    def _disconnect_velocity_proposal(self, reason: str) -> dict:
+        return {
+            "topic_in": [velocity_proposal_port(self._proposal.topic)],
+            **self._proposal.disconnect(reason),
+        }
 
     def _stop_continuous_move(self) -> bool:
         with self._continuous_move_lock:
@@ -735,10 +788,26 @@ class LocoPlugin:
         return {"ret": 0, "status": "running", "vx": vx, "vy": vy, "vyaw": vyaw_dps, "duration": -1}
 
     def dispatch(self, action: str, args: dict) -> dict | None:
+        tool_name = args.get("_tool_name", "loco")
         if action == "start":
+            if tool_name == "loco":
+                return self._connect_velocity_proposal(args)
             return {"state": "ready"}
         if action == "stop":
+            if tool_name == "loco":
+                return self._disconnect_velocity_proposal("canvas_stop")
             return {"state": "idle"}
+        if action == "info":
+            if tool_name != "loco":
+                return {"state": "ready"}
+            return {
+                "topic_in": [velocity_proposal_port(self._proposal.topic)],
+                **self._proposal.status(),
+            }
+
+        # Direct locomotion/gait/gesture actions take authority away from Nav2.
+        if not self._proposal.manual_override():
+            return {"ret": -1, "error": "manual_override_stop_unconfirmed"}
 
         # ── loco tool actions ──
         if action == "move":

--- a/unitree/go2/device.py
+++ b/unitree/go2/device.py
@@ -482,6 +482,8 @@ class _LocoStateNode(Node):
             imu = msg.imu_state
             data = {
                 "mode": int(msg.error_code) if hasattr(msg, 'error_code') else 0,
+                "sport_mode": int(msg.mode),
+                "gait_type": int(msg.gait_type),
                 "position": [round(float(p), 4) for p in msg.position],
                 "velocity": [round(float(v), 4) for v in msg.velocity],
                 "body_height": round(float(msg.body_height), 4),

--- a/unitree/go2/main.py
+++ b/unitree/go2/main.py
@@ -112,6 +112,18 @@ class Go2DeviceBundle:
             self._plugins.append(LidarPlugin(plugins_cfg["lidar"], namespace, executor))
             print("[bundle] LidarPlugin loaded")
 
+        if plugins_cfg.get("navigation_sensors", {}).get("enabled", False):
+            from navigation_sensor_bridge import NavigationSensorPlugin
+            self._plugins.append(
+                NavigationSensorPlugin(
+                    plugins_cfg["navigation_sensors"],
+                    namespace,
+                    executor,
+                    network_iface=network_iface,
+                )
+            )
+            print("[bundle] NavigationSensorPlugin loaded")
+
         if plugins_cfg.get("controlled_spatial", {}).get("enabled", False):
             from controlled_spatial import ControlledSpatialPlugin
             controlled_cfg = dict(plugins_cfg["controlled_spatial"])
@@ -152,7 +164,9 @@ class Go2DeviceBundle:
         print(f"[bundle] All {len(self._plugins)} plugins started", flush=True)
 
     def stop_all(self) -> None:
-        for p in self._plugins:
+        for p in sorted(
+            self._plugins, key=lambda plugin: getattr(plugin, "STOP_PRIORITY", 100)
+        ):
             p.stop()
         print("[bundle] All plugins stopped")
 

--- a/unitree/go2/navigation_pointcloud.py
+++ b/unitree/go2/navigation_pointcloud.py
@@ -1,0 +1,258 @@
+"""MID360 PointCloud2 conversion for the generic navigation sensor contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+# sensor_msgs/msg/PointField datatype constants
+UINT8 = 2
+UINT16 = 4
+FLOAT32 = 7
+FLOAT64 = 8
+
+
+@dataclass(frozen=True)
+class PointFieldSpec:
+    name: str
+    offset: int
+    datatype: int
+    count: int = 1
+
+
+# Stable navigation layout: PCL_ADD_POINT4D, intensity, tag, line, alignment
+# padding and an absolute per-point timestamp in the normalized ROS clock.
+NAVIGATION_FIELDS = (
+    PointFieldSpec("x", 0, FLOAT32),
+    PointFieldSpec("y", 4, FLOAT32),
+    PointFieldSpec("z", 8, FLOAT32),
+    PointFieldSpec("intensity", 16, FLOAT32),
+    PointFieldSpec("tag", 20, UINT8),
+    PointFieldSpec("line", 21, UINT8),
+    PointFieldSpec("timestamp", 24, FLOAT64),
+)
+NAVIGATION_POINT_STEP = 32
+_NAVIGATION_DTYPE = np.dtype(
+    {
+        "names": [field.name for field in NAVIGATION_FIELDS],
+        "formats": ["<f4", "<f4", "<f4", "<f4", "u1", "u1", "<f8"],
+        "offsets": [field.offset for field in NAVIGATION_FIELDS],
+        "itemsize": NAVIGATION_POINT_STEP,
+    }
+)
+
+_EXPECTED_INPUT_TYPES = {
+    "x": FLOAT32,
+    "y": FLOAT32,
+    "z": FLOAT32,
+    "intensity": FLOAT32,
+    "ring": UINT16,
+    "time": FLOAT32,
+}
+_INPUT_DTYPES = {
+    "x": "<f4",
+    "y": "<f4",
+    "z": "<f4",
+    "intensity": "<f4",
+    "ring": "<u2",
+    "time": "<f4",
+}
+
+
+def validated_rotation_matrix(values: object | None) -> np.ndarray:
+    """Return a proper 3x3 rotation matrix from a row-major config value."""
+    if values is None:
+        return np.eye(3, dtype=np.float64)
+
+    rotation = np.asarray(values, dtype=np.float64)
+    if rotation.size != 9:
+        raise ValueError("sensor_rotation_matrix must contain 9 values")
+    rotation = rotation.reshape(3, 3)
+    if not np.isfinite(rotation).all():
+        raise ValueError("sensor_rotation_matrix contains non-finite values")
+    if not np.allclose(rotation @ rotation.T, np.eye(3), atol=1e-6):
+        raise ValueError("sensor_rotation_matrix must be orthonormal")
+    if not np.isclose(np.linalg.det(rotation), 1.0, atol=1e-6):
+        raise ValueError("sensor_rotation_matrix must be a proper rotation")
+    return rotation
+
+
+def rotate_vector3(values: object, rotation: np.ndarray) -> tuple[float, float, float]:
+    """Rotate one xyz vector from the raw MID360 frame into navigation frame."""
+    vector = np.asarray(values, dtype=np.float64)
+    if vector.size != 3:
+        raise ValueError("vector must contain 3 values")
+    rotated = rotation @ vector.reshape(3)
+    return tuple(float(value) for value in rotated)
+
+
+def rotate_covariance9(values: object, rotation: np.ndarray) -> list[float]:
+    """Rotate a row-major 3x3 covariance into the navigation frame."""
+    covariance = np.asarray(values, dtype=np.float64)
+    if covariance.size != 9:
+        raise ValueError("covariance must contain 9 values")
+    rotated = rotation @ covariance.reshape(3, 3) @ rotation.T
+    return [float(value) for value in rotated.reshape(9)]
+
+
+def rotate_orientation_xyzw(
+    values: object, rotation: np.ndarray
+) -> tuple[float, float, float, float]:
+    """Express a raw-frame orientation quaternion in the corrected frame.
+
+    ``rotation`` maps raw sensor vectors into the corrected navigation frame.
+    An IMU orientation describes the raw sensor frame in the world, so the
+    corrected-frame orientation is ``R_world_raw * rotation.T``.
+    """
+    quaternion = np.asarray(values, dtype=np.float64)
+    if quaternion.size != 4:
+        raise ValueError("quaternion must contain 4 values")
+    norm = float(np.linalg.norm(quaternion))
+    if not np.isfinite(norm) or norm < 1e-12:
+        raise ValueError("quaternion must be finite and non-zero")
+    x, y, z, w = quaternion / norm
+    raw_to_world = np.array(
+        [
+            [1.0 - 2.0 * (y * y + z * z), 2.0 * (x * y - z * w), 2.0 * (x * z + y * w)],
+            [2.0 * (x * y + z * w), 1.0 - 2.0 * (x * x + z * z), 2.0 * (y * z - x * w)],
+            [2.0 * (x * z - y * w), 2.0 * (y * z + x * w), 1.0 - 2.0 * (x * x + y * y)],
+        ],
+        dtype=np.float64,
+    )
+    corrected_to_world = raw_to_world @ rotation.T
+
+    trace = float(np.trace(corrected_to_world))
+    if trace > 0.0:
+        scale = 2.0 * np.sqrt(trace + 1.0)
+        qw = 0.25 * scale
+        qx = (corrected_to_world[2, 1] - corrected_to_world[1, 2]) / scale
+        qy = (corrected_to_world[0, 2] - corrected_to_world[2, 0]) / scale
+        qz = (corrected_to_world[1, 0] - corrected_to_world[0, 1]) / scale
+    else:
+        index = int(np.argmax(np.diag(corrected_to_world)))
+        if index == 0:
+            scale = 2.0 * np.sqrt(
+                1.0 + corrected_to_world[0, 0]
+                - corrected_to_world[1, 1]
+                - corrected_to_world[2, 2]
+            )
+            qw = (corrected_to_world[2, 1] - corrected_to_world[1, 2]) / scale
+            qx = 0.25 * scale
+            qy = (corrected_to_world[0, 1] + corrected_to_world[1, 0]) / scale
+            qz = (corrected_to_world[0, 2] + corrected_to_world[2, 0]) / scale
+        elif index == 1:
+            scale = 2.0 * np.sqrt(
+                1.0 + corrected_to_world[1, 1]
+                - corrected_to_world[0, 0]
+                - corrected_to_world[2, 2]
+            )
+            qw = (corrected_to_world[0, 2] - corrected_to_world[2, 0]) / scale
+            qx = (corrected_to_world[0, 1] + corrected_to_world[1, 0]) / scale
+            qy = 0.25 * scale
+            qz = (corrected_to_world[1, 2] + corrected_to_world[2, 1]) / scale
+        else:
+            scale = 2.0 * np.sqrt(
+                1.0 + corrected_to_world[2, 2]
+                - corrected_to_world[0, 0]
+                - corrected_to_world[1, 1]
+            )
+            qw = (corrected_to_world[1, 0] - corrected_to_world[0, 1]) / scale
+            qx = (corrected_to_world[0, 2] + corrected_to_world[2, 0]) / scale
+            qy = (corrected_to_world[1, 2] + corrected_to_world[2, 1]) / scale
+            qz = 0.25 * scale
+
+    corrected = np.array([qx, qy, qz, qw], dtype=np.float64)
+    corrected /= np.linalg.norm(corrected)
+    return tuple(float(value) for value in corrected)
+
+
+def unitree_mid360_to_navigation_cloud(
+    *,
+    data: bytes,
+    height: int,
+    width: int,
+    point_step: int,
+    row_step: int,
+    fields: list[tuple[str, int, int, int]],
+    header_stamp_ns: int,
+    rotation_matrix: np.ndarray | None = None,
+) -> bytes:
+    """Convert Unitree's packed MID360 points to the navigation PCL schema.
+
+    Unitree provides ``time`` as a per-point offset in nanoseconds.  The output
+    preserves it as an absolute nanosecond ``timestamp`` in the same normalized
+    clock domain as the ROS header and navigation IMU.
+    """
+    height = int(height)
+    width = int(width)
+    point_step = int(point_step)
+    row_step = int(row_step)
+    header_stamp_ns = int(header_stamp_ns)
+    if min(height, width, point_step, row_step, header_stamp_ns) < 1:
+        raise ValueError(
+            "height, width, point_step, row_step and header_stamp_ns must be positive"
+        )
+    expected_row_step = width * point_step
+    if row_step != expected_row_step:
+        raise ValueError(
+            "MID360 PointCloud2 rows must be tightly packed: "
+            f"row_step={row_step}, expected={expected_row_step}"
+        )
+    expected_size = height * row_step
+    if len(data) != expected_size:
+        raise ValueError(
+            f"point cloud data size must equal row_step * height: "
+            f"expected={expected_size}, actual={len(data)}"
+        )
+    point_count = height * width
+
+    field_map = {name: (int(offset), int(datatype), int(count)) for name, offset, datatype, count in fields}
+    for name, expected_type in _EXPECTED_INPUT_TYPES.items():
+        if name not in field_map:
+            raise ValueError(f"missing MID360 field: {name}")
+        offset, datatype, count = field_map[name]
+        if datatype != expected_type or count != 1:
+            raise ValueError(
+                f"unexpected MID360 field {name}: datatype={datatype}, count={count}"
+            )
+        if offset < 0 or offset + np.dtype(_INPUT_DTYPES[name]).itemsize > point_step:
+            raise ValueError(f"MID360 field {name} exceeds point_step")
+
+    def view(name: str) -> np.ndarray:
+        offset = field_map[name][0]
+        return np.ndarray(
+            shape=(point_count,),
+            dtype=_INPUT_DTYPES[name],
+            buffer=data,
+            offset=offset,
+            strides=(point_step,),
+        )
+
+    ring = view("ring")
+    if int(ring.max(initial=0)) > 255:
+        raise ValueError("MID360 ring value exceeds uint8 line range")
+
+    relative_time_ns = view("time")
+    if not np.isfinite(relative_time_ns).all() or float(relative_time_ns.min()) < 0:
+        raise ValueError("MID360 time contains negative or non-finite values")
+
+    rotation = validated_rotation_matrix(rotation_matrix)
+    xyz = np.column_stack((view("x"), view("y"), view("z"))).astype(
+        np.float32, copy=False
+    )
+    if not np.array_equal(rotation, np.eye(3)):
+        xyz = xyz @ rotation.astype(np.float32).T
+
+    converted = np.zeros(point_count, dtype=_NAVIGATION_DTYPE)
+    converted["x"] = xyz[:, 0]
+    converted["y"] = xyz[:, 1]
+    converted["z"] = xyz[:, 2]
+    converted["intensity"] = view("intensity")
+    converted["tag"] = 0x10
+    converted["line"] = ring.astype(np.uint8, copy=False)
+    converted["timestamp"] = np.float64(header_stamp_ns) + relative_time_ns.astype(
+        np.float64, copy=False
+    )
+    return converted.tobytes(order="C")

--- a/unitree/go2/navigation_pointcloud.py
+++ b/unitree/go2/navigation_pointcloud.py
@@ -68,14 +68,14 @@ def validated_rotation_matrix(values: object | None) -> np.ndarray:
 
     rotation = np.asarray(values, dtype=np.float64)
     if rotation.size != 9:
-        raise ValueError("sensor_rotation_matrix must contain 9 values")
+        raise ValueError("device_to_sensor_rotation_matrix must contain 9 values")
     rotation = rotation.reshape(3, 3)
     if not np.isfinite(rotation).all():
-        raise ValueError("sensor_rotation_matrix contains non-finite values")
+        raise ValueError("device_to_sensor_rotation_matrix contains non-finite values")
     if not np.allclose(rotation @ rotation.T, np.eye(3), atol=1e-6):
-        raise ValueError("sensor_rotation_matrix must be orthonormal")
+        raise ValueError("device_to_sensor_rotation_matrix must be orthonormal")
     if not np.isclose(np.linalg.det(rotation), 1.0, atol=1e-6):
-        raise ValueError("sensor_rotation_matrix must be a proper rotation")
+        raise ValueError("device_to_sensor_rotation_matrix must be a proper rotation")
     return rotation
 
 
@@ -181,8 +181,8 @@ def unitree_mid360_to_navigation_cloud(
 ) -> bytes:
     """Convert Unitree's packed MID360 points to the navigation PCL schema.
 
-    Unitree provides ``time`` as a per-point offset in nanoseconds.  The output
-    preserves it as an absolute nanosecond ``timestamp`` in the same normalized
+    Unitree provides ``time`` as a per-point offset in seconds.  The output
+    converts it to an absolute nanosecond ``timestamp`` in the same normalized
     clock domain as the ROS header and navigation IMU.
     """
     height = int(height)
@@ -234,9 +234,17 @@ def unitree_mid360_to_navigation_cloud(
     if int(ring.max(initial=0)) > 255:
         raise ValueError("MID360 ring value exceeds uint8 line range")
 
-    relative_time_ns = view("time")
-    if not np.isfinite(relative_time_ns).all() or float(relative_time_ns.min()) < 0:
+    relative_time_seconds = view("time")
+    if (
+        not np.isfinite(relative_time_seconds).all()
+        or float(relative_time_seconds.min()) < 0
+    ):
         raise ValueError("MID360 time contains negative or non-finite values")
+    absolute_timestamps_ns = np.float64(header_stamp_ns) + np.rint(
+        relative_time_seconds.astype(np.float64, copy=False) * 1_000_000_000.0
+    )
+    if point_count > 1 and not np.all(np.diff(absolute_timestamps_ns) > 0.0):
+        raise ValueError("MID360 time does not produce increasing timestamps")
 
     rotation = validated_rotation_matrix(rotation_matrix)
     xyz = np.column_stack((view("x"), view("y"), view("z"))).astype(
@@ -252,7 +260,5 @@ def unitree_mid360_to_navigation_cloud(
     converted["intensity"] = view("intensity")
     converted["tag"] = 0x10
     converted["line"] = ring.astype(np.uint8, copy=False)
-    converted["timestamp"] = np.float64(header_stamp_ns) + relative_time_ns.astype(
-        np.float64, copy=False
-    )
+    converted["timestamp"] = absolute_timestamps_ns
     return converted.tobytes(order="C")

--- a/unitree/go2/navigation_pointcloud.py
+++ b/unitree/go2/navigation_pointcloud.py
@@ -178,6 +178,7 @@ def unitree_mid360_to_navigation_cloud(
     fields: list[tuple[str, int, int, int]],
     header_stamp_ns: int,
     rotation_matrix: np.ndarray | None = None,
+    min_range_m: float = 0.0,
 ) -> bytes:
     """Convert Unitree's packed MID360 points to the navigation PCL schema.
 
@@ -190,10 +191,13 @@ def unitree_mid360_to_navigation_cloud(
     point_step = int(point_step)
     row_step = int(row_step)
     header_stamp_ns = int(header_stamp_ns)
+    min_range_m = float(min_range_m)
     if min(height, width, point_step, row_step, header_stamp_ns) < 1:
         raise ValueError(
             "height, width, point_step, row_step and header_stamp_ns must be positive"
         )
+    if not np.isfinite(min_range_m) or min_range_m < 0.0:
+        raise ValueError("min_range_m must be finite and non-negative")
     expected_row_step = width * point_step
     if row_step != expected_row_step:
         raise ValueError(
@@ -243,22 +247,49 @@ def unitree_mid360_to_navigation_cloud(
     absolute_timestamps_ns = np.float64(header_stamp_ns) + np.rint(
         relative_time_seconds.astype(np.float64, copy=False) * 1_000_000_000.0
     )
-    if point_count > 1 and not np.all(np.diff(absolute_timestamps_ns) > 0.0):
-        raise ValueError("MID360 time does not produce increasing timestamps")
 
     rotation = validated_rotation_matrix(rotation_matrix)
     xyz = np.column_stack((view("x"), view("y"), view("z"))).astype(
         np.float32, copy=False
     )
+    keep = np.isfinite(xyz).all(axis=1)
+    if min_range_m > 0.0:
+        keep &= np.linalg.norm(xyz, axis=1) >= min_range_m
+    if not keep.any():
+        return b""
     if not np.array_equal(rotation, np.eye(3)):
         xyz = xyz @ rotation.astype(np.float32).T
 
-    converted = np.zeros(point_count, dtype=_NAVIGATION_DTYPE)
-    converted["x"] = xyz[:, 0]
-    converted["y"] = xyz[:, 1]
-    converted["z"] = xyz[:, 2]
-    converted["intensity"] = view("intensity")
+    absolute_timestamps_ns = absolute_timestamps_ns[keep]
+    order = np.argsort(absolute_timestamps_ns, kind="stable")
+    absolute_timestamps_ns = absolute_timestamps_ns[order].copy()
+    for index in range(1, len(absolute_timestamps_ns)):
+        if absolute_timestamps_ns[index] <= absolute_timestamps_ns[index - 1]:
+            absolute_timestamps_ns[index] = np.nextafter(
+                absolute_timestamps_ns[index - 1], np.inf
+            )
+
+    kept_xyz = xyz[keep][order]
+    converted = np.zeros(len(order), dtype=_NAVIGATION_DTYPE)
+    converted["x"] = kept_xyz[:, 0]
+    converted["y"] = kept_xyz[:, 1]
+    converted["z"] = kept_xyz[:, 2]
+    converted["intensity"] = view("intensity")[keep][order]
     converted["tag"] = 0x10
-    converted["line"] = ring.astype(np.uint8, copy=False)
+    converted["line"] = ring[keep][order].astype(np.uint8, copy=False)
     converted["timestamp"] = absolute_timestamps_ns
     return converted.tobytes(order="C")
+
+
+def merge_navigation_clouds(clouds: list[bytes]) -> bytes:
+    """Merge converted packets into one timestamp-ordered navigation scan."""
+    payload = b"".join(cloud for cloud in clouds if cloud)
+    if not payload:
+        return b""
+    merged = np.frombuffer(payload, dtype=_NAVIGATION_DTYPE).copy()
+    merged = merged[np.argsort(merged["timestamp"], kind="stable")].copy()
+    timestamps = merged["timestamp"]
+    for index in range(1, len(timestamps)):
+        if timestamps[index] <= timestamps[index - 1]:
+            timestamps[index] = np.nextafter(timestamps[index - 1], np.inf)
+    return merged.tobytes(order="C")

--- a/unitree/go2/navigation_sensor_bridge.py
+++ b/unitree/go2/navigation_sensor_bridge.py
@@ -1,0 +1,627 @@
+"""Raw MID360 DDS to standard ROS2 sensor topics for traditional navigation.
+
+The bridge is intentionally independent from the dashboard-oriented LidarPlugin.
+It preserves raw PointCloud2 fields, normalizes LiDAR/IMU timestamps into the
+Jetson ROS clock domain, and applies one fixed mounting rotation to both the
+estimator point cloud and IMU.  It never applies dynamic gravity alignment.
+"""
+
+from __future__ import annotations
+
+from array import array
+import json
+import os
+from pathlib import Path
+import queue
+import subprocess
+import sys
+import threading
+import time
+
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import Imu, PointCloud2, PointField
+from std_msgs.msg import String
+
+from navigation_pointcloud import (
+    NAVIGATION_FIELDS,
+    NAVIGATION_POINT_STEP,
+    rotate_covariance9,
+    rotate_orientation_xyzw,
+    rotate_vector3,
+    unitree_mid360_to_navigation_cloud,
+    validated_rotation_matrix,
+)
+from navigation_time import ClockOffsetEstimator, split_ns, stamp_to_ns
+from unitree_sdk2py.core.channel import ChannelSubscriber
+from unitree_sdk2py.idl.sensor_msgs.msg.dds_ import Imu_, PointCloud2_
+
+
+_NAVIGATION_CLOUD_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=2,
+    durability=DurabilityPolicy.VOLATILE,
+)
+_IMU_QOS = QoSProfile(
+    # Navigation estimators generally use a reliable IMU subscription.  Match
+    # that contract so the endpoint cannot silently disconnect on QoS.
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=200,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+
+def _absolute_topic(value: str | None, fallback: str) -> str:
+    topic = (value or fallback).strip()
+    return topic if topic.startswith("/") else f"/{topic}"
+
+
+class _NavigationSensorNode(Node):
+    def __init__(self, config: dict, namespace: str):
+        super().__init__("go2_navigation_sensor_bridge")
+
+        prefix = f"/{namespace}/navigation"
+        self.cloud_topic = _absolute_topic(config.get("cloud_topic"), f"{prefix}/lidar")
+        self.imu_topic = _absolute_topic(config.get("imu_topic"), f"{prefix}/imu")
+        self._status_topic = f"{prefix}/_bridge_status"
+        self._raw_cloud_topic = config.get(
+            "raw_cloud_topic", "rt/utlidar/cloud"
+        )
+        self._raw_imu_topic = config.get(
+            "raw_imu_topic", "rt/utlidar/imu"
+        )
+        self._lidar_frame = config.get("lidar_frame", "utlidar_lidar")
+        self._imu_frame = config.get("imu_frame", self._lidar_frame)
+        self._sensor_rotation = validated_rotation_matrix(
+            config.get("sensor_rotation_matrix")
+        )
+
+        # Do not use ``self._clock``: rclpy.node.Node owns that attribute and
+        # get_clock() returns it internally.
+        self._clock_offset = ClockOffsetEstimator(
+            warmup_samples=int(config.get("clock_warmup_samples", 32)),
+            window_samples=int(config.get("clock_window_samples", 400)),
+            reset_threshold_ns=int(
+                float(config.get("clock_reset_threshold_ms", 1000.0)) * 1_000_000
+            ),
+            reset_confirm_samples=int(config.get("clock_reset_confirm_samples", 8)),
+        )
+
+        self._cloud_pub = self.create_publisher(
+            PointCloud2,
+            self.cloud_topic,
+            _NAVIGATION_CLOUD_QOS,
+        )
+        self._imu_pub = self.create_publisher(Imu, self.imu_topic, _IMU_QOS)
+        self._status_pub = self.create_publisher(String, self._status_topic, 10)
+
+        self._cloud_queue: queue.Queue = queue.Queue(maxsize=2)
+        self._imu_queue: queue.Queue = queue.Queue(maxsize=4)
+        self._stop = threading.Event()
+        self._cloud_worker = threading.Thread(
+            target=self._cloud_loop, name="navigation_cloud", daemon=True
+        )
+        self._imu_worker = threading.Thread(
+            target=self._imu_loop, name="navigation_imu", daemon=True
+        )
+        self._cloud_worker.start()
+        self._imu_worker.start()
+
+        self._last_stamp_ns = {"cloud": 0, "imu": 0}
+        self._last_status_time = 0.0
+        self._counters = {
+            "cloud_received": 0,
+            "cloud_published": 0,
+            "cloud_dropped": 0,
+            "imu_received": 0,
+            "imu_published": 0,
+            "imu_dropped": 0,
+            "cloud_invalid_timestamps": 0,
+            "imu_invalid_timestamps": 0,
+            "stamp_clamped": 0,
+        }
+        self._last_receive_monotonic = {"cloud": 0.0, "imu": 0.0}
+
+        self._cloud_sub = ChannelSubscriber(self._raw_cloud_topic, PointCloud2_)
+        self._cloud_sub.Init(self._on_cloud, 1)
+        self._imu_sub = ChannelSubscriber(self._raw_imu_topic, Imu_)
+        # Direct callback avoids the SDK BQueue dropping new samples when its
+        # single slot is occupied.  This callback only timestamps and enqueues.
+        self._imu_sub.Init(self._on_imu)
+        self.get_logger().info(
+            f"Navigation sensors: {self._raw_cloud_topic} -> "
+            f"{self.cloud_topic}; "
+            f"{self._raw_imu_topic} -> {self.imu_topic}; "
+            f"frame={self._lidar_frame}, "
+            f"sensor_rotation={self._sensor_rotation.reshape(9).tolist()}"
+        )
+
+    def _correct_stamp(self, source_stamp, stream: str) -> int | None:
+        try:
+            source_ns = stamp_to_ns(source_stamp.sec, source_stamp.nanosec)
+            host_ns = self.get_clock().now().nanoseconds
+            corrected_ns = self._clock_offset.correct_observation(source_ns, host_ns)
+        except (AttributeError, TypeError, ValueError) as exc:
+            counter = f"{stream}_invalid_timestamps"
+            self._counters[counter] += 1
+            count = self._counters[counter]
+            if count == 1 or count % 100 == 0:
+                self.get_logger().warning(
+                    f"invalid {stream} timestamp count={count}: {exc}"
+                )
+            return None
+
+        if corrected_ns is None:
+            return None
+        if corrected_ns <= self._last_stamp_ns[stream]:
+            corrected_ns = self._last_stamp_ns[stream] + 1
+            self._counters["stamp_clamped"] += 1
+        self._last_stamp_ns[stream] = corrected_ns
+        return corrected_ns
+
+    @staticmethod
+    def _set_stamp(header, timestamp_ns: int, frame_id: str) -> None:
+        sec, nanosec = split_ns(timestamp_ns)
+        header.stamp.sec = sec
+        header.stamp.nanosec = nanosec
+        header.frame_id = frame_id
+
+    def _on_cloud(self, msg) -> None:
+        self._counters["cloud_received"] += 1
+        self._last_receive_monotonic["cloud"] = time.monotonic()
+        corrected_ns = self._correct_stamp(msg.header.stamp, "cloud")
+        if corrected_ns is None:
+            self._counters["cloud_dropped"] += 1
+            self._maybe_publish_status()
+            return
+
+        fields = [
+            (str(field.name), int(field.offset), int(field.datatype), int(field.count))
+            for field in msg.fields
+        ]
+        item = (
+            corrected_ns,
+            int(msg.height),
+            int(msg.width),
+            fields,
+            bool(msg.is_bigendian),
+            int(msg.point_step),
+            int(msg.row_step),
+            bytes(msg.data),
+            bool(msg.is_dense),
+        )
+        try:
+            self._cloud_queue.put_nowait(item)
+        except queue.Full:
+            try:
+                self._cloud_queue.get_nowait()
+            except queue.Empty:
+                pass
+            self._counters["cloud_dropped"] += 1
+            self._cloud_queue.put_nowait(item)
+        self._maybe_publish_status()
+
+    def _cloud_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                item = self._cloud_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if item is None:
+                break
+
+            (
+                corrected_ns,
+                height,
+                width,
+                fields,
+                is_bigendian,
+                point_step,
+                row_step,
+                data,
+                is_dense,
+            ) = item
+            try:
+                converted = unitree_mid360_to_navigation_cloud(
+                    data=data,
+                    height=height,
+                    width=width,
+                    point_step=point_step,
+                    row_step=row_step,
+                    fields=fields,
+                    header_stamp_ns=corrected_ns,
+                    rotation_matrix=self._sensor_rotation,
+                )
+                out = PointCloud2()
+                self._set_stamp(out.header, corrected_ns, self._lidar_frame)
+                out.height = 1
+                out.width = height * width
+                out.fields = [
+                    PointField(
+                        name=field.name,
+                        offset=field.offset,
+                        datatype=field.datatype,
+                        count=field.count,
+                    )
+                    for field in NAVIGATION_FIELDS
+                ]
+                out.is_bigendian = False
+                out.point_step = NAVIGATION_POINT_STEP
+                out.row_step = NAVIGATION_POINT_STEP * out.width
+                # Humble's generated setter validates a bytes object one element
+                # at a time in debug mode. array('B') uses its constant-time path.
+                out.data = array("B", converted)
+                out.is_dense = is_dense
+                self._cloud_pub.publish(out)
+                self._counters["cloud_published"] += 1
+            except (TypeError, ValueError) as exc:
+                self._counters["cloud_dropped"] += 1
+                if self._counters["cloud_dropped"] <= 3:
+                    self.get_logger().warning(
+                        f"navigation cloud conversion failed: {exc}"
+                    )
+
+    def _on_imu(self, msg) -> None:
+        self._counters["imu_received"] += 1
+        self._last_receive_monotonic["imu"] = time.monotonic()
+        corrected_ns = self._correct_stamp(msg.header.stamp, "imu")
+        if corrected_ns is None:
+            self._counters["imu_dropped"] += 1
+            self._maybe_publish_status()
+            return
+
+        try:
+            self._imu_queue.put_nowait((corrected_ns, msg))
+        except queue.Full:
+            # Prefer fresh inertial data over completing a stale backlog.
+            try:
+                self._imu_queue.get_nowait()
+            except queue.Empty:
+                pass
+            self._counters["imu_dropped"] += 1
+            self._imu_queue.put_nowait((corrected_ns, msg))
+        self._maybe_publish_status()
+
+    def _imu_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                item = self._imu_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if item is None:
+                break
+            corrected_ns, msg = item
+
+            out = Imu()
+            self._set_stamp(out.header, corrected_ns, self._imu_frame)
+
+            q = msg.orientation
+            q_norm_sq = (
+                float(q.x) ** 2
+                + float(q.y) ** 2
+                + float(q.z) ** 2
+                + float(q.w) ** 2
+            )
+            if q_norm_sq > 0.25:
+                qx, qy, qz, qw = rotate_orientation_xyzw(
+                    (float(q.x), float(q.y), float(q.z), float(q.w)),
+                    self._sensor_rotation,
+                )
+                out.orientation.x = qx
+                out.orientation.y = qy
+                out.orientation.z = qz
+                out.orientation.w = qw
+                out.orientation_covariance = rotate_covariance9(
+                    msg.orientation_covariance, self._sensor_rotation
+                )
+            else:
+                # The live MID360 stream reports an all-zero quaternion.  Publish
+                # identity and mark orientation unavailable per REP-145.
+                out.orientation.w = 1.0
+                out.orientation_covariance[0] = -1.0
+
+            wx, wy, wz = rotate_vector3(
+                (
+                    float(msg.angular_velocity.x),
+                    float(msg.angular_velocity.y),
+                    float(msg.angular_velocity.z),
+                ),
+                self._sensor_rotation,
+            )
+            out.angular_velocity.x = wx
+            out.angular_velocity.y = wy
+            out.angular_velocity.z = wz
+            out.angular_velocity_covariance = rotate_covariance9(
+                msg.angular_velocity_covariance, self._sensor_rotation
+            )
+            ax, ay, az = rotate_vector3(
+                (
+                    float(msg.linear_acceleration.x),
+                    float(msg.linear_acceleration.y),
+                    float(msg.linear_acceleration.z),
+                ),
+                self._sensor_rotation,
+            )
+            out.linear_acceleration.x = ax
+            out.linear_acceleration.y = ay
+            out.linear_acceleration.z = az
+            out.linear_acceleration_covariance = rotate_covariance9(
+                msg.linear_acceleration_covariance, self._sensor_rotation
+            )
+            self._imu_pub.publish(out)
+            self._counters["imu_published"] += 1
+
+    def _maybe_publish_status(self) -> None:
+        now = time.monotonic()
+        if now - self._last_status_time < 1.0:
+            return
+        self._last_status_time = now
+        status = self.status()
+        clock = status["clock"]
+        if clock["offset_ns"] is not None:
+            clock["offset_sec"] = round(clock["offset_ns"] / 1_000_000_000, 6)
+        if clock["residual_ns"] is not None:
+            clock["residual_ms"] = round(clock["residual_ns"] / 1_000_000, 3)
+        out = String()
+        out.data = json.dumps(
+            {
+                **status,
+                "raw_topics": {
+                    "cloud": self._raw_cloud_topic,
+                    "imu": self._raw_imu_topic,
+                },
+                "frames": {
+                    "lidar": self._lidar_frame,
+                    "imu": self._imu_frame,
+                },
+                "sensor_rotation_matrix": [
+                    float(value) for value in self._sensor_rotation.reshape(9)
+                ],
+            },
+            separators=(",", ":"),
+        )
+        self._status_pub.publish(out)
+
+    def status(self) -> dict:
+        now = time.monotonic()
+        ages = {
+            stream: (
+                round((now - received_at) * 1000.0, 1)
+                if received_at > 0.0
+                else None
+            )
+            for stream, received_at in self._last_receive_monotonic.items()
+        }
+        clock = self._clock_offset.snapshot().to_dict()
+        blockers = []
+        if not clock["ready"]:
+            blockers.append("clock_not_ready")
+        if ages["cloud"] is None or ages["cloud"] > 500.0:
+            blockers.append("cloud_stale")
+        if ages["imu"] is None or ages["imu"] > 100.0:
+            blockers.append("imu_stale")
+        if not self._counters["cloud_published"]:
+            blockers.append("cloud_not_published")
+        if not self._counters["imu_published"]:
+            blockers.append("imu_not_published")
+        return {
+            "ready": not blockers,
+            "blockers": blockers,
+            "receive_age_ms": ages,
+            "clock": clock,
+            "counters": dict(self._counters),
+        }
+
+    def close(self) -> None:
+        for subscriber in (self._cloud_sub, self._imu_sub):
+            try:
+                subscriber.Close()
+            except Exception:
+                pass
+        self._stop.set()
+        for work_queue in (self._cloud_queue, self._imu_queue):
+            try:
+                work_queue.put_nowait(None)
+            except queue.Full:
+                try:
+                    work_queue.get_nowait()
+                except queue.Empty:
+                    pass
+                work_queue.put_nowait(None)
+        self._cloud_worker.join(timeout=2.0)
+        self._imu_worker.join(timeout=2.0)
+
+
+class _NavigationSensorMonitorNode(Node):
+    """Lightweight main-process monitor for the isolated bridge worker."""
+
+    def __init__(self, config: dict, namespace: str):
+        super().__init__("go2_navigation_sensor_status")
+        prefix = f"/{namespace}/navigation"
+        self.cloud_topic = _absolute_topic(config.get("cloud_topic"), f"{prefix}/lidar")
+        self.imu_topic = _absolute_topic(config.get("imu_topic"), f"{prefix}/imu")
+        self.lidar_frame = config.get("lidar_frame", "utlidar_lidar")
+        self.imu_frame = config.get("imu_frame", self.lidar_frame)
+        self._status_topic = f"{prefix}/_bridge_status"
+        self._lock = threading.RLock()
+        self._last_status = None
+        self._last_status_monotonic = 0.0
+        self._status_sub = self.create_subscription(
+            String, self._status_topic, self._on_status, 10
+        )
+
+    def _on_status(self, msg) -> None:
+        try:
+            payload = json.loads(msg.data)
+        except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+            return
+        if not isinstance(payload, dict):
+            return
+        with self._lock:
+            self._last_status = payload
+            self._last_status_monotonic = time.monotonic()
+
+    def status(self, worker_running: bool) -> dict:
+        with self._lock:
+            payload = dict(self._last_status or {})
+            received_at = self._last_status_monotonic
+
+        status_age_ms = (
+            round((time.monotonic() - received_at) * 1000.0, 1)
+            if received_at > 0.0
+            else None
+        )
+        blockers = list(payload.get("blockers") or [])
+        if not worker_running:
+            blockers.append("worker_not_running")
+        if status_age_ms is None:
+            blockers.append("status_not_received")
+        elif status_age_ms > 2000.0:
+            blockers.append("status_stale")
+
+        blockers = list(dict.fromkeys(blockers))
+        return {
+            **payload,
+            "ready": not blockers,
+            "blockers": blockers,
+            "worker_running": bool(worker_running),
+            "status_age_ms": status_age_ms,
+        }
+
+
+class NavigationSensorPlugin:
+    PREFIX = "navigation_sensors"
+
+    def __init__(
+        self,
+        plugin_config: dict,
+        namespace: str,
+        executor,
+        network_iface: str = "eth0",
+    ):
+        self._executor = executor
+        self._namespace = namespace
+        self._network_iface = network_iface
+        self._status_node = _NavigationSensorMonitorNode(plugin_config, namespace)
+        executor.add_node(self._status_node)
+        self._worker_path = Path(__file__).with_name("navigation_sensor_bridge_main.py")
+        self._proc = None
+
+    def get_tools(self) -> list[dict]:
+        return [
+            self._tool(
+                "navigation_lidar",
+                "Normalized Go2 MID360 PointCloud2 for navigation consumers",
+                self._status_node.cloud_topic,
+                "sensor/pointcloud",
+                "sensor_msgs/msg/PointCloud2",
+                "RELIABLE + KEEP_LAST(depth=2) + VOLATILE",
+                self._status_node.lidar_frame,
+            ),
+            self._tool(
+                "navigation_imu",
+                "Normalized MID360 IMU in the same clock domain as LiDAR",
+                self._status_node.imu_topic,
+                "sensor/imu",
+                "sensor_msgs/msg/Imu",
+                "RELIABLE + KEEP_LAST(depth=200) + VOLATILE",
+                self._status_node.imu_frame,
+            ),
+        ]
+
+    @staticmethod
+    def _tool(
+        name: str,
+        description: str,
+        topic: str,
+        message_format: str,
+        ros_type: str,
+        qos: str,
+        frame_id: str,
+    ) -> dict:
+        descriptor = {
+            "topic": topic,
+            "format": message_format,
+            "ros_type": ros_type,
+            "qos": qos,
+            "timestamp": "MID360 source clock normalized to ROS system time",
+        }
+        if frame_id:
+            descriptor["frame_id"] = frame_id
+        return {
+            "name": name,
+            "type": "sensor",
+            "multiInstance": False,
+            "description": f"{description}. Publishes to {topic}",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [descriptor],
+        }
+
+    def start(self) -> None:
+        if self._worker_running():
+            return
+        if not self._worker_path.is_file():
+            raise FileNotFoundError(f"navigation sensor worker missing: {self._worker_path}")
+        env = os.environ.copy()
+        env["ROS_NAMESPACE"] = self._namespace
+        self._proc = subprocess.Popen(
+            [sys.executable, str(self._worker_path), self._network_iface],
+            cwd=str(self._worker_path.parent),
+            env=env,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+        print(
+            f"[navigation-sensors] isolated worker started pid={self._proc.pid}",
+            flush=True,
+        )
+
+    def _worker_running(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
+
+    def _stop_worker(self) -> None:
+        proc = self._proc
+        if proc is None:
+            return
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=2.0)
+        self._proc = None
+
+    def stop(self) -> None:
+        self._stop_worker()
+        try:
+            self._executor.remove_node(self._status_node)
+            self._status_node.destroy_node()
+        except Exception:
+            pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action in {"start", "info"}:
+            if action == "start" and not self._worker_running():
+                self.start()
+            tool_name = args.get("_tool_name", "")
+            tools = {tool["name"]: tool for tool in self.get_tools()}
+            selected = tools.get(tool_name, tools["navigation_lidar"])
+            worker_running = self._worker_running()
+            status = self._status_node.status(worker_running)
+            if action == "start":
+                state = "running" if worker_running else "error"
+            else:
+                state = "ready" if status["ready"] else "not_ready"
+            return {
+                "state": state,
+                "topic_out": selected["topic_out"],
+                "worker_pid": self._proc.pid if worker_running else None,
+                **status,
+            }
+        if action == "stop":
+            self._stop_worker()
+            return {"state": "idle", "worker_running": False, "worker_pid": None}
+        return None

--- a/unitree/go2/navigation_sensor_bridge.py
+++ b/unitree/go2/navigation_sensor_bridge.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from array import array
 import json
+import math
 import os
 from pathlib import Path
 import queue
@@ -18,10 +19,12 @@ import sys
 import threading
 import time
 
+from geometry_msgs.msg import TransformStamped
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import Imu, PointCloud2, PointField
 from std_msgs.msg import String
+from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
 
 from navigation_pointcloud import (
     NAVIGATION_FIELDS,
@@ -65,6 +68,38 @@ def _required_sensor_frame(config: dict) -> str:
     return frame.strip()
 
 
+def _required_static_transform(config: dict, sensor_frame: str) -> tuple:
+    base_frame = config.get("base_frame")
+    if not isinstance(base_frame, str) or not base_frame.strip():
+        raise ValueError("navigation base_frame must be a non-empty string")
+    base_frame = base_frame.strip()
+    if base_frame == sensor_frame:
+        raise ValueError("navigation base_frame and sensor_frame must differ")
+
+    values = []
+    for key in ("base_to_sensor_translation_m", "base_to_sensor_rotation_rpy_rad"):
+        raw = config.get(key)
+        if not isinstance(raw, (list, tuple)) or len(raw) != 3:
+            raise ValueError(f"navigation {key} must contain 3 values")
+        parsed = tuple(float(value) for value in raw)
+        if not all(math.isfinite(value) for value in parsed):
+            raise ValueError(f"navigation {key} contains non-finite values")
+        values.append(parsed)
+    return base_frame, values[0], values[1]
+
+
+def _quaternion_from_rpy(roll: float, pitch: float, yaw: float) -> tuple:
+    cr, sr = math.cos(roll / 2.0), math.sin(roll / 2.0)
+    cp, sp = math.cos(pitch / 2.0), math.sin(pitch / 2.0)
+    cy, sy = math.cos(yaw / 2.0), math.sin(yaw / 2.0)
+    return (
+        sr * cp * cy - cr * sp * sy,
+        cr * sp * cy + sr * cp * sy,
+        cr * cp * sy - sr * sp * cy,
+        cr * cp * cy + sr * sp * sy,
+    )
+
+
 class _NavigationSensorNode(Node):
     def __init__(self, config: dict, namespace: str):
         super().__init__("go2_navigation_sensor_bridge")
@@ -80,6 +115,11 @@ class _NavigationSensorNode(Node):
             "raw_imu_topic", "rt/utlidar/imu"
         )
         self._sensor_frame = _required_sensor_frame(config)
+        (
+            self._base_frame,
+            self._base_to_sensor_translation,
+            self._base_to_sensor_rpy,
+        ) = _required_static_transform(config, self._sensor_frame)
         self._sensor_rotation = validated_rotation_matrix(
             config.get(
                 "device_to_sensor_rotation_matrix",
@@ -105,6 +145,7 @@ class _NavigationSensorNode(Node):
         )
         self._imu_pub = self.create_publisher(Imu, self.imu_topic, _IMU_QOS)
         self._status_pub = self.create_publisher(String, self._status_topic, 10)
+        self._publish_static_transform()
 
         self._cloud_queue: queue.Queue = queue.Queue(maxsize=2)
         self._imu_queue: queue.Queue = queue.Queue(maxsize=4)
@@ -144,8 +185,25 @@ class _NavigationSensorNode(Node):
             f"{self.cloud_topic}; "
             f"{self._raw_imu_topic} -> {self.imu_topic}; "
             f"frame={self._sensor_frame}, "
+            f"static_tf={self._base_frame}->{self._sensor_frame} "
+            f"xyz={self._base_to_sensor_translation} "
+            f"rpy={self._base_to_sensor_rpy}, "
             f"device_to_sensor_rotation={self._sensor_rotation.reshape(9).tolist()}"
         )
+
+    def _publish_static_transform(self) -> None:
+        transform = TransformStamped()
+        transform.header.stamp = self.get_clock().now().to_msg()
+        transform.header.frame_id = self._base_frame
+        transform.child_frame_id = self._sensor_frame
+        translation = transform.transform.translation
+        translation.x, translation.y, translation.z = self._base_to_sensor_translation
+        rotation = transform.transform.rotation
+        rotation.x, rotation.y, rotation.z, rotation.w = _quaternion_from_rpy(
+            *self._base_to_sensor_rpy
+        )
+        self._static_tf_broadcaster = StaticTransformBroadcaster(self)
+        self._static_tf_broadcaster.sendTransform(transform)
 
     def _correct_stamp(self, source_stamp, stream: str) -> int | None:
         try:
@@ -382,9 +440,14 @@ class _NavigationSensorNode(Node):
                     "imu": self._raw_imu_topic,
                 },
                 "frames": {
+                    "base": self._base_frame,
                     "sensor": self._sensor_frame,
                     "lidar": self._sensor_frame,
                     "imu": self._sensor_frame,
+                },
+                "base_to_sensor_transform": {
+                    "translation_m": self._base_to_sensor_translation,
+                    "rotation_rpy_rad": self._base_to_sensor_rpy,
                 },
                 "device_to_sensor_rotation_matrix": [
                     float(value) for value in self._sensor_rotation.reshape(9)

--- a/unitree/go2/navigation_sensor_bridge.py
+++ b/unitree/go2/navigation_sensor_bridge.py
@@ -2,8 +2,8 @@
 
 The bridge is intentionally independent from the dashboard-oriented LidarPlugin.
 It preserves raw PointCloud2 fields, normalizes LiDAR/IMU timestamps into the
-Jetson ROS clock domain, and applies one fixed mounting rotation to both the
-estimator point cloud and IMU.  It never applies dynamic gravity alignment.
+Jetson ROS clock domain, and transforms both streams into one configured
+REP-103 sensor frame.  It never applies dynamic gravity alignment.
 """
 
 from __future__ import annotations
@@ -58,6 +58,13 @@ def _absolute_topic(value: str | None, fallback: str) -> str:
     return topic if topic.startswith("/") else f"/{topic}"
 
 
+def _required_sensor_frame(config: dict) -> str:
+    frame = config.get("sensor_frame", config.get("lidar_frame", "utlidar_lidar"))
+    if not isinstance(frame, str) or not frame.strip():
+        raise ValueError("navigation sensor_frame must be a non-empty string")
+    return frame.strip()
+
+
 class _NavigationSensorNode(Node):
     def __init__(self, config: dict, namespace: str):
         super().__init__("go2_navigation_sensor_bridge")
@@ -72,10 +79,12 @@ class _NavigationSensorNode(Node):
         self._raw_imu_topic = config.get(
             "raw_imu_topic", "rt/utlidar/imu"
         )
-        self._lidar_frame = config.get("lidar_frame", "utlidar_lidar")
-        self._imu_frame = config.get("imu_frame", self._lidar_frame)
+        self._sensor_frame = _required_sensor_frame(config)
         self._sensor_rotation = validated_rotation_matrix(
-            config.get("sensor_rotation_matrix")
+            config.get(
+                "device_to_sensor_rotation_matrix",
+                config.get("sensor_rotation_matrix"),
+            )
         )
 
         # Do not use ``self._clock``: rclpy.node.Node owns that attribute and
@@ -134,8 +143,8 @@ class _NavigationSensorNode(Node):
             f"Navigation sensors: {self._raw_cloud_topic} -> "
             f"{self.cloud_topic}; "
             f"{self._raw_imu_topic} -> {self.imu_topic}; "
-            f"frame={self._lidar_frame}, "
-            f"sensor_rotation={self._sensor_rotation.reshape(9).tolist()}"
+            f"frame={self._sensor_frame}, "
+            f"device_to_sensor_rotation={self._sensor_rotation.reshape(9).tolist()}"
         )
 
     def _correct_stamp(self, source_stamp, stream: str) -> int | None:
@@ -235,7 +244,7 @@ class _NavigationSensorNode(Node):
                     rotation_matrix=self._sensor_rotation,
                 )
                 out = PointCloud2()
-                self._set_stamp(out.header, corrected_ns, self._lidar_frame)
+                self._set_stamp(out.header, corrected_ns, self._sensor_frame)
                 out.height = 1
                 out.width = height * width
                 out.fields = [
@@ -295,7 +304,7 @@ class _NavigationSensorNode(Node):
             corrected_ns, msg = item
 
             out = Imu()
-            self._set_stamp(out.header, corrected_ns, self._imu_frame)
+            self._set_stamp(out.header, corrected_ns, self._sensor_frame)
 
             q = msg.orientation
             q_norm_sq = (
@@ -373,10 +382,11 @@ class _NavigationSensorNode(Node):
                     "imu": self._raw_imu_topic,
                 },
                 "frames": {
-                    "lidar": self._lidar_frame,
-                    "imu": self._imu_frame,
+                    "sensor": self._sensor_frame,
+                    "lidar": self._sensor_frame,
+                    "imu": self._sensor_frame,
                 },
-                "sensor_rotation_matrix": [
+                "device_to_sensor_rotation_matrix": [
                     float(value) for value in self._sensor_rotation.reshape(9)
                 ],
             },
@@ -442,8 +452,7 @@ class _NavigationSensorMonitorNode(Node):
         prefix = f"/{namespace}/navigation"
         self.cloud_topic = _absolute_topic(config.get("cloud_topic"), f"{prefix}/lidar")
         self.imu_topic = _absolute_topic(config.get("imu_topic"), f"{prefix}/imu")
-        self.lidar_frame = config.get("lidar_frame", "utlidar_lidar")
-        self.imu_frame = config.get("imu_frame", self.lidar_frame)
+        self.sensor_frame = _required_sensor_frame(config)
         self._status_topic = f"{prefix}/_bridge_status"
         self._lock = threading.RLock()
         self._last_status = None
@@ -518,7 +527,7 @@ class NavigationSensorPlugin:
                 "sensor/pointcloud",
                 "sensor_msgs/msg/PointCloud2",
                 "RELIABLE + KEEP_LAST(depth=2) + VOLATILE",
-                self._status_node.lidar_frame,
+                self._status_node.sensor_frame,
             ),
             self._tool(
                 "navigation_imu",
@@ -527,7 +536,7 @@ class NavigationSensorPlugin:
                 "sensor/imu",
                 "sensor_msgs/msg/Imu",
                 "RELIABLE + KEEP_LAST(depth=200) + VOLATILE",
-                self._status_node.imu_frame,
+                self._status_node.sensor_frame,
             ),
         ]
 

--- a/unitree/go2/navigation_sensor_bridge.py
+++ b/unitree/go2/navigation_sensor_bridge.py
@@ -29,6 +29,7 @@ from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
 from navigation_pointcloud import (
     NAVIGATION_FIELDS,
     NAVIGATION_POINT_STEP,
+    merge_navigation_clouds,
     rotate_covariance9,
     rotate_orientation_xyzw,
     rotate_vector3,
@@ -126,6 +127,16 @@ class _NavigationSensorNode(Node):
                 config.get("sensor_rotation_matrix"),
             )
         )
+        self._cloud_packets_per_scan = int(config.get("cloud_packets_per_scan", 2))
+        self._cloud_min_range_m = float(config.get("cloud_min_range_m", 0.5))
+        cloud_max_packet_gap_ms = float(config.get("cloud_max_packet_gap_ms", 120.0))
+        if self._cloud_packets_per_scan < 1:
+            raise ValueError("cloud_packets_per_scan must be positive")
+        if not math.isfinite(self._cloud_min_range_m) or self._cloud_min_range_m < 0.0:
+            raise ValueError("cloud_min_range_m must be finite and non-negative")
+        if not math.isfinite(cloud_max_packet_gap_ms) or cloud_max_packet_gap_ms <= 0.0:
+            raise ValueError("cloud_max_packet_gap_ms must be finite and positive")
+        self._cloud_max_packet_gap_ns = int(cloud_max_packet_gap_ms * 1_000_000)
 
         # Do not use ``self._clock``: rclpy.node.Node owns that attribute and
         # get_clock() returns it internally.
@@ -171,6 +182,10 @@ class _NavigationSensorNode(Node):
             "cloud_invalid_timestamps": 0,
             "imu_invalid_timestamps": 0,
             "stamp_clamped": 0,
+            "cloud_raw_points": 0,
+            "cloud_environment_points": 0,
+            "cloud_packets_aggregated": 0,
+            "cloud_aggregation_resets": 0,
         }
         self._last_receive_monotonic = {"cloud": 0.0, "imu": 0.0}
 
@@ -188,6 +203,8 @@ class _NavigationSensorNode(Node):
             f"static_tf={self._base_frame}->{self._sensor_frame} "
             f"xyz={self._base_to_sensor_translation} "
             f"rpy={self._base_to_sensor_rpy}, "
+            f"cloud_packets_per_scan={self._cloud_packets_per_scan}, "
+            f"cloud_min_range_m={self._cloud_min_range_m}, "
             f"device_to_sensor_rotation={self._sensor_rotation.reshape(9).tolist()}"
         )
 
@@ -271,6 +288,8 @@ class _NavigationSensorNode(Node):
         self._maybe_publish_status()
 
     def _cloud_loop(self) -> None:
+        pending_packets = []
+        previous_stamp_ns = None
         while not self._stop.is_set():
             try:
                 item = self._cloud_queue.get(timeout=0.5)
@@ -290,6 +309,13 @@ class _NavigationSensorNode(Node):
                 data,
                 is_dense,
             ) = item
+            if pending_packets and (
+                corrected_ns <= previous_stamp_ns
+                or corrected_ns - previous_stamp_ns > self._cloud_max_packet_gap_ns
+            ):
+                pending_packets.clear()
+                self._counters["cloud_aggregation_resets"] += 1
+            previous_stamp_ns = corrected_ns
             try:
                 converted = unitree_mid360_to_navigation_cloud(
                     data=data,
@@ -300,11 +326,30 @@ class _NavigationSensorNode(Node):
                     fields=fields,
                     header_stamp_ns=corrected_ns,
                     rotation_matrix=self._sensor_rotation,
+                    min_range_m=self._cloud_min_range_m,
                 )
+                self._counters["cloud_raw_points"] += height * width
+                self._counters["cloud_environment_points"] += (
+                    len(converted) // NAVIGATION_POINT_STEP
+                )
+                pending_packets.append((corrected_ns, converted, is_dense))
+                if len(pending_packets) < self._cloud_packets_per_scan:
+                    continue
+
+                frame_stamp_ns = pending_packets[0][0]
+                converted = merge_navigation_clouds(
+                    [packet[1] for packet in pending_packets]
+                )
+                is_dense = all(packet[2] for packet in pending_packets)
+                self._counters["cloud_packets_aggregated"] += len(pending_packets)
+                pending_packets.clear()
+                if not converted:
+                    self._counters["cloud_dropped"] += 1
+                    continue
                 out = PointCloud2()
-                self._set_stamp(out.header, corrected_ns, self._sensor_frame)
+                self._set_stamp(out.header, frame_stamp_ns, self._sensor_frame)
                 out.height = 1
-                out.width = height * width
+                out.width = len(converted) // NAVIGATION_POINT_STEP
                 out.fields = [
                     PointField(
                         name=field.name,
@@ -324,6 +369,10 @@ class _NavigationSensorNode(Node):
                 self._cloud_pub.publish(out)
                 self._counters["cloud_published"] += 1
             except (TypeError, ValueError) as exc:
+                if pending_packets:
+                    pending_packets.clear()
+                    self._counters["cloud_aggregation_resets"] += 1
+                previous_stamp_ns = None
                 self._counters["cloud_dropped"] += 1
                 if self._counters["cloud_dropped"] <= 3:
                     self.get_logger().warning(
@@ -452,6 +501,11 @@ class _NavigationSensorNode(Node):
                 "device_to_sensor_rotation_matrix": [
                     float(value) for value in self._sensor_rotation.reshape(9)
                 ],
+                "cloud_processing": {
+                    "packets_per_scan": self._cloud_packets_per_scan,
+                    "min_range_m": self._cloud_min_range_m,
+                    "max_packet_gap_ms": self._cloud_max_packet_gap_ns / 1_000_000,
+                },
             },
             separators=(",", ":"),
         )

--- a/unitree/go2/navigation_sensor_bridge_main.py
+++ b/unitree/go2/navigation_sensor_bridge_main.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Isolated MID360 bridge worker for the Go2 Driver navigation sensor card."""
+
+from __future__ import annotations
+
+try:
+    from common import logsafe
+    logsafe.install(check_fd=False)
+except ImportError:
+    pass
+
+import os
+import re
+import signal
+import socket
+import sys
+import threading
+from pathlib import Path
+
+import rclpy
+from rclpy.executors import MultiThreadedExecutor
+import yaml
+
+from navigation_sensor_bridge import _NavigationSensorNode
+from unitree_sdk2py.core.channel import ChannelFactoryInitialize
+
+
+def _load_config() -> dict:
+    path = Path(os.environ.get("CONFIG_PATH", Path(__file__).with_name("config.yaml")))
+    with path.open() as stream:
+        config = yaml.safe_load(stream)
+    if not isinstance(config, dict):
+        raise ValueError(f"navigation bridge config must be a mapping: {path}")
+    return config
+
+
+def _resolve_namespace(config: dict) -> str:
+    value = os.environ.get("ROS_NAMESPACE", "").strip()
+    if not value:
+        value = str(config.get("ros_namespace", "")).strip()
+    if not value:
+        value = socket.gethostname()
+    value = re.sub(r"[^a-zA-Z0-9_]", "_", value.strip("/"))
+    if not value:
+        raise ValueError("ROS namespace resolves to an empty value")
+    return value
+
+
+def main() -> int:
+    network_interface = (
+        sys.argv[1] if len(sys.argv) > 1 else os.environ.get("NETWORK_INTERFACE", "eth0")
+    )
+    config = _load_config()
+    plugin_config = config.get("plugins", {}).get("navigation_sensors", {})
+    if not plugin_config.get("enabled", False):
+        raise RuntimeError("plugins.navigation_sensors.enabled must be true")
+
+    namespace = _resolve_namespace(config)
+    ChannelFactoryInitialize(0, network_interface)
+    print(
+        f"[navigation-sensors-worker] DDS initialized on {network_interface}; "
+        f"ROS namespace={namespace}",
+        flush=True,
+    )
+
+    rclpy.init()
+    executor = MultiThreadedExecutor(num_threads=3)
+    node = _NavigationSensorNode(plugin_config, namespace)
+    executor.add_node(node)
+    stop = threading.Event()
+
+    def _request_stop(signum, _frame):
+        print(
+            f"[navigation-sensors-worker] signal {signum}, shutting down",
+            flush=True,
+        )
+        stop.set()
+
+    signal.signal(signal.SIGTERM, _request_stop)
+    signal.signal(signal.SIGINT, _request_stop)
+
+    try:
+        while rclpy.ok() and not stop.is_set():
+            executor.spin_once(timeout_sec=0.2)
+    finally:
+        node.close()
+        executor.remove_node(node)
+        node.destroy_node()
+        executor.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unitree/go2/navigation_time.py
+++ b/unitree/go2/navigation_time.py
@@ -1,0 +1,150 @@
+"""Clock-domain normalization helpers for the G1 navigation sensor bridge.
+
+Unitree's MID360 publishes LiDAR and IMU headers in a shared sensor clock that
+is not guaranteed to match the Jetson system clock.  Estimators and planners
+must still receive ROS timestamps in one coherent clock domain.  This module is
+kept free of ROS dependencies so the correction policy can be unit tested on a
+development machine.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import asdict, dataclass
+import threading
+
+
+NSEC_PER_SEC = 1_000_000_000
+
+
+def stamp_to_ns(sec: int, nanosec: int) -> int:
+    """Convert a ROS-style ``sec``/``nanosec`` pair to integer nanoseconds."""
+    if not 0 <= int(nanosec) < NSEC_PER_SEC:
+        raise ValueError(f"nanosec out of range: {nanosec}")
+    return int(sec) * NSEC_PER_SEC + int(nanosec)
+
+
+def split_ns(timestamp_ns: int) -> tuple[int, int]:
+    """Split integer nanoseconds into a normalized ROS timestamp pair."""
+    sec, nanosec = divmod(int(timestamp_ns), NSEC_PER_SEC)
+    return sec, nanosec
+
+
+@dataclass(frozen=True)
+class ClockSnapshot:
+    ready: bool
+    samples: int
+    offset_ns: int | None
+    residual_ns: int | None
+    resets: int
+    rejected: int
+    pending_reset_samples: int
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class ClockOffsetEstimator:
+    """Estimate ``host_time - sensor_time`` from callback arrival times.
+
+    Transport and scheduling latency is non-negative, so the minimum candidate
+    in a rolling window is a better offset estimate than an average.  A single
+    late callback is rejected instead of shifting every subsequent timestamp.
+    Persistent jumps are treated as a source-clock reset and require a new
+    warm-up period.
+    """
+
+    def __init__(
+        self,
+        *,
+        warmup_samples: int = 32,
+        window_samples: int = 400,
+        reset_threshold_ns: int = NSEC_PER_SEC,
+        reset_confirm_samples: int = 8,
+    ) -> None:
+        if warmup_samples < 1:
+            raise ValueError("warmup_samples must be positive")
+        if window_samples < warmup_samples:
+            raise ValueError("window_samples must be >= warmup_samples")
+        if reset_threshold_ns < 1:
+            raise ValueError("reset_threshold_ns must be positive")
+        if reset_confirm_samples < 2:
+            raise ValueError("reset_confirm_samples must be >= 2")
+
+        self._warmup_samples = warmup_samples
+        self._reset_threshold_ns = reset_threshold_ns
+        self._reset_confirm_samples = reset_confirm_samples
+        self._candidates: deque[int] = deque(maxlen=window_samples)
+        self._pending_reset: list[int] = []
+        self._offset_ns: int | None = None
+        self._residual_ns: int | None = None
+        self._ready = False
+        self._resets = 0
+        self._rejected = 0
+        self._lock = threading.Lock()
+
+    def correct_observation(self, source_ns: int, host_arrival_ns: int) -> int | None:
+        """Observe one sample and return its corrected host timestamp when ready.
+
+        ``None`` means the sample must not be published: either the initial
+        offset is still warming up or the observation looks like a clock jump.
+        """
+        source_ns = int(source_ns)
+        host_arrival_ns = int(host_arrival_ns)
+        if source_ns <= 0 or host_arrival_ns <= 0:
+            raise ValueError("timestamps must be positive")
+
+        candidate = host_arrival_ns - source_ns
+        with self._lock:
+            if self._offset_ns is None:
+                self._accept_locked(candidate)
+            else:
+                delta = candidate - self._offset_ns
+                if delta < -self._reset_threshold_ns:
+                    # The source clock jumped forward.  Re-baseline immediately;
+                    # normal callback latency cannot make this candidate smaller.
+                    self._reset_locked(candidate)
+                elif delta > self._reset_threshold_ns:
+                    # This may be one delayed callback or a source clock that
+                    # jumped backwards.  Require consecutive evidence so a large
+                    # point-cloud callback cannot reset the IMU clock domain.
+                    self._pending_reset.append(candidate)
+                    self._rejected += 1
+                    self._residual_ns = delta
+                    if len(self._pending_reset) >= self._reset_confirm_samples:
+                        self._reset_locked(min(self._pending_reset))
+                    return None
+                else:
+                    self._pending_reset.clear()
+                    self._accept_locked(candidate)
+
+            if not self._ready:
+                return None
+            return source_ns + int(self._offset_ns)
+
+    def snapshot(self) -> ClockSnapshot:
+        with self._lock:
+            return ClockSnapshot(
+                ready=self._ready,
+                samples=len(self._candidates),
+                offset_ns=self._offset_ns,
+                residual_ns=self._residual_ns,
+                resets=self._resets,
+                rejected=self._rejected,
+                pending_reset_samples=len(self._pending_reset),
+            )
+
+    def _accept_locked(self, candidate: int) -> None:
+        self._candidates.append(candidate)
+        self._offset_ns = min(self._candidates)
+        self._residual_ns = candidate - self._offset_ns
+        self._ready = len(self._candidates) >= self._warmup_samples
+
+    def _reset_locked(self, candidate: int) -> None:
+        self._candidates.clear()
+        self._pending_reset.clear()
+        self._offset_ns = None
+        self._residual_ns = None
+        self._ready = False
+        self._resets += 1
+        self._accept_locked(candidate)

--- a/unitree/go2/proposal_controller.py
+++ b/unitree/go2/proposal_controller.py
@@ -1,0 +1,452 @@
+"""Go2 execution adapter for validated Nav2 velocity proposals."""
+
+from __future__ import annotations
+
+import json
+import math
+import queue
+import threading
+import time
+
+from rclpy.node import Node
+from rclpy.qos import (
+    DurabilityPolicy,
+    HistoryPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+from std_msgs.msg import String
+
+from velocity_proposal import ProposalLimits, VelocityProposalGate
+
+
+_PROPOSAL_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    durability=DurabilityPolicy.VOLATILE,
+)
+_STATE_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+
+class Go2VelocityProposalController(Node):
+    """Own the Go2 proposal subscription, lease, watchdog and StopMove path."""
+
+    def __init__(self, config: dict, namespace: str, rpc_proxy):
+        super().__init__("go2_velocity_proposal")
+        self._rpc = rpc_proxy
+        self._topic = str(
+            config.get(
+                "velocity_proposal_topic",
+                "/ubuntu/navigation/nav2/velocity_proposal",
+            )
+        ).strip()
+        if not self._topic.startswith("/"):
+            self._topic = f"/{self._topic}"
+        self._state_topic = f"/{namespace}/loco/state"
+        self._limits = ProposalLimits(
+            max_ttl_ms=int(config.get("velocity_proposal_max_ttl_ms", 250)),
+            min_x=float(config.get("velocity_proposal_min_x", -1.0)),
+            max_x=float(config.get("velocity_proposal_max_x", 1.0)),
+            max_abs_y=float(config.get("velocity_proposal_max_abs_y", 1.0)),
+            max_abs_yaw=float(config.get("velocity_proposal_max_abs_yaw", 2.0)),
+            max_planar_speed=float(
+                config.get("velocity_proposal_max_planar_speed", math.sqrt(2.0))
+            ),
+        )
+        self._gate = VelocityProposalGate(self._limits)
+        self._lock = threading.RLock()
+        self._rpc_lock = threading.Lock()
+        self._state_condition = threading.Condition()
+        self._last_state_monotonic = 0.0
+        self._last_velocity = (float("inf"), float("inf"), float("inf"))
+        self._stop_timeout = max(
+            0.2, float(config.get("velocity_proposal_stop_confirm_timeout", 1.0))
+        )
+        self._linear_epsilon = max(
+            0.0, float(config.get("velocity_proposal_stop_linear_epsilon", 0.04))
+        )
+        self._yaw_epsilon = max(
+            0.0, float(config.get("velocity_proposal_stop_yaw_epsilon", 0.08))
+        )
+        self._proposal_sub = None
+        self._state_sub = self.create_subscription(
+            String, self._state_topic, self._on_state, _STATE_QOS
+        )
+        self._commands: queue.Queue = queue.Queue(maxsize=1)
+        self._shutdown = threading.Event()
+        self._stop_transition = threading.Event()
+        self._last_stop_attempt_monotonic = 0.0
+        self._counters = {
+            "received": 0,
+            "accepted": 0,
+            "applied": 0,
+            "rejected": 0,
+            "coalesced": 0,
+            "rejections_by_reason": {},
+            "watchdog_faults_by_reason": {},
+        }
+        self._last_rpc = {
+            "ret": None,
+            "duration_ms": None,
+            "error": None,
+            "nav_id": None,
+            "sequence": None,
+        }
+        self._worker = threading.Thread(
+            target=self._command_loop,
+            name="go2_velocity_proposal_apply",
+            daemon=True,
+        )
+        self._watchdog = threading.Thread(
+            target=self._watchdog_loop,
+            name="go2_velocity_proposal_watchdog",
+            daemon=True,
+        )
+        self._worker.start()
+        self._watchdog.start()
+
+    @property
+    def topic(self) -> str:
+        return self._topic
+
+    def _record_rejection(self, reason: str) -> None:
+        self._counters["rejected"] += 1
+        reasons = self._counters["rejections_by_reason"]
+        reasons[reason] = reasons.get(reason, 0) + 1
+
+    def _record_watchdog(self, reason: str) -> None:
+        reasons = self._counters["watchdog_faults_by_reason"]
+        reasons[reason] = reasons.get(reason, 0) + 1
+
+    def _on_state(self, msg) -> None:
+        try:
+            payload = json.loads(msg.data)
+            velocity = payload["velocity"]
+            sample = (
+                float(velocity[0]),
+                float(velocity[1]),
+                float(payload["yaw_speed"]),
+            )
+        except (KeyError, IndexError, TypeError, ValueError, json.JSONDecodeError):
+            return
+        with self._state_condition:
+            self._last_velocity = sample
+            self._last_state_monotonic = time.monotonic()
+            self._state_condition.notify_all()
+
+    def _put_latest(self, command: dict) -> None:
+        try:
+            self._commands.put_nowait(command)
+            return
+        except queue.Full:
+            pass
+        try:
+            self._commands.get_nowait()
+        except queue.Empty:
+            pass
+        else:
+            self._counters["coalesced"] += 1
+        self._commands.put_nowait(command)
+
+    def _enqueue_stop(self, reason: str) -> None:
+        if self._stop_transition.is_set():
+            return
+        self._stop_transition.set()
+        self._put_latest({"kind": "stop", "reason": reason})
+
+    def _on_proposal(self, msg) -> None:
+        now = time.monotonic()
+        now_unix_ms = time.time() * 1000.0
+        with self._lock:
+            self._counters["received"] += 1
+            if self._stop_transition.is_set():
+                self._record_rejection("stop_transition")
+                return
+            try:
+                payload = json.loads(msg.data)
+            except (AttributeError, TypeError, json.JSONDecodeError):
+                self._record_rejection("invalid_json")
+                if self._gate.armed:
+                    self._gate.disarm("invalid_json")
+                    self._enqueue_stop("invalid_json")
+                return
+            was_armed = self._gate.armed
+            decision = self._gate.accept(payload, now, now_unix_ms=now_unix_ms)
+            if decision.stop:
+                if decision.reason != "proposal_zero":
+                    self._record_rejection(decision.reason)
+                if was_armed or self._gate.armed or self._gate.terminal_pending_stop:
+                    self._enqueue_stop(decision.reason)
+                return
+            if not decision.execute or decision.proposal is None:
+                self._record_rejection(decision.reason or "proposal_not_executable")
+                return
+            proposal = decision.proposal
+            self._counters["accepted"] += 1
+            self._put_latest(
+                {
+                    "kind": "move",
+                    "nav_id": proposal.nav_id,
+                    "sequence": proposal.sequence,
+                    "vx": proposal.x,
+                    "vy": proposal.y,
+                    "vyaw": proposal.yaw,
+                    "deadline": self._gate.deadline_monotonic,
+                }
+            )
+
+    def _apply_move(self, command: dict) -> None:
+        with self._lock:
+            if (
+                self._stop_transition.is_set()
+                or not self._gate.armed
+                or command["nav_id"] != self._gate.expected_nav_id
+                or command["sequence"] != self._gate.last_sequence
+            ):
+                return
+            if time.monotonic() >= command["deadline"]:
+                self._record_rejection("proposal_ttl_expired")
+                self._gate.watchdog(time.monotonic())
+                self._record_watchdog("proposal_ttl_expired")
+                self._enqueue_stop("proposal_ttl_expired")
+                return
+
+        started = time.monotonic()
+        error = None
+        try:
+            with self._rpc_lock:
+                if time.monotonic() >= command["deadline"]:
+                    ret = None
+                    error = "proposal_ttl_expired_before_rpc"
+                else:
+                    ret = self._rpc.Move(
+                        command["vx"], command["vy"], command["vyaw"]
+                    )
+                    if ret == 0 and time.monotonic() >= command["deadline"]:
+                        error = "proposal_ttl_expired_after_rpc"
+        except Exception as exc:  # hardware boundary: fail closed
+            ret = None
+            error = str(exc)
+        duration_ms = round((time.monotonic() - started) * 1000.0, 1)
+        with self._lock:
+            self._last_rpc = {
+                "ret": ret,
+                "duration_ms": duration_ms,
+                "error": error,
+                "nav_id": command["nav_id"],
+                "sequence": command["sequence"],
+            }
+            if error or ret != 0:
+                reason = (
+                    "proposal_ttl_expired"
+                    if error in {
+                        "proposal_ttl_expired_before_rpc",
+                        "proposal_ttl_expired_after_rpc",
+                    }
+                    else "set_velocity_failed"
+                )
+                self._record_rejection(reason)
+                if reason == "proposal_ttl_expired":
+                    self._gate.request_ttl_stop(time.monotonic())
+                else:
+                    self._gate.disarm(reason)
+                self._enqueue_stop(reason)
+                return
+            self._counters["applied"] += 1
+
+    def _stop_and_confirm(self) -> tuple[int | None, bool, str | None]:
+        for _attempt in range(2):
+            boundary = time.monotonic()
+            try:
+                with self._rpc_lock:
+                    ret = self._rpc.StopMove()
+            except Exception as exc:  # hardware boundary: fail closed
+                return None, False, str(exc)
+            if ret != 0:
+                return ret, False, None
+            deadline = time.monotonic() + self._stop_timeout
+            with self._state_condition:
+                while time.monotonic() < deadline:
+                    vx, vy, vyaw = self._last_velocity
+                    if (
+                        self._last_state_monotonic >= boundary
+                        and math.hypot(vx, vy) <= self._linear_epsilon
+                        and abs(vyaw) <= self._yaw_epsilon
+                    ):
+                        return ret, True, None
+                    self._state_condition.wait(
+                        timeout=min(0.05, max(0.0, deadline - time.monotonic()))
+                    )
+        return ret, False, None
+
+    def _process_stop(self, reason: str) -> None:
+        self._last_stop_attempt_monotonic = time.monotonic()
+        ret, confirmed, error = self._stop_and_confirm()
+        with self._lock:
+            terminal = self._gate.terminal_pending_stop
+            if terminal:
+                self._gate.record_terminal_stop_result(confirmed)
+            elif confirmed and reason == "proposal_ttl_expired" and self._gate.armed:
+                self._gate.hold_after_confirmed_stop("proposal_ttl_expired")
+            elif not confirmed and self._gate.armed:
+                self._gate.disarm("stop_unconfirmed")
+            self._last_rpc.update(
+                {
+                    "stop_ret": ret,
+                    "stop_confirmed": confirmed,
+                    "stop_error": error,
+                }
+            )
+            self._stop_transition.clear()
+
+    def _command_loop(self) -> None:
+        while not self._shutdown.is_set():
+            try:
+                command = self._commands.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            if command is None:
+                return
+            if command["kind"] == "stop":
+                self._process_stop(command["reason"])
+            else:
+                self._apply_move(command)
+
+    def _watchdog_loop(self) -> None:
+        while not self._shutdown.wait(0.025):
+            with self._lock:
+                if self._stop_transition.is_set():
+                    continue
+                if self._gate.terminal_pending_stop:
+                    if time.monotonic() - self._last_stop_attempt_monotonic >= 0.25:
+                        self._enqueue_stop("terminal_retry")
+                    continue
+                decision = self._gate.watchdog(time.monotonic())
+                if decision.stop:
+                    self._record_watchdog(decision.reason)
+                    self._enqueue_stop(decision.reason)
+
+    def connect(self, topic: str, expected_nav_id: str | None = None) -> dict:
+        if topic != self._topic:
+            return {"error": "unexpected_velocity_proposal_topic", **self.status()}
+        with self._lock:
+            if self._proposal_sub is not None:
+                if (
+                    expected_nav_id is not None
+                    and self._gate.expected_nav_id
+                    and self._gate.expected_nav_id != expected_nav_id
+                ):
+                    return {"error": "proposal_lease_already_connected", **self.status()}
+                return self.status()
+            self._stop_transition.set()
+        self._clear_commands()
+        ret, confirmed, error = self._stop_and_confirm()
+        if not confirmed:
+            with self._lock:
+                self._stop_transition.clear()
+                self._last_rpc.update(
+                    {"stop_ret": ret, "stop_confirmed": False, "stop_error": error}
+                )
+            return {
+                "error": error or "StopMove was not confirmed before proposal bind",
+                **self.status(),
+            }
+        try:
+            proposal_sub = self.create_subscription(
+                String, topic, self._on_proposal, _PROPOSAL_QOS
+            )
+            with self._lock:
+                self._gate.bind(topic, expected_nav_id)
+                self._proposal_sub = proposal_sub
+        except Exception as exc:
+            if "proposal_sub" in locals():
+                self.destroy_subscription(proposal_sub)
+            with self._lock:
+                self._gate.unbind("proposal_bind_failed")
+                self._stop_transition.clear()
+            return {"error": str(exc), **self.status()}
+        with self._lock:
+            self._stop_transition.clear()
+        return self.status()
+
+    def _clear_commands(self) -> None:
+        while True:
+            try:
+                self._commands.get_nowait()
+            except queue.Empty:
+                return
+
+    def disconnect(self, reason: str = "canvas_stop") -> dict:
+        self._stop_transition.set()
+        self._clear_commands()
+        ret, confirmed, error = self._stop_and_confirm()
+        with self._lock:
+            sub = self._proposal_sub
+            self._proposal_sub = None
+            if sub is not None:
+                self.destroy_subscription(sub)
+            self._gate.unbind(reason)
+            self._stop_transition.clear()
+            self._last_rpc.update(
+                {"stop_ret": ret, "stop_confirmed": confirmed, "stop_error": error}
+            )
+            result = self.status()
+        if not confirmed:
+            result["error"] = error or "StopMove was not confirmed"
+        return result
+
+    def manual_override(self) -> bool:
+        with self._lock:
+            if not self._gate.connected_topic:
+                return True
+            self._gate.disarm("manual_override")
+            self._stop_transition.set()
+        self._clear_commands()
+        ret, confirmed, error = self._stop_and_confirm()
+        with self._lock:
+            self._last_rpc.update(
+                {"stop_ret": ret, "stop_confirmed": confirmed, "stop_error": error}
+            )
+            self._stop_transition.clear()
+        return confirmed
+
+    def status(self) -> dict:
+        with self._lock:
+            snapshot = self._gate.snapshot(time.monotonic())
+            state_age_ms = (
+                round((time.monotonic() - self._last_state_monotonic) * 1000.0)
+                if self._last_state_monotonic > 0.0
+                else None
+            )
+            return {
+                **snapshot,
+                "state": "ready" if snapshot["connected"] else "idle",
+                "canvas_running": snapshot["connected"],
+                "driver_authorized": snapshot["armed"],
+                "proposal_execution": {
+                    **self._counters,
+                    "last_rpc": dict(self._last_rpc),
+                },
+                "loco_state_age_ms": state_age_ms,
+                "stop_transition_active": self._stop_transition.is_set(),
+            }
+
+    def close(self) -> None:
+        self.disconnect("driver_stop")
+        self._shutdown.set()
+        try:
+            self._commands.put_nowait(None)
+        except queue.Full:
+            try:
+                self._commands.get_nowait()
+            except queue.Empty:
+                pass
+            self._commands.put_nowait(None)
+        self._worker.join(timeout=2.0)
+        self._watchdog.join(timeout=2.0)

--- a/unitree/go2/proposal_controller.py
+++ b/unitree/go2/proposal_controller.py
@@ -65,6 +65,8 @@ class Go2VelocityProposalController(Node):
         self._state_condition = threading.Condition()
         self._last_state_monotonic = 0.0
         self._last_velocity = (float("inf"), float("inf"), float("inf"))
+        self._last_sport_mode = None
+        self._last_gait_type = None
         self._stop_timeout = max(
             0.2, float(config.get("velocity_proposal_stop_confirm_timeout", 1.0))
         )
@@ -133,10 +135,14 @@ class Go2VelocityProposalController(Node):
                 float(velocity[1]),
                 float(payload["yaw_speed"]),
             )
+            sport_mode = int(payload["sport_mode"])
+            gait_type = int(payload["gait_type"])
         except (KeyError, IndexError, TypeError, ValueError, json.JSONDecodeError):
             return
         with self._state_condition:
             self._last_velocity = sample
+            self._last_sport_mode = sport_mode
+            self._last_gait_type = gait_type
             self._last_state_monotonic = time.monotonic()
             self._state_condition.notify_all()
 
@@ -268,7 +274,7 @@ class Go2VelocityProposalController(Node):
                     ret = self._rpc.StopMove()
             except Exception as exc:  # hardware boundary: fail closed
                 return None, False, str(exc)
-            if ret != 0:
+            if ret not in (0, -1):
                 return ret, False, None
             deadline = time.monotonic() + self._stop_timeout
             with self._state_condition:
@@ -278,6 +284,13 @@ class Go2VelocityProposalController(Node):
                         self._last_state_monotonic >= boundary
                         and math.hypot(vx, vy) <= self._linear_epsilon
                         and abs(vyaw) <= self._yaw_epsilon
+                        and (
+                            ret == 0
+                            or (
+                                self._last_sport_mode == 0
+                                and self._last_gait_type == 0
+                            )
+                        )
                     ):
                         return ret, True, None
                     self._state_condition.wait(

--- a/unitree/go2/rpc_proxy.py
+++ b/unitree/go2/rpc_proxy.py
@@ -16,6 +16,12 @@ import time
 def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.Queue,
                 network_iface: str):
     """Subprocess: holds dedicated RPC clients, processes commands sequentially."""
+    try:
+        from common import logsafe
+        logsafe.install(check_fd=False)
+    except ImportError:
+        pass
+
     from unitree_sdk2py.core.channel import ChannelFactoryInitialize, ChannelPublisher
     from unitree_sdk2py.go2.sport.sport_client import SportClient
     from unitree_sdk2py.go2.obstacles_avoid.obstacles_avoid_client import ObstaclesAvoidClient

--- a/unitree/go2/tests/test_navigation_pointcloud.py
+++ b/unitree/go2/tests/test_navigation_pointcloud.py
@@ -1,0 +1,207 @@
+import struct
+import sys
+import unittest
+
+# Some legacy Driver tests install a minimal numpy import stub before importing
+# device.py. Restore the real dependency when the complete suite runs in one
+# interpreter so this numeric conversion test remains order-independent.
+if not hasattr(sys.modules.get("numpy"), "dtype"):
+    sys.modules.pop("numpy", None)
+import numpy as np
+
+from navigation_pointcloud import (
+    NAVIGATION_FIELDS,
+    NAVIGATION_POINT_STEP,
+    FLOAT32,
+    UINT16,
+    rotate_covariance9,
+    rotate_orientation_xyzw,
+    rotate_vector3,
+    unitree_mid360_to_navigation_cloud,
+    validated_rotation_matrix,
+)
+
+
+UNITREE_FIELDS = [
+    ("x", 0, FLOAT32, 1),
+    ("y", 4, FLOAT32, 1),
+    ("z", 8, FLOAT32, 1),
+    ("intensity", 16, FLOAT32, 1),
+    ("ring", 20, UINT16, 1),
+    ("time", 24, FLOAT32, 1),
+]
+UNITREE_POINT_STEP = 32
+
+
+class Mid360ConversionTest(unittest.TestCase):
+    def make_cloud(self):
+        data = bytearray(2 * UNITREE_POINT_STEP)
+        for index, values in enumerate(
+            (
+                (1.0, 2.0, 3.0, 42.0, 0, 5_000.0),
+                (-1.0, -2.0, -3.0, 163.0, 3, 100_320_000.0),
+            )
+        ):
+            base = index * UNITREE_POINT_STEP
+            x, y, z, intensity, ring, point_time = values
+            struct.pack_into("<fff", data, base, x, y, z)
+            struct.pack_into("<f", data, base + 16, intensity)
+            struct.pack_into("<H", data, base + 20, ring)
+            struct.pack_into("<f", data, base + 24, point_time)
+        return bytes(data)
+
+    def decode(self, converted):
+        dtype = np.dtype(
+            {
+                "names": [field.name for field in NAVIGATION_FIELDS],
+                "formats": ["<f4", "<f4", "<f4", "<f4", "u1", "u1", "<f8"],
+                "offsets": [field.offset for field in NAVIGATION_FIELDS],
+                "itemsize": NAVIGATION_POINT_STEP,
+            }
+        )
+        return np.frombuffer(converted, dtype=dtype)
+
+    def test_converts_relative_time_to_absolute_nanoseconds(self):
+        header_ns = 1_785_811_000_000_000_000
+        converted = unitree_mid360_to_navigation_cloud(
+            data=self.make_cloud(),
+            height=1,
+            width=2,
+            point_step=UNITREE_POINT_STEP,
+            row_step=2 * UNITREE_POINT_STEP,
+            fields=UNITREE_FIELDS,
+            header_stamp_ns=header_ns,
+        )
+        points = self.decode(converted)
+
+        self.assertEqual(len(converted), 2 * NAVIGATION_POINT_STEP)
+        np.testing.assert_allclose(points["x"], [1.0, -1.0])
+        np.testing.assert_allclose(points["intensity"], [42.0, 163.0])
+        np.testing.assert_array_equal(points["tag"], [0x10, 0x10])
+        np.testing.assert_array_equal(points["line"], [0, 3])
+        np.testing.assert_allclose(
+            points["timestamp"] - np.float64(header_ns),
+            [5_000.0, 100_320_000.0],
+            atol=256.0,
+        )
+
+    def test_rejects_missing_time_field(self):
+        with self.assertRaisesRegex(ValueError, "missing MID360 field: time"):
+            unitree_mid360_to_navigation_cloud(
+                data=self.make_cloud(),
+                height=1,
+                width=2,
+                point_step=UNITREE_POINT_STEP,
+                row_step=2 * UNITREE_POINT_STEP,
+                fields=[field for field in UNITREE_FIELDS if field[0] != "time"],
+                header_stamp_ns=1_000_000_000,
+            )
+
+    def test_rejects_short_data(self):
+        with self.assertRaisesRegex(ValueError, "size must equal"):
+            unitree_mid360_to_navigation_cloud(
+                data=b"short",
+                height=1,
+                width=2,
+                point_step=UNITREE_POINT_STEP,
+                row_step=2 * UNITREE_POINT_STEP,
+                fields=UNITREE_FIELDS,
+                header_stamp_ns=1_000_000_000,
+            )
+
+    def test_rejects_organized_cloud_row_padding(self):
+        with self.assertRaisesRegex(ValueError, "tightly packed"):
+            unitree_mid360_to_navigation_cloud(
+                data=self.make_cloud() + b"\0" * 4,
+                height=2,
+                width=1,
+                point_step=UNITREE_POINT_STEP,
+                row_step=UNITREE_POINT_STEP + 2,
+                fields=UNITREE_FIELDS,
+                header_stamp_ns=1_000_000_000,
+            )
+
+    def test_rejects_row_step_smaller_than_one_row(self):
+        with self.assertRaisesRegex(ValueError, "tightly packed"):
+            unitree_mid360_to_navigation_cloud(
+                data=self.make_cloud()[:60],
+                height=1,
+                width=2,
+                point_step=UNITREE_POINT_STEP,
+                row_step=60,
+                fields=UNITREE_FIELDS,
+                header_stamp_ns=1_000_000_000,
+            )
+
+    def test_applies_fixed_rotation_without_changing_auxiliary_fields(self):
+        rotation = validated_rotation_matrix(
+            [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                -1.0,
+                0.0,
+                0.0,
+                0.0,
+                -1.0,
+            ]
+        )
+        header_ns = 1_785_811_000_000_000_000
+        converted = unitree_mid360_to_navigation_cloud(
+            data=self.make_cloud(),
+            height=1,
+            width=2,
+            point_step=UNITREE_POINT_STEP,
+            row_step=2 * UNITREE_POINT_STEP,
+            fields=UNITREE_FIELDS,
+            header_stamp_ns=header_ns,
+            rotation_matrix=rotation,
+        )
+        points = self.decode(converted)
+
+        np.testing.assert_allclose(points["x"], [1.0, -1.0])
+        np.testing.assert_allclose(points["y"], [-2.0, 2.0])
+        np.testing.assert_allclose(points["z"], [-3.0, 3.0])
+        np.testing.assert_allclose(points["intensity"], [42.0, 163.0])
+        np.testing.assert_array_equal(points["tag"], [0x10, 0x10])
+        np.testing.assert_array_equal(points["line"], [0, 3])
+        np.testing.assert_allclose(
+            points["timestamp"] - np.float64(header_ns),
+            [5_000.0, 100_320_000.0],
+            atol=256.0,
+        )
+
+    def test_rotation_helpers_use_the_same_corrected_frame(self):
+        rotation = validated_rotation_matrix(
+            [1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0]
+        )
+
+        np.testing.assert_allclose(
+            rotate_vector3((1.0, 2.0, 3.0), rotation),
+            (1.0, -2.0, -3.0),
+        )
+        np.testing.assert_allclose(
+            rotate_covariance9(
+                [1.0, 2.0, 3.0, 2.0, 4.0, 5.0, 3.0, 5.0, 6.0],
+                rotation,
+            ),
+            [1.0, -2.0, -3.0, -2.0, 4.0, 5.0, -3.0, 5.0, 6.0],
+        )
+        qx, qy, qz, qw = rotate_orientation_xyzw(
+            (0.0, 0.0, 0.0, 1.0), rotation
+        )
+        self.assertAlmostEqual(abs(qx), 1.0)
+        self.assertAlmostEqual(qy, 0.0)
+        self.assertAlmostEqual(qz, 0.0)
+        self.assertAlmostEqual(qw, 0.0)
+
+    def test_rejects_non_rotation_matrix(self):
+        with self.assertRaisesRegex(ValueError, "orthonormal"):
+            validated_rotation_matrix([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 2.0])
+        with self.assertRaisesRegex(ValueError, "proper rotation"):
+            validated_rotation_matrix([-1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/go2/tests/test_navigation_pointcloud.py
+++ b/unitree/go2/tests/test_navigation_pointcloud.py
@@ -38,8 +38,8 @@ class Mid360ConversionTest(unittest.TestCase):
         data = bytearray(2 * UNITREE_POINT_STEP)
         for index, values in enumerate(
             (
-                (1.0, 2.0, 3.0, 42.0, 0, 5_000.0),
-                (-1.0, -2.0, -3.0, 163.0, 3, 100_320_000.0),
+                (1.0, 2.0, 3.0, 42.0, 0, 0.0005),
+                (-1.0, -2.0, -3.0, 163.0, 3, 0.0625),
             )
         ):
             base = index * UNITREE_POINT_STEP
@@ -61,7 +61,7 @@ class Mid360ConversionTest(unittest.TestCase):
         )
         return np.frombuffer(converted, dtype=dtype)
 
-    def test_converts_relative_time_to_absolute_nanoseconds(self):
+    def test_converts_relative_seconds_to_absolute_nanoseconds(self):
         header_ns = 1_785_811_000_000_000_000
         converted = unitree_mid360_to_navigation_cloud(
             data=self.make_cloud(),
@@ -81,9 +81,24 @@ class Mid360ConversionTest(unittest.TestCase):
         np.testing.assert_array_equal(points["line"], [0, 3])
         np.testing.assert_allclose(
             points["timestamp"] - np.float64(header_ns),
-            [5_000.0, 100_320_000.0],
+            [500_000.0, 62_500_000.0],
             atol=256.0,
         )
+        self.assertTrue(np.all(np.diff(points["timestamp"]) > 0.0))
+
+    def test_rejects_non_increasing_relative_seconds(self):
+        data = bytearray(self.make_cloud())
+        struct.pack_into("<f", data, UNITREE_POINT_STEP + 24, 0.0001)
+        with self.assertRaisesRegex(ValueError, "increasing timestamps"):
+            unitree_mid360_to_navigation_cloud(
+                data=bytes(data),
+                height=1,
+                width=2,
+                point_step=UNITREE_POINT_STEP,
+                row_step=2 * UNITREE_POINT_STEP,
+                fields=UNITREE_FIELDS,
+                header_stamp_ns=1_000_000_000,
+            )
 
     def test_rejects_missing_time_field(self):
         with self.assertRaisesRegex(ValueError, "missing MID360 field: time"):
@@ -168,7 +183,7 @@ class Mid360ConversionTest(unittest.TestCase):
         np.testing.assert_array_equal(points["line"], [0, 3])
         np.testing.assert_allclose(
             points["timestamp"] - np.float64(header_ns),
-            [5_000.0, 100_320_000.0],
+            [500_000.0, 62_500_000.0],
             atol=256.0,
         )
 

--- a/unitree/go2/tests/test_navigation_pointcloud.py
+++ b/unitree/go2/tests/test_navigation_pointcloud.py
@@ -14,6 +14,7 @@ from navigation_pointcloud import (
     NAVIGATION_POINT_STEP,
     FLOAT32,
     UINT16,
+    merge_navigation_clouds,
     rotate_covariance9,
     rotate_orientation_xyzw,
     rotate_vector3,
@@ -86,19 +87,61 @@ class Mid360ConversionTest(unittest.TestCase):
         )
         self.assertTrue(np.all(np.diff(points["timestamp"]) > 0.0))
 
-    def test_rejects_non_increasing_relative_seconds(self):
+    def test_sorts_non_increasing_relative_seconds(self):
         data = bytearray(self.make_cloud())
         struct.pack_into("<f", data, UNITREE_POINT_STEP + 24, 0.0001)
-        with self.assertRaisesRegex(ValueError, "increasing timestamps"):
-            unitree_mid360_to_navigation_cloud(
-                data=bytes(data),
-                height=1,
-                width=2,
-                point_step=UNITREE_POINT_STEP,
-                row_step=2 * UNITREE_POINT_STEP,
-                fields=UNITREE_FIELDS,
-                header_stamp_ns=1_000_000_000,
-            )
+        converted = unitree_mid360_to_navigation_cloud(
+            data=bytes(data),
+            height=1,
+            width=2,
+            point_step=UNITREE_POINT_STEP,
+            row_step=2 * UNITREE_POINT_STEP,
+            fields=UNITREE_FIELDS,
+            header_stamp_ns=1_000_000_000,
+        )
+        points = self.decode(converted)
+        np.testing.assert_allclose(points["x"], [-1.0, 1.0])
+        self.assertTrue(np.all(np.diff(points["timestamp"]) > 0.0))
+
+    def test_filters_near_field_and_merges_consecutive_packets(self):
+        data = bytearray(self.make_cloud())
+        struct.pack_into("<fff", data, 0, 0.1, 0.0, 0.0)
+        filtered = unitree_mid360_to_navigation_cloud(
+            data=bytes(data),
+            height=1,
+            width=2,
+            point_step=UNITREE_POINT_STEP,
+            row_step=2 * UNITREE_POINT_STEP,
+            fields=UNITREE_FIELDS,
+            header_stamp_ns=1_000_000_000,
+            min_range_m=0.5,
+        )
+        points = self.decode(filtered)
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points["line"].tolist(), [3])
+
+        first = unitree_mid360_to_navigation_cloud(
+            data=self.make_cloud(),
+            height=1,
+            width=2,
+            point_step=UNITREE_POINT_STEP,
+            row_step=2 * UNITREE_POINT_STEP,
+            fields=UNITREE_FIELDS,
+            header_stamp_ns=1_000_000_000,
+        )
+        second = unitree_mid360_to_navigation_cloud(
+            data=self.make_cloud(),
+            height=1,
+            width=2,
+            point_step=UNITREE_POINT_STEP,
+            row_step=2 * UNITREE_POINT_STEP,
+            fields=UNITREE_FIELDS,
+            header_stamp_ns=1_050_000_000,
+        )
+        merged = self.decode(merge_navigation_clouds([first, second]))
+        self.assertEqual(len(merged), 4)
+        self.assertEqual(merged["line"].tolist(), [0, 0, 3, 3])
+        self.assertTrue(np.all(np.diff(merged["timestamp"]) > 0.0))
 
     def test_rejects_missing_time_field(self):
         with self.assertRaisesRegex(ValueError, "missing MID360 field: time"):

--- a/unitree/go2/tests/test_navigation_sensor_card.py
+++ b/unitree/go2/tests/test_navigation_sensor_card.py
@@ -1,0 +1,314 @@
+import ast
+import importlib
+from pathlib import Path
+import sys
+import threading
+import time
+import types
+import unittest
+from unittest import mock
+
+
+GO2_DIR = Path(__file__).resolve().parents[1]
+
+
+class NavigationSensorCardContractTest(unittest.TestCase):
+    @staticmethod
+    def load_bridge_module():
+        if not hasattr(sys.modules.get("numpy"), "dtype"):
+            sys.modules.pop("numpy", None)
+
+        rclpy = sys.modules.setdefault("rclpy", types.ModuleType("rclpy"))
+        rclpy_node = types.ModuleType("rclpy.node")
+        rclpy_node.Node = type("Node", (), {})
+        rclpy_qos = types.ModuleType("rclpy.qos")
+
+        class QoSProfile:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        policy = type(
+            "Policy",
+            (),
+            {
+                "BEST_EFFORT": "best_effort",
+                "RELIABLE": "reliable",
+                "KEEP_LAST": "keep_last",
+                "VOLATILE": "volatile",
+            },
+        )
+        rclpy_qos.QoSProfile = QoSProfile
+        rclpy_qos.ReliabilityPolicy = policy
+        rclpy_qos.HistoryPolicy = policy
+        rclpy_qos.DurabilityPolicy = policy
+        sys.modules["rclpy.node"] = rclpy_node
+        sys.modules["rclpy.qos"] = rclpy_qos
+        rclpy.node = rclpy_node
+        rclpy.qos = rclpy_qos
+
+        sensor_msgs = types.ModuleType("sensor_msgs")
+        sensor_msgs_msg = types.ModuleType("sensor_msgs.msg")
+        for name in ("Imu", "PointCloud2", "PointField"):
+            setattr(sensor_msgs_msg, name, type(name, (), {}))
+        sensor_msgs.msg = sensor_msgs_msg
+        sys.modules["sensor_msgs"] = sensor_msgs
+        sys.modules["sensor_msgs.msg"] = sensor_msgs_msg
+
+        std_msgs = sys.modules.setdefault("std_msgs", types.ModuleType("std_msgs"))
+        std_msgs_msg = sys.modules.setdefault(
+            "std_msgs.msg", types.ModuleType("std_msgs.msg")
+        )
+        std_msgs_msg.String = type("String", (), {})
+        std_msgs.msg = std_msgs_msg
+
+        channel = types.ModuleType("unitree_sdk2py.core.channel")
+        channel.ChannelSubscriber = type("ChannelSubscriber", (), {})
+        idl = types.ModuleType("unitree_sdk2py.idl.sensor_msgs.msg.dds_")
+        idl.Imu_ = type("Imu_", (), {})
+        idl.PointCloud2_ = type("PointCloud2_", (), {})
+        sys.modules["unitree_sdk2py.core.channel"] = channel
+        sys.modules["unitree_sdk2py.idl.sensor_msgs.msg.dds_"] = idl
+
+        sys.modules.pop("navigation_sensor_bridge", None)
+        return importlib.import_module("navigation_sensor_bridge")
+
+    def test_bundle_registers_the_read_only_sensor_plugin(self):
+        source = (GO2_DIR / "main.py").read_text()
+        self.assertIn('plugins_cfg.get("navigation_sensors"', source)
+        self.assertIn("NavigationSensorPlugin", source)
+        self.assertIn("network_iface,", source)
+        ast.parse(source)
+
+    def test_default_config_uses_mid360_raw_dds_and_native_ros_topics(self):
+        config = (GO2_DIR / "config.yaml").read_text()
+        for expected in (
+            "velocity_proposal_topic: /ubuntu/navigation/nav2/velocity_proposal",
+            "navigation_sensors:\n    enabled: true",
+            "raw_cloud_topic: rt/utlidar/cloud",
+            "raw_imu_topic: rt/utlidar/imu",
+            "cloud_topic: /ubuntu/navigation/lidar",
+            "imu_topic: /ubuntu/navigation/imu",
+        ):
+            self.assertIn(expected, config)
+
+    def test_tools_declare_native_types_qos_and_fail_closed_status(self):
+        source = (GO2_DIR / "navigation_sensor_bridge.py").read_text()
+        for expected in (
+            '"navigation_lidar"',
+            '"navigation_imu"',
+            '"sensor/pointcloud"',
+            '"sensor_msgs/msg/PointCloud2"',
+            '"sensor_msgs/msg/Imu"',
+            '"RELIABLE + KEEP_LAST(depth=2) + VOLATILE"',
+            '"RELIABLE + KEEP_LAST(depth=200) + VOLATILE"',
+            'state = "running" if worker_running else "error"',
+            'blockers.append("clock_not_ready")',
+            'blockers.append("cloud_stale")',
+            'blockers.append("imu_stale")',
+            'blockers.append("worker_not_running")',
+            'subprocess.Popen(',
+        ):
+            self.assertIn(expected, source)
+        self.assertNotIn('"sensor/pointcloud2"', source)
+        ast.parse(source)
+
+    def test_runtime_exposes_only_generic_navigation_sensor_tools(self):
+        module = self.load_bridge_module()
+        plugin = module.NavigationSensorPlugin.__new__(module.NavigationSensorPlugin)
+        plugin._status_node = types.SimpleNamespace(
+            cloud_topic="/ubuntu/navigation/lidar",
+            imu_topic="/ubuntu/navigation/imu",
+            lidar_frame="custom_lidar_frame",
+            imu_frame="custom_imu_frame",
+            status=lambda worker_running: {
+                "ready": False,
+                "blockers": ["clock_not_ready"],
+                "receive_age_ms": {"cloud": None, "imu": None},
+                "clock": {"ready": False},
+                "counters": {},
+            },
+        )
+        plugin._proc = types.SimpleNamespace(poll=lambda: None, pid=1234)
+
+        tools = {tool["name"]: tool for tool in plugin.get_tools()}
+        self.assertEqual(set(tools), {"navigation_lidar", "navigation_imu"})
+        lidar = tools["navigation_lidar"]["topic_out"][0]
+        imu = tools["navigation_imu"]["topic_out"][0]
+        self.assertEqual(lidar["format"], "sensor/pointcloud")
+        self.assertEqual(lidar["ros_type"], "sensor_msgs/msg/PointCloud2")
+        self.assertEqual(lidar["qos"], "RELIABLE + KEEP_LAST(depth=2) + VOLATILE")
+        self.assertEqual(lidar["frame_id"], "custom_lidar_frame")
+        self.assertEqual(imu["format"], "sensor/imu")
+        self.assertEqual(imu["ros_type"], "sensor_msgs/msg/Imu")
+        self.assertEqual(imu["qos"], "RELIABLE + KEEP_LAST(depth=200) + VOLATILE")
+        self.assertEqual(imu["frame_id"], "custom_imu_frame")
+
+        info = plugin.dispatch("info", {"_tool_name": "navigation_lidar"})
+        self.assertEqual(info["state"], "not_ready")
+        self.assertEqual(info["blockers"], ["clock_not_ready"])
+
+    def test_monitor_preserves_configured_sensor_frames(self):
+        module = self.load_bridge_module()
+        with mock.patch.object(module.Node, "__init__", return_value=None), mock.patch.object(
+            module.Node,
+            "create_subscription",
+            return_value=object(),
+            create=True,
+        ):
+            monitor = module._NavigationSensorMonitorNode(
+                {
+                    "lidar_frame": "configured_lidar_frame",
+                    "imu_frame": "configured_imu_frame",
+                },
+                "ubuntu",
+            )
+
+        self.assertEqual(monitor.lidar_frame, "configured_lidar_frame")
+        self.assertEqual(monitor.imu_frame, "configured_imu_frame")
+
+    def test_driver_image_contains_the_sensor_card_runtime(self):
+        dockerfile = (GO2_DIR / "Dockerfile").read_text()
+        for filename in (
+            "navigation_sensor_bridge.py",
+            "navigation_sensor_bridge_main.py",
+            "navigation_pointcloud.py",
+            "navigation_time.py",
+        ):
+            self.assertIn(f"COPY {filename} /work/{filename}", dockerfile)
+
+    def test_worker_entry_owns_the_heavy_sensor_node(self):
+        source = (GO2_DIR / "navigation_sensor_bridge_main.py").read_text()
+        self.assertIn("_NavigationSensorNode(plugin_config, namespace)", source)
+        self.assertIn("ChannelFactoryInitialize(0, network_interface)", source)
+        self.assertLess(
+            source.index("logsafe.install(check_fd=False)"),
+            source.index("import rclpy"),
+        )
+        self.assertNotIn("NavigationSensorPlugin(", source)
+        ast.parse(source)
+
+    def test_plugin_starts_and_stops_one_isolated_worker(self):
+        module = self.load_bridge_module()
+        plugin = module.NavigationSensorPlugin.__new__(module.NavigationSensorPlugin)
+        plugin._namespace = "ubuntu"
+        plugin._network_iface = "eth0"
+        plugin._worker_path = GO2_DIR / "navigation_sensor_bridge_main.py"
+        plugin._proc = None
+        plugin._executor = mock.Mock()
+        plugin._status_node = mock.Mock()
+        proc = mock.Mock(pid=4321)
+        proc.poll.return_value = None
+
+        with mock.patch.object(module.subprocess, "Popen", return_value=proc) as popen:
+            plugin.start()
+            plugin.start()
+
+        popen.assert_called_once()
+        self.assertEqual(
+            popen.call_args.args[0],
+            [sys.executable, str(plugin._worker_path), "eth0"],
+        )
+        plugin.stop()
+        proc.terminate.assert_called_once_with()
+        proc.wait.assert_called_once_with(timeout=5.0)
+        self.assertIsNone(plugin._proc)
+        plugin._executor.remove_node.assert_called_once_with(plugin._status_node)
+        plugin._status_node.destroy_node.assert_called_once_with()
+
+    def test_either_card_stop_terminates_shared_worker_and_allows_restart(self):
+        module = self.load_bridge_module()
+
+        for tool_name in ("navigation_lidar", "navigation_imu"):
+            with self.subTest(tool_name=tool_name):
+                plugin = module.NavigationSensorPlugin.__new__(
+                    module.NavigationSensorPlugin
+                )
+                plugin._namespace = "ubuntu"
+                plugin._network_iface = "eth0"
+                plugin._worker_path = GO2_DIR / "navigation_sensor_bridge_main.py"
+                plugin._proc = None
+                plugin._status_node = types.SimpleNamespace(
+                    cloud_topic="/ubuntu/navigation/lidar",
+                    imu_topic="/ubuntu/navigation/imu",
+                    lidar_frame="utlidar_lidar",
+                    imu_frame="utlidar_imu",
+                    status=lambda running: {
+                        "ready": False,
+                        "blockers": ["clock_not_ready"],
+                    },
+                )
+                first = mock.Mock(pid=1001)
+                second = mock.Mock(pid=1002)
+                first.poll.return_value = None
+                second.poll.return_value = None
+
+                with mock.patch.object(
+                    module.subprocess,
+                    "Popen",
+                    side_effect=(first, second),
+                ) as popen:
+                    plugin.start()
+                    stopped = plugin.dispatch("stop", {"_tool_name": tool_name})
+                    stopped_again = plugin.dispatch(
+                        "stop", {"_tool_name": tool_name}
+                    )
+                    restarted = plugin.dispatch(
+                        "start", {"_tool_name": tool_name}
+                    )
+
+                self.assertEqual(
+                    stopped,
+                    {"state": "idle", "worker_running": False, "worker_pid": None},
+                )
+                self.assertEqual(stopped_again, stopped)
+                first.terminate.assert_called_once_with()
+                first.wait.assert_called_once_with(timeout=5.0)
+                self.assertEqual(popen.call_count, 2)
+                self.assertEqual(restarted["state"], "running")
+                self.assertFalse(restarted["ready"])
+                self.assertEqual(restarted["blockers"], ["clock_not_ready"])
+                self.assertEqual(restarted["worker_pid"], 1002)
+
+    def test_status_monitor_fails_closed_for_dead_or_stale_worker(self):
+        module = self.load_bridge_module()
+        node = module._NavigationSensorMonitorNode.__new__(
+            module._NavigationSensorMonitorNode
+        )
+        node._lock = threading.RLock()
+        node._last_status = {"ready": True, "blockers": []}
+        node._last_status_monotonic = time.monotonic() - 3.0
+
+        stale = node.status(worker_running=True)
+        self.assertFalse(stale["ready"])
+        self.assertIn("status_stale", stale["blockers"])
+
+        dead = node.status(worker_running=False)
+        self.assertFalse(dead["ready"])
+        self.assertIn("worker_not_running", dead["blockers"])
+
+    def test_invalid_timestamp_warnings_are_sampled_per_stream(self):
+        module = self.load_bridge_module()
+        node = module._NavigationSensorNode.__new__(module._NavigationSensorNode)
+        node._counters = {
+            "cloud_invalid_timestamps": 0,
+            "imu_invalid_timestamps": 0,
+        }
+        logger = mock.Mock()
+        node.get_logger = lambda: logger
+
+        for _ in range(201):
+            self.assertIsNone(node._correct_stamp(object(), "imu"))
+        self.assertIsNone(node._correct_stamp(object(), "cloud"))
+
+        self.assertEqual(node._counters["imu_invalid_timestamps"], 201)
+        self.assertEqual(node._counters["cloud_invalid_timestamps"], 1)
+        self.assertEqual(logger.warning.call_count, 4)
+        messages = [call.args[0] for call in logger.warning.call_args_list]
+        self.assertIn("invalid imu timestamp count=1", messages[0])
+        self.assertIn("invalid imu timestamp count=100", messages[1])
+        self.assertIn("invalid imu timestamp count=200", messages[2])
+        self.assertIn("invalid cloud timestamp count=1", messages[3])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/go2/tests/test_navigation_sensor_card.py
+++ b/unitree/go2/tests/test_navigation_sensor_card.py
@@ -54,6 +54,31 @@ class NavigationSensorCardContractTest(unittest.TestCase):
         sys.modules["sensor_msgs"] = sensor_msgs
         sys.modules["sensor_msgs.msg"] = sensor_msgs_msg
 
+        class TransformStamped:
+            def __init__(self):
+                self.header = types.SimpleNamespace(stamp=None, frame_id="")
+                self.child_frame_id = ""
+                self.transform = types.SimpleNamespace(
+                    translation=types.SimpleNamespace(x=0.0, y=0.0, z=0.0),
+                    rotation=types.SimpleNamespace(x=0.0, y=0.0, z=0.0, w=0.0),
+                )
+
+        geometry_msgs = types.ModuleType("geometry_msgs")
+        geometry_msgs_msg = types.ModuleType("geometry_msgs.msg")
+        geometry_msgs_msg.TransformStamped = TransformStamped
+        geometry_msgs.msg = geometry_msgs_msg
+        sys.modules["geometry_msgs"] = geometry_msgs
+        sys.modules["geometry_msgs.msg"] = geometry_msgs_msg
+
+        tf2_ros = types.ModuleType("tf2_ros")
+        tf2_static = types.ModuleType("tf2_ros.static_transform_broadcaster")
+        tf2_static.StaticTransformBroadcaster = type(
+            "StaticTransformBroadcaster", (), {}
+        )
+        tf2_ros.static_transform_broadcaster = tf2_static
+        sys.modules["tf2_ros"] = tf2_ros
+        sys.modules["tf2_ros.static_transform_broadcaster"] = tf2_static
+
         std_msgs = sys.modules.setdefault("std_msgs", types.ModuleType("std_msgs"))
         std_msgs_msg = sys.modules.setdefault(
             "std_msgs.msg", types.ModuleType("std_msgs.msg")
@@ -88,7 +113,10 @@ class NavigationSensorCardContractTest(unittest.TestCase):
             "raw_imu_topic: rt/utlidar/imu",
             "cloud_topic: /ubuntu/navigation/lidar",
             "imu_topic: /ubuntu/navigation/imu",
+            "base_frame: base_link",
             "sensor_frame: utlidar_lidar",
+            "base_to_sensor_translation_m: [0.28945, 0.0, -0.046825]",
+            "base_to_sensor_rotation_rpy_rad: [0.0, 2.8782, 0.0]",
             "device_to_sensor_rotation_matrix: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]",
         ):
             self.assertIn(expected, config)
@@ -165,6 +193,61 @@ class NavigationSensorCardContractTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "non-empty"):
             module._required_sensor_frame({"sensor_frame": "  "})
+
+    def test_worker_publishes_required_base_to_sensor_static_transform(self):
+        module = self.load_bridge_module()
+        config = {
+            "base_frame": "base_link",
+            "base_to_sensor_translation_m": [0.28945, 0.0, -0.046825],
+            "base_to_sensor_rotation_rpy_rad": [0.0, 2.8782, 0.0],
+        }
+        base_frame, translation, rpy = module._required_static_transform(
+            config, "utlidar_lidar"
+        )
+        node = module._NavigationSensorNode.__new__(module._NavigationSensorNode)
+        node._base_frame = base_frame
+        node._sensor_frame = "utlidar_lidar"
+        node._base_to_sensor_translation = translation
+        node._base_to_sensor_rpy = rpy
+        stamp = object()
+        node.get_clock = lambda: types.SimpleNamespace(
+            now=lambda: types.SimpleNamespace(to_msg=lambda: stamp)
+        )
+        broadcaster = mock.Mock()
+
+        with mock.patch.object(
+            module, "StaticTransformBroadcaster", return_value=broadcaster
+        ):
+            node._publish_static_transform()
+
+        transform = broadcaster.sendTransform.call_args.args[0]
+        self.assertIs(transform.header.stamp, stamp)
+        self.assertEqual(transform.header.frame_id, "base_link")
+        self.assertEqual(transform.child_frame_id, "utlidar_lidar")
+        self.assertEqual(
+            (
+                transform.transform.translation.x,
+                transform.transform.translation.y,
+                transform.transform.translation.z,
+            ),
+            translation,
+        )
+        quaternion = (
+            transform.transform.rotation.x,
+            transform.transform.rotation.y,
+            transform.transform.rotation.z,
+            transform.transform.rotation.w,
+        )
+        self.assertAlmostEqual(sum(value * value for value in quaternion), 1.0)
+
+        for invalid in (
+            {},
+            {**config, "base_frame": "utlidar_lidar"},
+            {**config, "base_to_sensor_translation_m": [0.0, 0.0]},
+            {**config, "base_to_sensor_rotation_rpy_rad": [0.0, float("nan"), 0.0]},
+        ):
+            with self.assertRaises(ValueError):
+                module._required_static_transform(invalid, "utlidar_lidar")
 
     def test_driver_image_contains_the_sensor_card_runtime(self):
         dockerfile = (GO2_DIR / "Dockerfile").read_text()

--- a/unitree/go2/tests/test_navigation_sensor_card.py
+++ b/unitree/go2/tests/test_navigation_sensor_card.py
@@ -118,6 +118,9 @@ class NavigationSensorCardContractTest(unittest.TestCase):
             "base_to_sensor_translation_m: [0.28945, 0.0, -0.046825]",
             "base_to_sensor_rotation_rpy_rad: [0.0, 2.8782, 0.0]",
             "device_to_sensor_rotation_matrix: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]",
+            "cloud_packets_per_scan: 2",
+            "cloud_min_range_m: 0.5",
+            "cloud_max_packet_gap_ms: 120",
         ):
             self.assertIn(expected, config)
 
@@ -136,6 +139,8 @@ class NavigationSensorCardContractTest(unittest.TestCase):
             'blockers.append("cloud_stale")',
             'blockers.append("imu_stale")',
             'blockers.append("worker_not_running")',
+            "merge_navigation_clouds(",
+            "min_range_m=self._cloud_min_range_m",
             'subprocess.Popen(',
         ):
             self.assertIn(expected, source)

--- a/unitree/go2/tests/test_navigation_sensor_card.py
+++ b/unitree/go2/tests/test_navigation_sensor_card.py
@@ -88,6 +88,8 @@ class NavigationSensorCardContractTest(unittest.TestCase):
             "raw_imu_topic: rt/utlidar/imu",
             "cloud_topic: /ubuntu/navigation/lidar",
             "imu_topic: /ubuntu/navigation/imu",
+            "sensor_frame: utlidar_lidar",
+            "device_to_sensor_rotation_matrix: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]",
         ):
             self.assertIn(expected, config)
 
@@ -118,8 +120,7 @@ class NavigationSensorCardContractTest(unittest.TestCase):
         plugin._status_node = types.SimpleNamespace(
             cloud_topic="/ubuntu/navigation/lidar",
             imu_topic="/ubuntu/navigation/imu",
-            lidar_frame="custom_lidar_frame",
-            imu_frame="custom_imu_frame",
+            sensor_frame="custom_sensor_frame",
             status=lambda worker_running: {
                 "ready": False,
                 "blockers": ["clock_not_ready"],
@@ -137,17 +138,17 @@ class NavigationSensorCardContractTest(unittest.TestCase):
         self.assertEqual(lidar["format"], "sensor/pointcloud")
         self.assertEqual(lidar["ros_type"], "sensor_msgs/msg/PointCloud2")
         self.assertEqual(lidar["qos"], "RELIABLE + KEEP_LAST(depth=2) + VOLATILE")
-        self.assertEqual(lidar["frame_id"], "custom_lidar_frame")
+        self.assertEqual(lidar["frame_id"], "custom_sensor_frame")
         self.assertEqual(imu["format"], "sensor/imu")
         self.assertEqual(imu["ros_type"], "sensor_msgs/msg/Imu")
         self.assertEqual(imu["qos"], "RELIABLE + KEEP_LAST(depth=200) + VOLATILE")
-        self.assertEqual(imu["frame_id"], "custom_imu_frame")
+        self.assertEqual(imu["frame_id"], "custom_sensor_frame")
 
         info = plugin.dispatch("info", {"_tool_name": "navigation_lidar"})
         self.assertEqual(info["state"], "not_ready")
         self.assertEqual(info["blockers"], ["clock_not_ready"])
 
-    def test_monitor_preserves_configured_sensor_frames(self):
+    def test_monitor_requires_one_configured_sensor_frame(self):
         module = self.load_bridge_module()
         with mock.patch.object(module.Node, "__init__", return_value=None), mock.patch.object(
             module.Node,
@@ -156,15 +157,14 @@ class NavigationSensorCardContractTest(unittest.TestCase):
             create=True,
         ):
             monitor = module._NavigationSensorMonitorNode(
-                {
-                    "lidar_frame": "configured_lidar_frame",
-                    "imu_frame": "configured_imu_frame",
-                },
+                {"sensor_frame": "configured_sensor_frame"},
                 "ubuntu",
             )
 
-        self.assertEqual(monitor.lidar_frame, "configured_lidar_frame")
-        self.assertEqual(monitor.imu_frame, "configured_imu_frame")
+        self.assertEqual(monitor.sensor_frame, "configured_sensor_frame")
+
+        with self.assertRaisesRegex(ValueError, "non-empty"):
+            module._required_sensor_frame({"sensor_frame": "  "})
 
     def test_driver_image_contains_the_sensor_card_runtime(self):
         dockerfile = (GO2_DIR / "Dockerfile").read_text()
@@ -230,8 +230,7 @@ class NavigationSensorCardContractTest(unittest.TestCase):
                 plugin._status_node = types.SimpleNamespace(
                     cloud_topic="/ubuntu/navigation/lidar",
                     imu_topic="/ubuntu/navigation/imu",
-                    lidar_frame="utlidar_lidar",
-                    imu_frame="utlidar_imu",
+                    sensor_frame="utlidar_lidar",
                     status=lambda running: {
                         "ready": False,
                         "blockers": ["clock_not_ready"],

--- a/unitree/go2/tests/test_navigation_time.py
+++ b/unitree/go2/tests/test_navigation_time.py
@@ -1,0 +1,104 @@
+import unittest
+
+from navigation_time import ClockOffsetEstimator, split_ns, stamp_to_ns
+
+
+class TimestampHelpersTest(unittest.TestCase):
+    def test_round_trip(self):
+        timestamp_ns = stamp_to_ns(1_769_941_368, 987_654_321)
+        self.assertEqual(split_ns(timestamp_ns), (1_769_941_368, 987_654_321))
+
+    def test_invalid_nanoseconds(self):
+        with self.assertRaises(ValueError):
+            stamp_to_ns(1, 1_000_000_000)
+
+
+class ClockOffsetEstimatorTest(unittest.TestCase):
+    def make_estimator(self):
+        return ClockOffsetEstimator(
+            warmup_samples=3,
+            window_samples=5,
+            reset_threshold_ns=1_000_000_000,
+            reset_confirm_samples=3,
+        )
+
+    def test_uses_minimum_arrival_latency_after_warmup(self):
+        estimator = self.make_estimator()
+        offset = 15_869_770_000_000_000
+        source = 1_769_941_368_000_000_000
+
+        self.assertIsNone(estimator.correct_observation(source, source + offset + 8_000_000))
+        self.assertIsNone(
+            estimator.correct_observation(source + 5_000_000, source + 5_000_000 + offset + 2_000_000)
+        )
+        corrected = estimator.correct_observation(
+            source + 10_000_000, source + 10_000_000 + offset + 5_000_000
+        )
+
+        self.assertEqual(corrected, source + 10_000_000 + offset + 2_000_000)
+        self.assertTrue(estimator.snapshot().ready)
+
+    def test_one_late_callback_is_rejected_without_reset(self):
+        estimator = self.make_estimator()
+        source = 10_000_000_000
+        offset = 20_000_000_000
+        for index in range(3):
+            estimator.correct_observation(
+                source + index * 10_000_000,
+                source + index * 10_000_000 + offset + 1_000_000,
+            )
+
+        late = estimator.correct_observation(
+            source + 30_000_000,
+            source + 30_000_000 + offset + 2_000_000_000,
+        )
+        recovered = estimator.correct_observation(
+            source + 40_000_000,
+            source + 40_000_000 + offset + 2_000_000,
+        )
+
+        self.assertIsNone(late)
+        self.assertIsNotNone(recovered)
+        self.assertEqual(estimator.snapshot().resets, 0)
+
+    def test_persistent_backward_clock_jump_restarts_warmup(self):
+        estimator = self.make_estimator()
+        source = 10_000_000_000
+        offset = 20_000_000_000
+        for index in range(3):
+            estimator.correct_observation(
+                source + index * 10_000_000,
+                source + index * 10_000_000 + offset,
+            )
+
+        for index in range(3):
+            self.assertIsNone(
+                estimator.correct_observation(
+                    source + 30_000_000 + index * 10_000_000,
+                    source + 30_000_000 + index * 10_000_000 + offset + 2_000_000_000,
+                )
+            )
+
+        snapshot = estimator.snapshot()
+        self.assertFalse(snapshot.ready)
+        self.assertEqual(snapshot.resets, 1)
+        self.assertEqual(snapshot.samples, 1)
+
+    def test_forward_clock_jump_restarts_immediately(self):
+        estimator = self.make_estimator()
+        source = 10_000_000_000
+        offset = 20_000_000_000
+        for index in range(3):
+            estimator.correct_observation(
+                source + index * 10_000_000,
+                source + index * 10_000_000 + offset,
+            )
+
+        self.assertIsNone(
+            estimator.correct_observation(source + 2_000_000_000, source + offset + 100_000_000)
+        )
+        self.assertEqual(estimator.snapshot().resets, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/go2/tests/test_proposal_controller.py
+++ b/unitree/go2/tests/test_proposal_controller.py
@@ -1,0 +1,231 @@
+import json
+from pathlib import Path
+import queue
+import sys
+import threading
+import time
+import types
+import unittest
+
+
+def _install_ros_stubs():
+    rclpy = types.ModuleType("rclpy")
+    node = types.ModuleType("rclpy.node")
+    node.Node = type("Node", (), {})
+    qos = types.ModuleType("rclpy.qos")
+
+    class QoSProfile:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    policy = type(
+        "Policy",
+        (),
+        {
+            "RELIABLE": "reliable",
+            "BEST_EFFORT": "best_effort",
+            "KEEP_LAST": "keep_last",
+            "VOLATILE": "volatile",
+        },
+    )
+    qos.QoSProfile = QoSProfile
+    qos.ReliabilityPolicy = policy
+    qos.HistoryPolicy = policy
+    qos.DurabilityPolicy = policy
+    rclpy.node = node
+    rclpy.qos = qos
+    sys.modules.setdefault("rclpy", rclpy)
+    sys.modules.setdefault("rclpy.node", node)
+    sys.modules.setdefault("rclpy.qos", qos)
+
+    std_msgs = types.ModuleType("std_msgs")
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    std_msgs_msg.String = type("String", (), {})
+    std_msgs.msg = std_msgs_msg
+    sys.modules.setdefault("std_msgs", std_msgs)
+    sys.modules.setdefault("std_msgs.msg", std_msgs_msg)
+
+
+_install_ros_stubs()
+
+from proposal_controller import Go2VelocityProposalController  # noqa: E402
+from velocity_proposal import ProposalLimits, VelocityProposalGate  # noqa: E402
+
+
+class FakeRpc:
+    def __init__(self):
+        self.moves = []
+        self.stops = 0
+        self.on_stop = None
+        self.move_delay = 0.0
+
+    def Move(self, vx, vy, vyaw):
+        time.sleep(self.move_delay)
+        self.moves.append((vx, vy, vyaw))
+        return 0
+
+    def StopMove(self):
+        self.stops += 1
+        if self.on_stop:
+            self.on_stop()
+        return 0
+
+
+def proposal(nav_id="nav-1", sequence=1, **changes):
+    payload = {
+        "schema": "phanthy.navigation.velocity_proposal.v1",
+        "nav_id": nav_id,
+        "sequence": sequence,
+        "issued_at_unix_ms": time.time() * 1000.0,
+        "ttl_ms": 250,
+        "frame": "base_link",
+        "shadow_only": True,
+        "physical_execution": False,
+        "nav_status": "navigating",
+        "velocity": {"x": 0.2, "y": 0.0, "yaw": 0.4},
+    }
+    payload.update(changes)
+    return payload
+
+
+class ProposalControllerTest(unittest.TestCase):
+    def make_controller(self):
+        controller = Go2VelocityProposalController.__new__(
+            Go2VelocityProposalController
+        )
+        controller._rpc = FakeRpc()
+        controller._topic = "/ubuntu/navigation/nav2/velocity_proposal"
+        controller._proposal_sub = None
+        controller._limits = ProposalLimits()
+        controller._gate = VelocityProposalGate(controller._limits)
+        controller._gate.bind("/ubuntu/navigation/nav2/velocity_proposal")
+        controller._lock = threading.RLock()
+        controller._rpc_lock = threading.Lock()
+        controller._state_condition = threading.Condition()
+        controller._last_state_monotonic = 0.0
+        controller._last_velocity = (float("inf"),) * 3
+        controller._stop_timeout = 0.05
+        controller._linear_epsilon = 0.04
+        controller._yaw_epsilon = 0.08
+        controller._commands = queue.Queue(maxsize=1)
+        controller._stop_transition = threading.Event()
+        controller._counters = {
+            "received": 0,
+            "accepted": 0,
+            "applied": 0,
+            "rejected": 0,
+            "coalesced": 0,
+            "rejections_by_reason": {},
+            "watchdog_faults_by_reason": {},
+        }
+        controller._last_rpc = {}
+        return controller
+
+    def test_callback_keeps_only_latest_valid_proposal(self):
+        controller = self.make_controller()
+        controller._on_proposal(
+            types.SimpleNamespace(data=json.dumps(proposal(sequence=1)))
+        )
+        controller._on_proposal(
+            types.SimpleNamespace(data=json.dumps(proposal(sequence=2)))
+        )
+
+        queued = controller._commands.get_nowait()
+        self.assertEqual(queued["kind"], "move")
+        self.assertEqual(queued["sequence"], 2)
+        self.assertEqual(controller._counters["coalesced"], 1)
+
+    def test_invalid_active_proposal_replaces_motion_with_stop(self):
+        controller = self.make_controller()
+        controller._on_proposal(
+            types.SimpleNamespace(data=json.dumps(proposal(sequence=1)))
+        )
+        invalid = proposal(sequence=2)
+        invalid["velocity"]["yaw"] = 3.0
+        controller._on_proposal(types.SimpleNamespace(data=json.dumps(invalid)))
+
+        queued = controller._commands.get_nowait()
+        self.assertEqual(queued, {"kind": "stop", "reason": "velocity_yaw_limit"})
+        self.assertFalse(controller._gate.armed)
+
+    def test_rpc_completion_after_ttl_requests_a_stop(self):
+        controller = self.make_controller()
+        controller._on_proposal(
+            types.SimpleNamespace(data=json.dumps(proposal(sequence=1)))
+        )
+        command = controller._commands.get_nowait()
+        command["deadline"] = time.monotonic() + 0.001
+        controller._rpc.move_delay = 0.005
+
+        controller._apply_move(command)
+
+        self.assertEqual(controller._counters["applied"], 0)
+        self.assertEqual(controller._counters["rejections_by_reason"], {"proposal_ttl_expired": 1})
+        self.assertEqual(
+            controller._commands.get_nowait(),
+            {"kind": "stop", "reason": "proposal_ttl_expired"},
+        )
+
+    def test_stop_requires_a_fresh_zero_loco_state(self):
+        controller = self.make_controller()
+
+        def publish_zero():
+            with controller._state_condition:
+                controller._last_velocity = (0.01, 0.01, 0.02)
+                controller._last_state_monotonic = time.monotonic()
+                controller._state_condition.notify_all()
+
+        controller._rpc.on_stop = publish_zero
+        ret, confirmed, error = controller._stop_and_confirm()
+
+        self.assertEqual(ret, 0)
+        self.assertTrue(confirmed)
+        self.assertIsNone(error)
+        self.assertEqual(controller._rpc.stops, 1)
+
+    def test_repeated_connect_rejects_a_conflicting_explicit_lease(self):
+        controller = self.make_controller()
+        controller._gate.bind(controller._topic, "nav-1")
+        controller._proposal_sub = object()
+
+        result = controller.connect(controller._topic, "nav-2")
+
+        self.assertEqual(result["error"], "proposal_lease_already_connected")
+        self.assertEqual(result["expected_nav_id"], "nav-1")
+
+    def test_subscription_creation_failure_leaves_gate_unbound(self):
+        controller = self.make_controller()
+        controller._gate.unbind("test_reset")
+        controller._stop_and_confirm = lambda: (0, True, None)
+        controller.create_subscription = lambda *_args: (_ for _ in ()).throw(
+            RuntimeError("subscribe failed")
+        )
+
+        result = controller.connect(controller._topic)
+
+        self.assertEqual(result["error"], "subscribe failed")
+        self.assertFalse(result["connected"])
+        self.assertEqual(result["last_reason"], "proposal_bind_failed")
+
+    def test_manual_override_fails_closed_without_zero_confirmation(self):
+        controller = self.make_controller()
+        controller._stop_and_confirm = lambda: (0, False, None)
+
+        self.assertFalse(controller.manual_override())
+        self.assertFalse(controller._gate.armed)
+        self.assertEqual(controller._gate.last_reason, "manual_override")
+
+        source = (Path(__file__).resolve().parents[1] / "device.py").read_text()
+        self.assertIn('"error": "manual_override_stop_unconfirmed"', source)
+
+    def test_spawned_rpc_worker_installs_atomic_logging_first(self):
+        source = (Path(__file__).resolve().parents[1] / "rpc_proxy.py").read_text()
+        worker = source[source.index("def _rpc_worker") : source.index("class RpcProxy")]
+        self.assertLess(
+            worker.index("logsafe.install(check_fd=False)"),
+            worker.index("ChannelFactoryInitialize"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/go2/tests/test_proposal_controller.py
+++ b/unitree/go2/tests/test_proposal_controller.py
@@ -58,6 +58,7 @@ class FakeRpc:
         self.stops = 0
         self.on_stop = None
         self.move_delay = 0.0
+        self.stop_ret = 0
 
     def Move(self, vx, vy, vyaw):
         time.sleep(self.move_delay)
@@ -68,7 +69,7 @@ class FakeRpc:
         self.stops += 1
         if self.on_stop:
             self.on_stop()
-        return 0
+        return self.stop_ret
 
 
 def proposal(nav_id="nav-1", sequence=1, **changes):
@@ -104,6 +105,8 @@ class ProposalControllerTest(unittest.TestCase):
         controller._state_condition = threading.Condition()
         controller._last_state_monotonic = 0.0
         controller._last_velocity = (float("inf"),) * 3
+        controller._last_sport_mode = None
+        controller._last_gait_type = None
         controller._stop_timeout = 0.05
         controller._linear_epsilon = 0.04
         controller._yaw_epsilon = 0.08
@@ -182,6 +185,46 @@ class ProposalControllerTest(unittest.TestCase):
         self.assertTrue(confirmed)
         self.assertIsNone(error)
         self.assertEqual(controller._rpc.stops, 1)
+
+    def test_minus_one_stop_accepts_only_a_fresh_idle_zero_state(self):
+        controller = self.make_controller()
+        controller._rpc.stop_ret = -1
+
+        def publish_idle_zero():
+            with controller._state_condition:
+                controller._last_velocity = (0.01, 0.01, 0.02)
+                controller._last_sport_mode = 0
+                controller._last_gait_type = 0
+                controller._last_state_monotonic = time.monotonic()
+                controller._state_condition.notify_all()
+
+        controller._rpc.on_stop = publish_idle_zero
+        ret, confirmed, error = controller._stop_and_confirm()
+
+        self.assertEqual(ret, -1)
+        self.assertTrue(confirmed)
+        self.assertIsNone(error)
+        self.assertEqual(controller._rpc.stops, 1)
+
+    def test_minus_one_stop_fails_closed_outside_idle(self):
+        controller = self.make_controller()
+        controller._rpc.stop_ret = -1
+
+        def publish_non_idle_zero():
+            with controller._state_condition:
+                controller._last_velocity = (0.0, 0.0, 0.0)
+                controller._last_sport_mode = 3
+                controller._last_gait_type = 1
+                controller._last_state_monotonic = time.monotonic()
+                controller._state_condition.notify_all()
+
+        controller._rpc.on_stop = publish_non_idle_zero
+        ret, confirmed, error = controller._stop_and_confirm()
+
+        self.assertEqual(ret, -1)
+        self.assertFalse(confirmed)
+        self.assertIsNone(error)
+        self.assertEqual(controller._rpc.stops, 2)
 
     def test_repeated_connect_rejects_a_conflicting_explicit_lease(self):
         controller = self.make_controller()

--- a/unitree/go2/tests/test_velocity_proposal.py
+++ b/unitree/go2/tests/test_velocity_proposal.py
@@ -1,0 +1,626 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+import unittest
+
+import yaml
+
+from velocity_proposal import (
+    DEFAULT_VELOCITY_PROPOSAL_TOPIC,
+    ProposalLimits,
+    VelocityProposalGate,
+    VelocityProposalValidationError,
+    resolve_expected_nav_id,
+    resolve_input_topic,
+    resolve_optional_expected_nav_id,
+    validate_velocity_proposal,
+    velocity_proposal_port,
+)
+
+
+EXPECTED_TOPIC = "/ubuntu/navigation/nav2/velocity_proposal"
+GO2_DIR = Path(__file__).resolve().parents[1]
+
+
+def proposal(**changes):
+    value = {
+        "schema": "phanthy.navigation.velocity_proposal.v1",
+        "nav_id": "nav-001",
+        "sequence": 1,
+        "issued_at_unix_ms": 1_800_000_000_000,
+        "ttl_ms": 200,
+        "frame": "base_link",
+        "shadow_only": True,
+        "physical_execution": False,
+        "nav_status": "navigating",
+        "velocity": {"x": 0.10, "y": 0.02, "yaw": 0.15},
+    }
+    value.update(changes)
+    return value
+
+
+class TopicResolutionTest(unittest.TestCase):
+    def test_n5_topic_is_not_namespace_dependent(self):
+        self.assertEqual(DEFAULT_VELOCITY_PROPOSAL_TOPIC, EXPECTED_TOPIC)
+
+    def test_port_matches_n5_contract(self):
+        self.assertEqual(
+            velocity_proposal_port(EXPECTED_TOPIC),
+            {
+                "port": "velocity_proposal",
+                "topic": EXPECTED_TOPIC,
+                "format": "data/json",
+                "ros_type": "std_msgs/msg/String",
+                "qos": "RELIABLE + KEEP_LAST(depth=1) + VOLATILE",
+                "schema": "phanthy.navigation.velocity_proposal.v1",
+            },
+        )
+
+    def test_accepts_single_input_topic(self):
+        self.assertEqual(
+            resolve_input_topic({"input_topic": EXPECTED_TOPIC}, EXPECTED_TOPIC),
+            EXPECTED_TOPIC,
+        )
+
+    def test_accepts_single_input_topics_entry(self):
+        self.assertEqual(
+            resolve_input_topic({"input_topics": [EXPECTED_TOPIC]}, EXPECTED_TOPIC),
+            EXPECTED_TOPIC,
+        )
+
+    def test_rejects_empty_multiple_or_unexpected_topics(self):
+        for args in (
+            {},
+            {"input_topics": []},
+            {"input_topics": [EXPECTED_TOPIC, ""]},
+            {"input_topics": [EXPECTED_TOPIC, "/other"]},
+            {
+                "input_topic": EXPECTED_TOPIC,
+                "input_topics": [EXPECTED_TOPIC],
+            },
+            {"input_topic": "/ubuntu/navigation/nav2/cmd_vel_shadow"},
+        ):
+            with self.subTest(args=args), self.assertRaises(ValueError):
+                resolve_input_topic(args, EXPECTED_TOPIC)
+
+    def test_resolves_trusted_expected_nav_id_from_control_plane(self):
+        self.assertEqual(
+            resolve_expected_nav_id({"expected_nav_id": " nav-001 "}),
+            "nav-001",
+        )
+
+    def test_rejects_missing_or_invalid_expected_nav_id(self):
+        for args in (
+            {},
+            {"expected_nav_id": ""},
+            {"expected_nav_id": 123},
+            {"expected_nav_id": "x" * 129},
+        ):
+            with self.subTest(args=args), self.assertRaises(ValueError):
+                resolve_expected_nav_id(args)
+
+    def test_optional_control_plane_nav_id_supports_implicit_subscription(self):
+        self.assertIsNone(resolve_optional_expected_nav_id({}))
+        self.assertIsNone(
+            resolve_optional_expected_nav_id({"expected_nav_id": ""})
+        )
+        self.assertEqual(
+            resolve_optional_expected_nav_id(
+                {"expected_nav_id": " nav-001 "}
+            ),
+            "nav-001",
+        )
+        with self.assertRaises(ValueError):
+            resolve_optional_expected_nav_id({"expected_nav_id": 123})
+
+class ProposalValidationTest(unittest.TestCase):
+    def setUp(self):
+        self.limits = ProposalLimits()
+
+    def test_valid_proposal(self):
+        result = validate_velocity_proposal(proposal(), self.limits)
+        self.assertEqual(result.nav_id, "nav-001")
+        self.assertEqual(result.ttl_ms, 200)
+        self.assertFalse(result.is_zero)
+
+    def test_default_config_matches_loco_contract_velocity_limits(self):
+        config = yaml.safe_load((GO2_DIR / "config.yaml").read_text())
+        loco = config["plugins"]["loco"]
+
+        self.assertEqual(loco["velocity_proposal_min_x"], self.limits.min_x)
+        self.assertEqual(loco["velocity_proposal_max_x"], self.limits.max_x)
+        self.assertEqual(
+            loco["velocity_proposal_max_abs_y"],
+            self.limits.max_abs_y,
+        )
+        self.assertEqual(
+            loco["velocity_proposal_max_abs_yaw"],
+            self.limits.max_abs_yaw,
+        )
+        self.assertEqual(
+            loco["velocity_proposal_max_planar_speed"],
+            self.limits.max_planar_speed,
+        )
+
+    def test_accepts_loco_contract_velocity_boundaries(self):
+        for velocity in (
+            {"x": 1.0, "y": 0.0, "yaw": 2.0},
+            {"x": -1.0, "y": 0.0, "yaw": -2.0},
+            {"x": 0.0, "y": 1.0, "yaw": 0.0},
+            {"x": 0.0, "y": -1.0, "yaw": 0.0},
+            {"x": 1.0, "y": 1.0, "yaw": 0.0},
+        ):
+            with self.subTest(velocity=velocity):
+                result = validate_velocity_proposal(
+                    proposal(velocity=velocity),
+                    self.limits,
+                )
+                self.assertEqual(result.x, velocity["x"])
+                self.assertEqual(result.y, velocity["y"])
+                self.assertEqual(result.yaw, velocity["yaw"])
+
+    def test_rejects_wrong_schema_frame_or_flags(self):
+        cases = (
+            {"schema": "other"},
+            {"frame": "map"},
+            {"shadow_only": False},
+            {"physical_execution": True},
+        )
+        for changes in cases:
+            with self.subTest(changes=changes), self.assertRaises(VelocityProposalValidationError):
+                validate_velocity_proposal(proposal(**changes), self.limits)
+
+    def test_rejects_invalid_identity_timing_and_status_fields(self):
+        cases = (
+            {"nav_id": ""},
+            {"sequence": True},
+            {"issued_at_unix_ms": math.inf},
+            {"ttl_ms": True},
+            {"nav_status": "unknown"},
+            {"nav_status": None, "status": "navigating"},
+            {"nav_status": "navigating", "status": "navigating"},
+        )
+        for changes in cases:
+            with self.subTest(changes=changes), self.assertRaises(VelocityProposalValidationError):
+                validate_velocity_proposal(proposal(**changes), self.limits)
+
+    def test_rejects_nonfinite_and_independent_speed_limits(self):
+        velocities = (
+            {"x": math.nan, "y": 0.0, "yaw": 0.0},
+            {"x": 1.001, "y": 0.0, "yaw": 0.0},
+            {"x": -1.001, "y": 0.0, "yaw": 0.0},
+            {"x": 0.0, "y": 1.001, "yaw": 0.0},
+            {"x": 0.0, "y": 0.0, "yaw": 2.001},
+        )
+        for velocity in velocities:
+            with self.subTest(velocity=velocity), self.assertRaises(VelocityProposalValidationError):
+                validate_velocity_proposal(proposal(velocity=velocity), self.limits)
+
+    def test_rejects_ttl_above_250_ms(self):
+        with self.assertRaises(VelocityProposalValidationError):
+            validate_velocity_proposal(proposal(ttl_ms=251), self.limits)
+
+    def test_terminal_status_requires_zero_velocity(self):
+        with self.assertRaises(VelocityProposalValidationError):
+            validate_velocity_proposal(proposal(nav_status="arrived"), self.limits)
+        result = validate_velocity_proposal(
+            proposal(nav_status="arrived", velocity={"x": 0.0, "y": 0.0, "yaw": 0.0}),
+            self.limits,
+        )
+        self.assertTrue(result.is_terminal)
+        self.assertTrue(result.is_zero)
+
+
+class ProposalGateTest(unittest.TestCase):
+    def setUp(self):
+        self.gate = VelocityProposalGate(ProposalLimits())
+        self.gate.bind(EXPECTED_TOPIC, "nav-001")
+
+    def test_mismatched_packet_cannot_replace_control_plane_nav_lease(self):
+        rejected = self.gate.accept(
+            proposal(nav_id="attacker-selected", sequence=1), now=10.0
+        )
+        self.assertFalse(rejected.stop)
+        self.assertFalse(rejected.execute)
+        self.assertEqual(rejected.reason, "nav_id_mismatch")
+        self.assertTrue(self.gate.armed)
+        self.assertEqual(self.gate.expected_nav_id, "nav-001")
+
+    def test_first_fresh_legal_nonzero_proposal_binds_and_executes(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+
+        waiting = gate.snapshot(10.0)
+        self.assertTrue(waiting["connected"])
+        self.assertFalse(waiting["armed"])
+        self.assertTrue(waiting["awaiting_nav_id"])
+        self.assertEqual(
+            waiting["nav_id_binding_mode"],
+            "first_valid_proposal",
+        )
+
+        accepted = gate.accept(
+            proposal(sequence=7, issued_at_unix_ms=1_000),
+            now=10.0,
+            now_unix_ms=1_050,
+        )
+
+        self.assertTrue(accepted.execute)
+        self.assertEqual(gate.expected_nav_id, "nav-001")
+        self.assertTrue(gate.armed)
+        self.assertFalse(gate.awaiting_nav_id)
+        self.assertEqual(gate.last_sequence, 7)
+
+    def test_invalid_stale_zero_and_terminal_bootstrap_do_not_bind(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+
+        cases = (
+            (
+                gate.accept(proposal(frame="map"), now=10.0),
+                "frame_mismatch",
+            ),
+            (
+                gate.accept(
+                    proposal(issued_at_unix_ms=1_000),
+                    now=10.1,
+                    now_unix_ms=1_201,
+                ),
+                "proposal_ttl_expired",
+            ),
+            (
+                gate.accept(
+                    proposal(
+                        sequence=2,
+                        velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+                    ),
+                    now=10.2,
+                ),
+                "bootstrap_nonzero_proposal_required",
+            ),
+            (
+                gate.accept(
+                    proposal(
+                        sequence=3,
+                        nav_status="arrived",
+                        velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+                    ),
+                    now=10.3,
+                ),
+                "bootstrap_nonzero_proposal_required",
+            ),
+        )
+        for decision, reason in cases:
+            with self.subTest(reason=reason):
+                self.assertTrue(decision.stop)
+                self.assertEqual(decision.reason, reason)
+                self.assertFalse(gate.armed)
+                self.assertTrue(gate.awaiting_nav_id)
+
+    def test_mid_task_other_nav_id_is_rejected_without_interrupting_active_task(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+        self.assertTrue(gate.accept(proposal(sequence=1), now=10.0).execute)
+
+        rejected = gate.accept(
+            proposal(nav_id="nav-002", sequence=2),
+            now=10.1,
+        )
+
+        self.assertFalse(rejected.stop)
+        self.assertFalse(rejected.execute)
+        self.assertEqual(rejected.reason, "nav_id_mismatch")
+        self.assertTrue(gate.armed)
+        self.assertEqual(gate.expected_nav_id, "nav-001")
+        self.assertEqual(gate.last_sequence, 1)
+
+    def test_failed_terminal_stop_then_success_releases_for_next_nav_id(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+        self.assertTrue(gate.accept(proposal(sequence=1), now=10.0).execute)
+
+        terminal = gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+        self.assertTrue(terminal.stop)
+        self.assertFalse(gate.armed)
+        self.assertFalse(gate.awaiting_nav_id)
+        self.assertTrue(gate.terminal_pending_stop)
+        self.assertEqual(gate.last_reason, "terminal_pending_stop")
+        self.assertEqual(gate.snapshot(10.1)["active_nav_id"], "nav-001")
+
+        self.assertFalse(gate.record_terminal_stop_result(False))
+        self.assertFalse(gate.armed)
+        self.assertFalse(gate.awaiting_nav_id)
+        self.assertTrue(gate.terminal_pending_stop)
+        self.assertEqual(gate.last_reason, "terminal_stop_unconfirmed")
+
+        blocked = gate.accept(
+            proposal(nav_id="nav-002", sequence=1),
+            now=10.2,
+        )
+        self.assertFalse(blocked.stop)
+        self.assertFalse(blocked.execute)
+        self.assertEqual(blocked.reason, "terminal_stop_unconfirmed")
+
+        self.assertTrue(gate.record_terminal_stop_result(True))
+        self.assertFalse(gate.armed)
+        self.assertTrue(gate.awaiting_nav_id)
+        self.assertFalse(gate.terminal_pending_stop)
+        self.assertEqual(gate.last_reason, "awaiting_first_valid_proposal")
+
+        replay = gate.accept(proposal(sequence=3), now=10.3)
+        self.assertEqual(replay.reason, "retired_nav_id_replay")
+        self.assertTrue(gate.awaiting_nav_id)
+
+        next_task = gate.accept(
+            proposal(nav_id="nav-002", sequence=1),
+            now=10.4,
+        )
+        self.assertTrue(next_task.execute)
+        self.assertEqual(gate.expected_nav_id, "nav-002")
+
+    def test_confirmed_manual_stop_releases_for_next_task(self):
+        gate = VelocityProposalGate(ProposalLimits())
+        gate.bind(EXPECTED_TOPIC)
+        self.assertTrue(gate.accept(proposal(sequence=1), now=10.0).execute)
+
+        gate.release_after_confirmed_stop()
+
+        self.assertFalse(gate.armed)
+        self.assertTrue(gate.awaiting_nav_id)
+        self.assertIn("nav-001", gate.retired_nav_ids)
+        self.assertTrue(
+            gate.accept(
+                proposal(nav_id="nav-002", sequence=1),
+                now=10.1,
+            ).execute
+        )
+
+    def test_sequence_must_strictly_increase_for_active_nav(self):
+        first = self.gate.accept(proposal(sequence=10), now=100.0)
+        second = self.gate.accept(proposal(sequence=11), now=100.05)
+        replay = self.gate.accept(proposal(sequence=11), now=100.10)
+        self.assertTrue(first.execute)
+        self.assertTrue(second.execute)
+        self.assertTrue(replay.stop)
+        self.assertFalse(self.gate.armed)
+        self.assertEqual(replay.reason, "sequence_not_increasing")
+
+    def test_nav_id_cannot_change_mid_task(self):
+        self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
+        rejected = self.gate.accept(proposal(nav_id="nav-002", sequence=2), now=10.1)
+        self.assertFalse(rejected.stop)
+        self.assertFalse(rejected.execute)
+        self.assertEqual(rejected.reason, "nav_id_mismatch")
+        self.assertTrue(self.gate.armed)
+
+    def test_control_plane_terminal_waits_for_confirmation_before_rebind(self):
+        self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
+        terminal = self.gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+        self.assertTrue(terminal.stop)
+        self.assertFalse(self.gate.armed)
+        self.assertTrue(self.gate.terminal_pending_stop)
+        next_task = self.gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.2)
+        self.assertFalse(next_task.execute)
+        self.assertFalse(next_task.stop)
+        self.assertEqual(next_task.reason, "terminal_pending_stop")
+
+        self.assertTrue(self.gate.record_terminal_stop_result(True))
+        self.gate.bind(EXPECTED_TOPIC, "nav-002")
+        self.assertTrue(
+            self.gate.accept(proposal(nav_id="nav-002", sequence=1), now=10.3).execute
+        )
+
+    def test_completed_nav_id_cannot_be_replayed(self):
+        self.assertTrue(self.gate.accept(proposal(), now=10.0).execute)
+        self.gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+        self.assertTrue(self.gate.record_terminal_stop_result(True))
+        with self.assertRaises(ValueError):
+            self.gate.bind(EXPECTED_TOPIC, "nav-001")
+
+    def test_watchdog_requests_stop_without_retiring_trusted_lease(self):
+        accepted = self.gate.accept(proposal(ttl_ms=200), now=50.0)
+        self.assertAlmostEqual(accepted.duration, 0.2)
+        self.assertFalse(self.gate.watchdog(now=50.199).stop)
+        expired = self.gate.watchdog(now=50.201)
+        self.assertTrue(expired.stop)
+        self.assertEqual(expired.reason, "proposal_ttl_expired")
+        self.assertTrue(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
+
+        self.gate.hold_after_confirmed_stop("proposal_ttl_expired")
+        recovered = self.gate.accept(proposal(sequence=2), now=50.202)
+        self.assertTrue(recovered.execute)
+        self.assertTrue(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
+
+    def test_end_to_end_ttl_rejects_proposal_already_expired_at_driver(self):
+        rejected = self.gate.accept(
+            proposal(issued_at_unix_ms=1_000, ttl_ms=200),
+            now=50.0,
+            now_unix_ms=1_201,
+        )
+
+        self.assertTrue(rejected.stop)
+        self.assertEqual(rejected.reason, "proposal_ttl_expired")
+        self.assertTrue(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
+        self.assertEqual(self.gate.last_reason, "proposal_ttl_expired")
+
+        self.gate.hold_after_confirmed_stop("proposal_ttl_expired")
+        self.assertEqual(
+            self.gate.last_reason,
+            "proposal_ttl_stop_recoverable",
+        )
+        self.assertTrue(
+            self.gate.accept(proposal(sequence=2), now=50.1).execute
+        )
+
+    def test_confirmed_obstacle_stop_keeps_lease_for_fresh_escape_command(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=1), now=50.0).execute)
+        self.gate.hold_for_obstacle()
+
+        held = self.gate.snapshot(50.1)
+        self.assertTrue(held["connected"])
+        self.assertTrue(held["armed"])
+        self.assertTrue(held["recoverable_stop_active"])
+        self.assertEqual(held["active_nav_id"], "nav-001")
+        self.assertEqual(held["last_reason"], "obstacle_stop_recoverable")
+
+        stale = self.gate.accept(
+            proposal(sequence=2, issued_at_unix_ms=1_000, ttl_ms=200),
+            now=50.2,
+            now_unix_ms=1_201,
+        )
+        self.assertTrue(stale.stop)
+        self.assertEqual(stale.reason, "proposal_ttl_expired")
+        self.assertTrue(self.gate.armed)
+        self.assertTrue(self.gate.recoverable_stop_active)
+        self.assertEqual(self.gate.last_sequence, 2)
+
+        escape = self.gate.accept(
+            proposal(
+                sequence=3,
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.2},
+            ),
+            now=50.3,
+        )
+        self.assertTrue(escape.execute)
+        self.assertTrue(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
+
+    def test_stale_samples_drain_during_confirmed_ttl_hold(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=1), now=50.0).execute)
+        self.gate.watchdog(now=50.3)
+        self.gate.hold_after_confirmed_stop("proposal_ttl_expired")
+
+        stale = self.gate.accept(
+            proposal(sequence=2, issued_at_unix_ms=1_000, ttl_ms=200),
+            now=50.4,
+            now_unix_ms=1_201,
+        )
+
+        self.assertTrue(stale.stop)
+        self.assertEqual(stale.reason, "proposal_ttl_expired")
+        self.assertTrue(self.gate.armed)
+        self.assertTrue(self.gate.recoverable_stop_active)
+        self.assertEqual(
+            self.gate.last_reason,
+            "proposal_ttl_stop_recoverable",
+        )
+        self.assertTrue(
+            self.gate.accept(proposal(sequence=3), now=50.5).execute
+        )
+
+    def test_hard_fault_still_disarms_from_recoverable_obstacle_stop(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=1), now=10.0).execute)
+        self.gate.hold_for_obstacle()
+
+        rejected = self.gate.accept(
+            proposal(sequence=2, frame="map"),
+            now=10.1,
+        )
+
+        self.assertTrue(rejected.stop)
+        self.assertEqual(rejected.reason, "frame_mismatch")
+        self.assertFalse(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
+
+    def test_terminal_zero_pending_clears_recoverable_obstacle_hold(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=1), now=10.0).execute)
+        self.gate.hold_for_obstacle()
+
+        terminal = self.gate.accept(
+            proposal(
+                sequence=2,
+                nav_status="arrived",
+                velocity={"x": 0.0, "y": 0.0, "yaw": 0.0},
+            ),
+            now=10.1,
+        )
+
+        self.assertTrue(terminal.stop)
+        self.assertFalse(self.gate.armed)
+        self.assertFalse(self.gate.recoverable_stop_active)
+        self.assertTrue(self.gate.terminal_pending_stop)
+        self.assertTrue(self.gate.record_terminal_stop_result(True))
+
+    def test_end_to_end_ttl_uses_only_remaining_producer_lease(self):
+        accepted = self.gate.accept(
+            proposal(issued_at_unix_ms=1_000, ttl_ms=200),
+            now=50.0,
+            now_unix_ms=1_150,
+        )
+
+        self.assertTrue(accepted.execute)
+        self.assertAlmostEqual(accepted.duration, 0.05)
+        self.assertAlmostEqual(self.gate.deadline_monotonic, 50.05)
+
+    def test_future_producer_timestamp_cannot_extend_max_ttl(self):
+        accepted = self.gate.accept(
+            proposal(issued_at_unix_ms=2_000, ttl_ms=200),
+            now=50.0,
+            now_unix_ms=1_000,
+        )
+
+        self.assertAlmostEqual(accepted.duration, 0.2)
+        self.assertAlmostEqual(self.gate.deadline_monotonic, 50.2)
+
+    def test_invalid_payload_disarms_until_explicit_bind(self):
+        rejected = self.gate.accept(proposal(frame="map"), now=10.0)
+        self.assertTrue(rejected.stop)
+        self.assertFalse(self.gate.armed)
+        still_rejected = self.gate.accept(proposal(sequence=2), now=10.1)
+        self.assertFalse(still_rejected.execute)
+        with self.assertRaises(ValueError):
+            self.gate.bind(EXPECTED_TOPIC, "nav-001")
+        self.gate.bind(EXPECTED_TOPIC, "nav-002")
+        self.assertTrue(
+            self.gate.accept(proposal(nav_id="nav-002"), now=10.2).execute
+        )
+
+    def test_canvas_unbind_retires_nav_id_against_delayed_replay(self):
+        self.gate.unbind("canvas_stop")
+        with self.assertRaises(ValueError):
+            self.gate.bind(EXPECTED_TOPIC, "nav-001")
+
+    def test_repeated_identical_bind_is_idempotent_without_sequence_reset(self):
+        self.assertTrue(self.gate.accept(proposal(sequence=10), now=10.0).execute)
+        self.gate.bind(EXPECTED_TOPIC, "nav-001")
+        replay = self.gate.accept(proposal(sequence=10), now=10.1)
+        self.assertTrue(replay.stop)
+        self.assertEqual(replay.reason, "sequence_not_increasing")
+
+    def test_retired_nav_ids_are_not_dropped_after_a_fixed_window(self):
+        self.gate.unbind("canvas_stop")
+        for index in range(2, 41):
+            self.gate.bind(EXPECTED_TOPIC, f"nav-{index:03d}")
+            self.gate.unbind("canvas_stop")
+        for index in range(1, 41):
+            with self.subTest(index=index), self.assertRaises(ValueError):
+                self.gate.bind(EXPECTED_TOPIC, f"nav-{index:03d}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/go2/velocity_proposal.py
+++ b/unitree/go2/velocity_proposal.py
@@ -1,0 +1,519 @@
+"""Pure validation and lease state for the Go2 Nav2 velocity proposal gate.
+
+This module deliberately has no ROS 2 or Unitree dependency.  The Go2 proposal
+controller owns authorization and only forwards an approved ProposalDecision
+to SportClient for physical execution.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+
+VELOCITY_PROPOSAL_SCHEMA = "phanthy.navigation.velocity_proposal.v1"
+DEFAULT_VELOCITY_PROPOSAL_TOPIC = "/ubuntu/navigation/nav2/velocity_proposal"
+TERMINAL_STATUSES = {
+    "paused",
+    "arrived",
+    "cancelled",
+    "stopped",
+    "error",
+    "aborted",
+    "rejected",
+}
+ACTIVE_STATUSES = {"planning", "navigating", "replanning", "running", "active"}
+ALLOWED_STATUSES = TERMINAL_STATUSES | ACTIVE_STATUSES
+_STATUS_FIELD = "nav_status"
+_UNSUPPORTED_STATUS_ALIASES = {"status", "navigation_status", "navigation_state"}
+
+
+def velocity_proposal_port(topic: str) -> dict:
+    """Return the authoritative N5 canvas port declaration."""
+    return {
+        "port": "velocity_proposal",
+        "topic": topic,
+        "format": "data/json",
+        "ros_type": "std_msgs/msg/String",
+        "qos": "RELIABLE + KEEP_LAST(depth=1) + VOLATILE",
+        "schema": VELOCITY_PROPOSAL_SCHEMA,
+    }
+
+
+class VelocityProposalValidationError(ValueError):
+    """Validation error with a stable fail-closed reason code."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class ProposalLimits:
+    schema: str = VELOCITY_PROPOSAL_SCHEMA
+    frame: str = "base_link"
+    max_ttl_ms: int = 250
+    min_x: float = -1.0
+    max_x: float = 1.0
+    max_abs_y: float = 1.0
+    max_abs_yaw: float = 2.0
+    max_planar_speed: float = math.sqrt(2.0)
+
+
+@dataclass(frozen=True)
+class ValidatedVelocityProposal:
+    nav_id: str
+    sequence: int
+    issued_at_unix_ms: float
+    ttl_ms: int
+    frame: str
+    status: str
+    x: float
+    y: float
+    yaw: float
+
+    @property
+    def is_zero(self) -> bool:
+        return self.x == 0.0 and self.y == 0.0 and self.yaw == 0.0
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in TERMINAL_STATUSES
+
+
+@dataclass(frozen=True)
+class ProposalDecision:
+    execute: bool = False
+    stop: bool = False
+    reason: str = ""
+    duration: float = 0.0
+    proposal: Optional[ValidatedVelocityProposal] = None
+
+
+def resolve_input_topic(args: Mapping[str, Any], expected_topic: str) -> str:
+    """Resolve the canvas connection and reject every topic except the N5 port."""
+    has_input_topic = bool(str(args.get("input_topic") or "").strip())
+    has_input_topics = args.get("input_topics") is not None
+    if has_input_topic and has_input_topics:
+        raise ValueError("input_topic_and_input_topics_are_mutually_exclusive")
+    topics = []
+    input_topics = args.get("input_topics")
+    if input_topics is not None:
+        if not isinstance(input_topics, (list, tuple)):
+            raise ValueError("input_topics_must_be_a_list")
+        if len(input_topics) != 1:
+            raise ValueError("exactly_one_velocity_proposal_topic_required")
+        topics.append(str(input_topics[0]).strip())
+    input_topic = str(args.get("input_topic") or "").strip()
+    if input_topic and input_topic not in topics:
+        topics.append(input_topic)
+    if len(topics) != 1:
+        raise ValueError("exactly_one_velocity_proposal_topic_required")
+    if topics[0] != expected_topic:
+        raise ValueError("unexpected_velocity_proposal_topic")
+    return topics[0]
+
+
+def resolve_expected_nav_id(args: Mapping[str, Any]) -> str:
+    """Resolve the task lease supplied by the trusted lifecycle control plane."""
+    value = args.get("expected_nav_id")
+    if value is None or value == "":
+        raise ValueError("expected_nav_id_required")
+    if not isinstance(value, str):
+        raise ValueError("invalid_expected_nav_id")
+    nav_id = value.strip()
+    if not nav_id:
+        raise ValueError("expected_nav_id_required")
+    if len(nav_id) > 128:
+        raise ValueError("invalid_expected_nav_id")
+    return nav_id
+
+
+def resolve_optional_expected_nav_id(
+    args: Mapping[str, Any],
+) -> Optional[str]:
+    """Resolve the optional internal lease used while wiring a subscription."""
+    value = args.get("expected_nav_id")
+    if value is None or value == "":
+        return None
+    return resolve_expected_nav_id(args)
+
+
+def _finite_number(value: Any, code: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise VelocityProposalValidationError(code)
+    result = float(value)
+    if not math.isfinite(result):
+        raise VelocityProposalValidationError(code)
+    return result
+
+
+def _status(payload: Mapping[str, Any]) -> str:
+    if any(field in payload for field in _UNSUPPORTED_STATUS_ALIASES):
+        raise VelocityProposalValidationError("unsupported_navigation_status_field")
+    status = payload.get(_STATUS_FIELD)
+    if not isinstance(status, str) or not status.strip():
+        raise VelocityProposalValidationError("invalid_navigation_status")
+    normalized = status.strip().lower()
+    if normalized not in ALLOWED_STATUSES:
+        raise VelocityProposalValidationError("unsupported_navigation_status")
+    return normalized
+
+
+def validate_velocity_proposal(
+    payload: Mapping[str, Any],
+    limits: ProposalLimits,
+) -> ValidatedVelocityProposal:
+    if not isinstance(payload, Mapping):
+        raise VelocityProposalValidationError("proposal_must_be_object")
+    if payload.get("schema") != limits.schema:
+        raise VelocityProposalValidationError("schema_mismatch")
+    if payload.get("frame") != limits.frame:
+        raise VelocityProposalValidationError("frame_mismatch")
+    if payload.get("shadow_only") is not True:
+        raise VelocityProposalValidationError("shadow_only_flag_required")
+    if payload.get("physical_execution") is not False:
+        raise VelocityProposalValidationError("physical_execution_flag_must_be_false")
+
+    nav_id = payload.get("nav_id")
+    if not isinstance(nav_id, str) or not nav_id.strip() or len(nav_id) > 128:
+        raise VelocityProposalValidationError("invalid_nav_id")
+    sequence = payload.get("sequence")
+    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 0:
+        raise VelocityProposalValidationError("invalid_sequence")
+    ttl_ms = payload.get("ttl_ms")
+    if (
+        isinstance(ttl_ms, bool)
+        or not isinstance(ttl_ms, int)
+        or ttl_ms <= 0
+        or ttl_ms > limits.max_ttl_ms
+    ):
+        raise VelocityProposalValidationError("invalid_ttl_ms")
+    issued_at = _finite_number(payload.get("issued_at_unix_ms"), "invalid_issued_at_unix_ms")
+
+    velocity = payload.get("velocity")
+    if not isinstance(velocity, Mapping):
+        raise VelocityProposalValidationError("velocity_must_be_object")
+    x = _finite_number(velocity.get("x"), "invalid_velocity_x")
+    y = _finite_number(velocity.get("y"), "invalid_velocity_y")
+    yaw = _finite_number(velocity.get("yaw"), "invalid_velocity_yaw")
+    if x < limits.min_x or x > limits.max_x:
+        raise VelocityProposalValidationError("velocity_x_limit")
+    if abs(y) > limits.max_abs_y:
+        raise VelocityProposalValidationError("velocity_y_limit")
+    if abs(yaw) > limits.max_abs_yaw:
+        raise VelocityProposalValidationError("velocity_yaw_limit")
+    if math.hypot(x, y) > limits.max_planar_speed:
+        raise VelocityProposalValidationError("planar_speed_limit")
+
+    result = ValidatedVelocityProposal(
+        nav_id=nav_id.strip(),
+        sequence=sequence,
+        issued_at_unix_ms=issued_at,
+        ttl_ms=ttl_ms,
+        frame=limits.frame,
+        status=_status(payload),
+        x=x,
+        y=y,
+        yaw=yaw,
+    )
+    if result.is_terminal and not result.is_zero:
+        raise VelocityProposalValidationError("terminal_status_requires_zero_velocity")
+    return result
+
+
+class VelocityProposalGate:
+    """Connection, task lease, replay protection, and monotonic TTL state."""
+
+    def __init__(self, limits: ProposalLimits):
+        self.limits = limits
+        self.connected_topic = ""
+        self.armed = False
+        self.expected_nav_id = ""
+        self.awaiting_nav_id = False
+        self.nav_id_binding_mode = ""
+        self.retired_nav_ids: set[str] = set()
+        self.last_sequence = -1
+        self.last_receive_monotonic = 0.0
+        self.deadline_monotonic = 0.0
+        self.last_reason = "not_connected"
+        self.recoverable_stop_active = False
+        self.terminal_pending_stop = False
+
+    def bind(self, topic: str, expected_nav_id: Optional[str] = None) -> None:
+        nav_id = resolve_optional_expected_nav_id(
+            {"expected_nav_id": expected_nav_id}
+        )
+        if self.is_bound_to(topic, nav_id):
+            return
+        if nav_id is not None and nav_id in self.retired_nav_ids:
+            raise ValueError("retired_nav_id_replay")
+        self.connected_topic = topic
+        self.armed = nav_id is not None
+        self.expected_nav_id = nav_id or ""
+        self.awaiting_nav_id = nav_id is None
+        self.nav_id_binding_mode = (
+            "control_plane" if nav_id is not None else "first_valid_proposal"
+        )
+        self.last_sequence = -1
+        self.last_receive_monotonic = 0.0
+        self.deadline_monotonic = 0.0
+        self.last_reason = (
+            "" if nav_id is not None else "awaiting_first_valid_proposal"
+        )
+        self.recoverable_stop_active = False
+        self.terminal_pending_stop = False
+
+    def unbind(self, reason: str = "canvas_stop") -> None:
+        self._retire_expected_nav_id()
+        self.connected_topic = ""
+        self.armed = False
+        self.expected_nav_id = ""
+        self.awaiting_nav_id = False
+        self.nav_id_binding_mode = ""
+        self.last_sequence = -1
+        self.last_receive_monotonic = 0.0
+        self.deadline_monotonic = 0.0
+        self.last_reason = reason
+        self.recoverable_stop_active = False
+        self.terminal_pending_stop = False
+
+    def disarm(self, reason: str) -> None:
+        self._retire_expected_nav_id()
+        self.armed = False
+        self.awaiting_nav_id = False
+        self.deadline_monotonic = 0.0
+        self.last_reason = reason
+        self.recoverable_stop_active = False
+        self.terminal_pending_stop = False
+
+    def hold_for_obstacle(self) -> None:
+        """Keep the nav lease armed after a confirmed local obstacle stop."""
+        self.hold_after_confirmed_stop("obstacle")
+
+    def hold_after_confirmed_stop(self, reason: str) -> None:
+        """Keep a trusted nav lease after a confirmed recoverable stop.
+
+        Ordinary obstacle stops and a single proposal TTL lapse are local
+        braking events, not proof that the Agent Core lease is invalid.  The
+        caller must only enter this state after StopMove has been acknowledged
+        and fresh odometry has confirmed zero velocity.
+        """
+        if not self.armed:
+            return
+        recoverable_reasons = {
+            "obstacle": "obstacle_stop_recoverable",
+            "proposal_ttl_expired": "proposal_ttl_stop_recoverable",
+        }
+        if reason not in recoverable_reasons:
+            raise ValueError("unsupported_recoverable_stop_reason")
+        self.deadline_monotonic = 0.0
+        self.last_reason = recoverable_reasons[reason]
+        self.recoverable_stop_active = True
+
+    def request_ttl_stop(
+        self,
+        now: float,
+        proposal: Optional[ValidatedVelocityProposal] = None,
+    ) -> ProposalDecision:
+        """Request fail-closed braking without retiring the trusted lease.
+
+        The lease remains armed only so the stop path can move it into a
+        recoverable hold after measured zero velocity.  No new command can be
+        executed while that serialized stop confirmation is in progress.
+        """
+        if proposal is not None:
+            self.last_sequence = proposal.sequence
+            self.last_receive_monotonic = now
+        self.deadline_monotonic = 0.0
+        self.last_reason = "proposal_ttl_expired"
+        self.recoverable_stop_active = False
+        return ProposalDecision(
+            stop=True,
+            reason="proposal_ttl_expired",
+            proposal=proposal,
+        )
+
+    def _retire_expected_nav_id(self) -> None:
+        if self.expected_nav_id:
+            self.retired_nav_ids.add(self.expected_nav_id)
+
+    def is_bound_to(
+        self,
+        topic: str,
+        expected_nav_id: Optional[str],
+    ) -> bool:
+        if self.connected_topic != topic:
+            return False
+        if expected_nav_id is None:
+            return self.awaiting_nav_id and not self.expected_nav_id
+        return self.armed and self.expected_nav_id == expected_nav_id
+
+    def _adopt_first_valid_nav_id(self, nav_id: str) -> bool:
+        if not self.awaiting_nav_id or nav_id in self.retired_nav_ids:
+            return False
+        self.expected_nav_id = nav_id
+        self.armed = True
+        self.awaiting_nav_id = False
+        self.last_reason = ""
+        return True
+
+    def release_after_confirmed_stop(self, reason: str = "manual_stop") -> None:
+        """Retire the active task while retaining the sole subscription."""
+        self._retire_expected_nav_id()
+        self.armed = False
+        self.expected_nav_id = ""
+        self.last_sequence = -1
+        self.deadline_monotonic = 0.0
+        self.recoverable_stop_active = False
+        self.terminal_pending_stop = False
+        if self.connected_topic and self.nav_id_binding_mode == "first_valid_proposal":
+            self.awaiting_nav_id = True
+            self.last_reason = "awaiting_first_valid_proposal"
+        else:
+            self.awaiting_nav_id = False
+            self.last_reason = reason
+
+    def begin_terminal_stop(self) -> None:
+        """Block execution while retaining the task until stop is confirmed."""
+        self.armed = False
+        self.awaiting_nav_id = False
+        self.deadline_monotonic = 0.0
+        self.recoverable_stop_active = False
+        self.terminal_pending_stop = True
+        self.last_reason = "terminal_pending_stop"
+
+    def record_terminal_stop_result(self, stop_confirmed: bool) -> bool:
+        """Release a terminal task only after a measured stop succeeds."""
+        if not self.terminal_pending_stop:
+            return False
+        if stop_confirmed:
+            self.release_after_confirmed_stop("nav_task_terminal")
+            return True
+        self.armed = False
+        self.awaiting_nav_id = False
+        self.deadline_monotonic = 0.0
+        self.last_reason = "terminal_stop_unconfirmed"
+        return False
+
+    def accept(
+        self,
+        payload: Mapping[str, Any],
+        now: float,
+        now_unix_ms: Optional[float] = None,
+    ) -> ProposalDecision:
+        if not self.connected_topic:
+            return ProposalDecision(stop=True, reason="proposal_not_connected")
+        if self.terminal_pending_stop:
+            return ProposalDecision(reason=self.last_reason or "terminal_pending_stop")
+        bootstrap = self.awaiting_nav_id
+        if not self.armed and not bootstrap:
+            return ProposalDecision(stop=True, reason=self.last_reason or "proposal_not_armed")
+        try:
+            proposal = validate_velocity_proposal(payload, self.limits)
+        except VelocityProposalValidationError as exc:
+            if bootstrap:
+                return ProposalDecision(stop=True, reason=exc.code)
+            self.disarm(exc.code)
+            return ProposalDecision(stop=True, reason=exc.code)
+
+        if bootstrap and (proposal.is_terminal or proposal.is_zero):
+            return ProposalDecision(
+                stop=True,
+                reason="bootstrap_nonzero_proposal_required",
+                proposal=proposal,
+            )
+
+        duration = proposal.ttl_ms / 1000.0
+        if now_unix_ms is not None:
+            remaining = (
+                proposal.issued_at_unix_ms
+                + proposal.ttl_ms
+                - float(now_unix_ms)
+            ) / 1000.0
+            if remaining <= 0.0:
+                if bootstrap:
+                    return ProposalDecision(
+                        stop=True,
+                        reason="proposal_ttl_expired",
+                        proposal=proposal,
+                    )
+                if self.recoverable_stop_active:
+                    # Stop confirmation can outlive the proposal TTL while
+                    # ROS retains newer samples.  The robot is already at a
+                    # confirmed stop, so reject this stale sample without
+                    # retiring the task lease; only a fresh later sample may
+                    # resume execution.
+                    self.last_sequence = proposal.sequence
+                    self.last_receive_monotonic = now
+                    self.deadline_monotonic = 0.0
+                    # Preserve whether this hold came from an obstacle or a
+                    # prior TTL stop while stale retained samples drain.
+                    return ProposalDecision(
+                        stop=True,
+                        reason="proposal_ttl_expired",
+                        proposal=proposal,
+                    )
+                return self.request_ttl_stop(now, proposal)
+            # A future producer timestamp may not extend the configured TTL.
+            duration = min(duration, remaining)
+
+        if bootstrap:
+            if not self._adopt_first_valid_nav_id(proposal.nav_id):
+                return ProposalDecision(
+                    stop=True,
+                    reason="retired_nav_id_replay",
+                    proposal=proposal,
+                )
+        elif proposal.nav_id != self.expected_nav_id:
+            return ProposalDecision(
+                reason="nav_id_mismatch",
+                proposal=proposal,
+            )
+        if proposal.sequence <= self.last_sequence:
+            self.disarm("sequence_not_increasing")
+            return ProposalDecision(stop=True, reason="sequence_not_increasing", proposal=proposal)
+
+        self.last_sequence = proposal.sequence
+        self.last_receive_monotonic = now
+        if proposal.is_zero:
+            self.deadline_monotonic = 0.0
+            if proposal.is_terminal:
+                self.begin_terminal_stop()
+            else:
+                self.last_reason = proposal.status
+            return ProposalDecision(stop=True, reason="proposal_zero", proposal=proposal)
+
+        self.deadline_monotonic = now + duration
+        self.last_reason = ""
+        self.recoverable_stop_active = False
+        return ProposalDecision(execute=True, duration=duration, proposal=proposal)
+
+    def watchdog(self, now: float) -> ProposalDecision:
+        if self.deadline_monotonic <= 0.0 or now < self.deadline_monotonic:
+            return ProposalDecision()
+        return self.request_ttl_stop(now)
+
+    def snapshot(self, now: float) -> dict:
+        age_ms = None
+        if self.last_receive_monotonic > 0.0:
+            age_ms = max(0, round((now - self.last_receive_monotonic) * 1000))
+        return {
+            "connected": bool(self.connected_topic),
+            "armed": self.armed,
+            "topic": self.connected_topic or None,
+            "expected_nav_id": self.expected_nav_id or None,
+            "active_nav_id": (
+                self.expected_nav_id
+                if self.armed or self.terminal_pending_stop
+                else None
+            ),
+            "awaiting_nav_id": self.awaiting_nav_id,
+            "nav_id_binding_mode": self.nav_id_binding_mode or None,
+            "terminal_pending_stop": self.terminal_pending_stop,
+            "last_sequence": self.last_sequence if self.last_sequence >= 0 else None,
+            "last_message_age_ms": age_ms,
+            "last_reason": self.last_reason or None,
+            "recoverable_stop_active": self.recoverable_stop_active,
+        }


### PR DESCRIPTION
## 背景

将 G1 PR #154 已验证的导航速度提案与 MID360 导航传感器合同适配到 Unitree Go2。该 PR 基于最新 `main`，只包含 Go2 改动，不重复携带 PR #154 的 G1 提交。

## 主要改动

- `loco` 接入 `/ubuntu/navigation/nav2/velocity_proposal`，使用 `phanthy.navigation.velocity_proposal.v1`。
- proposal 订阅与执行均采用 latest-only：`RELIABLE + KEEP_LAST(depth=1)` 与容量为 1 的执行队列。
- 支持首条合法 proposal 原子绑定 `nav_id`、跨任务隔离、防重放、TTL 可恢复停车、终态停车确认和手动控制接管。
- 速度以 m/s、rad/s 原样交给 Go2 `SportClient.Move`；合同边界为 `vx/vy ±1.0 m/s`、`vyaw ±2.0 rad/s`。
- 新增 `navigation_lidar` 与 `navigation_imu` 卡片，直接读取 Go2 MID360 原始 DDS：
  - `rt/utlidar/cloud` → `/ubuntu/navigation/lidar` (`PointCloud2`)
  - `rt/utlidar/imu` → `/ubuntu/navigation/imu` (`Imu`)
- LiDAR/IMU 共用隔离 worker 和同一源时钟归一化器；时钟未就绪、重置或输入非法时 fail-closed 丢帧。
- 补充 Go2 构建镜像源、worker 原子日志和中英文合同说明。

## 安全边界

- Driver 启动后默认未连接、未武装，不会自行执行运动。
- 非法、过期、越界、异 `nav_id` 和乱序 proposal 在运动 RPC 前拒绝。
- 终态、TTL 超时和直接 loco/步态/动作调用均先停车，并要求新的零速 `loco_state` 样本确认。
- `nav_id` 用于任务隔离和防重放，不替代 DDS 网络身份认证。

## 验证

- `PYTHONPATH=unitree/go2 python3 -m unittest discover -s unitree/go2/tests -q`
- 结果：71 项测试通过。
- 等价 Go2 实现已部署至 `sh-go2` 做只读运行验收：
  - Driver 容器稳定运行，重启次数为 0；
  - `loco` 为 `connected=false`、`armed=false`，未触发机器人运动；
  - `navigation_lidar`、`navigation_imu` 均报告 `ready=true`；
  - MID360 时钟估计就绪，无 reset/reject，LiDAR/IMU 持续发布。

## 关联

- G1 对应合同：#154
- 导航消费卡片：[4paradigm/phanthymotus#141](https://github.com/4paradigm/phanthymotus/pull/141)

