### PR TITLE
feat(t800): add odometer and close loco distance loop

### DIFF
--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -24,7 +24,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_command_feedback` | sensor | Native SDK 最近关节控制命令反馈 |
 | `gamepad` | sensor | 遥控器连接、按键和摇杆状态 |
 | `motion_state` | sensor | 当前 Native SDK motion state 和允许转换 |
-| `odometer` | sensor | Odin2 位置、航向、速度、累计/单次里程、静止时长及断流/跳变诊断 |
+| `odometer` | sensor | Odin2 位置、航向、速度、累计/单次里程，以及运动轨迹和朝向鸟瞰画面 |
 | `driver_health` | actuator | 每次执行返回一次机器人、麦克风与 Odin2 点云/双目/深度数据流的最新健康 JSON，不持续发布 |
 | `robot_snapshot` | sensor | 运动、关节、IMU、电源和电机健康聚合快照 |
 | `fault_summary` | sensor | 电机掉线/禁用/错误/过温及电源错误摘要 |
@@ -81,6 +81,10 @@ pending。
 才解除。
 卡片 UI 对未填写的 move 可选字段可能发送 `null`；Driver 将其等同于省略，
 使用 `vy=0`、`vyaw=0`、`duration=1s` 默认值，布尔值和字符串仍严格拒绝。
+
+`odometer` 同时发布 `data/json` 状态面板和 `sensor/mapping` 鸟瞰画面。画面以
+当前单次行程起点为原点，显示运动轨迹、当前位置和朝向箭头；`reset_trip` 会
+清零单次里程并清空画面轨迹，但不会修改 Odin2 原始坐标或累计总里程。
 
 `gesture.play` 与旧的 `joint_plan.preset` 不同：前者执行官方示例里的完整多步
 动作（挥手包含准备、举手、5 次摆动和复位；握手包含伸手、收手和复位），

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -24,6 +24,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `joint_command_feedback` | sensor | Native SDK 最近关节控制命令反馈 |
 | `gamepad` | sensor | 遥控器连接、按键和摇杆状态 |
 | `motion_state` | sensor | 当前 Native SDK motion state 和允许转换 |
+| `odometer` | sensor | Odin2 位置、航向、速度、累计/单次里程、静止时长及断流/跳变诊断 |
 | `driver_health` | actuator | 每次执行返回一次机器人、麦克风与 Odin2 点云/双目/深度数据流的最新健康 JSON，不持续发布 |
 | `robot_snapshot` | sensor | 运动、关节、IMU、电源和电机健康聚合快照 |
 | `fault_summary` | sensor | 电机掉线/禁用/错误/过温及电源错误摘要 |

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -25,6 +25,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `gamepad` | sensor | 遥控器连接、按键和摇杆状态 |
 | `motion_state` | sensor | 当前 Native SDK motion state 和允许转换 |
 | `odometer` | sensor | Odin2 位置、航向、速度、累计/单次里程，以及运动轨迹和朝向鸟瞰画面 |
+| `odometer_control` | actuator | 清零 odometer 单次行程和画面轨迹，不修改累计总里程或 Odin2 坐标系 |
 | `driver_health` | actuator | 每次执行返回一次机器人、麦克风与 Odin2 点云/双目/深度数据流的最新健康 JSON，不持续发布 |
 | `robot_snapshot` | sensor | 运动、关节、IMU、电源和电机健康聚合快照 |
 | `fault_summary` | sensor | 电机掉线/禁用/错误/过温及电源错误摘要 |
@@ -68,7 +69,8 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 达到目标后立即发布零速度，不再用固定预备时间估算实际路程。反馈在起步前
 不可用会拒绝动作，运行中断流、坐标系重置或安全超时会 fail-closed 停车并以
 错误完成。闭环动作返回 `closed_loop: true`、目标值和最终实测值。
-若部署显式禁用 `odometer`，有限动作才退回旧的时间开环和 1 秒预备补偿。
+若部署禁用或未能启动 `odometer`，有限动作会以 `ODOMETRY_UNAVAILABLE` 拒绝，
+不会退回可能产生距离偏差的时间开环。
 有限时长动作的用户 `duration` 最多 10 秒；预计或安全最长执行时间超过 3 秒
 时返回唯一 `action_id`，并在自然结束、异常或取消时发送 ACP completion；短
 动作保持同步语义。
@@ -85,7 +87,8 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 
 `odometer` 同时发布 `data/json` 状态面板和 `sensor/mapping` 鸟瞰画面。画面以
 当前单次行程起点为原点，显示运动轨迹、当前位置和朝向箭头；`reset_trip` 会
-清零单次里程并清空画面轨迹，但不会修改 Odin2 原始坐标或累计总里程。
+通过 `odometer_control` 清零单次里程并清空画面轨迹，但不会修改 Odin2 原始
+坐标或累计总里程。
 
 `gesture.play` 与旧的 `joint_plan.preset` 不同：前者执行官方示例里的完整多步
 动作（挥手包含准备、举手、5 次摆动和复位；握手包含伸手、收手和复位），

--- a/engineai/t800/README.md
+++ b/engineai/t800/README.md
@@ -33,7 +33,7 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 | `capabilities` | sensor | Driver 能力发现、原生状态和已知限制 |
 | `ros_graph` | sensor | 实时发现固件节点、topic、service 和尚未映射的新接口 |
 | `model` | resource | 官方 `serial_t800.urdf` |
-| `loco` | actuator | 100 Hz 速度控制；定时/持续、相对位移、转角和圆弧开环动作 |
+| `loco` | actuator | 100 Hz 速度控制；有限动作由 Odin2 里程/航向反馈闭环终止，持续动作手动停止 |
 | `motion_mode` | actuator | 任意状态切换及 idle/passive/站立/行走/舞蹈/起身/躺下快捷动作 |
 | `gait` | actuator | 基于 Native SDK motion state 的步态选择；自动适配 `rl_basic`/`walk` 版本差异 |
 | `dance` | actuator | 舞蹈列表、播放、停止和状态；官方基线为 `dance.mnn` + `dance.npz` |
@@ -62,18 +62,19 @@ Domain 69；Agent Core 数据流使用 Domain 42。驱动兼容两种部署方�
 状态会立即归零停流。
 `force=true` 仅保留给 joint override 和 joint bridge 的专家级接口。
 
-`loco.move_displacement`、`turn_angle` 和 `arc` 由速度乘时间换算。T800
-基础运动协议没有供控制闭环使用的定位反馈，因此它们仍是开环动作并返回
-`open_loop: true`。若 Odin2 固件提供配置中的 odometry topic，
-`motion_command_trace` 会把它用于状态显示，但不会据此闭环控制动作。
-有限时长动作的用户有效 `duration` 最多 10 秒；Driver 会先额外发送 1 秒
-预备命令，再完整执行用户填写的时长，因此固件起步准备不再消耗有效行动
-时间。预备+行动总时长超过 3 秒的有限动作返回唯一 `action_id`，并在自然
-结束、异常或取消时发送 ACP completion；短动作保持同步语义，不建立无意义
-pending。
+启用默认 `odometer` 后，`loco` 的有限动作共享其经校验的 Odin2 反馈。
+`move` 以 `hypot(vx, vy) × duration` 和 `abs(vyaw) × duration` 作为目标里程与
+累计转角；`move_displacement`、`turn_angle` 和 `arc` 使用相同闭环终止逻辑。
+达到目标后立即发布零速度，不再用固定预备时间估算实际路程。反馈在起步前
+不可用会拒绝动作，运行中断流、坐标系重置或安全超时会 fail-closed 停车并以
+错误完成。闭环动作返回 `closed_loop: true`、目标值和最终实测值。
+若部署显式禁用 `odometer`，有限动作才退回旧的时间开环和 1 秒预备补偿。
+有限时长动作的用户 `duration` 最多 10 秒；预计或安全最长执行时间超过 3 秒
+时返回唯一 `action_id`，并在自然结束、异常或取消时发送 ACP completion；短
+动作保持同步语义。
 `stop_move` 是 `on_interrupt_motion` hook，可绕过 barrier 立即归零。
 `duration=-1` 仍持续发送到手动停止且不建立无限期 ACP pending。
-默认护栏为 `vx=±2.0m/s`、`vy=±1.0m/s`、`vyaw=±2.0rad/s`。所有速度、
+官方护栏为 `vx=±1.0m/s`、`vy=±1.0m/s`、`vyaw=±1.0rad/s`。所有速度、
 角速度、复合动作速度和 duration 都必须是有限值并落在配置安全
 范围内；越界输入返回 `INVALID_ARGUMENT` / `SAFETY_LIMIT` 并立即归零旧速度流，
 不会静默截断后继续执行。零速 release 发布失败时，原 action 以 `error` 完成，

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -12,10 +12,14 @@ control:
   velocity_rate_hz: 100.0
   low_level_rate_hz: 500.0
   override_rate_hz: 100.0
-  max_vx: 2.0
+  max_vx: 1.0
   max_vy: 1.0
-  max_vyaw: 2.0
+  max_vyaw: 1.0
   locomotion_prepare_duration_sec: 1.0
+  locomotion_closed_loop_timeout_scale: 1.5
+  locomotion_closed_loop_timeout_margin_sec: 1.0
+  locomotion_distance_tolerance_m: 0.03
+  locomotion_angle_tolerance_rad: 0.03
   mode_transition_timeout_sec: 5.0
   motor_warning_temperature_c: 70.0
   tilt_warning_rad: 0.45

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -68,6 +68,12 @@ plugins:
     enabled: true
   motion_command_trace:
     enabled: true
+  odometer:
+    enabled: true
+    publish_rate_hz: 5.0
+    stationary_enter_m_s: 0.03
+    stationary_exit_m_s: 0.05
+    jump_tolerance_m: 0.25
   native_interface_probe:
     enabled: true
   locomotion:

--- a/engineai/t800/config.yaml
+++ b/engineai/t800/config.yaml
@@ -74,6 +74,9 @@ plugins:
     stationary_enter_m_s: 0.03
     stationary_exit_m_s: 0.05
     jump_tolerance_m: 0.25
+    trajectory_spacing_m: 0.025
+    trajectory_max_points: 4000
+    trajectory_view_extent_m: 5.0
   native_interface_probe:
     enabled: true
   locomotion:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -677,7 +677,9 @@ class StatePlugin:
                 "dof": len(T800_JOINT_NAMES),
                 "native_motion_states": list(MOTION_STATES),
                 "control": [
-                    "body_velocity", "open_loop_displacement", "open_loop_turn", "open_loop_arc",
+                    "body_velocity", "odometry_closed_loop_move",
+                    "odometry_closed_loop_displacement",
+                    "odometry_closed_loop_turn", "odometry_closed_loop_arc",
                     "motion_fsm", "joint_plan", "joint_override", "joint_bridge", "native_node_control",
                     "gesture_sequences", "dance", "virtual_gamepad", "soft_emergency_stop",
                     "motor_power", "led", "tts", "ros_graph_discovery",
@@ -688,7 +690,7 @@ class StatePlugin:
                     "motion_events", "mainboard",
                 ],
                 "limitations": [
-                    "odometry is display/statistics only; displacement/turn/arc control remains open-loop",
+                    "finite loco actions require fresh Odin2 odometry feedback",
                     "no public dexterous-hand interface in the referenced T800 protocol",
                 ],
                 "timestamp_ms": _now_ms(),
@@ -1552,7 +1554,6 @@ class OdometerPlugin:
         schema = action_schema(
             _with_lifecycle({
                 "status": ([], "返回最新里程计、行程和数据健康状态"),
-                "reset_trip": ([], "清零单次行程和画面轨迹，不修改 Odin2 坐标系"),
             }),
             {},
             "里程计传感器动作",
@@ -1569,6 +1570,24 @@ class OdometerPlugin:
             "topic_out": self._topic_out(),
         }
 
+    def get_tools(self) -> list[dict]:
+        return [self.get_tool(), {
+            "name": "odometer_control",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "重置 T800 odometer 单次行程和轨迹显示",
+            "inputSchema": action_schema(
+                _with_lifecycle({
+                    "reset_trip": (
+                        [],
+                        "清零单次行程和画面轨迹，不修改累计总里程或 Odin2 坐标系",
+                    ),
+                }),
+                {},
+                "里程计控制动作",
+            ),
+        }]
+
     def start(self) -> None:
         from nav_msgs.msg import Odometry
 
@@ -1582,28 +1601,40 @@ class OdometerPlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict:
+        tool_name = str(args.get("_tool_name", "odometer"))
+        if tool_name == "odometer_control":
+            if action == "start":
+                return {"state": "ready"}
+            if action == "stop":
+                return {"state": "idle"}
+            if action in ("info", "status"):
+                return {"state": "ready"}
+            if action == "reset_trip":
+                return self._reset_trip()
+            return {"error": f"unknown odometer control action: {action}"}
         if action == "info":
             return {**self._snapshot(), "topic_out": self._topic_out()}
         if action == "start":
             return {"state": "running"}
         if action in ("odometer", "status"):
             return self._snapshot()
-        if action == "reset_trip":
-            with self._lock:
-                self._trip_distance_m = 0.0
-                self._trip_rotation_rad = 0.0
-                if self._latest is None:
-                    self._visual_origin = None
-                    self._visual_pose = None
-                    self._trajectory.clear()
-                else:
-                    position = self._latest["position_m"]
-                    yaw = float(self._latest["orientation"]["yaw_rad"])
-                    self._reset_visual_locked(float(position["x"]), float(position["y"]), yaw)
-            return {**self._snapshot(), "trip_reset": True}
         if action == "stop":
             return {"state": "idle"}
         return {"error": f"unknown odometer action: {action}"}
+
+    def _reset_trip(self) -> dict:
+        with self._lock:
+            self._trip_distance_m = 0.0
+            self._trip_rotation_rad = 0.0
+            if self._latest is None:
+                self._visual_origin = None
+                self._visual_pose = None
+                self._trajectory.clear()
+            else:
+                position = self._latest["position_m"]
+                yaw = float(self._latest["orientation"]["yaw_rad"])
+                self._reset_visual_locked(float(position["x"]), float(position["y"]), yaw)
+        return {**self._snapshot(), "trip_reset": True}
 
     def _record_invalid(self, reason: str) -> None:
         with self._lock:
@@ -2684,6 +2715,7 @@ class LocomotionPlugin:
         self._acp_notify = _t800_acp_notify
         self._interrupt_group: MotionInterruptGroup | None = None
         self._odometer: OdometerPlugin | None = None
+        self._odometer_wired = False
 
     def get_tool(self) -> dict:
         schema = action_schema(
@@ -2861,6 +2893,7 @@ class LocomotionPlugin:
 
     def set_odometer(self, odometer: OdometerPlugin | None) -> None:
         self._odometer = odometer
+        self._odometer_wired = True
 
     def motion_active(self) -> bool:
         with self._lifecycle_lock:
@@ -2917,7 +2950,6 @@ class LocomotionPlugin:
                 limits=self._limits,
                 max_timed_duration_sec=self._MAX_TIMED_DURATION_SEC,
             )
-            feedback_goal = self._closed_loop_goal(command)
         except ControlValidationError as exc:
             return self._reject_and_halt(
                 str(exc), code=exc.code
@@ -2926,8 +2958,6 @@ class LocomotionPlugin:
         vy = command["vy"]
         vyaw = command["vyaw"]
         duration = command["duration"]
-        closed_loop = feedback_goal is not None
-        open_loop = not closed_loop and duration not in (-1, 0)
         with self._lifecycle_lock:
             if self.motion_active():
                 halt_result = self._halt_locked()
@@ -2936,6 +2966,12 @@ class LocomotionPlugin:
                         **halt_result,
                         "code": "RELEASE_FAILED",
                     }
+            try:
+                feedback_goal = self._closed_loop_goal(command)
+            except ControlValidationError as exc:
+                return self._reject_and_halt(str(exc), code=exc.code)
+            closed_loop = feedback_goal is not None
+            open_loop = not closed_loop and duration not in (-1, 0)
             if closed_loop:
                 command_duration = min(
                     self._ACP_TIMEOUT_SEC - 1.0,
@@ -3008,7 +3044,16 @@ class LocomotionPlugin:
 
     def _closed_loop_goal(self, command: dict) -> dict | None:
         duration = float(command["duration"])
-        if self._odometer is None or duration in (-1.0, 0.0):
+        if duration in (-1.0, 0.0):
+            return None
+        if self._odometer is None:
+            if self._odometer_wired:
+                raise ControlValidationError(
+                    "ODOMETRY_UNAVAILABLE",
+                    "finite movement requires the odometer sensor plugin",
+                )
+            # Direct plugin construction is retained for isolated legacy tests;
+            # the production bundle always calls set_odometer(), including None.
             return None
         target_distance = math.hypot(command["vx"], command["vy"]) * duration
         target_rotation = abs(command["vyaw"]) * duration

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -260,6 +260,39 @@ def _notify_acp_completion(
     return _t800_acp_notify(action_id, status, result, tool)
 
 
+def _max_reasonable_odometry_speed(config: dict) -> float:
+    """Return a shared upper bound for T800 planar odometry validation."""
+    control = config.get("control", {})
+    max_vx = abs(float(control.get("max_vx", 3.0)))
+    max_vy = abs(float(control.get("max_vy", 1.0)))
+    return max(1.0, math.hypot(max_vx, max_vy) * 1.5)
+
+
+def _ros_stamp_seconds(header) -> float | None:
+    stamp = getattr(header, "stamp", None)
+    if stamp is None:
+        return None
+    try:
+        seconds = float(stamp.sec) + float(stamp.nanosec) * 1e-9
+    except (AttributeError, TypeError, ValueError, OverflowError):
+        return None
+    return seconds if math.isfinite(seconds) and seconds > 0.0 else None
+
+
+def _quaternion_yaw(x: float, y: float, z: float, w: float) -> float:
+    values = (x, y, z, w)
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError("odometry quaternion contains a non-finite value")
+    norm = math.sqrt(sum(value * value for value in values))
+    if norm <= 1e-9:
+        raise ValueError("odometry quaternion has zero length")
+    qx, qy, qz, qw = (value / norm for value in values)
+    return math.atan2(
+        2.0 * (qw * qz + qx * qy),
+        1.0 - 2.0 * (qy * qy + qz * qz),
+    )
+
+
 _GAMEPAD_BUTTON_NAMES = {
     0: "LB", 1: "RB", 2: "A", 3: "B", 4: "X", 5: "Y",
     6: "BACK", 7: "START", 8: "CROSS_X_UP", 9: "CROSS_X_DOWN",
@@ -649,11 +682,11 @@ class StatePlugin:
                 ],
                 "feedback": list(self._STREAMS) + [
                     "joint_plan_state", "heartbeat_status",
-                    "motion_command_trace", "native_interface_probe",
+                    "motion_command_trace", "odometer", "native_interface_probe",
                     "motion_events", "mainboard",
                 ],
                 "limitations": [
-                    "no odometry topic: displacement/turn/arc are time-integrated open-loop estimates",
+                    "odometry is display/statistics only; displacement/turn/arc control remains open-loop",
                     "no public dexterous-hand interface in the referenced T800 protocol",
                 ],
                 "timestamp_ms": _now_ms(),
@@ -1221,12 +1254,9 @@ class MotionCommandTracePlugin:
         self._odometry_updated: float | None = None
 
     def _max_reasonable_speed(self) -> float:
-        control = self._config.get("control", {})
-        max_vx = abs(float(control.get("max_vx", 3.0)))
-        max_vy = abs(float(control.get("max_vy", 1.0)))
         # Leave a small margin for measured odometry noise while still rejecting
         # ODIN2-internal values that are not robot m/s velocity on T800.
-        return max(1.0, math.hypot(max_vx, max_vy) * 1.5)
+        return _max_reasonable_odometry_speed(self._config)
 
     def _is_valid_speed(self, speed: float) -> bool:
         return math.isfinite(speed) and 0.0 <= speed <= self._max_reasonable_speed()
@@ -1441,6 +1471,294 @@ class MotionCommandTracePlugin:
 
     def _publish(self) -> None:
         self._publisher.publish(_json_message(self._snapshot()))
+
+
+class OdometerPlugin:
+    """Normalize Odin2 odometry into a dashboard-friendly trip card."""
+
+    def __init__(self, config: dict, namespace: str, ros2):
+        self._config = config
+        self._ns = namespace
+        self._topic = f"/{namespace}/state/odometer"
+        plugin_config = config.get("plugins", {}).get("odometer", {})
+        self._timeout = max(
+            0.1,
+            float(plugin_config.get(
+                "source_timeout_sec",
+                config.get("ros", {}).get("source_timeout_sec", 1.0),
+            )),
+        )
+        self._publish_rate_hz = max(0.2, float(plugin_config.get("publish_rate_hz", 5.0)))
+        self._stationary_enter = max(
+            0.0, float(plugin_config.get("stationary_enter_m_s", 0.03))
+        )
+        self._stationary_exit = max(
+            self._stationary_enter,
+            float(plugin_config.get("stationary_exit_m_s", 0.05)),
+        )
+        self._jump_tolerance = max(
+            0.0, float(plugin_config.get("jump_tolerance_m", 0.25))
+        )
+        self._max_speed = _max_reasonable_odometry_speed(config)
+
+        self._node = Node("t800_odometer", context=ros2.ctx_robot)
+        self._pub_node = Node("t800_odometer_pub", context=ros2.ctx_core)
+        ros2.executor_robot.add_node(self._node)
+        ros2.executor_core.add_node(self._pub_node)
+        self._publisher = self._pub_node.create_publisher(String, self._topic, _RELIABLE)
+
+        self._lock = threading.RLock()
+        self._latest: dict | None = None
+        self._updated: float | None = None
+        self._baseline: dict | None = None
+        self._distance_total_m = 0.0
+        self._trip_distance_m = 0.0
+        self._stationary: bool | None = None
+        self._stationary_since: float | None = None
+        self._received_count = 0
+        self._valid_count = 0
+        self._invalid_count = 0
+        self._jump_rejected_count = 0
+        self._timestamp_rejected_count = 0
+        self._frame_reset_count = 0
+        self._last_rejection: str | None = None
+
+    def get_tool(self) -> dict:
+        schema = action_schema(
+            _with_lifecycle({
+                "status": ([], "返回最新里程计、行程和数据健康状态"),
+                "reset_trip": ([], "清零 Driver 内部单次行程，不修改 Odin2 坐标系"),
+            }),
+            {},
+            "里程计传感器动作",
+        )
+        # Keep direct sensor reads compatible with Agent Core.
+        schema.pop("required", None)
+        return {
+            "name": "odometer",
+            "type": "sensor",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": "T800 Odin2 位置、航向、速度、累计里程、单次行程与静止状态可视化",
+            "inputSchema": schema,
+            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+        }
+
+    def start(self) -> None:
+        from nav_msgs.msg import Odometry
+
+        source_topic = str(self._config.get("topics", {}).get("odometry", "")).strip()
+        if not source_topic:
+            raise ValueError("topics.odometry must be configured when odometer is enabled")
+        self._node.create_subscription(Odometry, source_topic, self._on_odometry, _BEST_EFFORT)
+        self._pub_node.create_timer(1.0 / self._publish_rate_hz, self._publish)
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action == "info":
+            return _with_topic_out(self._snapshot(), self._topic)
+        if action in ("odometer", "status", "start"):
+            return self._snapshot()
+        if action == "reset_trip":
+            with self._lock:
+                self._trip_distance_m = 0.0
+            return {**self._snapshot(), "trip_reset": True}
+        if action == "stop":
+            return {"state": "idle"}
+        return {"error": f"unknown odometer action: {action}"}
+
+    def _record_invalid(self, reason: str) -> None:
+        with self._lock:
+            self._received_count += 1
+            self._invalid_count += 1
+            self._last_rejection = reason
+
+    def _on_odometry(self, msg) -> None:
+        received_at = time.monotonic()
+        try:
+            pose = msg.pose.pose
+            twist = msg.twist.twist
+            position = (
+                float(pose.position.x),
+                float(pose.position.y),
+                float(pose.position.z),
+            )
+            quaternion = (
+                float(pose.orientation.x),
+                float(pose.orientation.y),
+                float(pose.orientation.z),
+                float(pose.orientation.w),
+            )
+            linear = (
+                float(twist.linear.x),
+                float(twist.linear.y),
+                float(twist.linear.z),
+            )
+            angular = (
+                float(twist.angular.x),
+                float(twist.angular.y),
+                float(twist.angular.z),
+            )
+        except (AttributeError, TypeError, ValueError, OverflowError):
+            self._record_invalid("malformed_message")
+            return
+
+        values = (*position, *linear, *angular)
+        if not all(math.isfinite(value) for value in values):
+            self._record_invalid("non_finite_value")
+            return
+        try:
+            yaw = _quaternion_yaw(*quaternion)
+        except ValueError as exc:
+            self._record_invalid(str(exc))
+            return
+
+        speed = math.hypot(linear[0], linear[1])
+        if speed > self._max_speed:
+            self._record_invalid("implausible_linear_speed")
+            return
+
+        header = getattr(msg, "header", None)
+        frame_id = str(getattr(header, "frame_id", ""))
+        child_frame_id = str(getattr(msg, "child_frame_id", ""))
+        source_stamp = _ros_stamp_seconds(header)
+        source_timestamp_ms = None if source_stamp is None else int(source_stamp * 1000.0)
+
+        with self._lock:
+            self._received_count += 1
+            baseline = self._baseline
+            jump_rejected = False
+            baseline_reset = baseline is None
+
+            if baseline is not None and frame_id != baseline["frame_id"]:
+                self._frame_reset_count += 1
+                self._last_rejection = "frame_changed"
+                baseline_reset = True
+            elif (
+                baseline is not None
+                and source_stamp is not None
+                and baseline["source_stamp"] is not None
+                and source_stamp <= baseline["source_stamp"]
+            ):
+                self._timestamp_rejected_count += 1
+                self._last_rejection = "timestamp_not_increasing"
+                return
+            elif baseline is not None:
+                delta = math.hypot(position[0] - baseline["x"], position[1] - baseline["y"])
+                if source_stamp is not None and baseline["source_stamp"] is not None:
+                    delta_time = source_stamp - baseline["source_stamp"]
+                else:
+                    delta_time = received_at - baseline["received_at"]
+                maximum_delta = self._max_speed * max(0.0, delta_time) + self._jump_tolerance
+                if delta > maximum_delta:
+                    self._jump_rejected_count += 1
+                    self._last_rejection = "position_jump"
+                    jump_rejected = True
+                    baseline_reset = True
+                else:
+                    self._distance_total_m += delta
+                    self._trip_distance_m += delta
+                    self._last_rejection = None
+
+            self._baseline = {
+                "x": position[0],
+                "y": position[1],
+                "frame_id": frame_id,
+                "source_stamp": source_stamp,
+                "received_at": received_at,
+            }
+
+            if self._stationary is None:
+                self._stationary = speed <= self._stationary_enter
+                self._stationary_since = received_at if self._stationary else None
+            elif self._stationary and speed >= self._stationary_exit:
+                self._stationary = False
+                self._stationary_since = None
+            elif not self._stationary and speed <= self._stationary_enter:
+                self._stationary = True
+                self._stationary_since = received_at
+
+            self._latest = {
+                "frame_id": frame_id,
+                "child_frame_id": child_frame_id,
+                "position_m": {"x": position[0], "y": position[1], "z": position[2]},
+                "orientation": {
+                    "quaternion_xyzw": list(quaternion),
+                    "yaw_rad": yaw,
+                    "heading_deg": math.degrees(yaw) % 360.0,
+                },
+                "linear_velocity_m_s": {
+                    "x": linear[0], "y": linear[1], "z": linear[2],
+                },
+                "angular_velocity_rad_s": {
+                    "x": angular[0], "y": angular[1], "z": angular[2],
+                },
+                "speed_m_s": speed,
+                "motion_state": "stationary" if self._stationary else "moving",
+                "stationary": bool(self._stationary),
+                "source_timestamp_ms": source_timestamp_ms,
+                "jump_rejected": jump_rejected,
+                "baseline_reset": baseline_reset,
+            }
+            self._updated = received_at
+            self._valid_count += 1
+
+    def _snapshot(self) -> dict:
+        now = time.monotonic()
+        with self._lock:
+            latest = None if self._latest is None else dict(self._latest)
+            updated = self._updated
+            total = self._distance_total_m
+            trip = self._trip_distance_m
+            stationary_since = self._stationary_since
+            counts = {
+                "received": self._received_count,
+                "valid": self._valid_count,
+                "invalid": self._invalid_count,
+                "jump_rejected": self._jump_rejected_count,
+                "timestamp_rejected": self._timestamp_rejected_count,
+                "frame_resets": self._frame_reset_count,
+            }
+            last_rejection = self._last_rejection
+
+        if latest is None or updated is None:
+            return {
+                "state": "no_data",
+                "stale": True,
+                "age_sec": None,
+                "distance_total_m": round(total, 6),
+                "trip_distance_m": round(trip, 6),
+                "sample_count": counts,
+                "last_rejection": last_rejection,
+                "timestamp_ms": _now_ms(),
+            }
+
+        age_sec = max(0.0, now - updated)
+        stale = age_sec > self._timeout
+        if latest["stationary"] and stationary_since is not None:
+            stationary_end = min(now, updated + self._timeout)
+            stationary_sec = max(0.0, stationary_end - stationary_since)
+        else:
+            stationary_sec = 0.0
+        return {
+            "state": "stale" if stale else "running",
+            **latest,
+            "distance_total_m": round(total, 6),
+            "trip_distance_m": round(trip, 6),
+            "stationary_sec": round(stationary_sec, 3),
+            "age_sec": round(age_sec, 3),
+            "stale": stale,
+            "source_topic": str(self._config.get("topics", {}).get("odometry", "")),
+            "sample_count": counts,
+            "last_rejection": last_rejection,
+            "timestamp_ms": _now_ms(),
+        }
+
+    def _publish(self) -> None:
+        self._publisher.publish(_json_message(self._snapshot()))
+
 
 class MotionEventsPlugin:
     """Read-only event timeline for T800 motion-related MCP calls and feedback."""

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -1582,7 +1582,9 @@ class OdometerPlugin:
     def dispatch(self, action: str, args: dict) -> dict:
         if action == "info":
             return {**self._snapshot(), "topic_out": self._topic_out()}
-        if action in ("odometer", "status", "start"):
+        if action == "start":
+            return {"state": "running"}
+        if action in ("odometer", "status"):
             return self._snapshot()
         if action == "reset_trip":
             with self._lock:

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -1527,6 +1527,8 @@ class OdometerPlugin:
         self._baseline: dict | None = None
         self._distance_total_m = 0.0
         self._trip_distance_m = 0.0
+        self._rotation_total_rad = 0.0
+        self._trip_rotation_rad = 0.0
         self._stationary: bool | None = None
         self._stationary_since: float | None = None
         self._received_count = 0
@@ -1589,6 +1591,7 @@ class OdometerPlugin:
         if action == "reset_trip":
             with self._lock:
                 self._trip_distance_m = 0.0
+                self._trip_rotation_rad = 0.0
                 if self._latest is None:
                     self._visual_origin = None
                     self._visual_pose = None
@@ -1693,11 +1696,18 @@ class OdometerPlugin:
                 else:
                     self._distance_total_m += delta
                     self._trip_distance_m += delta
+                    yaw_delta = math.atan2(
+                        math.sin(yaw - baseline["yaw"]),
+                        math.cos(yaw - baseline["yaw"]),
+                    )
+                    self._rotation_total_rad += yaw_delta
+                    self._trip_rotation_rad += yaw_delta
                     self._last_rejection = None
 
             self._baseline = {
                 "x": position[0],
                 "y": position[1],
+                "yaw": yaw,
                 "frame_id": frame_id,
                 "source_stamp": source_stamp,
                 "received_at": received_at,
@@ -1753,6 +1763,8 @@ class OdometerPlugin:
             updated = self._updated
             total = self._distance_total_m
             trip = self._trip_distance_m
+            rotation_total = self._rotation_total_rad
+            trip_rotation = self._trip_rotation_rad
             stationary_since = self._stationary_since
             counts = {
                 "received": self._received_count,
@@ -1773,6 +1785,8 @@ class OdometerPlugin:
                 "age_sec": None,
                 "distance_total_m": round(total, 6),
                 "trip_distance_m": round(trip, 6),
+                "rotation_total_rad": round(rotation_total, 6),
+                "trip_rotation_rad": round(trip_rotation, 6),
                 "trajectory_point_count": trajectory_count,
                 "sample_count": counts,
                 "last_rejection": last_rejection,
@@ -1791,6 +1805,8 @@ class OdometerPlugin:
             **latest,
             "distance_total_m": round(total, 6),
             "trip_distance_m": round(trip, 6),
+            "rotation_total_rad": round(rotation_total, 6),
+            "trip_rotation_rad": round(trip_rotation, 6),
             "trajectory_position_m": None if visual_pose is None else {
                 "x": round(visual_pose[0], 6),
                 "y": round(visual_pose[1], 6),
@@ -1803,6 +1819,28 @@ class OdometerPlugin:
             "sample_count": counts,
             "last_rejection": last_rejection,
             "timestamp_ms": _now_ms(),
+        }
+
+    def control_feedback(self) -> dict:
+        """Return unrounded, thread-safe motion progress for locomotion control."""
+        now = time.monotonic()
+        with self._lock:
+            latest = self._latest
+            updated = self._updated
+            distance_total = self._distance_total_m
+            rotation_total = self._rotation_total_rad
+            frame_resets = self._frame_reset_count
+            jump_rejections = self._jump_rejected_count
+        age_sec = None if updated is None else max(0.0, now - updated)
+        stale = age_sec is None or age_sec > self._timeout
+        return {
+            "state": "no_data" if latest is None else ("stale" if stale else "running"),
+            "age_sec": age_sec,
+            "distance_total_m": distance_total,
+            "rotation_total_rad": rotation_total,
+            "frame_id": None if latest is None else latest["frame_id"],
+            "frame_resets": frame_resets,
+            "jump_rejections": jump_rejections,
         }
 
     def _publish(self) -> None:
@@ -2610,6 +2648,32 @@ class LocomotionPlugin:
             raise ValueError(
                 "locomotion_prepare_duration_sec must be within [0, 3]"
             )
+        self._closed_loop_timeout_scale = float(
+            limits.get("locomotion_closed_loop_timeout_scale", 1.5)
+        )
+        self._closed_loop_timeout_margin_sec = float(
+            limits.get("locomotion_closed_loop_timeout_margin_sec", 1.0)
+        )
+        self._distance_tolerance_m = float(
+            limits.get("locomotion_distance_tolerance_m", 0.03)
+        )
+        self._angle_tolerance_rad = float(
+            limits.get("locomotion_angle_tolerance_rad", 0.03)
+        )
+        closed_loop_settings = (
+            self._closed_loop_timeout_scale,
+            self._closed_loop_timeout_margin_sec,
+            self._distance_tolerance_m,
+            self._angle_tolerance_rad,
+        )
+        if (
+            not all(math.isfinite(value) for value in closed_loop_settings)
+            or self._closed_loop_timeout_scale < 1.0
+            or self._closed_loop_timeout_margin_sec < 0.0
+            or self._distance_tolerance_m < 0.0
+            or self._angle_tolerance_rad < 0.0
+        ):
+            raise ValueError("invalid locomotion closed-loop configuration")
         self._action_lock = threading.Lock()
         self._lifecycle_lock = threading.RLock()
         self._active_action_id: str | None = None
@@ -2619,25 +2683,26 @@ class LocomotionPlugin:
         self._release_error: str | None = None
         self._acp_notify = _t800_acp_notify
         self._interrupt_group: MotionInterruptGroup | None = None
+        self._odometer: OdometerPlugin | None = None
 
     def get_tool(self) -> dict:
         schema = action_schema(
             {
                 "move": (
                     ["vx", "vy", "vyaw", "duration"],
-                    "按速度移动；duration=-1 持续到 stop_move",
+                    "有限动作按速度×时间生成里程目标；duration=-1 持续到 stop_move",
                 ),
                 "move_displacement": (
                     ["x_m", "y_m", "speed_m_s"],
-                    "按时间积分估算相对位移（开环，无里程计反馈）",
+                    "按 Odin2 里程反馈执行相对位移",
                 ),
                 "turn_angle": (
                     ["angle_rad", "angular_speed_rad_s"],
-                    "按时间积分估算原地转角（开环）",
+                    "按 Odin2 航向反馈执行原地转角",
                 ),
                 "arc": (
                     ["radius_m", "angle_rad", "linear_speed_m_s"],
-                    "按给定半径和角度走圆弧（开环）",
+                    "按 Odin2 里程和航向反馈执行圆弧",
                 ),
                 "stop_move": ([], "立即发布零速度并停止刷新"),
                 "status": ([], "查询速度控制刷新状态"),
@@ -2676,9 +2741,8 @@ class LocomotionPlugin:
                         },
                     ],
                     "description": (
-                        "实际行动时间（秒），不含内部"
-                        f"{self._prepare_duration_sec:g}秒预备补偿；"
-                        "-1=持续到 stop_move，0=停止"
+                        "有限动作的速度积分目标时间（秒）；启用里程计时以"
+                        "速度×时间作为闭环目标，-1=持续到 stop_move，0=停止"
                     ),
                 },
                 "x_m": {"type": "number", "description": "机身坐标系前向位移，米"},
@@ -2721,7 +2785,7 @@ class LocomotionPlugin:
             "name": "loco",
             "type": "actuator",
             "multiInstance": False,
-            "description": "T800 全向速度控制，支持定时和持续运动",
+            "description": "T800 全向速度控制，有限动作由 Odin2 里程反馈闭环终止",
             "inputSchema": schema,
         }
 
@@ -2795,6 +2859,9 @@ class LocomotionPlugin:
     def set_interrupt_group(self, group: MotionInterruptGroup) -> None:
         self._interrupt_group = group
 
+    def set_odometer(self, odometer: OdometerPlugin | None) -> None:
+        self._odometer = odometer
+
     def motion_active(self) -> bool:
         with self._lifecycle_lock:
             with self._action_lock:
@@ -2850,6 +2917,7 @@ class LocomotionPlugin:
                 limits=self._limits,
                 max_timed_duration_sec=self._MAX_TIMED_DURATION_SEC,
             )
+            feedback_goal = self._closed_loop_goal(command)
         except ControlValidationError as exc:
             return self._reject_and_halt(
                 str(exc), code=exc.code
@@ -2858,7 +2926,8 @@ class LocomotionPlugin:
         vy = command["vy"]
         vyaw = command["vyaw"]
         duration = command["duration"]
-        open_loop = command["open_loop"]
+        closed_loop = feedback_goal is not None
+        open_loop = not closed_loop and duration not in (-1, 0)
         with self._lifecycle_lock:
             if self.motion_active():
                 halt_result = self._halt_locked()
@@ -2867,11 +2936,18 @@ class LocomotionPlugin:
                         **halt_result,
                         "code": "RELEASE_FAILED",
                     }
-            command_duration = (
-                duration
-                if duration in (-1, 0)
-                else duration + self._prepare_duration_sec
-            )
+            if closed_loop:
+                command_duration = min(
+                    self._ACP_TIMEOUT_SEC - 1.0,
+                    duration * self._closed_loop_timeout_scale
+                    + self._closed_loop_timeout_margin_sec,
+                )
+            else:
+                command_duration = (
+                    duration
+                    if duration in (-1, 0)
+                    else duration + self._prepare_duration_sec
+                )
             self._command_generation += 1
             command_generation = self._command_generation
             action_id = None
@@ -2890,7 +2966,13 @@ class LocomotionPlugin:
         if action_id is not None:
             threading.Thread(
                 target=self._monitor_action,
-                args=(action_id, generation, duration),
+                args=(
+                    action_id,
+                    generation,
+                    command_generation,
+                    duration,
+                    feedback_goal,
+                ),
                 daemon=True,
                 name="t800-loco-acp",
             ).start()
@@ -2901,17 +2983,125 @@ class LocomotionPlugin:
             "vyaw": vyaw,
             "duration": duration,
             "preparation_duration": (
-                self._prepare_duration_sec if duration not in (-1, 0) else 0.0
+                self._prepare_duration_sec
+                if duration not in (-1, 0) and not closed_loop
+                else 0.0
             ),
             "command_duration": command_duration,
             "open_loop": open_loop,
+            "closed_loop": closed_loop,
             "stream": asdict(snapshot),
         }
+        if feedback_goal is not None:
+            result.update({
+                "target_distance_m": feedback_goal["target_distance_m"],
+                "target_rotation_rad": feedback_goal["target_rotation_rad"],
+                "odometry_frame": feedback_goal["frame_id"],
+            })
         if action_id is not None:
             result["action_id"] = action_id
         elif duration not in (-1, 0):
-            return self._wait_synchronous_action(result, command_generation)
+            return self._wait_synchronous_action(
+                result, command_generation, feedback_goal
+            )
         return result
+
+    def _closed_loop_goal(self, command: dict) -> dict | None:
+        duration = float(command["duration"])
+        if self._odometer is None or duration in (-1.0, 0.0):
+            return None
+        target_distance = math.hypot(command["vx"], command["vy"]) * duration
+        target_rotation = abs(command["vyaw"]) * duration
+        if target_distance == 0.0 and target_rotation == 0.0:
+            return None
+        feedback = self._odometer.control_feedback()
+        if feedback["state"] != "running":
+            age = feedback.get("age_sec")
+            age_text = "no samples" if age is None else f"age={age:.3f}s"
+            raise ControlValidationError(
+                "ODOMETRY_UNAVAILABLE",
+                f"fresh Odin2 odometry is required for finite movement ({age_text})",
+            )
+        return {
+            "distance_start_m": feedback["distance_total_m"],
+            "rotation_start_rad": feedback["rotation_total_rad"],
+            "target_distance_m": target_distance,
+            "target_rotation_rad": target_rotation,
+            "frame_id": feedback["frame_id"],
+            "frame_resets": feedback["frame_resets"],
+            "jump_rejections": feedback["jump_rejections"],
+        }
+
+    def _closed_loop_progress(self, goal: dict) -> dict:
+        feedback = self._odometer.control_feedback()
+        measured_distance = max(
+            0.0,
+            feedback["distance_total_m"] - goal["distance_start_m"],
+        )
+        measured_rotation = abs(
+            feedback["rotation_total_rad"] - goal["rotation_start_rad"]
+        )
+        result = {
+            "target_distance_m": goal["target_distance_m"],
+            "measured_distance_m": measured_distance,
+            "target_rotation_rad": goal["target_rotation_rad"],
+            "measured_rotation_rad": measured_rotation,
+            "odometry_age_sec": feedback.get("age_sec"),
+        }
+        if feedback["state"] != "running":
+            return {
+                **result,
+                "error": "Odin2 odometry became unavailable during movement",
+                "code": "ODOMETRY_LOST",
+                "reached": False,
+            }
+        if (
+            feedback["frame_id"] != goal["frame_id"]
+            or feedback["frame_resets"] != goal["frame_resets"]
+            or feedback["jump_rejections"] != goal["jump_rejections"]
+        ):
+            return {
+                **result,
+                "error": "Odin2 odometry reset or jump detected during movement",
+                "code": "ODOMETRY_RESET",
+                "reached": False,
+            }
+        distance_tolerance = min(
+            self._distance_tolerance_m,
+            goal["target_distance_m"] * 0.1,
+        )
+        angle_tolerance = min(
+            self._angle_tolerance_rad,
+            goal["target_rotation_rad"] * 0.1,
+        )
+        distance_reached = (
+            goal["target_distance_m"] == 0.0
+            or measured_distance + distance_tolerance >= goal["target_distance_m"]
+        )
+        rotation_reached = (
+            goal["target_rotation_rad"] == 0.0
+            or measured_rotation + angle_tolerance >= goal["target_rotation_rad"]
+        )
+        return {
+            **result,
+            "error": None,
+            "code": None,
+            "reached": distance_reached and rotation_reached,
+        }
+
+    def _stop_for_goal(self, command_generation: int) -> str | None:
+        with self._lifecycle_lock:
+            if self._command_generation != command_generation:
+                return "movement was superseded"
+            try:
+                self._halt_stream()
+            except Exception as exc:
+                self._release_failed = True
+                self._release_error = str(exc)
+                return f"zero velocity release failed: {exc}"
+            self._release_failed = False
+            self._release_error = None
+            return None
 
     def _reject_and_halt(self, error: str, *, code: str = "INVALID_ARGUMENT") -> dict:
         self.halt()
@@ -2927,7 +3117,9 @@ class LocomotionPlugin:
         self,
         action_id: str,
         generation: int,
+        command_generation: int,
         effective_duration: float,
+        feedback_goal: dict | None,
     ) -> None:
         while True:
             with self._action_lock:
@@ -2936,6 +3128,27 @@ class LocomotionPlugin:
                     or self._active_action_generation != generation
                 ):
                     return
+            progress = (
+                None
+                if feedback_goal is None
+                else self._closed_loop_progress(feedback_goal)
+            )
+            if progress is not None and (progress["error"] or progress["reached"]):
+                stop_error = self._stop_for_goal(command_generation)
+                if stop_error is not None:
+                    progress = {
+                        **progress,
+                        "error": stop_error,
+                        "code": "RELEASE_FAILED",
+                    }
+                status = "error" if progress["error"] else "completed"
+                self._finish_active_action(status, {
+                    "duration": effective_duration,
+                    "preparation_duration": 0.0,
+                    **{key: value for key, value in progress.items()
+                       if key != "reached"},
+                }, expected_action_id=action_id)
+                return
             snapshot = self._stream.snapshot()
             if not snapshot.active:
                 if (
@@ -2945,11 +3158,25 @@ class LocomotionPlugin:
                     with self._lifecycle_lock:
                         self._release_failed = True
                         self._release_error = snapshot.error
-                status = "error" if snapshot.error else "completed"
+                target_error = (
+                    "odometry target was not reached before the safety timeout"
+                    if feedback_goal is not None and not snapshot.error
+                    else None
+                )
+                status = "error" if snapshot.error or target_error else "completed"
+                progress_result = {} if progress is None else {
+                    key: value for key, value in progress.items()
+                    if key not in ("reached", "error", "code")
+                }
                 self._finish_active_action(status, {
                     "duration": effective_duration,
-                    "preparation_duration": self._prepare_duration_sec,
-                    "error": snapshot.error,
+                    "preparation_duration": (
+                        0.0 if feedback_goal is not None
+                        else self._prepare_duration_sec
+                    ),
+                    "error": snapshot.error or target_error,
+                    "code": "TARGET_NOT_REACHED" if target_error else None,
+                    **progress_result,
                 }, expected_action_id=action_id)
                 return
             time.sleep(0.01)
@@ -2987,7 +3214,10 @@ class LocomotionPlugin:
         ).start()
 
     def _wait_synchronous_action(
-        self, result: dict, command_generation: int
+        self,
+        result: dict,
+        command_generation: int,
+        feedback_goal: dict | None,
     ) -> dict:
         while True:
             with self._lifecycle_lock:
@@ -2997,6 +3227,36 @@ class LocomotionPlugin:
                         "state": "cancelled",
                         "stream": asdict(self._stream.snapshot()),
                     }
+            progress = (
+                None
+                if feedback_goal is None
+                else self._closed_loop_progress(feedback_goal)
+            )
+            if progress is not None and (progress["error"] or progress["reached"]):
+                stop_error = self._stop_for_goal(command_generation)
+                if stop_error is not None:
+                    return {
+                        "error": stop_error,
+                        "code": "RELEASE_FAILED",
+                        **{key: value for key, value in progress.items()
+                           if key not in ("error", "code", "reached")},
+                        "stream": asdict(self._stream.snapshot()),
+                    }
+                if progress["error"]:
+                    return {
+                        "error": progress["error"],
+                        "code": progress["code"],
+                        **{key: value for key, value in progress.items()
+                           if key not in ("error", "code", "reached")},
+                        "stream": asdict(self._stream.snapshot()),
+                    }
+                return {
+                    **result,
+                    **{key: value for key, value in progress.items()
+                       if key not in ("error", "code", "reached")},
+                    "state": "completed",
+                    "stream": asdict(self._stream.snapshot()),
+                }
             snapshot = self._stream.snapshot()
             if not snapshot.active:
                 if snapshot.error:
@@ -3007,6 +3267,14 @@ class LocomotionPlugin:
                     return {
                         "error": snapshot.error,
                         "code": "COMMAND_FAILED",
+                        "stream": asdict(snapshot),
+                    }
+                if feedback_goal is not None:
+                    return {
+                        "error": "odometry target was not reached before the safety timeout",
+                        "code": "TARGET_NOT_REACHED",
+                        **{key: value for key, value in progress.items()
+                           if key not in ("error", "code", "reached")},
                         "stream": asdict(snapshot),
                     }
                 return {

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -15,9 +15,11 @@ import os
 import queue
 import re
 import sqlite3
+import struct
 import subprocess
 import threading
 import time
+from array import array
 from collections import deque
 from collections.abc import Callable
 from dataclasses import asdict
@@ -27,7 +29,7 @@ from uuid import uuid4
 import numpy as np
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
-from std_msgs.msg import String
+from std_msgs.msg import String, UInt8MultiArray
 
 # Open3D is optional; fall back to numpy-only PCD writing when unavailable.
 try:
@@ -1480,6 +1482,7 @@ class OdometerPlugin:
         self._config = config
         self._ns = namespace
         self._topic = f"/{namespace}/state/odometer"
+        self._visual_topic = f"/{namespace}/state/odometer/trajectory"
         plugin_config = config.get("plugins", {}).get("odometer", {})
         self._timeout = max(
             0.1,
@@ -1499,6 +1502,14 @@ class OdometerPlugin:
         self._jump_tolerance = max(
             0.0, float(plugin_config.get("jump_tolerance_m", 0.25))
         )
+        self._trajectory_spacing = max(
+            0.005, float(plugin_config.get("trajectory_spacing_m", 0.025))
+        )
+        trajectory_capacity = int(plugin_config.get("trajectory_max_points", 4000))
+        self._trajectory_capacity = max(50, min(trajectory_capacity, 20000))
+        self._visual_extent = max(
+            2.0, min(float(plugin_config.get("trajectory_view_extent_m", 5.0)), 50.0)
+        )
         self._max_speed = _max_reasonable_odometry_speed(config)
 
         self._node = Node("t800_odometer", context=ros2.ctx_robot)
@@ -1506,6 +1517,9 @@ class OdometerPlugin:
         ros2.executor_robot.add_node(self._node)
         ros2.executor_core.add_node(self._pub_node)
         self._publisher = self._pub_node.create_publisher(String, self._topic, _RELIABLE)
+        self._visual_publisher = self._pub_node.create_publisher(
+            UInt8MultiArray, self._visual_topic, _RELIABLE_ONE
+        )
 
         self._lock = threading.RLock()
         self._latest: dict | None = None
@@ -1522,12 +1536,21 @@ class OdometerPlugin:
         self._timestamp_rejected_count = 0
         self._frame_reset_count = 0
         self._last_rejection: str | None = None
+        self._visual_origin: tuple[float, float] | None = None
+        self._visual_pose: tuple[float, float, float] | None = None
+        self._trajectory = deque(maxlen=self._trajectory_capacity)
+
+    def _topic_out(self) -> list[dict]:
+        return [
+            {"topic": self._topic, "format": "data/json"},
+            {"topic": self._visual_topic, "format": "sensor/mapping"},
+        ]
 
     def get_tool(self) -> dict:
         schema = action_schema(
             _with_lifecycle({
                 "status": ([], "返回最新里程计、行程和数据健康状态"),
-                "reset_trip": ([], "清零 Driver 内部单次行程，不修改 Odin2 坐标系"),
+                "reset_trip": ([], "清零单次行程和画面轨迹，不修改 Odin2 坐标系"),
             }),
             {},
             "里程计传感器动作",
@@ -1539,9 +1562,9 @@ class OdometerPlugin:
             "type": "sensor",
             "multiInstance": False,
             "readOnly": True,
-            "description": "T800 Odin2 位置、航向、速度、累计里程、单次行程与静止状态可视化",
+            "description": "T800 Odin2 里程状态，以及机器人运动轨迹和朝向的鸟瞰可视化",
             "inputSchema": schema,
-            "topic_out": [{"topic": self._topic, "format": "data/json"}],
+            "topic_out": self._topic_out(),
         }
 
     def start(self) -> None:
@@ -1558,12 +1581,20 @@ class OdometerPlugin:
 
     def dispatch(self, action: str, args: dict) -> dict:
         if action == "info":
-            return _with_topic_out(self._snapshot(), self._topic)
+            return {**self._snapshot(), "topic_out": self._topic_out()}
         if action in ("odometer", "status", "start"):
             return self._snapshot()
         if action == "reset_trip":
             with self._lock:
                 self._trip_distance_m = 0.0
+                if self._latest is None:
+                    self._visual_origin = None
+                    self._visual_pose = None
+                    self._trajectory.clear()
+                else:
+                    position = self._latest["position_m"]
+                    yaw = float(self._latest["orientation"]["yaw_rad"])
+                    self._reset_visual_locked(float(position["x"]), float(position["y"]), yaw)
             return {**self._snapshot(), "trip_reset": True}
         if action == "stop":
             return {"state": "idle"}
@@ -1670,6 +1701,14 @@ class OdometerPlugin:
                 "received_at": received_at,
             }
 
+            if baseline_reset or self._visual_origin is None:
+                self._reset_visual_locked(position[0], position[1], yaw)
+            else:
+                relative_x = position[0] - self._visual_origin[0]
+                relative_y = position[1] - self._visual_origin[1]
+                self._visual_pose = (relative_x, relative_y, yaw)
+                self._append_trajectory_locked(relative_x, relative_y, yaw)
+
             if self._stationary is None:
                 self._stationary = speed <= self._stationary_enter
                 self._stationary_since = received_at if self._stationary else None
@@ -1722,6 +1761,8 @@ class OdometerPlugin:
                 "frame_resets": self._frame_reset_count,
             }
             last_rejection = self._last_rejection
+            trajectory_count = len(self._trajectory)
+            visual_pose = self._visual_pose
 
         if latest is None or updated is None:
             return {
@@ -1730,6 +1771,7 @@ class OdometerPlugin:
                 "age_sec": None,
                 "distance_total_m": round(total, 6),
                 "trip_distance_m": round(trip, 6),
+                "trajectory_point_count": trajectory_count,
                 "sample_count": counts,
                 "last_rejection": last_rejection,
                 "timestamp_ms": _now_ms(),
@@ -1747,6 +1789,11 @@ class OdometerPlugin:
             **latest,
             "distance_total_m": round(total, 6),
             "trip_distance_m": round(trip, 6),
+            "trajectory_position_m": None if visual_pose is None else {
+                "x": round(visual_pose[0], 6),
+                "y": round(visual_pose[1], 6),
+            },
+            "trajectory_point_count": trajectory_count,
             "stationary_sec": round(stationary_sec, 3),
             "age_sec": round(age_sec, 3),
             "stale": stale,
@@ -1758,6 +1805,118 @@ class OdometerPlugin:
 
     def _publish(self) -> None:
         self._publisher.publish(_json_message(self._snapshot()))
+        self._publish_visual()
+
+    def _reset_visual_locked(self, x: float, y: float, yaw: float) -> None:
+        self._visual_origin = (x, y)
+        self._visual_pose = (0.0, 0.0, yaw)
+        self._trajectory.clear()
+        self._trajectory.append((0.0, 0.0, yaw))
+
+    def _append_trajectory_locked(self, x: float, y: float, yaw: float) -> None:
+        if not self._trajectory:
+            self._trajectory.append((x, y, yaw))
+            return
+        old_x, old_y, _old_yaw = self._trajectory[-1]
+        distance = math.hypot(x - old_x, y - old_y)
+        if distance < self._trajectory_spacing:
+            return
+        steps = min(
+            self._trajectory_capacity,
+            max(1, int(math.ceil(distance / self._trajectory_spacing))),
+        )
+        for index in range(1, steps + 1):
+            ratio = index / steps
+            self._trajectory.append((
+                old_x + (x - old_x) * ratio,
+                old_y + (y - old_y) * ratio,
+                yaw,
+            ))
+
+    def _visual_reference_points(self) -> list[tuple[float, float, float]]:
+        extent = self._visual_extent
+        step = 0.25
+        count = int((2.0 * extent) / step) + 1
+        points: list[tuple[float, float, float]] = []
+        for index in range(count):
+            value = -extent + index * step
+            points.append((value, 0.0, 0.0))
+            points.append((0.0, value, 0.0))
+            if index % 2 == 0:
+                points.append((value, -extent, -0.02))
+                points.append((value, extent, -0.02))
+                points.append((-extent, value, -0.02))
+                points.append((extent, value, -0.02))
+        return points
+
+    @staticmethod
+    def _heading_arrow_points(x: float, y: float, yaw: float) -> list[tuple[float, float, float]]:
+        points: list[tuple[float, float, float]] = []
+        length = 0.55
+        for index in range(24):
+            distance = length * index / 23.0
+            points.append((
+                x + math.cos(yaw) * distance,
+                y + math.sin(yaw) * distance,
+                0.28,
+            ))
+        tip_x = x + math.cos(yaw) * length
+        tip_y = y + math.sin(yaw) * length
+        for angle in (yaw + 2.55, yaw - 2.55):
+            for index in range(10):
+                distance = 0.025 * index
+                points.append((
+                    tip_x + math.cos(angle) * distance,
+                    tip_y + math.sin(angle) * distance,
+                    0.28,
+                ))
+        return points
+
+    def _visual_payload(self) -> bytes:
+        with self._lock:
+            pose = self._visual_pose
+            trajectory = list(self._trajectory)
+            frame_id = None if self._latest is None else self._latest.get("frame_id")
+            stale = self._updated is None or time.monotonic() - self._updated > self._timeout
+
+        robot_x, robot_y, robot_yaw = pose or (0.0, 0.0, 0.0)
+        points = self._visual_reference_points()
+        points.extend((x, y, 0.14) for x, y, _yaw in trajectory)
+        if pose is not None:
+            points.extend(self._heading_arrow_points(robot_x, robot_y, robot_yaw))
+        point_array = np.asarray(points, dtype=np.float32).reshape(-1, 3)
+        metadata = {
+            "version": 3,
+            "active_map": "odometer_trajectory",
+            "point_source": "odometer",
+            "frame_id": frame_id,
+            "stale": stale,
+            "trajectory_points": len(trajectory),
+            "robot": {
+                "x": robot_x,
+                "y": robot_y,
+                "yaw": robot_yaw,
+                "pose_available": pose is not None,
+            },
+            "maps": [],
+            "tags": [],
+        }
+        metadata_bytes = json.dumps(metadata, ensure_ascii=False).encode("utf-8")
+        flags = 0x03 | 0x04
+        header = struct.pack(
+            "<fffBI", robot_x, robot_y, -robot_yaw, flags, len(point_array)
+        )
+        return (
+            header
+            + point_array.tobytes()
+            + struct.pack("<I", len(metadata_bytes))
+            + metadata_bytes
+        )
+
+    def _publish_visual(self) -> None:
+        message = UInt8MultiArray()
+        message.data = array("B", self._visual_payload())
+        self._visual_publisher.publish(message)
 
 
 class MotionEventsPlugin:

--- a/engineai/t800/driver.yaml
+++ b/engineai/t800/driver.yaml
@@ -6,6 +6,6 @@ hardware_model: "t800"
 image_name: engineai-t800
 port: 15708
 mcp_url: "http://localhost:15708/mcp"
-description: "EngineAI T800 开发版 — speaker 音频播放、loco 安全运动、gait 步态切换、motion_recorder 录制回放、head 头部控制，以及 ROS2/Native SDK、全身状态、舞蹈/手势、虚拟手柄与 LED 控制"
+description: "EngineAI T800 开发版 — odometer 里程轨迹、loco 里程闭环运动、speaker 音频播放、gait 步态切换、motion_recorder 录制回放、head 头部控制，以及 ROS2/Native SDK、全身状态、舞蹈/手势、虚拟手柄与 LED 控制"
 build_context_extras:
   - ../../common

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -231,6 +231,7 @@ class T800DeviceBundle:
 
         locomotion = instances.get("locomotion")
         if locomotion is not None:
+            locomotion.set_odometer(instances.get("odometer"))
             locomotion.set_interrupt_group(motion_interrupt_group)
             motion_interrupt_group.register(
                 "locomotion", locomotion.halt, locomotion.motion_active

--- a/engineai/t800/main.py
+++ b/engineai/t800/main.py
@@ -160,6 +160,7 @@ class T800DeviceBundle:
             NativeInterfaceProbePlugin,
             NativeNodeControlPlugin,
             NativeSdkPlugin,
+            OdometerPlugin,
             SafetyControlPlugin,
             SpeakerPlugin,
             StatePlugin,
@@ -200,6 +201,7 @@ class T800DeviceBundle:
         plugin_types = (
             ("heartbeat_status", HeartbeatStatusPlugin, (config, namespace, ros2)),
             ("motion_command_trace", MotionCommandTracePlugin, (config, namespace, ros2)),
+            ("odometer", OdometerPlugin, (config, namespace, ros2)),
             ("native_interface_probe", NativeInterfaceProbePlugin, (config, namespace, ros2)),
             ("locomotion", LocomotionPlugin, (config, namespace, ros2, state)),
             ("motion_mode", MotionModePlugin, (config, namespace, ros2, state)),

--- a/engineai/t800/tests/test_contracts.py
+++ b/engineai/t800/tests/test_contracts.py
@@ -486,12 +486,12 @@ class McpHttpContractTests(unittest.TestCase):
 
 
 class VendoredContractTests(unittest.TestCase):
-    def test_default_loco_profile_matches_approved_real_device_limits(self):
+    def test_default_loco_profile_matches_official_body_velocity_limits(self):
         config_text = (ROOT / "config.yaml").read_text()
         for declaration in (
-            "max_vx: 2.0",
+            "max_vx: 1.0",
             "max_vy: 1.0",
-            "max_vyaw: 2.0",
+            "max_vyaw: 1.0",
             "locomotion_prepare_duration_sec: 1.0",
         ):
             self.assertIn(declaration, config_text)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -367,7 +367,8 @@ class DevicePluginContractTests(unittest.TestCase):
             {"joints", "imu", "battery", "motor_health", "motor_state", "motor_command", "joint_command_feedback",
              "gamepad", "motion_state", "driver_health", "model",
              "robot_snapshot", "fault_summary", "stability", "joint_groups", "capabilities", "ros_graph",
-             "mainboard", "heartbeat_status", "motion_command_trace", "odometer", "motion_events",
+             "mainboard", "heartbeat_status", "motion_command_trace", "odometer",
+             "odometer_control", "motion_events",
              "native_interface_probe",
              "loco", "motion_mode", "dance", "joint_plan", "joint_plan_state", "gesture", "head",
              "joint_override", "joint_bridge",
@@ -375,8 +376,8 @@ class DevicePluginContractTests(unittest.TestCase):
              "motor_power", "native_node_control", "virtual_gamepad", "safety", "native_sdk"},
             names,
         )
-        self.assertEqual(44, len(names))
-        self.assertEqual(44, len(definitions), "tool names must be unique")
+        self.assertEqual(45, len(names))
+        self.assertEqual(45, len(definitions), "tool names must be unique")
         for tool in definitions:
             schema = tool.get("inputSchema")
             self.assertEqual("object", schema.get("type"), tool["name"])
@@ -486,8 +487,16 @@ class DevicePluginContractTests(unittest.TestCase):
             tool["topic_out"],
         )
         actions = tool["inputSchema"]["properties"]["action"]["enum"]
-        self.assertTrue({"start", "info", "status", "reset_trip", "stop"}.issubset(actions))
+        self.assertTrue({"start", "info", "status", "stop"}.issubset(actions))
+        self.assertNotIn("reset_trip", actions)
         self.assertNotIn("required", tool["inputSchema"])
+
+        control = {item["name"]: item for item in plugin.get_tools()}["odometer_control"]
+        self.assertEqual("actuator", control["type"])
+        self.assertIn(
+            "reset_trip",
+            control["inputSchema"]["properties"]["action"]["enum"],
+        )
 
     def test_odometer_starts_with_configured_source_and_no_data_status(self):
         plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
@@ -521,7 +530,7 @@ class DevicePluginContractTests(unittest.TestCase):
         plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
         plugin._on_odometry(odometry_message(stamp=1.0))
         plugin._on_odometry(odometry_message(x=0.4, stamp=2.0))
-        reset = plugin.dispatch("reset_trip", {})
+        reset = plugin.dispatch("reset_trip", {"_tool_name": "odometer_control"})
         self.assertTrue(reset["trip_reset"])
         self.assertEqual(0.4, reset["distance_total_m"])
         self.assertEqual(0.0, reset["trip_distance_m"])
@@ -866,6 +875,12 @@ class DevicePluginContractTests(unittest.TestCase):
         capabilities = self.state.dispatch("capabilities", {})
         self.assertEqual(25, capabilities["dof"])
         self.assertIn("odometer", capabilities["feedback"])
+        self.assertIn("odometry_closed_loop_move", capabilities["control"])
+        self.assertNotIn("open_loop_displacement", capabilities["control"])
+        self.assertNotIn(
+            "display/statistics only",
+            " ".join(capabilities["limitations"]),
+        )
         self.assertNotIn("no odometry topic", " ".join(capabilities["limitations"]))
         self.assertEqual([23, 24], [item["index"] for item in
                                    self.state.dispatch("joint_groups", {})["groups"]["head"]])
@@ -1170,6 +1185,70 @@ class DevicePluginContractTests(unittest.TestCase):
         result = plugin.dispatch("move", {"vx": 0.2, "duration": 1.0})
 
         self.assertEqual("ODOMETRY_UNAVAILABLE", result["code"])
+        self.assertFalse(plugin._stream.snapshot().active)
+
+    def test_locomotion_rejects_finite_move_when_bundle_has_no_odometer(self):
+        plugin = self.device.LocomotionPlugin(CONFIG, "robot", self.ros, self.state)
+        plugin.set_odometer(None)
+        plugin.start()
+        self.state._on_motion(types.SimpleNamespace(
+            current_motion_task="rl_basic",
+            available_transition_motions=["passive"],
+        ))
+
+        result = plugin.dispatch("move", {"vx": 0.2, "duration": 0.01})
+
+        self.assertEqual("ODOMETRY_UNAVAILABLE", result["code"])
+        self.assertFalse(plugin._stream.snapshot().active)
+
+    def test_locomotion_captures_odometer_baseline_after_stopping_old_motion(self):
+        class Feedback:
+            def __init__(self):
+                self.distance = 0.0
+
+            def control_feedback(self):
+                return {
+                    "state": "running",
+                    "age_sec": 0.0,
+                    "distance_total_m": self.distance,
+                    "rotation_total_rad": 0.0,
+                    "frame_id": "odom",
+                    "frame_resets": 0,
+                    "jump_rejections": 0,
+                }
+
+        feedback = Feedback()
+        plugin = self.device.LocomotionPlugin(CONFIG, "robot", self.ros, self.state)
+        plugin.set_odometer(feedback)
+        plugin.start()
+        plugin._ACP_MIN_DURATION_SEC = 0.01
+        plugin._acp_notify = lambda *_args: None
+        self.state._on_motion(types.SimpleNamespace(
+            current_motion_task="rl_basic",
+            available_transition_motions=["passive"],
+        ))
+        plugin.dispatch("move", {"vx": 0.1, "duration": -1})
+        real_publish = plugin._publisher.publish
+
+        def publish(message):
+            if (
+                list(message.linear_velocity) == [0.0, 0.0]
+                and float(message.yaw_velocity) == 0.0
+            ):
+                feedback.distance = 1.0
+            real_publish(message)
+
+        plugin._publisher.publish = publish
+
+        result = plugin.dispatch("move", {"vx": 0.2, "duration": 0.1})
+        time.sleep(0.05)
+
+        self.assertTrue(result["closed_loop"])
+        self.assertTrue(plugin._stream.snapshot().active)
+        feedback.distance = 1.02
+        deadline = time.monotonic() + 0.5
+        while plugin._stream.snapshot().active and time.monotonic() < deadline:
+            time.sleep(0.01)
         self.assertFalse(plugin._stream.snapshot().active)
 
     def test_locomotion_fails_closed_when_odometer_rebases_after_a_jump(self):

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -476,7 +476,13 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual("sensor", tool["type"])
         self.assertTrue(tool["readOnly"])
         self.assertEqual(
-            [{"topic": "/runtime_robot/state/odometer", "format": "data/json"}],
+            [
+                {"topic": "/runtime_robot/state/odometer", "format": "data/json"},
+                {
+                    "topic": "/runtime_robot/state/odometer/trajectory",
+                    "format": "sensor/mapping",
+                },
+            ],
             tool["topic_out"],
         )
         actions = tool["inputSchema"]["properties"]["action"]["enum"]
@@ -497,6 +503,8 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual({"x": 1.25, "y": -0.18, "z": 0.02}, status["position_m"])
         self.assertEqual(0.0, status["distance_total_m"])
         self.assertEqual(0.0, status["trip_distance_m"])
+        self.assertEqual({"x": 0.0, "y": 0.0}, status["trajectory_position_m"])
+        self.assertEqual(1, status["trajectory_point_count"])
         self.assertTrue(status["baseline_reset"])
 
     def test_odometer_accumulates_planar_distance_and_ignores_z(self):
@@ -515,6 +523,8 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertTrue(reset["trip_reset"])
         self.assertEqual(0.4, reset["distance_total_m"])
         self.assertEqual(0.0, reset["trip_distance_m"])
+        self.assertEqual({"x": 0.0, "y": 0.0}, reset["trajectory_position_m"])
+        self.assertEqual(1, reset["trajectory_point_count"])
         plugin._on_odometry(odometry_message(x=0.6, stamp=3.0))
         status = plugin.dispatch("status", {})
         self.assertEqual(0.6, status["distance_total_m"])
@@ -573,6 +583,7 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual(0.0, rejected["distance_total_m"])
         self.assertTrue(rejected["jump_rejected"])
         self.assertEqual(1, rejected["sample_count"]["jump_rejected"])
+        self.assertEqual({"x": 0.0, "y": 0.0}, rejected["trajectory_position_m"])
         plugin._on_odometry(odometry_message(x=20.1, stamp=3.0))
         self.assertAlmostEqual(0.1, plugin.dispatch("status", {})["distance_total_m"])
 
@@ -602,6 +613,7 @@ class DevicePluginContractTests(unittest.TestCase):
         changed = plugin.dispatch("status", {})
         self.assertEqual(0.0, changed["distance_total_m"])
         self.assertEqual(1, changed["sample_count"]["frame_resets"])
+        self.assertEqual({"x": 0.0, "y": 0.0}, changed["trajectory_position_m"])
         plugin._on_odometry(odometry_message(x=1.2, stamp=3.0, frame_id="map"))
         self.assertAlmostEqual(0.2, plugin.dispatch("status", {})["distance_total_m"])
 
@@ -620,6 +632,37 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertIn("orientation", payload)
         self.assertIn("distance_total_m", payload)
         self.assertIn("stationary_sec", payload)
+        self.assertEqual(1, len(plugin._visual_publisher.messages))
+
+    def test_odometer_mapping_payload_renders_relative_trajectory_and_heading(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(x=10.0, y=20.0, stamp=1.0))
+        half_yaw = math.pi / 4.0
+        plugin._on_odometry(odometry_message(
+            x=10.3,
+            y=20.4,
+            quaternion=(0.0, 0.0, math.sin(half_yaw), math.cos(half_yaw)),
+            stamp=2.0,
+        ))
+        raw = plugin._visual_payload()
+        robot_x, robot_y, display_yaw, flags, point_count = struct.unpack_from(
+            "<fffBI", raw, 0
+        )
+        self.assertAlmostEqual(0.3, robot_x, places=5)
+        self.assertAlmostEqual(0.4, robot_y, places=5)
+        self.assertAlmostEqual(-math.pi / 2.0, display_yaw, places=5)
+        self.assertEqual(7, flags)
+        self.assertGreater(point_count, plugin.dispatch("status", {})["trajectory_point_count"])
+
+        metadata_offset = struct.calcsize("<fffBI") + point_count * 12
+        metadata_length = struct.unpack_from("<I", raw, metadata_offset)[0]
+        metadata = json.loads(raw[
+            metadata_offset + 4:metadata_offset + 4 + metadata_length
+        ].decode("utf-8"))
+        self.assertEqual("odometer", metadata["point_source"])
+        self.assertTrue(metadata["robot"]["pose_available"])
+        self.assertGreater(metadata["trajectory_points"], 1)
+        self.assertAlmostEqual(math.pi / 2.0, metadata["robot"]["yaw"])
 
     def test_motion_trace_prefers_fresh_command_over_stale_odometry(self):
         plugin = self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros)

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -492,6 +492,8 @@ class DevicePluginContractTests(unittest.TestCase):
     def test_odometer_starts_with_configured_source_and_no_data_status(self):
         plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
         self.assertEqual("no_data", plugin.dispatch("status", {})["state"])
+        self.assertEqual({"state": "running"}, plugin.dispatch("start", {}))
+        self.assertEqual("no_data", plugin.dispatch("status", {})["state"])
         plugin.start()
         self.assertEqual(CONFIG["topics"]["odometry"], plugin._node.subscriptions[0].topic)
 

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -13,6 +13,7 @@ import types
 import unittest
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -279,6 +280,39 @@ CONFIG = {
 }
 
 
+def odometry_message(
+    *,
+    x=0.0,
+    y=0.0,
+    z=0.0,
+    quaternion=(0.0, 0.0, 0.0, 1.0),
+    linear=(0.0, 0.0, 0.0),
+    angular=(0.0, 0.0, 0.0),
+    stamp=1.0,
+    frame_id="odom",
+    child_frame_id="base_link",
+):
+    seconds = int(stamp)
+    nanoseconds = int(round((stamp - seconds) * 1_000_000_000))
+    return types.SimpleNamespace(
+        header=types.SimpleNamespace(
+            frame_id=frame_id,
+            stamp=types.SimpleNamespace(sec=seconds, nanosec=nanoseconds),
+        ),
+        child_frame_id=child_frame_id,
+        pose=types.SimpleNamespace(pose=types.SimpleNamespace(
+            position=types.SimpleNamespace(x=x, y=y, z=z),
+            orientation=types.SimpleNamespace(
+                x=quaternion[0], y=quaternion[1], z=quaternion[2], w=quaternion[3],
+            ),
+        )),
+        twist=types.SimpleNamespace(twist=types.SimpleNamespace(
+            linear=types.SimpleNamespace(x=linear[0], y=linear[1], z=linear[2]),
+            angular=types.SimpleNamespace(x=angular[0], y=angular[1], z=angular[2]),
+        )),
+    )
+
+
 class DevicePluginContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -318,6 +352,7 @@ class DevicePluginContractTests(unittest.TestCase):
             self.device.NativeSdkPlugin({"mode": "external"}, "robot", self.ros),
             self.device.HeartbeatStatusPlugin(CONFIG, "robot", self.ros),
             self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros),
+            self.device.OdometerPlugin(CONFIG, "robot", self.ros),
             self.device.MotionEventsPlugin(CONFIG, "robot", self.ros),
             self.device.NativeInterfaceProbePlugin(CONFIG, "robot", self.ros),
             VirtualGamepadPlugin({}, "robot", self.ros),
@@ -332,7 +367,7 @@ class DevicePluginContractTests(unittest.TestCase):
             {"joints", "imu", "battery", "motor_health", "motor_state", "motor_command", "joint_command_feedback",
              "gamepad", "motion_state", "driver_health", "model",
              "robot_snapshot", "fault_summary", "stability", "joint_groups", "capabilities", "ros_graph",
-             "mainboard", "heartbeat_status", "motion_command_trace", "motion_events",
+             "mainboard", "heartbeat_status", "motion_command_trace", "odometer", "motion_events",
              "native_interface_probe",
              "loco", "motion_mode", "dance", "joint_plan", "joint_plan_state", "gesture", "head",
              "joint_override", "joint_bridge",
@@ -340,8 +375,8 @@ class DevicePluginContractTests(unittest.TestCase):
              "motor_power", "native_node_control", "virtual_gamepad", "safety", "native_sdk"},
             names,
         )
-        self.assertEqual(43, len(names))
-        self.assertEqual(43, len(definitions), "tool names must be unique")
+        self.assertEqual(44, len(names))
+        self.assertEqual(44, len(definitions), "tool names must be unique")
         for tool in definitions:
             schema = tool.get("inputSchema")
             self.assertEqual("object", schema.get("type"), tool["name"])
@@ -391,6 +426,7 @@ class DevicePluginContractTests(unittest.TestCase):
             self.state,
             self.device.HeartbeatStatusPlugin(CONFIG, "robot", self.ros),
             self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros),
+            self.device.OdometerPlugin(CONFIG, "robot", self.ros),
             self.device.MotionEventsPlugin(CONFIG, "robot", self.ros),
             self.device.NativeInterfaceProbePlugin(CONFIG, "robot", self.ros),
             self.device.VisionPlugin(CONFIG, "robot", self.ros),
@@ -426,12 +462,164 @@ class DevicePluginContractTests(unittest.TestCase):
         plugins = [
             self.device.HeartbeatStatusPlugin(CONFIG, "robot", self.ros),
             self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros),
+            self.device.OdometerPlugin(CONFIG, "robot", self.ros),
             self.device.MotionEventsPlugin(CONFIG, "robot", self.ros),
             self.device.NativeInterfaceProbePlugin(CONFIG, "robot", self.ros),
         ]
         for plugin in plugins:
             plugin.start()
             plugin.stop()
+
+    def test_odometer_declares_dashboard_topic_and_sensor_actions(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "runtime_robot", self.ros)
+        tool = plugin.get_tool()
+        self.assertEqual("sensor", tool["type"])
+        self.assertTrue(tool["readOnly"])
+        self.assertEqual(
+            [{"topic": "/runtime_robot/state/odometer", "format": "data/json"}],
+            tool["topic_out"],
+        )
+        actions = tool["inputSchema"]["properties"]["action"]["enum"]
+        self.assertTrue({"start", "info", "status", "reset_trip", "stop"}.issubset(actions))
+        self.assertNotIn("required", tool["inputSchema"])
+
+    def test_odometer_starts_with_configured_source_and_no_data_status(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        self.assertEqual("no_data", plugin.dispatch("status", {})["state"])
+        plugin.start()
+        self.assertEqual(CONFIG["topics"]["odometry"], plugin._node.subscriptions[0].topic)
+
+    def test_odometer_first_frame_sets_baseline_and_exposes_pose(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(x=1.25, y=-0.18, z=0.02, stamp=5.0))
+        status = plugin.dispatch("status", {})
+        self.assertEqual("running", status["state"])
+        self.assertEqual({"x": 1.25, "y": -0.18, "z": 0.02}, status["position_m"])
+        self.assertEqual(0.0, status["distance_total_m"])
+        self.assertEqual(0.0, status["trip_distance_m"])
+        self.assertTrue(status["baseline_reset"])
+
+    def test_odometer_accumulates_planar_distance_and_ignores_z(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(z=2.0, stamp=1.0))
+        plugin._on_odometry(odometry_message(x=0.3, y=0.4, z=20.0, stamp=2.0))
+        status = plugin.dispatch("status", {})
+        self.assertAlmostEqual(0.5, status["distance_total_m"])
+        self.assertAlmostEqual(0.5, status["trip_distance_m"])
+
+    def test_odometer_reset_trip_preserves_total_distance(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(stamp=1.0))
+        plugin._on_odometry(odometry_message(x=0.4, stamp=2.0))
+        reset = plugin.dispatch("reset_trip", {})
+        self.assertTrue(reset["trip_reset"])
+        self.assertEqual(0.4, reset["distance_total_m"])
+        self.assertEqual(0.0, reset["trip_distance_m"])
+        plugin._on_odometry(odometry_message(x=0.6, stamp=3.0))
+        status = plugin.dispatch("status", {})
+        self.assertEqual(0.6, status["distance_total_m"])
+        self.assertEqual(0.2, status["trip_distance_m"])
+
+    def test_odometer_computes_yaw_heading_and_velocities(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        half_yaw = math.pi / 4.0
+        plugin._on_odometry(odometry_message(
+            quaternion=(0.0, 0.0, math.sin(half_yaw), math.cos(half_yaw)),
+            linear=(0.3, 0.4, 0.2),
+            angular=(0.1, -0.2, 0.8),
+        ))
+        status = plugin.dispatch("status", {})
+        self.assertAlmostEqual(math.pi / 2.0, status["orientation"]["yaw_rad"])
+        self.assertAlmostEqual(90.0, status["orientation"]["heading_deg"])
+        self.assertAlmostEqual(0.5, status["speed_m_s"])
+        self.assertEqual({"x": 0.1, "y": -0.2, "z": 0.8}, status["angular_velocity_rad_s"])
+
+    def test_odometer_stationary_hysteresis_and_duration(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        with mock.patch.object(self.device.time, "monotonic", return_value=10.0):
+            plugin._on_odometry(odometry_message(linear=(0.02, 0.0, 0.0), stamp=1.0))
+        with mock.patch.object(self.device.time, "monotonic", return_value=10.5):
+            status = plugin.dispatch("status", {})
+        self.assertTrue(status["stationary"])
+        self.assertAlmostEqual(0.5, status["stationary_sec"])
+
+        with mock.patch.object(self.device.time, "monotonic", return_value=10.6):
+            plugin._on_odometry(odometry_message(linear=(0.04, 0.0, 0.0), stamp=2.0))
+        self.assertTrue(plugin.dispatch("status", {})["stationary"])
+        with mock.patch.object(self.device.time, "monotonic", return_value=10.7):
+            plugin._on_odometry(odometry_message(linear=(0.05, 0.0, 0.0), stamp=3.0))
+        self.assertFalse(plugin.dispatch("status", {})["stationary"])
+        with mock.patch.object(self.device.time, "monotonic", return_value=10.8):
+            plugin._on_odometry(odometry_message(linear=(0.04, 0.0, 0.0), stamp=4.0))
+        self.assertFalse(plugin.dispatch("status", {})["stationary"])
+        with mock.patch.object(self.device.time, "monotonic", return_value=10.9):
+            plugin._on_odometry(odometry_message(linear=(0.03, 0.0, 0.0), stamp=5.0))
+        self.assertTrue(plugin.dispatch("status", {})["stationary"])
+
+    def test_odometer_rejects_non_finite_and_zero_quaternion_samples(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(x=float("nan")))
+        plugin._on_odometry(odometry_message(linear=(float("inf"), 0.0, 0.0)))
+        plugin._on_odometry(odometry_message(quaternion=(0.0, 0.0, 0.0, 0.0)))
+        status = plugin.dispatch("status", {})
+        self.assertEqual("no_data", status["state"])
+        self.assertEqual(3, status["sample_count"]["invalid"])
+
+    def test_odometer_rejects_jump_then_recovers_from_new_baseline(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(stamp=1.0))
+        plugin._on_odometry(odometry_message(x=20.0, stamp=2.0))
+        rejected = plugin.dispatch("status", {})
+        self.assertEqual(0.0, rejected["distance_total_m"])
+        self.assertTrue(rejected["jump_rejected"])
+        self.assertEqual(1, rejected["sample_count"]["jump_rejected"])
+        plugin._on_odometry(odometry_message(x=20.1, stamp=3.0))
+        self.assertAlmostEqual(0.1, plugin.dispatch("status", {})["distance_total_m"])
+
+    def test_odometer_rejects_non_increasing_source_timestamp(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(stamp=2.0))
+        plugin._on_odometry(odometry_message(x=0.2, stamp=1.0))
+        status = plugin.dispatch("status", {})
+        self.assertEqual(0.0, status["distance_total_m"])
+        self.assertEqual(0.0, status["position_m"]["x"])
+        self.assertEqual(1, status["sample_count"]["timestamp_rejected"])
+        self.assertEqual("timestamp_not_increasing", status["last_rejection"])
+
+    def test_odometer_marks_stale_while_retaining_last_pose(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(x=1.0))
+        plugin._updated = time.monotonic() - 2.0
+        status = plugin.dispatch("status", {})
+        self.assertEqual("stale", status["state"])
+        self.assertTrue(status["stale"])
+        self.assertEqual(1.0, status["position_m"]["x"])
+
+    def test_odometer_frame_change_resets_distance_baseline(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        plugin._on_odometry(odometry_message(stamp=1.0, frame_id="odom"))
+        plugin._on_odometry(odometry_message(x=1.0, stamp=2.0, frame_id="map"))
+        changed = plugin.dispatch("status", {})
+        self.assertEqual(0.0, changed["distance_total_m"])
+        self.assertEqual(1, changed["sample_count"]["frame_resets"])
+        plugin._on_odometry(odometry_message(x=1.2, stamp=3.0, frame_id="map"))
+        self.assertAlmostEqual(0.2, plugin.dispatch("status", {})["distance_total_m"])
+
+    def test_odometer_info_stop_and_dashboard_json_contract(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        info = plugin.dispatch("info", {})
+        self.assertEqual("no_data", info["state"])
+        self.assertEqual(plugin.get_tool()["topic_out"], info["topic_out"])
+        self.assertEqual({"state": "idle"}, plugin.dispatch("stop", {}))
+
+        plugin._on_odometry(odometry_message(x=0.2, linear=(0.1, 0.0, 0.0)))
+        plugin._publish()
+        payload = json.loads(plugin._publisher.messages[-1].data)
+        self.assertEqual("running", payload["state"])
+        self.assertIn("position_m", payload)
+        self.assertIn("orientation", payload)
+        self.assertIn("distance_total_m", payload)
+        self.assertIn("stationary_sec", payload)
 
     def test_motion_trace_prefers_fresh_command_over_stale_odometry(self):
         plugin = self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros)
@@ -609,7 +797,10 @@ class DevicePluginContractTests(unittest.TestCase):
         faults = self.state.dispatch("fault_summary", {})
         self.assertEqual([1], faults["offline_joints"])
         self.assertEqual(7, faults["motor_errors"][0]["code"])
-        self.assertEqual(25, self.state.dispatch("capabilities", {})["dof"])
+        capabilities = self.state.dispatch("capabilities", {})
+        self.assertEqual(25, capabilities["dof"])
+        self.assertIn("odometer", capabilities["feedback"])
+        self.assertNotIn("no odometry topic", " ".join(capabilities["limitations"]))
         self.assertEqual([23, 24], [item["index"] for item in
                                    self.state.dispatch("joint_groups", {})["groups"]["head"]])
 

--- a/engineai/t800/tests/test_device_contract.py
+++ b/engineai/t800/tests/test_device_contract.py
@@ -666,6 +666,27 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertGreater(metadata["trajectory_points"], 1)
         self.assertAlmostEqual(math.pi / 2.0, metadata["robot"]["yaw"])
 
+    def test_odometer_control_feedback_accumulates_unwrapped_rotation(self):
+        plugin = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        first_yaw = math.radians(179.0)
+        second_yaw = math.radians(-179.0)
+        plugin._on_odometry(odometry_message(
+            quaternion=(0.0, 0.0, math.sin(first_yaw / 2.0), math.cos(first_yaw / 2.0)),
+            stamp=1.0,
+        ))
+        plugin._on_odometry(odometry_message(
+            x=0.1,
+            quaternion=(0.0, 0.0, math.sin(second_yaw / 2.0), math.cos(second_yaw / 2.0)),
+            stamp=1.1,
+        ))
+
+        feedback = plugin.control_feedback()
+
+        self.assertEqual("running", feedback["state"])
+        self.assertAlmostEqual(0.1, feedback["distance_total_m"])
+        self.assertAlmostEqual(math.radians(2.0), feedback["rotation_total_rad"])
+        self.assertEqual("odom", feedback["frame_id"])
+
     def test_motion_trace_prefers_fresh_command_over_stale_odometry(self):
         plugin = self.device.MotionCommandTracePlugin(CONFIG, "robot", self.ros)
         plugin._on_odometry(types.SimpleNamespace(
@@ -1087,6 +1108,96 @@ class DevicePluginContractTests(unittest.TestCase):
         self.assertEqual(0.0, plugin._publisher.messages[-1].yaw_velocity)
         self.assertEqual(result["action_id"], completions[0][0])
         self.assertEqual("completed", completions[0][1])
+
+    def test_locomotion_uses_odometer_to_reach_speed_times_duration_distance(self):
+        config = {
+            **CONFIG,
+            "control": {
+                **CONFIG["control"],
+                "locomotion_prepare_duration_sec": 0.04,
+            },
+        }
+        odometer = self.device.OdometerPlugin(config, "robot", self.ros)
+        odometer._on_odometry(odometry_message(stamp=1.0))
+        plugin = self.device.LocomotionPlugin(config, "robot", self.ros, self.state)
+        plugin.set_odometer(odometer)
+        plugin.start()
+        plugin._ACP_MIN_DURATION_SEC = 0.01
+        completions = []
+        plugin._acp_notify = lambda *args: completions.append(args)
+        self.state._on_motion(types.SimpleNamespace(
+            current_motion_task="rl_basic",
+            available_transition_motions=["passive"],
+        ))
+
+        result = plugin.dispatch("move", {"vx": 1.0, "duration": 0.03})
+
+        self.assertTrue(result["closed_loop"])
+        self.assertFalse(result["open_loop"])
+        self.assertEqual(0.0, result["preparation_duration"])
+        self.assertAlmostEqual(0.03, result["target_distance_m"])
+        time.sleep(0.06)
+        self.assertTrue(
+            plugin._stream.snapshot().active,
+            "the command must continue past nominal duration until odometry reaches the target",
+        )
+
+        odometer._on_odometry(odometry_message(x=0.03, stamp=1.1))
+        deadline = time.monotonic() + 1.0
+        while plugin._stream.snapshot().active and time.monotonic() < deadline:
+            time.sleep(0.01)
+        while not completions and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        self.assertFalse(plugin._stream.snapshot().active)
+        self.assertEqual(0.0, plugin._publisher.messages[-1].yaw_velocity)
+        self.assertEqual(result["action_id"], completions[0][0])
+        self.assertEqual("completed", completions[0][1])
+        self.assertAlmostEqual(0.03, completions[0][2]["measured_distance_m"])
+
+    def test_locomotion_rejects_closed_loop_move_when_odometer_is_stale(self):
+        odometer = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        odometer._on_odometry(odometry_message(stamp=1.0))
+        odometer._updated = time.monotonic() - 2.0
+        plugin = self.device.LocomotionPlugin(CONFIG, "robot", self.ros, self.state)
+        plugin.set_odometer(odometer)
+        plugin.start()
+        self.state._on_motion(types.SimpleNamespace(
+            current_motion_task="rl_basic",
+            available_transition_motions=["passive"],
+        ))
+
+        result = plugin.dispatch("move", {"vx": 0.2, "duration": 1.0})
+
+        self.assertEqual("ODOMETRY_UNAVAILABLE", result["code"])
+        self.assertFalse(plugin._stream.snapshot().active)
+
+    def test_locomotion_fails_closed_when_odometer_rebases_after_a_jump(self):
+        odometer = self.device.OdometerPlugin(CONFIG, "robot", self.ros)
+        odometer._on_odometry(odometry_message(stamp=1.0))
+        plugin = self.device.LocomotionPlugin(CONFIG, "robot", self.ros, self.state)
+        plugin.set_odometer(odometer)
+        plugin.start()
+        plugin._ACP_MIN_DURATION_SEC = 0.01
+        completions = []
+        plugin._acp_notify = lambda *args: completions.append(args)
+        self.state._on_motion(types.SimpleNamespace(
+            current_motion_task="rl_basic",
+            available_transition_motions=["passive"],
+        ))
+        result = plugin.dispatch("move", {"vx": 0.2, "duration": 0.1})
+
+        odometer._on_odometry(odometry_message(x=20.0, stamp=1.1))
+        deadline = time.monotonic() + 0.3
+        while plugin._stream.snapshot().active and time.monotonic() < deadline:
+            time.sleep(0.01)
+        while not completions and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        self.assertFalse(plugin._stream.snapshot().active)
+        self.assertEqual(result["action_id"], completions[0][0])
+        self.assertEqual("error", completions[0][1])
+        self.assertEqual("ODOMETRY_RESET", completions[0][2]["code"])
 
     def test_locomotion_concurrent_starts_complete_every_action_id_once(self):
         plugin = self.device.LocomotionPlugin(CONFIG, "robot", self.ros, self.state)


### PR DESCRIPTION
## 背景

PR #190 合并时，reviewer 验收了 speaker、gait 和 motion_recorder，但指出 loco 卡片存在距离偏差：例如 `vx=1 m/s`、`duration=3 s` 时，实测路径不足 3 m。

调研官方《第 3 章 机体速度控制》及 `BodyVelCmd` 协议后确认：`/motion/body_vel_cmd` 只表达机体期望速度，需要持续发布；它不承诺实际速度等于命令速度，也不提供位移目标。因此仅靠 `速度 × 时间` 无法消除起步、控制器跟踪和地面条件造成的里程误差，有限动作需要 Odin2 odometry 反馈闭环。

本 PR 是 #190 的后续修复，并整合 #180 已评审的 odometer 卡片。

## 主要修改

### odometer / odometer_control

- 订阅 `/manifold/ODIN2/device0/odometry`（`nav_msgs/msg/Odometry`）。
- 提供位置、航向、速度、静止判断、累计/单次里程和数据健康诊断。
- 发布 `data/json` 状态与 `sensor/mapping` 轨迹/朝向鸟瞰画面。
- 校验非有限值、时间戳倒退、不合理速度和位置跳变。
- 累计跨 `±π` 连续航向变化，供转角闭环使用。
- 将有状态的 `reset_trip` 从只读 sensor 拆到 `odometer_control` actuator，保留累计总里程。
- `start` 按 sensor 生命周期契约返回 `{"state":"running"}`。

### loco 里程闭环

- 有限 `move` 将 `hypot(vx, vy) × duration` 和 `abs(vyaw) × duration` 转为目标里程/累计转角。
- `move_displacement`、`turn_angle`、`arc` 复用同一里程反馈终止逻辑。
- 达到实测目标后立即停止速度流并显式发布零速度；返回目标值与最终实测值。
- 在停止旧动作后、启动新动作前原子采集新里程基线，避免旧动作尾程计入新目标。
- 起步前无新鲜 odometry 时拒绝有限动作；运行中断流、坐标系变化、位置跳变或安全超时均 fail-closed。
- production bundle 不回退到时间开环；`duration=-1` 仍保持持续移动到 `stop_move` 的语义。
- 保持官方 100 Hz 发布、`frame_id="body"`、显式零速度停止，并将 `vx/vy/vyaw` 安全范围统一为官方 `[-1, 1]`。

## 验证

- T800 完整测试套件：`252 tests passed`
- `git diff --check` 通过
- `device.py`、`main.py`、`control.py` Python 语法编译通过
- 新增回归覆盖：
  - 名义时间结束但实测未达目标时继续发布；
  - 达到实测里程后立即归零；
  - stale / missing / frame reset / position jump fail-closed；
  - 旧动作停止后再采集新动作基线；
  - 航向跨 `±π` 连续累计；
  - sensor/actuator 生命周期与官方三轴限速。

## 真机说明

本 PR 尚未在 T800 真机上复测最终停止误差。合并前建议在空旷区域分别验证直行 3 m、侧移、原地转角和圆弧，并根据实测制动距离调整 `locomotion_distance_tolerance_m` / `locomotion_angle_tolerance_rad`。

相关：#180、#190

