### PR TITLE
fix(g1): correct FSM mode targets and add joint-derived posture

### DIFF
--- a/unitree/g1/Dockerfile
+++ b/unitree/g1/Dockerfile
@@ -51,6 +51,7 @@ COPY device.py /work/device.py
 COPY rpc_proxy.py /work/rpc_proxy.py
 COPY ext_devices.py /work/ext_devices.py
 COPY safety_harness.py /work/safety_harness.py
+COPY sport_mode_state.py /work/sport_mode_state.py
 COPY scan_context.py /work/scan_context.py
 COPY controlled_spatial.py /work/controlled_spatial.py
 COPY controlled_spatial_map.py /work/controlled_spatial_map.py

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -19,6 +19,7 @@ drivers/unitree/g1/device.py — Unitree G1 设备插件（重构版）。
 """
 
 import json
+import math
 import queue
 import socket
 import struct
@@ -34,6 +35,7 @@ from audio_msgs.msg import AudioChunk
 
 from unitree_sdk2py.g1.audio.g1_audio_client import AudioClient
 from pointcloud_utils import gravity_align_inplace
+import sport_mode_state as _SMS
 
 # ── 常量 ──────────────────────────────────────────────────────────────────────
 
@@ -1109,7 +1111,13 @@ class LedPlugin:
 # ── LocoStatePlugin (sensor) ─────────────────────────────────────────────────
 
 class _LocoStateNode(Node):
-    """Subscribes to DDS odommodestate + sportmodestate and republishes as JSON to ROS2."""
+    """Subscribes to DDS odommodestate + sportmodestate and republishes as JSON to ROS2.
+
+    The two topics carry *different* IDL types on G1: rt/odommodestate uses the
+    unitree_go SportModeState_ layout (odometry/IMU), while rt/sportmodestate uses
+    the much smaller unitree_hg SportModeState_ (fsm_id/fsm_mode/task_id/task_time).
+    Subscribing to the latter with the go type silently never matches.
+    """
 
     _ODOM_INTERVAL = 0.1  # 10 Hz throttle
 
@@ -1118,6 +1126,7 @@ class _LocoStateNode(Node):
         self._odom_pub   = self.create_publisher(String, odom_topic,   _LOW_LAT_QOS)
         self._motion_pub = self.create_publisher(String, motion_topic, _LOW_LAT_QOS)
         self._last_state: dict = {}
+        self._last_fsm: dict = {}
         self._lock       = threading.Lock()
         self._last_odom_time: float = 0.0
 
@@ -1132,8 +1141,8 @@ class _LocoStateNode(Node):
 
         try:
             from unitree_sdk2py.core.channel import ChannelSubscriber
-            from unitree_sdk2py.idl.unitree_go.msg.dds_ import SportModeState_
-            sport_sub = ChannelSubscriber("rt/sportmodestate", SportModeState_)
+            from sport_mode_state import SportModeState_ as HgSportModeState_
+            sport_sub = ChannelSubscriber("rt/sportmodestate", HgSportModeState_)
             sport_sub.Init(self._on_motion, 10)
             self.get_logger().info(f"LocoStateNode subscribed rt/sportmodestate → {motion_topic}")
         except Exception as e:
@@ -1171,7 +1180,19 @@ class _LocoStateNode(Node):
         self._odom_pub.publish(out)
 
     def _on_motion(self, msg) -> None:
-        state = self._format_state(msg)
+        state = {
+            "fsm_id":     int(msg.fsm_id),
+            "fsm_mode":   int(msg.fsm_mode),
+            "task_id":    int(msg.task_id),
+            "task_time":  float(msg.task_time),
+            "mode":       _SMS.fsm_name(int(msg.fsm_id)),
+            "balanced":   bool(_SMS.FSM_MODES.get(int(msg.fsm_id), {}).get("balanced", False)),
+            # fsm_mode 0=静态 (switching allowed), 1=动态 (most switches refused).
+            "switchable": int(msg.fsm_mode) == 0,
+            "ts":         time.time(),
+        }
+        with self._lock:
+            self._last_fsm = state
         out = String()
         out.data = json.dumps(state)
         self._motion_pub.publish(out)
@@ -1179,6 +1200,11 @@ class _LocoStateNode(Node):
     def get_last_state(self) -> dict:
         with self._lock:
             return dict(self._last_state)
+
+    def get_fsm(self) -> dict:
+        """Latest rt/sportmodestate snapshot, or {} if the topic has not been seen."""
+        with self._lock:
+            return dict(self._last_fsm)
 
 
 class LocoStatePlugin:
@@ -1208,10 +1234,18 @@ class LocoStatePlugin:
             "name": "loco_motion_state",
             "type": "sensor",
             "multiInstance": False,
-            "description": f"G1 sport mode state (only active when standing/walking) — same fields as loco_state but from motion controller. Publishes to {self._motion_topic}",
+            "description": (
+                "G1 FSM state from rt/sportmodestate — fsm_id (运控模式), fsm_mode "
+                "(0=静态/可切换, 1=动态/拒绝切换), switchable, balanced, task_id/task_time. "
+                f"This is the authoritative mode feed. Publishes to {self._motion_topic}"
+            ),
             "inputSchema": {"type": "object", "properties": {}},
             "topic_out": [{"topic": self._motion_topic, "format": "data/json"}],
         }
+
+    @property
+    def node(self):
+        return self._node
 
     def start(self) -> None:
         pass  # DDS subscription starts in __init__
@@ -1268,12 +1302,18 @@ def _loco_acp_notify(action_id: str, status: str, result: dict, tool: str = "loc
 class LocoPlugin:
     PREFIX = "loco"
 
-    def __init__(self, plugin_config: dict, namespace: str, executor, loco_client, slam_client=None, smart_motion=None):
+    def __init__(self, plugin_config: dict, namespace: str, executor, loco_client, slam_client=None,
+                 smart_motion=None, state_node=None, posture_node=None):
         self._client = loco_client
         self._slam_client = slam_client
         self._smart_motion = smart_motion
         self._namespace = namespace
         self._move_timer: threading.Timer | None = None
+        # _LocoStateNode — authoritative fsm_id/fsm_mode from rt/sportmodestate.
+        self._state_node = state_node
+        # _LowStateNode — joint-derived posture, needed to tell lying from squatting
+        # once the robot is limp (FSM 0/1), where the mode carries no pose info.
+        self._posture_node = posture_node
 
     def get_tools(self) -> list:
         tools = [self._loco_tool(), self._switch_mode_tool(), self._switch_mode_expert_tool()]
@@ -1334,11 +1374,57 @@ class LocoPlugin:
             },
         }
 
-    # ── FSM state groups for safety checks ──────────────────────────────────────
-    _GROUND_STATES = {0, 1}            # zero_torque, damp — lying on ground
-    _LOW_STATES = {2, 702}             # squat, prep — stable low stance
-    _STANDING_STATES = {500, 501, 801} # normal_loco, 3dof_waist, run — active balance
-    _UNSAFE_STATES = {3, 706}          # sit, balance_stand — not directly switchable
+    # ── FSM state groups ────────────────────────────────────────────────────────
+    # Official ID table: 专家接口 § 模式ID说明 at
+    # https://support.unitree.com/home/zh/G1_developer/sport_services_interface
+    #
+    #   0 零力矩 / 1 阻尼 / 2 位控下蹲 / 3 位控落座 / 4 锁定站立  → NO balance control
+    #   702 躺起 / 706 平衡下蹲、蹲起 / 500 常规运控 / 501 常规运控-3Dof-waist
+    #   801 走跑运控 (renumbered to 802 on 29-DoF from ai_sport 8.6.x.x)
+    #
+    # Two separate ways down from 主运控, and they are NOT interchangeable:
+    #   * 706 平衡下蹲、蹲起 — balanced squat, connects only to LOCO_STATES. Squatting
+    #     down and standing back up are the SAME id, i.e. it is a toggle. This is the
+    #     safe pair.
+    #   * 2/3 位控下蹲/落座 — position modes with no balance control, reachable from
+    #     阻尼 and needing 预备 + R1+X to get back up. Standing up this way is the
+    #     unbalanced path and is not used here.
+    _LOCO_STATES     = _SMS.LOCO_STATES       # 500/501/801/802 — upright, balanced
+    _LIMP_STATES     = _SMS.LIMP_STATES       # 0/1 — limp, posture is ambiguous
+    _POSITION_STATES = {2, 3, 4}              # 位控下蹲/落座/锁定站立 — no balance
+    _BALANCED_SQUAT  = _SMS.BALANCED_SQUAT    # 706
+    _LIE_TO_STAND    = _SMS.LIE_TO_STAND      # 702
+
+    # Physical transitions are slow; the old 15s budget expired mid-motion and the
+    # abort then reported failure while the robot was still moving.
+    _SQUAT_TIMEOUT = 25.0
+    _STAND_TIMEOUT = 45.0
+
+    def _read_fsm(self) -> tuple[int, int | None, str]:
+        """Return (fsm_id, fsm_mode, source).
+
+        Prefers the rt/sportmodestate feed, which also carries fsm_mode (0=静态,
+        switching allowed / 1=动态, most switches refused). Falls back to the
+        GetFsmId RPC when the topic has not been seen, in which case fsm_mode is
+        None and the caller cannot check switchability.
+        """
+        if self._state_node is not None:
+            fsm = self._state_node.get_fsm()
+            # Stale guard: the feed is ~high rate, anything older than a second
+            # means the subscription died and we should not trust it.
+            if fsm and (time.time() - fsm.get("ts", 0)) < 1.0:
+                return fsm["fsm_id"], fsm["fsm_mode"], "sportmodestate"
+        code, fsm_id = self._client.GetFsmId()
+        if code != 0:
+            return -1, None, "rpc_failed"
+        return fsm_id, None, "rpc"
+
+    def _posture(self) -> dict:
+        """Joint-derived posture, or {} when the lowstate node is not wired in."""
+        if self._posture_node is None:
+            return {}
+        return self._posture_node.get_posture()
+
 
     def _switch_mode_tool(self) -> dict:
         return {
@@ -1346,10 +1432,13 @@ class LocoPlugin:
             "type": "actuator",
             "multiInstance": False,
             "description": "G1 safe locomotion mode switch. "
-                           "lie2standup=安全起立(ground→主运控), standup2lie=安全躺下(standing→阻尼), "
-                           "standup2squat=站到蹲(standing→下蹲), squat2standup=蹲到站(下蹲→主运控), "
-                           "damp=阻尼(ground only), zero_torque=零力矩(ground only), "
-                           "emergency_stop=紧急阻尼(any state), get_current_mode=查询当前状态",
+                           "squat2standup=蹲到站(平衡蹲姿706→主运控), standup2squat=站到蹲(主运控→平衡蹲姿706), "
+                           "lie2standup=躺起(阻尼/零力矩→主运控), standup2lie=安全躺下(主运控→阻尼), "
+                           "damp=阻尼, zero_torque=零力矩, emergency_stop=紧急阻尼(任何状态都接受), "
+                           "get_current_mode=查询当前模式+姿态. "
+                           "注意 706(平衡下蹲、蹲起) 只与主运控直连；一旦落到阻尼(1)，"
+                           "平衡蹲姿就回不去了，只能用遥控器恢复。"
+                           "模式不等于姿态：阻尼下躺和蹲是同一个 fsm_id，姿态请看 posture 工具。",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -1363,17 +1452,17 @@ class LocoPlugin:
                 "required": ["mode"],
                 "x-completion": {
                     "actions": ["lie2standup", "standup2lie", "standup2squat", "squat2standup"],
-                    "timeout": 90,
+                    "timeout": 150,
                 },
                 "x-action-params": {
-                    "lie2standup":     {"params": [], "description": "安全起立 (ground/squat → standing)"},
-                    "standup2lie":     {"params": [], "description": "安全躺下 (standing → damping on ground)"},
-                    "standup2squat":   {"params": [], "description": "站到蹲 (standing → squat)"},
-                    "squat2standup":   {"params": [], "description": "蹲到站 (squat → standing)"},
-                    "damp":            {"params": [], "description": "阻尼模式 (ground only)"},
-                    "zero_torque":     {"params": [], "description": "零力矩 (ground only)"},
-                    "emergency_stop":  {"params": [], "description": "紧急阻尼 (any state)"},
-                    "get_current_mode": {"params": [], "description": "查询当前状态"},
+                    "lie2standup":     {"params": [], "description": "躺起 (阻尼/零力矩 → 主运控)"},
+                    "standup2lie":     {"params": [], "description": "安全躺下 (主运控 → 平衡蹲姿 → 阻尼)"},
+                    "standup2squat":   {"params": [], "description": "站到蹲 (主运控 → 平衡蹲姿 706)"},
+                    "squat2standup":   {"params": [], "description": "蹲到站 (平衡蹲姿 706 → 主运控)"},
+                    "damp":            {"params": [], "description": "阻尼 (仅限已在地面时)"},
+                    "zero_torque":     {"params": [], "description": "零力矩 (仅限已在地面时)"},
+                    "emergency_stop":  {"params": [], "description": "紧急阻尼 (任何状态)"},
+                    "get_current_mode": {"params": [], "description": "查询当前模式 + 姿态"},
                 },
             },
         }
@@ -1383,7 +1472,7 @@ class LocoPlugin:
             "name": "switch_mode_expert",
             "type": "actuator",
             "multiInstance": False,
-            "description": "G1 locomotion mode switch — directly set FSM mode ID (EXPERT ONLY, bypasses safety checks, robot may fall!). IDs: 0=zero_torque, 1=damp, 2=squat, 3=sit, 4=lock_stand, 500=normal_loco, 501=3dof_waist, 702=lie_to_stand, 706=balance_squat, 801=run_loco",
+            "description": "G1 locomotion mode switch — directly set FSM mode ID (EXPERT ONLY, bypasses safety checks, robot may fall!). IDs: 0=零力矩, 1=阻尼, 2=位控下蹲, 3=位控落座, 4=锁定站立 (0-4 均无平衡控制), 702=躺起, 706=平衡下蹲/蹲起, 500=常规运控, 501=常规运控-3Dof-waist, 801/802=走跑运控",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -1496,90 +1585,112 @@ class LocoPlugin:
             # x-action-params split: action is the mode directly
             # Legacy: action == "switch_mode" with mode in args
             mode = action if action != "switch_mode" else args.get("mode", "")
-            code, current_fsm = self._client.GetFsmId()
 
-            if code != 0:
-                return {"error": f"Cannot read current FSM state (code={code}). Aborting for safety."}
-
+            # 阻尼 is the guaranteed fallback mode — the vendor doc states it can
+            # always be entered, so emergency_stop must not be gated on anything.
             if mode == "emergency_stop":
                 ret = self._client.Damp()
                 return {"ret": ret, "mode": "emergency_stop",
                         "warning": "Emergency damp executed regardless of state"}
 
-            elif mode == "get_current_mode":
-                FSM_DESCRIPTIONS = {
-                    0: "lying down, zero torque (零力矩, no resistance)",
-                    1: "lying down, damping (阻尼, resists movement)",
-                    2: "squatting (下蹲, position hold, stable)",
-                    3: "sitting (落座, needs external support, unstable)",
-                    500: "standing, normal locomotion (主运控, balanced)",
-                    501: "standing, 3DOF waist locomotion (balanced)",
-                    702: "prep stance (预备模式, stable low stance)",
-                    706: "balance stand (过渡态, intermediate)",
-                    801: "standing, running gait (跑步运控, balanced)",
-                }
-                desc = FSM_DESCRIPTIONS.get(current_fsm, f"unknown state")
-                return {"fsm_id": current_fsm, "description": desc}
+            current_fsm, fsm_mode, src = self._read_fsm()
+            if current_fsm < 0:
+                return {"error": "Cannot read current FSM state. Aborting for safety."}
 
-            elif mode == "lie2standup":
-                if current_fsm in self._STANDING_STATES:
-                    return {"info": "Robot is already standing", "fsm_id": current_fsm}
-                if current_fsm in self._UNSAFE_STATES:
-                    return {"error": f"Robot is in unsafe state (FSM={current_fsm}). Use emergency_stop first."}
-                # From ground: damp → lie2stand(702) → auto到500
-                if current_fsm in self._GROUND_STATES:
-                    steps = []
-                    if current_fsm == 0:
-                        steps.append(("Damp", 1, "damp"))
-                    steps.append(("Lie2StandUp", 500, "lie2standup"))
-                    return self._async_fsm(mode, steps)
-                # From low states (squat/prep): start(500)
-                if current_fsm in self._LOW_STATES:
-                    steps = [("Start", 500, "start")]
-                    return self._async_fsm(mode, steps)
-                return {"error": f"Cannot stand up from FSM={current_fsm}"}
+            posture = self._posture()
 
-            elif mode == "standup2lie":
-                if current_fsm in self._GROUND_STATES:
-                    return {"info": "Robot is already on the ground", "fsm_id": current_fsm}
-                if current_fsm in self._STANDING_STATES:
-                    # Stop movement first, wait for stabilization
-                    self._client.StopMove()
-                    import time as _time; _time.sleep(1.0)
-                    steps = [("StandUp2Squat", 2, "standup2squat"), ("Damp", 1, "damp")]
-                    return self._async_fsm(mode, steps)
-                if current_fsm in self._LOW_STATES:
-                    steps = [("Damp", 1, "damp")]
-                    return self._async_fsm(mode, steps)
-                return {"error": f"Cannot lie down from FSM={current_fsm}. Use emergency_stop if needed."}
+            def _state(extra: dict | None = None) -> dict:
+                out = {"fsm_id": current_fsm, "fsm": _SMS.fsm_name(current_fsm),
+                       "fsm_mode": fsm_mode, "source": src}
+                if posture:
+                    out["posture"] = posture.get("posture")
+                    out["posture_detail"] = posture
+                if extra:
+                    out.update(extra)
+                return out
 
-            elif mode == "standup2squat":
-                if current_fsm in self._GROUND_STATES or current_fsm in self._LOW_STATES:
-                    return {"info": "Robot is already in low/ground state", "fsm_id": current_fsm}
-                if current_fsm in self._STANDING_STATES:
-                    self._client.StopMove()
-                    import time as _time; _time.sleep(1.0)
-                    steps = [("StandUp2Squat", 2, "standup2squat")]
-                    return self._async_fsm(mode, steps)
-                return {"error": f"Cannot squat from FSM={current_fsm}. Use emergency_stop if needed."}
+            if mode == "get_current_mode":
+                return _state({"description": _SMS.fsm_describe(current_fsm)})
+
+            # fsm_mode 1 = 动态: the controller itself refuses most switches while the
+            # robot is mid-motion. Honour it instead of firing and timing out.
+            if fsm_mode == 1:
+                return _state({"error": "Robot is in a dynamic state (fsm_mode=1) and refuses "
+                                        "mode switches. Wait for it to settle, or use "
+                                        "emergency_stop, which is always accepted."})
+
+            if mode == "standup2squat":
+                if current_fsm == self._BALANCED_SQUAT:
+                    return _state({"info": "Robot is already in a balanced squat"})
+                if current_fsm not in self._LOCO_STATES:
+                    return _state({"error": "Balanced squat (706) is only reachable from 主运控 "
+                                            f"({sorted(self._LOCO_STATES)}). Stand up first."})
+                self._client.StopMove()
+                import time as _time; _time.sleep(1.0)
+                # StandUp2Squat() sets FSM 706 — NOT 2. FSM 2 is 位控下蹲, which the
+                # Python SDK has no method for at all.
+                steps = [("StandUp2Squat", self._BALANCED_SQUAT, "standup2squat", self._SQUAT_TIMEOUT)]
+                return self._async_fsm(mode, steps)
 
             elif mode == "squat2standup":
-                if current_fsm in self._STANDING_STATES:
-                    return {"info": "Robot is already standing", "fsm_id": current_fsm}
-                if current_fsm in self._LOW_STATES:
-                    steps = [("Start", 500, "start")]
+                if current_fsm in self._LOCO_STATES:
+                    return _state({"info": "Robot is already standing"})
+                if current_fsm == self._BALANCED_SQUAT:
+                    # Squat2StandUp() also sets 706 — same toggle. The controller then
+                    # carries the robot back to 主运控 on its own.
+                    steps = [("Squat2StandUp", self._LOCO_STATES, "squat2standup", self._STAND_TIMEOUT)]
                     return self._async_fsm(mode, steps)
-                if current_fsm in self._GROUND_STATES:
-                    return {"error": f"Robot is on ground (FSM={current_fsm}). Use lie2standup instead."}
-                return {"error": f"Cannot stand from FSM={current_fsm}"}
+                if current_fsm in self._LIMP_STATES:
+                    pose = posture.get("posture", "unknown")
+                    hint = ("Posture reads as lying — use lie2standup." if pose == "lying"
+                            else "Posture reads as a collapsed squat. The balanced squat (706) "
+                                 "cannot be re-entered from 阻尼; only the unbalanced 位控 path "
+                                 "(预备 → R1+X) leads back up, which this driver will not do "
+                                 "automatically. Recover with the remote control.")
+                    return _state({"error": f"Robot is limp in {_SMS.fsm_name(current_fsm)}, "
+                                            f"not in a balanced squat. {hint}"})
+                return _state({"error": f"Cannot stand up from {_SMS.fsm_name(current_fsm)}"})
+
+            elif mode == "lie2standup":
+                if current_fsm in self._LOCO_STATES:
+                    return _state({"info": "Robot is already standing"})
+                if current_fsm not in self._LIMP_STATES:
+                    return _state({"error": f"躺起 (702) expects the robot limp on the ground "
+                                            f"(FSM 0/1), but it is in {_SMS.fsm_name(current_fsm)}."})
+                if posture and posture.get("posture") == "squat":
+                    return _state({"error": "Posture reads as a folded squat, not lying flat. "
+                                            "Running 躺起 from here may not recover. Use the "
+                                            "remote control, or emergency_stop then reposition."})
+                steps = []
+                if current_fsm == 0:
+                    steps.append(("Damp", 1, "damp", 10.0))
+                # Lie2StandUp() sets FSM 702 (躺起) — it does not jump straight to 500.
+                # Wait for 702 to latch, then for the controller to carry it to 主运控.
+                steps.append(("Lie2StandUp", self._LIE_TO_STAND, "lie2standup", self._SQUAT_TIMEOUT))
+                steps.append(("Start", self._LOCO_STATES, "start", self._STAND_TIMEOUT))
+                return self._async_fsm(mode, steps)
+
+            elif mode == "standup2lie":
+                if current_fsm in self._LIMP_STATES:
+                    return _state({"info": "Robot is already limp on the ground"})
+                if current_fsm in self._LOCO_STATES:
+                    self._client.StopMove()
+                    import time as _time; _time.sleep(1.0)
+                    steps = [("StandUp2Squat", self._BALANCED_SQUAT, "standup2squat", self._SQUAT_TIMEOUT),
+                             ("Damp", 1, "damp", 10.0)]
+                    return self._async_fsm(mode, steps)
+                if current_fsm in (self._BALANCED_SQUAT, self._LIE_TO_STAND) or \
+                        current_fsm in self._POSITION_STATES:
+                    steps = [("Damp", 1, "damp", 10.0)]
+                    return self._async_fsm(mode, steps)
+                return _state({"error": f"Cannot lie down from {_SMS.fsm_name(current_fsm)}. "
+                                        f"Use emergency_stop if needed."})
 
             elif mode in ("damp", "zero_torque"):
-                if current_fsm in self._STANDING_STATES or current_fsm in self._LOW_STATES:
-                    return {"error": f"Cannot enter {mode} from upright/low state (FSM={current_fsm}). "
-                                     f"Robot will collapse. Use standup2lie first."}
-                if current_fsm in self._UNSAFE_STATES:
-                    return {"error": f"Cannot enter {mode} from unsafe state (FSM={current_fsm}). "
-                                     f"Use emergency_stop first."}
+                if current_fsm not in self._LIMP_STATES:
+                    return _state({"error": f"Cannot enter {mode} from "
+                                            f"{_SMS.fsm_name(current_fsm)} — the robot will "
+                                            f"collapse. Use standup2lie first."})
                 fn = self._client.ZeroTorque if mode == "zero_torque" else self._client.Damp
                 ret = fn()
                 return {"ret": ret, "mode": mode}
@@ -1829,6 +1940,7 @@ class _LowStateNode(Node):
         self._mainboard_pub = self.create_publisher(String, mainboard_topic, _LOW_LAT_QOS)
         self._last_imu:     dict = {}
         self._last_battery: dict = {}
+        self._last_posture: dict = {}
         self._lock = threading.Lock()
         self._last_joints_time:    float = 0.0
         self._last_imu_time:       float = 0.0
@@ -1900,6 +2012,68 @@ class _LowStateNode(Node):
             joints_out.data = json.dumps({"joints": joints, "imu_quat": list(msg.imu_state.quaternion)})
             self._joints_pub.publish(joints_out)
 
+            posture = self._estimate_posture(msg)
+            with self._lock:
+                self._last_posture = posture
+
+    # ── Posture estimation ──────────────────────────────────────────────────
+    # The FSM ID reports the *control mode*, not the pose. In the unbalanced modes
+    # (0 zero_torque / 1 damp) the robot is limp, and lying flat vs. folded into a
+    # squat are the same FSM ID — so the pose has to be read off the joints.
+    #
+    # G1 29-DoF leg indices (unitree_hg motor order).
+    _J_HIP_PITCH = (0, 6)
+    _J_KNEE      = (3, 9)
+
+    # Calibrated against a real G1 (10.100.129.168) sitting in a collapsed squat:
+    # knee 2.90 rad, hip_pitch -2.53 rad, torso pitch 29°, |tau| 0.26 N·m.
+    # Standing/lying bounds are derived from the kinematics, not measured — hence
+    # the raw values are always returned so a caller can second-guess the label.
+    _KNEE_FOLDED_RAD   = 1.5   # above this the knee is deeply flexed
+    _KNEE_EXTENDED_RAD = 0.6   # below this the leg is essentially straight
+    _TORSO_TILT_DEG    = 50.0  # beyond this the torso is closer to horizontal
+    _LOADED_TAU_NM     = 5.0   # above this the joint is actively holding, not limp
+
+    def _estimate_posture(self, msg) -> dict:
+        try:
+            motors = msg.motor_state
+            knees = [float(motors[i].q) for i in self._J_KNEE]
+            hips  = [float(motors[i].q) for i in self._J_HIP_PITCH]
+            taus  = [abs(float(motors[i].tau_est)) for i in self._J_KNEE]
+            roll, pitch, _yaw = (math.degrees(v) for v in tuple(msg.imu_state.rpy)[:3])
+        except (AttributeError, IndexError, TypeError, ValueError) as e:
+            return {"posture": "unknown", "reason": f"cannot read joints/imu: {e}"}
+
+        knee = sum(knees) / len(knees)
+        hip  = sum(hips) / len(hips)
+        tau  = sum(taus) / len(taus)
+        tilt = max(abs(roll), abs(pitch))
+
+        if tilt > self._TORSO_TILT_DEG:
+            posture = "lying"
+        elif knee > self._KNEE_FOLDED_RAD:
+            posture = "squat"
+        elif knee < self._KNEE_EXTENDED_RAD:
+            posture = "standing"
+        else:
+            posture = "crouched"
+
+        return {
+            "posture":    posture,
+            "loaded":     tau > self._LOADED_TAU_NM,
+            "knee_rad":   round(knee, 3),
+            "hip_pitch_rad": round(hip, 3),
+            "knee_tau_nm": round(tau, 2),
+            "torso_roll_deg":  round(roll, 1),
+            "torso_pitch_deg": round(pitch, 1),
+            "ts": time.time(),
+        }
+
+    def get_posture(self) -> dict:
+        """Latest joint-derived posture estimate, or {} if rt/lowstate has not arrived."""
+        with self._lock:
+            return dict(self._last_posture)
+
     def _on_bms(self, msg) -> None:
         now = time.monotonic()
         if now - self._last_bms_time < self._BMS_INTERVAL:
@@ -1951,7 +2125,27 @@ class StatePlugin:
         executor.add_node(self._node)
 
     def get_tools(self) -> list:
-        return [self._imu_tool(), self._battery_tool(), self._joints_tool(), self._mainboard_tool(), self._model_tool()]
+        return [self._imu_tool(), self._battery_tool(), self._joints_tool(), self._mainboard_tool(),
+                self._posture_tool(), self._model_tool()]
+
+    @property
+    def node(self):
+        return self._node
+
+    def _posture_tool(self) -> dict:
+        return {
+            "name": "posture",
+            "type": "sensor",
+            "multiInstance": False,
+            "description": (
+                "G1 physical posture derived from joint angles + IMU — standing / squat / "
+                "crouched / lying, plus knee_rad, hip_pitch_rad, knee_tau_nm, torso tilt and "
+                "whether the joints are actively loaded. Use this when the FSM mode is "
+                "0 (zero_torque) or 1 (damp): those modes are limp and cannot distinguish "
+                "lying from squatting. On-demand query, does not publish."
+            ),
+            "inputSchema": {"type": "object", "properties": {}},
+        }
 
     def _imu_tool(self) -> dict:
         return {
@@ -2009,6 +2203,11 @@ class StatePlugin:
         pass
 
     def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "posture":
+            posture = self._node.get_posture()
+            if not posture:
+                return {"error": "No rt/lowstate data yet — posture unavailable"}
+            return posture
         if action == "start":
             return {"state": "running"}
         if action == "stop":
@@ -2024,6 +2223,8 @@ class StatePlugin:
             if tool_name in topic_map:
                 topic, fmt = topic_map[tool_name]
                 return {"state": "running", "topic_out": [{"topic": topic, "format": fmt}]}
+            if tool_name == 'posture':
+                return self._node.get_posture() or {"state": "running"}
             return {"state": "running"}
         if action == "model":
             from pathlib import Path

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -1383,12 +1383,13 @@ class LocoPlugin:
     #   801 走跑运控 (renumbered to 802 on 29-DoF from ai_sport 8.6.x.x)
     #
     # Two separate ways down from 主运控, and they are NOT interchangeable:
-    #   * 706 平衡下蹲、蹲起 — balanced squat, connects only to LOCO_STATES. Squatting
-    #     down and standing back up are the SAME id, i.e. it is a toggle. This is the
-    #     safe pair.
-    #   * 2/3 位控下蹲/落座 — position modes with no balance control, reachable from
-    #     阻尼 and needing 预备 + R1+X to get back up. Standing up this way is the
-    #     unbalanced path and is not used here.
+    #   * 706 平衡下蹲、蹲起 — balanced squat (遥控器 L2+A 蹲站切换). Getting back up
+    #     goes through 阻尼: 遥控说明 § 模式切换 note 1 says L2+A from 蹲姿 requires
+    #     L2+B first, and 蹲姿开机流程 is likewise ① 阻尼 → ⑥ 蹲站切换. So the damp
+    #     hop is part of the documented path, not a failure.
+    #   * 2/3/4 位控下蹲/落座/锁定站立 — position modes with no balance control.
+    #     锁定站立 (L2+UP) then R1+X is the *unbalanced* way to stand and is not
+    #     used here; 躺卧站立 (⑤) and 蹲站切换 (⑥) are the balanced ones.
     _LOCO_STATES     = _SMS.LOCO_STATES       # 500/501/801/802 — upright, balanced
     _LIMP_STATES     = _SMS.LIMP_STATES       # 0/1 — limp, posture is ambiguous
     _POSITION_STATES = {2, 3, 4}              # 位控下蹲/落座/锁定站立 — no balance
@@ -1436,9 +1437,9 @@ class LocoPlugin:
                            "lie2standup=躺起(阻尼/零力矩→主运控), standup2lie=安全躺下(主运控→阻尼), "
                            "damp=阻尼, zero_torque=零力矩, emergency_stop=紧急阻尼(任何状态都接受), "
                            "get_current_mode=查询当前模式+姿态. "
-                           "注意 706(平衡下蹲、蹲起) 只与主运控直连；一旦落到阻尼(1)，"
-                           "平衡蹲姿就回不去了，只能用遥控器恢复。"
-                           "模式不等于姿态：阻尼下躺和蹲是同一个 fsm_id，姿态请看 posture 工具。",
+                           "注意 蹲站切换(L2+A) 回主运控必须先经过阻尼(L2+B)，驱动已自动包含这一步；"
+                           "模式不等于姿态：阻尼下躺和蹲是同一个 fsm_id，"
+                           "所以蹲着用 squat2standup、躺着用 lie2standup，姿态请看 posture 工具。",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -1635,20 +1636,20 @@ class LocoPlugin:
             elif mode == "squat2standup":
                 if current_fsm in self._LOCO_STATES:
                     return _state({"info": "Robot is already standing"})
-                if current_fsm == self._BALANCED_SQUAT:
-                    # Squat2StandUp() also sets 706 — same toggle. The controller then
-                    # carries the robot back to 主运控 on its own.
-                    steps = [("Squat2StandUp", self._LOCO_STATES, "squat2standup", self._STAND_TIMEOUT)]
+                # 遥控说明 § 模式切换 note 1: after L2+A drops from 主运控 to 蹲姿,
+                # getting back to 主运控 requires L2+B (阻尼) FIRST and then L2+A
+                # again — 706 does not toggle straight back. The documented
+                # 蹲姿开机流程 is the same two steps: ① 阻尼 → ⑥ 蹲站切换.
+                # So always hop through damp, whether we sit at 706 or are already
+                # limp. Damp() from 阻尼 is a no-op and its poll passes immediately.
+                if current_fsm == self._BALANCED_SQUAT or current_fsm in self._LIMP_STATES:
+                    if posture and posture.get("posture") == "lying":
+                        return _state({"error": "Posture reads as lying, not squatting — "
+                                                "use lie2standup (躺卧站立) instead."})
+                    steps = [("Damp", 1, "damp", 10.0),
+                             ("Squat2StandUp", self._LOCO_STATES, "squat2standup",
+                              self._STAND_TIMEOUT)]
                     return self._async_fsm(mode, steps)
-                if current_fsm in self._LIMP_STATES:
-                    pose = posture.get("posture", "unknown")
-                    hint = ("Posture reads as lying — use lie2standup." if pose == "lying"
-                            else "Posture reads as a collapsed squat. The balanced squat (706) "
-                                 "cannot be re-entered from 阻尼; only the unbalanced 位控 path "
-                                 "(预备 → R1+X) leads back up, which this driver will not do "
-                                 "automatically. Recover with the remote control.")
-                    return _state({"error": f"Robot is limp in {_SMS.fsm_name(current_fsm)}, "
-                                            f"not in a balanced squat. {hint}"})
                 return _state({"error": f"Cannot stand up from {_SMS.fsm_name(current_fsm)}"})
 
             elif mode == "lie2standup":
@@ -1658,12 +1659,11 @@ class LocoPlugin:
                     return _state({"error": f"躺起 (702) expects the robot limp on the ground "
                                             f"(FSM 0/1), but it is in {_SMS.fsm_name(current_fsm)}."})
                 if posture and posture.get("posture") == "squat":
-                    return _state({"error": "Posture reads as a folded squat, not lying flat. "
-                                            "Running 躺起 from here may not recover. Use the "
-                                            "remote control, or emergency_stop then reposition."})
-                steps = []
-                if current_fsm == 0:
-                    steps.append(("Damp", 1, "damp", 10.0))
+                    return _state({"error": "Posture reads as a folded squat, not lying flat — "
+                                            "use squat2standup (蹲站切换) instead."})
+                # 躺倒开机流程: ① 阻尼 → ⑤ 躺卧站立. Damp first unconditionally; from
+                # 阻尼 it is a no-op whose poll passes at once.
+                steps = [("Damp", 1, "damp", 10.0)]
                 # Lie2StandUp() sets FSM 702 (躺起) — it does not jump straight to 500.
                 # Wait for 702 to latch, then for the controller to carry it to 主运控.
                 steps.append(("Lie2StandUp", self._LIE_TO_STAND, "lie2standup", self._SQUAT_TIMEOUT))

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -1435,7 +1435,7 @@ class LocoPlugin:
             "description": "G1 safe locomotion mode switch. "
                            "squat2standup=蹲到站(平衡蹲姿706→主运控), standup2squat=站到蹲(主运控→平衡蹲姿706), "
                            "lie2standup=躺起(阻尼/零力矩→主运控), standup2lie=安全躺下(主运控→阻尼), "
-                           "damp=阻尼, zero_torque=零力矩, emergency_stop=紧急阻尼(任何状态都接受), "
+                           "emergency_stop=紧急阻尼(任何状态都接受), "
                            "get_current_mode=查询当前模式+姿态. "
                            "注意 蹲站切换(L2+A) 回主运控必须先经过阻尼(L2+B)，驱动已自动包含这一步；"
                            "模式不等于姿态：阻尼下躺和蹲是同一个 fsm_id，"
@@ -1446,7 +1446,7 @@ class LocoPlugin:
                     "mode": {
                         "type": "string",
                         "enum": ["lie2standup", "standup2lie", "standup2squat", "squat2standup",
-                                 "damp", "zero_torque", "emergency_stop", "get_current_mode"],
+                                 "emergency_stop", "get_current_mode"],
                         "description": "Target mode",
                     },
                 },
@@ -1460,8 +1460,6 @@ class LocoPlugin:
                     "standup2lie":     {"params": [], "description": "安全躺下 (主运控 → 平衡蹲姿 → 阻尼)"},
                     "standup2squat":   {"params": [], "description": "站到蹲 (主运控 → 平衡蹲姿 706)"},
                     "squat2standup":   {"params": [], "description": "蹲到站 (平衡蹲姿 706 → 主运控)"},
-                    "damp":            {"params": [], "description": "阻尼 (仅限已在地面时)"},
-                    "zero_torque":     {"params": [], "description": "零力矩 (仅限已在地面时)"},
                     "emergency_stop":  {"params": [], "description": "紧急阻尼 (任何状态)"},
                     "get_current_mode": {"params": [], "description": "查询当前模式 + 姿态"},
                 },
@@ -1582,7 +1580,7 @@ class LocoPlugin:
             ret = self._client.StopMove()
             return {"ret": ret}
         elif action in ("switch_mode", "lie2standup", "standup2lie", "standup2squat",
-                        "squat2standup", "damp", "zero_torque", "emergency_stop", "get_current_mode"):
+                        "squat2standup", "emergency_stop", "get_current_mode"):
             # x-action-params split: action is the mode directly
             # Legacy: action == "switch_mode" with mode in args
             mode = action if action != "switch_mode" else args.get("mode", "")
@@ -1686,19 +1684,16 @@ class LocoPlugin:
                 return _state({"error": f"Cannot lie down from {_SMS.fsm_name(current_fsm)}. "
                                         f"Use emergency_stop if needed."})
 
-            elif mode in ("damp", "zero_torque"):
-                if current_fsm not in self._LIMP_STATES:
-                    return _state({"error": f"Cannot enter {mode} from "
-                                            f"{_SMS.fsm_name(current_fsm)} — the robot will "
-                                            f"collapse. Use standup2lie first."})
-                fn = self._client.ZeroTorque if mode == "zero_torque" else self._client.Damp
-                ret = fn()
-                return {"ret": ret, "mode": mode}
-
             else:
+                # damp / zero_torque are deliberately not exposed. They are raw
+                # primitives with no posture handling, and reaching them is always
+                # part of a larger transition — standup2lie ends there, and
+                # squat2standup / lie2standup hop through 阻尼 on the way up. The
+                # sequences do it in order on their own. emergency_stop covers the
+                # one case a caller legitimately needs 阻尼 directly.
                 return {"error": f"Unknown mode: {mode}. Available: lie2standup, standup2lie, "
-                                 f"standup2squat, squat2standup, damp, zero_torque, "
-                                 f"emergency_stop, get_current_mode"}
+                                 f"standup2squat, squat2standup, emergency_stop, "
+                                 f"get_current_mode"}
         elif action == "switch_mode_expert":
             fid = int(args.get("fsm_id", 0))
             ret = self._client.SetFsmId(fid)

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -107,9 +107,23 @@ class G1DeviceBundle:
             print("[bundle] LedPlugin loaded")
 
         if plugins_cfg.get("loco", {}).get("enabled", False):
-            from device import LocoStatePlugin, LocoPlugin
-            self._plugins.append(LocoStatePlugin(plugins_cfg["loco"], namespace, executor))
-            self._plugins.append(LocoPlugin(plugins_cfg["loco"], namespace, executor, loco_client, slam_client=slam_client, smart_motion=smart_motion))
+            from device import LocoStatePlugin, LocoPlugin, StatePlugin
+            loco_state = LocoStatePlugin(plugins_cfg["loco"], namespace, executor)
+            self._plugins.append(loco_state)
+            # StatePlugin owns the rt/lowstate subscription that posture is derived
+            # from. LocoPlugin needs it to tell lying from squatting once the robot
+            # is limp (FSM 0/1), so build it first when it is enabled and reuse the
+            # same instance rather than opening a second high-rate subscription.
+            posture_source = None
+            if plugins_cfg.get("state", {}).get("enabled", False):
+                state_plugin = StatePlugin(plugins_cfg["state"], namespace, executor)
+                self._plugins.append(state_plugin)
+                posture_source = state_plugin.node
+                print("[bundle] StatePlugin loaded (posture source for LocoPlugin)")
+            self._plugins.append(LocoPlugin(plugins_cfg["loco"], namespace, executor, loco_client,
+                                            slam_client=slam_client, smart_motion=smart_motion,
+                                            state_node=loco_state.node,
+                                            posture_node=posture_source))
             print("[bundle] LocoStatePlugin + LocoPlugin loaded")
 
         if plugins_cfg.get("arm", {}).get("enabled", False):
@@ -124,8 +138,12 @@ class G1DeviceBundle:
 
         if plugins_cfg.get("state", {}).get("enabled", False):
             from device import StatePlugin
-            self._plugins.append(StatePlugin(plugins_cfg["state"], namespace, executor))
-            print("[bundle] StatePlugin loaded")
+            # Already built above when loco is enabled, to hand LocoPlugin its
+            # posture source — a second instance would duplicate the rt/lowstate
+            # subscription and clash on the ROS node name.
+            if not any(isinstance(p, StatePlugin) for p in self._plugins):
+                self._plugins.append(StatePlugin(plugins_cfg["state"], namespace, executor))
+                print("[bundle] StatePlugin loaded")
 
         if plugins_cfg.get("camera", {}).get("enabled", False):
             from device import RealSensePlugin

--- a/unitree/g1/rpc_proxy.py
+++ b/unitree/g1/rpc_proxy.py
@@ -52,7 +52,14 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
             if method == "__run_fsm_sequence":
                 steps_spec, interval, step_timeout, settle_delay = args
                 completed = []
-                for method_name, target_fsm, step_name in steps_spec:
+                for step in steps_spec:
+                    # step = (method_name, targets, step_name[, timeout])
+                    # `targets` is a single FSM id or an iterable of acceptable ids —
+                    # several transitions settle into one of a few states (e.g. 躺起
+                    # lands on 702 and is then pushed on to 500 by the controller).
+                    method_name, targets, step_name = step[0], step[1], step[2]
+                    this_timeout = step[3] if len(step) > 3 else step_timeout
+                    targets = {targets} if isinstance(targets, int) else set(targets)
                     fn = getattr(loco, method_name)
                     ret = fn()
                     if ret != 0:
@@ -60,20 +67,21 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                             "error": f"Step '{step_name}' failed: code={ret}",
                             "step": step_name, "completed": completed}})
                         break  # abort sequence on failure
-                    # Poll FSM until target reached or timeout
+                    # Poll FSM until one of the target states is reached or timeout
                     elapsed = 0.0
                     ok = False
-                    while elapsed < step_timeout:
+                    while elapsed < this_timeout:
                         time.sleep(interval)
                         elapsed += interval
                         code, fsm_id = loco.GetFsmId()
-                        if code == 0 and fsm_id == target_fsm:
+                        if code == 0 and fsm_id in targets:
                             ok = True
                             break
                     if not ok:
                         _, current = loco.GetFsmId()
                         result_queue.put({"result": {
-                            "error": f"Timeout '{step_name}' (expected={target_fsm}, got={current})",
+                            "error": f"Timeout '{step_name}' after {this_timeout:.0f}s "
+                                     f"(expected={sorted(targets)}, got={current})",
                             "step": step_name, "fsm_id": current, "completed": completed}})
                         break  # abort sequence on timeout
                     completed.append(step_name)
@@ -81,8 +89,9 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                     time.sleep(settle_delay)
                 else:
                     # Only reached if loop completed without break (all steps succeeded)
+                    _, final = loco.GetFsmId()
                     result_queue.put({"result": {"ret": 0, "steps": completed,
-                                                 "fsm_id": steps_spec[-1][1]}})
+                                                 "fsm_id": final}})
                 continue  # next cmd
 
             fn = getattr(loco, method)
@@ -142,13 +151,16 @@ class RpcProxy:
 
     # ── LocoClient interface ──────────────────────────────────────────────────
 
-    def RunFsmSequence(self, steps: list, interval: float = 1.0, step_timeout: float = 15.0,
+    def RunFsmSequence(self, steps: list, interval: float = 1.0, step_timeout: float = 30.0,
                        settle_delay: float = 2.0):
         """Run FSM sequence entirely in subprocess (no GIL contention).
-        steps = [(method_name, target_fsm_to_poll, step_name), ...]
+        steps = [(method_name, targets, step_name[, timeout]), ...]
+        `targets` is an FSM id or an iterable of acceptable ids; the optional 4th
+        element overrides step_timeout for that step.
         settle_delay = seconds to wait after FSM confirms state change.
         Returns dict with {ret, steps, fsm_id} on success or {error, step} on failure."""
-        outer_timeout = len(steps) * (step_timeout + settle_delay + 5) + 10
+        budget = sum((s[3] if len(s) > 3 else step_timeout) + settle_delay + 5 for s in steps)
+        outer_timeout = budget + 10
         return self._call("__run_fsm_sequence", steps, interval, step_timeout, settle_delay,
                           timeout=outer_timeout)
 

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -265,6 +265,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     obstacle_dist = float("inf")
     obstacle_angle = 0.0
     lateral_obstacle = False
+    fwd_log_n = 0  # decel-zone log counter, reset on leaving the zone
 
     # Nav arrival state (updated by rt/slam_info DDS callback in this subprocess)
     slam_info_lock = threading.Lock()
@@ -331,7 +332,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
 
     # ── LiDAR DDS Subscription ──
     def on_cloud(msg):
-        nonlocal obstacle_dist, obstacle_angle, lateral_obstacle
+        nonlocal obstacle_dist, obstacle_angle, lateral_obstacle, fwd_log_n
 
         # Get heading
         if state == MotionState.MOVING and current_cmd:
@@ -399,17 +400,17 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                 # as long as an obstacle stays in range, so log the *entry* into
                 # that state unthrottled — that is the operationally interesting
                 # event — and then sample the steady-state readout.
-                self._fwd_log_n = getattr(self, '_fwd_log_n', 0) + 1
-                if self._fwd_log_n == 1 or self._fwd_log_n % 100 == 0:
+                fwd_log_n += 1
+                if fwd_log_n == 1 or fwd_log_n % 100 == 0:
                     print(f"[SmartMotion:lidar] closest_fwd: dist={min_fwd_dist:.2f}m "
                           f"xyz=({fwd_x:.2f},{fwd_y:.2f},{fwd_z:.2f}) "
                           f"angle={math.degrees(min_fwd_angle):.1f}° "
                           f"total_fwd_pts={int(forward_mask.sum())} "
                           f"heading={math.degrees(heading):.1f}° "
-                          f"(n={self._fwd_log_n})", flush=True)
+                          f"(n={fwd_log_n})", flush=True)
             else:
                 # Left the decel zone — reset so re-entry logs immediately.
-                self._fwd_log_n = 0
+                fwd_log_n = 0
 
         # Lateral (45°-90°, within stop_threshold)
         lat_mask = (angle_diffs >= math.radians(45)) & \

--- a/unitree/g1/sport_mode_state.py
+++ b/unitree/g1/sport_mode_state.py
@@ -1,0 +1,84 @@
+"""
+sport_mode_state.py — unitree_hg SportModeState_ IDL for G1.
+
+The bundled unitree_sdk2py only ships `unitree_go.msg.dds_.SportModeState_`
+(the quadruped layout: mode/gait_type/body_height/imu_state/...). G1 publishes a
+*different*, much smaller type on rt/sportmodestate:
+
+    module unitree_hg { module msg { module dds_ {
+        struct SportModeState_ {
+            unsigned long fsm_id;
+            unsigned long fsm_mode;
+            unsigned long task_id;
+            float task_time;
+        };
+    }; }; };
+
+DDS matches readers to writers by IDL type name, so subscribing with the
+unitree_go type never matches G1's writer — the callback simply never fires.
+Reference: https://support.unitree.com/home/zh/G1_developer/sport_services_interface
+(§ SportModeState接口, firmware >= 1.5.1)
+"""
+
+from dataclasses import dataclass
+
+import cyclonedds.idl as idl
+import cyclonedds.idl.annotations as annotate
+import cyclonedds.idl.types as types
+
+
+@dataclass
+@annotate.final
+@annotate.autoid("sequential")
+class SportModeState_(idl.IdlStruct, typename="unitree_hg.msg.dds_.SportModeState_"):
+    fsm_id: types.uint32
+    fsm_mode: types.uint32
+    task_id: types.uint32
+    task_time: types.float32
+
+
+# ── Official FSM mode IDs ───────────────────────────────────────────────────
+# From the vendor doc's 专家接口 § 模式ID说明. "balanced" marks the states that
+# run active balance control; the rest are open-loop/position modes that will
+# collapse or hold a fixed pose with no balancing.
+FSM_MODES: dict[int, dict] = {
+    0:   {"name": "zero_torque",   "zh": "零力矩",              "balanced": False},
+    1:   {"name": "damp",          "zh": "阻尼",                "balanced": False},
+    2:   {"name": "position_squat", "zh": "位控下蹲",           "balanced": False},
+    3:   {"name": "position_sit",  "zh": "位控落座",            "balanced": False},
+    4:   {"name": "locked_stand",  "zh": "锁定站立",            "balanced": False},
+    702: {"name": "lie_to_stand",  "zh": "躺起",                "balanced": True},
+    706: {"name": "balance_squat", "zh": "平衡下蹲、蹲起",       "balanced": True},
+    500: {"name": "normal_loco",   "zh": "常规运控",            "balanced": True},
+    501: {"name": "normal_loco_3dof_waist", "zh": "常规运控-3Dof-waist", "balanced": True},
+    801: {"name": "walk_run_loco", "zh": "走跑运控",            "balanced": True},
+    # 29-DoF devices renumber 走跑运控 to 802 from ai_sport 8.6.x.x onwards.
+    802: {"name": "walk_run_loco", "zh": "走跑运控",            "balanced": True},
+}
+
+# 常规运控 / 走跑运控 — upright with active balance, safe to issue velocity commands.
+LOCO_STATES = frozenset({500, 501, 801, 802})
+
+# Balanced low poses that connect *only* to LOCO_STATES.
+BALANCED_SQUAT = 706   # 平衡下蹲、蹲起 — squat down and stand up are the same ID
+LIE_TO_STAND   = 702   # 躺起
+
+# Open-loop, no balance control. Limp (0/1) or holding a fixed pose (2/3/4).
+UNBALANCED_STATES = frozenset({0, 1, 2, 3, 4})
+
+# Limp on the ground — the FSM ID alone cannot tell lying from squatting here,
+# because both collapse into damping. Posture has to come from joint angles.
+LIMP_STATES = frozenset({0, 1})
+
+
+def fsm_name(fsm_id: int) -> str:
+    m = FSM_MODES.get(fsm_id)
+    return f"{m['name']} ({m['zh']})" if m else f"unknown({fsm_id})"
+
+
+def fsm_describe(fsm_id: int) -> str:
+    m = FSM_MODES.get(fsm_id)
+    if not m:
+        return f"unknown FSM id {fsm_id}"
+    balance = "active balance control" if m["balanced"] else "NO balance control"
+    return f"{m['name']} / {m['zh']} — {balance}"

--- a/unitree/g1/tests/test_fsm_posture.py
+++ b/unitree/g1/tests/test_fsm_posture.py
@@ -307,23 +307,33 @@ class TestSquatTargets(unittest.TestCase):
         res = switch(plugin, "standup2squat")
         self.assertIn("info", res)
 
-    def test_squat2standup_from_706_targets_loco(self):
+    def test_squat2standup_from_706_hops_through_damp(self):
+        # 遥控说明 § 模式切换 note 1: L2+A from 蹲姿 needs L2+B (阻尼) first.
         plugin, _ = make_plugin(706)
-        res = switch(plugin, "squat2standup")
-        self.assertEqual(step_targets(res["_steps"], "squat2standup"), set(SMS.LOCO_STATES))
+        steps = switch(plugin, "squat2standup")["_steps"]
+        self.assertEqual([s[2] for s in steps], ["damp", "squat2standup"])
+        self.assertEqual(step_targets(steps, "damp"), {1})
+        self.assertEqual(step_targets(steps, "squat2standup"), set(SMS.LOCO_STATES))
 
-    def test_squat2standup_from_damp_is_refused_with_posture_hint(self):
-        # The exact hardware failure: limp in 阻尼, physically squatting.
+    def test_squat2standup_from_damp_stands_up(self):
+        # 蹲姿开机流程: ① 阻尼 → ⑥ 蹲站切换. Being limp in a squat is recoverable,
+        # so this must NOT be refused.
         plugin, _ = make_plugin(1, posture={"posture": "squat"})
         res = switch(plugin, "squat2standup")
-        self.assertIn("error", res)
-        self.assertIn("706", res["error"])
-        self.assertNotIn("_steps", res, "must not fire a doomed sequence")
+        self.assertNotIn("error", res)
+        self.assertEqual([s[2] for s in res["_steps"]], ["damp", "squat2standup"])
 
-    def test_squat2standup_from_damp_while_lying_points_at_lie2standup(self):
+    def test_squat2standup_from_zero_torque_stands_up(self):
+        plugin, _ = make_plugin(0, posture={"posture": "squat"})
+        res = switch(plugin, "squat2standup")
+        self.assertNotIn("error", res)
+        self.assertEqual(step_targets(res["_steps"], "damp"), {1})
+
+    def test_squat2standup_while_lying_points_at_lie2standup(self):
         plugin, _ = make_plugin(1, posture={"posture": "lying"})
         res = switch(plugin, "squat2standup")
         self.assertIn("lie2standup", res["error"])
+        self.assertNotIn("_steps", res)
 
     def test_squat2standup_idempotent_when_standing(self):
         for fsm in SMS.LOCO_STATES:
@@ -332,9 +342,11 @@ class TestSquatTargets(unittest.TestCase):
 
 
 class TestLieToStand(unittest.TestCase):
-    def test_waits_for_702_then_loco(self):
+    def test_damps_then_waits_for_702_then_loco(self):
+        # 躺倒开机流程: ① 阻尼 → ⑤ 躺卧站立.
         plugin, _ = make_plugin(1, posture={"posture": "lying"})
         steps = switch(plugin, "lie2standup")["_steps"]
+        self.assertEqual([s[2] for s in steps], ["damp", "lie2standup", "start"])
         self.assertEqual(step_targets(steps, "lie2standup"), {702})
         self.assertEqual(step_targets(steps, "start"), set(SMS.LOCO_STATES))
 
@@ -346,7 +358,7 @@ class TestLieToStand(unittest.TestCase):
     def test_refused_when_posture_is_a_squat(self):
         plugin, _ = make_plugin(1, posture={"posture": "squat"})
         res = switch(plugin, "lie2standup")
-        self.assertIn("error", res)
+        self.assertIn("squat2standup", res["error"])
         self.assertNotIn("_steps", res)
 
     def test_refused_from_706(self):

--- a/unitree/g1/tests/test_fsm_posture.py
+++ b/unitree/g1/tests/test_fsm_posture.py
@@ -441,12 +441,45 @@ class TestStateReporting(unittest.TestCase):
         res = switch(plugin, "get_current_mode")
         self.assertIn("error", res)
 
-    def test_damp_refused_from_upright(self):
-        for fsm in (500, 706, 2):
+    def test_damp_and_zero_torque_are_not_exposed(self):
+        # Raw primitives with no posture handling. Every legitimate use is a step
+        # inside a larger sequence, which the driver runs in order by itself.
+        plugin, _ = make_plugin(500)
+        tool = plugin._switch_mode_tool()
+        enum = tool["inputSchema"]["properties"]["mode"]["enum"]
+        params = tool["inputSchema"]["x-action-params"]
+        for name in ("damp", "zero_torque"):
+            self.assertNotIn(name, enum)
+            self.assertNotIn(name, params)
+        self.assertIn("emergency_stop", enum)
+
+    def test_damp_is_not_routed_if_called_anyway(self):
+        # dispatch() returns None, which main.py turns into JSON-RPC -32601
+        # "Unknown tool". The point is that no Damp() reaches the robot.
+        for fsm in (500, 706, 1):
             plugin, client = make_plugin(fsm)
-            res = switch(plugin, "damp")
-            self.assertIn("error", res, f"damp from {fsm} should be refused")
+            self.assertEqual(plugin.dispatch("damp", {}), None, f"damp from {fsm}")
+            self.assertEqual(plugin.dispatch("zero_torque", {}), None)
             self.assertNotIn("Damp", client.calls)
+            self.assertNotIn("ZeroTorque", client.calls)
+
+    def test_legacy_mode_arg_is_rejected(self):
+        # switch_mode(mode="damp") used to work; it must now be refused rather
+        # than silently doing something.
+        plugin, client = make_plugin(500)
+        res = plugin.dispatch("switch_mode", {"mode": "damp"})
+        self.assertIn("error", res)
+        self.assertIn("Unknown mode", res["error"])
+        self.assertNotIn("Damp", client.calls)
+
+    def test_intermediate_damp_still_runs_inside_sequences(self):
+        # Removing the action must not remove the hop the transitions depend on.
+        plugin, _ = make_plugin(706)
+        self.assertIn("damp", [s[2] for s in switch(plugin, "squat2standup")["_steps"]])
+        plugin, _ = make_plugin(1, posture={"posture": "lying"})
+        self.assertIn("damp", [s[2] for s in switch(plugin, "lie2standup")["_steps"]])
+        plugin, _ = make_plugin(500)
+        self.assertIn("damp", [s[2] for s in switch(plugin, "standup2lie")["_steps"]])
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_fsm_posture.py
+++ b/unitree/g1/tests/test_fsm_posture.py
@@ -1,0 +1,441 @@
+"""
+Tests for G1 FSM mode handling and joint-derived posture estimation.
+
+Covers the two things the FSM code got wrong and that hardware logs proved:
+
+  * FSM target ids. StandUp2Squat()/Squat2StandUp() both SetFsmId(706); Lie2StandUp()
+    sets 702. The old code polled for 2 and 500 respectively, so every squat and
+    every lie-to-stand timed out even when the robot physically completed it.
+  * mode != posture. In 零力矩/阻尼 (FSM 0/1) the robot is limp and lying flat is the
+    same fsm_id as folded into a squat, so the guard has to consult joint angles.
+
+Reference for the ID table and fsm_mode semantics:
+https://support.unitree.com/home/zh/G1_developer/sport_services_interface
+
+Run:  python3 -m unittest discover -s unitree/g1/tests -t .
+"""
+
+import importlib.util
+import math
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+class Message:
+    def __init__(self):
+        self.header = types.SimpleNamespace(stamp=None, frame_id="")
+
+
+class FakeNode:
+    def __init__(self, name):
+        self._name = name
+
+    def create_publisher(self, *a, **kw):
+        return types.SimpleNamespace(publish=lambda msg: None)
+
+    def create_subscription(self, *a, **kw):
+        return object()
+
+    def get_logger(self):
+        return types.SimpleNamespace(info=lambda *a: None, warn=lambda *a: None,
+                                     error=lambda *a: None, debug=lambda *a: None)
+
+
+def install_stubs():
+    rclpy = types.ModuleType("rclpy")
+    sys.modules.setdefault("rclpy", rclpy)
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_node.Node = FakeNode
+    rclpy_qos = types.ModuleType("rclpy.qos")
+    rclpy_qos.QoSProfile = lambda **kw: types.SimpleNamespace(**kw)
+    rclpy_qos.ReliabilityPolicy = types.SimpleNamespace(BEST_EFFORT=1, RELIABLE=2)
+    rclpy_qos.HistoryPolicy = types.SimpleNamespace(KEEP_LAST=1)
+    rclpy_qos.DurabilityPolicy = types.SimpleNamespace(VOLATILE=1)
+    sys.modules["rclpy.node"] = rclpy_node
+    sys.modules["rclpy.qos"] = rclpy_qos
+
+    std_msgs = types.ModuleType("std_msgs.msg")
+    std_msgs.Header = type("Header", (Message,), {})
+    std_msgs.String = type("String", (Message,),
+                           {"__init__": lambda self: setattr(self, "data", "")})
+    std_msgs.UInt8MultiArray = type("UInt8MultiArray", (Message,), {})
+    sys.modules["std_msgs.msg"] = std_msgs
+
+    audio_msgs = types.ModuleType("audio_msgs.msg")
+    audio_msgs.AudioChunk = type("AudioChunk", (Message,), {})
+    sys.modules["audio_msgs.msg"] = audio_msgs
+
+    # unitree_sdk2py: device.py only needs AudioClient to exist at import time.
+    for name in ("unitree_sdk2py", "unitree_sdk2py.g1", "unitree_sdk2py.g1.audio"):
+        sys.modules.setdefault(name, types.ModuleType(name))
+    audio_mod = types.ModuleType("unitree_sdk2py.g1.audio.g1_audio_client")
+    audio_mod.AudioClient = type("AudioClient", (), {})
+    sys.modules["unitree_sdk2py.g1.audio.g1_audio_client"] = audio_mod
+
+    pcu = types.ModuleType("pointcloud_utils")
+    pcu.gravity_align_inplace = lambda *a, **kw: None
+    sys.modules["pointcloud_utils"] = pcu
+
+    # cyclonedds is only needed for the IDL dataclass declaration.
+    cdds = types.ModuleType("cyclonedds")
+    idl = types.ModuleType("cyclonedds.idl")
+
+    class _IdlStruct:
+        def __init_subclass__(cls, **kw):
+            pass
+
+    idl.IdlStruct = _IdlStruct
+    ann = types.ModuleType("cyclonedds.idl.annotations")
+    ann.final = lambda c: c
+    ann.autoid = lambda kind: (lambda c: c)
+    tps = types.ModuleType("cyclonedds.idl.types")
+    tps.uint32 = int
+    tps.float32 = float
+    idl.annotations = ann
+    idl.types = tps
+    cdds.idl = idl
+    sys.modules.update({"cyclonedds": cdds, "cyclonedds.idl": idl,
+                        "cyclonedds.idl.annotations": ann, "cyclonedds.idl.types": tps})
+
+
+def load_device():
+    install_stubs()
+    spec = importlib.util.spec_from_file_location("g1_device_under_test", ROOT / "device.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["g1_device_under_test"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+DEV = load_device()
+import sport_mode_state as SMS  # noqa: E402  (needs the stubs installed first)
+
+
+# ── Fakes ───────────────────────────────────────────────────────────────────
+
+def make_lowstate(knee, hip_pitch, roll_deg=0.0, pitch_deg=0.0, tau=0.3, n=29):
+    """Minimal rt/lowstate stand-in with the leg joints the estimator reads."""
+    motors = [types.SimpleNamespace(q=0.0, dq=0.0, tau_est=0.0, temperature=[30, 30])
+              for _ in range(n)]
+    for i in (3, 9):        # knees
+        motors[i].q = knee
+        motors[i].tau_est = tau
+    for i in (0, 6):        # hip pitch
+        motors[i].q = hip_pitch
+    imu = types.SimpleNamespace(
+        quaternion=[1.0, 0.0, 0.0, 0.0], gyroscope=[0.0] * 3,
+        accelerometer=[0.0] * 3, temperature=30.0,
+        rpy=[math.radians(roll_deg), math.radians(pitch_deg), 0.0],
+    )
+    return types.SimpleNamespace(motor_state=motors, imu_state=imu)
+
+
+class FakeLocoClient:
+    """Records what the plugin actually commanded."""
+
+    def __init__(self, fsm_id=1):
+        self.fsm_id = fsm_id
+        self.calls = []
+
+    def _rec(self, name):
+        self.calls.append(name)
+        return 0
+
+    def GetFsmId(self):
+        return 0, self.fsm_id
+
+    def StopMove(self):
+        return self._rec("StopMove")
+
+    def Damp(self):
+        return self._rec("Damp")
+
+    def ZeroTorque(self):
+        return self._rec("ZeroTorque")
+
+    def RunFsmSequence(self, steps, **kw):
+        self.calls.append(("RunFsmSequence", steps))
+        return {"ret": 0, "steps": [s[2] for s in steps], "fsm_id": self.fsm_id}
+
+
+class FakeStateNode:
+    def __init__(self, fsm_id, fsm_mode=0, stale=False):
+        import time
+        self._fsm = {"fsm_id": fsm_id, "fsm_mode": fsm_mode,
+                     "ts": 0 if stale else time.time()}
+
+    def get_fsm(self):
+        return dict(self._fsm)
+
+
+class FakePostureNode:
+    def __init__(self, posture):
+        self._p = posture
+
+    def get_posture(self):
+        return dict(self._p) if self._p else {}
+
+
+def make_plugin(fsm_id, fsm_mode=0, posture=None, use_topic=True):
+    client = FakeLocoClient(fsm_id)
+    plugin = DEV.LocoPlugin(
+        {}, "ubuntu", None, client,
+        state_node=FakeStateNode(fsm_id, fsm_mode) if use_topic else None,
+        posture_node=FakePostureNode(posture) if posture is not None else None,
+    )
+    return plugin, client
+
+
+def switch(plugin, mode):
+    """Invoke switch_mode without the ACP background thread."""
+    captured = {}
+
+    def fake_async(m, steps):
+        captured["mode"] = m
+        captured["steps"] = steps
+        return {"status": "executing", "mode": m, "action_id": "test"}
+
+    plugin._async_fsm = fake_async
+    result = plugin.dispatch(mode, {})
+    result = dict(result or {})
+    if captured:
+        result["_steps"] = captured["steps"]
+    return result
+
+
+def step_targets(steps, name):
+    for s in steps:
+        if s[2] == name:
+            targets = s[1]
+            return {targets} if isinstance(targets, int) else set(targets)
+    raise AssertionError(f"no step named {name!r} in {steps}")
+
+
+# ── Official FSM table ──────────────────────────────────────────────────────
+
+class TestFsmTable(unittest.TestCase):
+    def test_unbalanced_modes_flagged(self):
+        for fsm_id in (0, 1, 2, 3, 4):
+            self.assertFalse(SMS.FSM_MODES[fsm_id]["balanced"],
+                             f"FSM {fsm_id} has no balance control per the vendor doc")
+
+    def test_balanced_modes_flagged(self):
+        for fsm_id in (500, 501, 702, 706, 801, 802):
+            self.assertTrue(SMS.FSM_MODES[fsm_id]["balanced"])
+
+    def test_802_is_a_loco_state(self):
+        # 29-DoF renumbers 走跑运控 801 -> 802 from ai_sport 8.6.x.x; the old
+        # _STANDING_STATES omitted it, so a walking robot read as "not standing".
+        self.assertIn(802, SMS.LOCO_STATES)
+        self.assertIn(801, SMS.LOCO_STATES)
+
+    def test_squat_and_lie_ids(self):
+        self.assertEqual(SMS.BALANCED_SQUAT, 706)
+        self.assertEqual(SMS.LIE_TO_STAND, 702)
+
+    def test_706_is_not_treated_as_a_loco_state(self):
+        self.assertNotIn(706, SMS.LOCO_STATES)
+
+
+# ── Posture estimation ─────────────────────────────────────────────────────
+
+class TestPosture(unittest.TestCase):
+    def setUp(self):
+        self.node = DEV._LowStateNode.__new__(DEV._LowStateNode)
+
+    def estimate(self, **kw):
+        return self.node._estimate_posture(make_lowstate(**kw))
+
+    def test_measured_squat_from_hardware(self):
+        # Values read off G1 10.100.129.168 while collapsed in a squat.
+        p = self.estimate(knee=2.899, hip_pitch=-2.527, pitch_deg=29.2, roll_deg=1.1, tau=0.26)
+        self.assertEqual(p["posture"], "squat")
+        self.assertFalse(p["loaded"], "0.26 N·m is limp, not actively holding")
+
+    def test_standing(self):
+        p = self.estimate(knee=0.15, hip_pitch=-0.1, pitch_deg=1.0, tau=40.0)
+        self.assertEqual(p["posture"], "standing")
+        self.assertTrue(p["loaded"])
+
+    def test_lying_detected_by_torso_tilt(self):
+        # Legs extended like standing, but the torso is horizontal.
+        p = self.estimate(knee=0.1, hip_pitch=0.0, pitch_deg=88.0)
+        self.assertEqual(p["posture"], "lying")
+
+    def test_intermediate_is_crouched_not_guessed(self):
+        p = self.estimate(knee=1.0, hip_pitch=-0.8)
+        self.assertEqual(p["posture"], "crouched")
+
+    def test_malformed_message_does_not_raise(self):
+        p = self.node._estimate_posture(types.SimpleNamespace())
+        self.assertEqual(p["posture"], "unknown")
+
+    def test_reported_values_round_trip(self):
+        p = self.estimate(knee=2.9, hip_pitch=-2.5, pitch_deg=29.0)
+        self.assertAlmostEqual(p["knee_rad"], 2.9, places=3)
+        self.assertAlmostEqual(p["hip_pitch_rad"], -2.5, places=3)
+        self.assertAlmostEqual(p["torso_pitch_deg"], 29.0, places=1)
+
+
+# ── switch_mode: FSM targets ───────────────────────────────────────────────
+
+class TestSquatTargets(unittest.TestCase):
+    def test_standup2squat_polls_706_not_2(self):
+        plugin, _ = make_plugin(500)
+        res = switch(plugin, "standup2squat")
+        self.assertEqual(step_targets(res["_steps"], "standup2squat"), {706})
+
+    def test_standup2squat_stops_motion_first(self):
+        plugin, client = make_plugin(500)
+        switch(plugin, "standup2squat")
+        self.assertIn("StopMove", client.calls)
+
+    def test_standup2squat_rejected_when_not_in_loco(self):
+        # 706 is only reachable from 主运控; from 阻尼 it is not.
+        plugin, _ = make_plugin(1, posture={"posture": "squat"})
+        res = switch(plugin, "standup2squat")
+        self.assertIn("error", res)
+        self.assertNotIn("_steps", res)
+
+    def test_standup2squat_idempotent(self):
+        plugin, _ = make_plugin(706)
+        res = switch(plugin, "standup2squat")
+        self.assertIn("info", res)
+
+    def test_squat2standup_from_706_targets_loco(self):
+        plugin, _ = make_plugin(706)
+        res = switch(plugin, "squat2standup")
+        self.assertEqual(step_targets(res["_steps"], "squat2standup"), set(SMS.LOCO_STATES))
+
+    def test_squat2standup_from_damp_is_refused_with_posture_hint(self):
+        # The exact hardware failure: limp in 阻尼, physically squatting.
+        plugin, _ = make_plugin(1, posture={"posture": "squat"})
+        res = switch(plugin, "squat2standup")
+        self.assertIn("error", res)
+        self.assertIn("706", res["error"])
+        self.assertNotIn("_steps", res, "must not fire a doomed sequence")
+
+    def test_squat2standup_from_damp_while_lying_points_at_lie2standup(self):
+        plugin, _ = make_plugin(1, posture={"posture": "lying"})
+        res = switch(plugin, "squat2standup")
+        self.assertIn("lie2standup", res["error"])
+
+    def test_squat2standup_idempotent_when_standing(self):
+        for fsm in SMS.LOCO_STATES:
+            plugin, _ = make_plugin(fsm)
+            self.assertIn("info", switch(plugin, "squat2standup"))
+
+
+class TestLieToStand(unittest.TestCase):
+    def test_waits_for_702_then_loco(self):
+        plugin, _ = make_plugin(1, posture={"posture": "lying"})
+        steps = switch(plugin, "lie2standup")["_steps"]
+        self.assertEqual(step_targets(steps, "lie2standup"), {702})
+        self.assertEqual(step_targets(steps, "start"), set(SMS.LOCO_STATES))
+
+    def test_damps_first_from_zero_torque(self):
+        plugin, _ = make_plugin(0, posture={"posture": "lying"})
+        steps = switch(plugin, "lie2standup")["_steps"]
+        self.assertEqual([s[2] for s in steps], ["damp", "lie2standup", "start"])
+
+    def test_refused_when_posture_is_a_squat(self):
+        plugin, _ = make_plugin(1, posture={"posture": "squat"})
+        res = switch(plugin, "lie2standup")
+        self.assertIn("error", res)
+        self.assertNotIn("_steps", res)
+
+    def test_refused_from_706(self):
+        # 706 was previously in _UNSAFE_STATES, which routed the caller to
+        # emergency_stop -> Damp() and destroyed the balanced squat.
+        plugin, _ = make_plugin(706)
+        res = switch(plugin, "lie2standup")
+        self.assertIn("error", res)
+        self.assertNotIn("emergency_stop", res["error"])
+
+    def test_timeouts_exceed_old_15s_budget(self):
+        plugin, _ = make_plugin(1, posture={"posture": "lying"})
+        steps = switch(plugin, "lie2standup")["_steps"]
+        for s in steps:
+            if s[2] in ("lie2standup", "start"):
+                self.assertGreater(s[3], 15.0, f"step {s[2]} still has the old budget")
+
+
+class TestStandUp2Lie(unittest.TestCase):
+    def test_from_loco_goes_via_706(self):
+        plugin, _ = make_plugin(500)
+        steps = switch(plugin, "standup2lie")["_steps"]
+        self.assertEqual(step_targets(steps, "standup2squat"), {706})
+        self.assertEqual(step_targets(steps, "damp"), {1})
+
+    def test_from_706_just_damps(self):
+        plugin, _ = make_plugin(706)
+        steps = switch(plugin, "standup2lie")["_steps"]
+        self.assertEqual([s[2] for s in steps], ["damp"])
+
+    def test_idempotent_when_limp(self):
+        plugin, _ = make_plugin(1)
+        self.assertIn("info", switch(plugin, "standup2lie"))
+
+
+# ── switch_mode: fsm_mode gating and reporting ─────────────────────────────
+
+class TestDynamicStateGate(unittest.TestCase):
+    def test_dynamic_state_refuses_switches(self):
+        plugin, client = make_plugin(500, fsm_mode=1)
+        res = switch(plugin, "standup2squat")
+        self.assertIn("error", res)
+        self.assertIn("fsm_mode=1", res["error"])
+        self.assertNotIn("_steps", res)
+
+    def test_emergency_stop_ignores_dynamic_state(self):
+        # 阻尼 is documented as always available; it must never be gated.
+        plugin, client = make_plugin(801, fsm_mode=1)
+        res = switch(plugin, "emergency_stop")
+        self.assertNotIn("error", res)
+        self.assertIn("Damp", client.calls)
+
+    def test_emergency_stop_does_not_need_the_topic(self):
+        plugin, client = make_plugin(500, use_topic=False)
+        switch(plugin, "emergency_stop")
+        self.assertIn("Damp", client.calls)
+
+
+class TestStateReporting(unittest.TestCase):
+    def test_get_current_mode_includes_posture(self):
+        plugin, _ = make_plugin(1, posture={"posture": "squat", "knee_rad": 2.9})
+        res = switch(plugin, "get_current_mode")
+        self.assertEqual(res["fsm_id"], 1)
+        self.assertEqual(res["posture"], "squat")
+        self.assertEqual(res["source"], "sportmodestate")
+        self.assertIn("NO balance control", res["description"])
+
+    def test_falls_back_to_rpc_when_topic_stale(self):
+        client = FakeLocoClient(706)
+        plugin = DEV.LocoPlugin({}, "ubuntu", None, client,
+                                state_node=FakeStateNode(706, stale=True))
+        res = switch(plugin, "get_current_mode")
+        self.assertEqual(res["source"], "rpc")
+        self.assertIsNone(res["fsm_mode"], "RPC cannot report switchability")
+
+    def test_rpc_failure_aborts(self):
+        client = FakeLocoClient(1)
+        client.GetFsmId = lambda: (-1, 0)
+        plugin = DEV.LocoPlugin({}, "ubuntu", None, client)
+        res = switch(plugin, "get_current_mode")
+        self.assertIn("error", res)
+
+    def test_damp_refused_from_upright(self):
+        for fsm in (500, 706, 2):
+            plugin, client = make_plugin(fsm)
+            res = switch(plugin, "damp")
+            self.assertIn("error", res, f"damp from {fsm} should be refused")
+            self.assertNotIn("Damp", client.calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

G1 could not stand up after squatting. `squat2standup` returned:

```
{"error": "Robot is on ground (FSM=1). Use lie2standup instead."}
```

…while the robot was visibly squatting. `lie2standup` then failed too, and the
agent loop bounced between the two.

Two independent root causes:

1. The FSM handling polled for target ids the SDK never sets, so transitions the
   robot *physically completed* were reported as timeouts.
2. It conflated **control mode** with **physical posture**. In 零力矩/阻尼 the robot
   is limp, and lying flat is the same `fsm_id` as folded into a squat.

Verified against the vendor docs — [高层运动服务接口 § 模式ID说明](https://support.unitree.com/home/zh/G1_developer/sport_services_interface)
and [遥控说明 § 模式切换](https://support.unitree.com/home/zh/G1_developer/remote_control) —
and against G1 `10.100.129.168`.

## Ground truth

`StandUp2Squat()` and `Squat2StandUp()` are **both** `SetFsmId(706)`; `Lie2StandUp()`
is `SetFsmId(702)`. 706 is 平衡下蹲、蹲起, 702 is 躺起.

Getting back up **must** pass through 阻尼 — 遥控说明 § 模式切换:

> note 1: 从主运控通过 L2+A 切回蹲姿状态后，在不关机的情况下，如果还想切回主运控模式，需要通过 **L2+B 进入阻尼模式，再通过 L2+A** 才能切回主运控。
>
> 蹲姿开机流程: 开机(蹲姿状态) → **① 阻尼** → **⑥ 蹲站切换** → 演示
> 躺倒开机流程: 开机(胯部贴平) → **① 阻尼** → **⑤ 躺卧站立** → 演示

where ① = L2+B = `Damp()`, ⑤ = L2+X = `Lie2StandUp()`, ⑥ = L2+A = `Squat2StandUp()`.
So the damp hop is part of the documented path, and 706 does **not** toggle
straight back to 主运控.

Separately, 锁定站立 (L2+UP, FSM 4) + R1+X is the *unbalanced* way to stand. This
driver deliberately does not use it.

## What was wrong

| | |
|---|---|
| `standup2squat` | Called `StandUp2Squat()` but polled for FSM **2**. Nothing in the Python SDK ever sets 2, so every squat timed out after 15s even though the robot completed it. |
| **706 in `_UNSAFE_STATES`** | The balanced squat was reported as a danger state, routing the caller to `emergency_stop` — which is `Damp()`. |
| `lie2standup` | Called `Lie2StandUp()` but polled for **500**, skipping the 702 state the call actually enters. 15s was also shorter than the physical motion. |
| 702's label | Described as a stable "prep stance / 预备模式". It is **躺起**, a transition. The LLM read the label and issued `Start(500)` mid-transition → `Timeout 'start' (expected=500, got=702)`. |
| `_STANDING_STATES` | Omitted **802**, the renumbered 走跑运控 on 29-DoF from `ai_sport 8.6.x.x` — a walking robot read as not standing. |
| `rt/sportmodestate` | Subscribed with the `unitree_go` `SportModeState_` layout instead of G1's `unitree_hg` one. DDS matches by type name, so the subscription **never fired** and `/ubuntu/loco/motion_state` published nothing (confirmed: zero messages in 8s). That discarded `fsm_mode`, the controller's own "switching allowed" flag. |
| `damp` / `zero_torque` exposed | Raw primitives with no posture handling, and a way for the LLM to drop a standing robot straight to limp. |

## Changes

- **New `sport_mode_state.py`** — correct `unitree_hg` IDL plus the official ID
  table. `LocoStateNode` subscribes with it and exposes `fsm_id` + `fsm_mode`.
- **`switch_mode`** reads state from that topic (RPC fallback when stale) and
  refuses to fire when `fsm_mode=1` (动态) instead of firing and timing out.
- **Transitions now match the documented startup flows**, damp hop included:

  | action | steps |
  |---|---|
  | `squat2standup` | `Damp`→1 → `Squat2StandUp`→主运控 |
  | `lie2standup` | `Damp`→1 → `Lie2StandUp`→702 → `Start`→主运控 |
  | `standup2lie` | `StandUp2Squat`→706 → `Damp`→1 |
  | `standup2squat` | `StopMove` → `StandUp2Squat`→706 |

  Per-step timeouts (25s/45s) replace the flat 15s. `RunFsmSequence` accepts a set
  of acceptable target ids plus a per-step timeout, and reports the real final
  `fsm_id` rather than the last step's declared target.
- **Posture** derived from leg joint angles and IMU tilt, exposed as a new
  `posture` sensor tool and folded into `get_current_mode`. It *picks between* the
  two recovery paths — squatting → ⑥ 蹲站切换, lying → ⑤ 躺卧站立 — and each refusal
  names the other tool.
- **`damp` / `zero_torque` removed** from the mode enum, `x-action-params`, and the
  dispatch routing, so `switch_mode__damp` is no longer a tool. The intermediate
  hops are unaffected — they are sequence steps, not dispatch actions.
  `emergency_stop` stays, ungated in every state, since 阻尼 is documented as always
  available.
- **Fixed a `NameError` in `safety_harness.on_cloud`** — a nested function that
  referenced `self._fwd_log_n`, so the LiDAR obstacle callback raised on every entry
  into the deceleration zone. Now a `nonlocal` counter.
- **Dockerfile** copies sources file by file, so the new module had to be added
  explicitly; without it the bundle died at import.

## Verification

**Hardware, read-only** — no actuator commands were issued; the robot was left in
the state its operator was recovering by hand.

- New IDL subscribes to live `rt/sportmodestate`:
  `SportModeState_(fsm_id=1, fsm_mode=0, task_id=4, task_time=0.0)`
- `_estimate_posture` against live `rt/lowstate` on the stuck robot:
  ```json
  {"posture": "squat", "loaded": false, "knee_rad": 2.898, "hip_pitch_rad": -2.527,
   "knee_tau_nm": 0.26, "torso_roll_deg": 1.1, "torso_pitch_deg": 29.2}
  ```
  `GetFsmId` said `1` (damp) at the same moment — exactly the case that broke.
- Deployed to the G1 container and restarted: clean startup, 16 plugins, and
  `get_current_mode` returns `source: "sportmodestate"` with both mode and posture.
- Live tool schema confirms `damp`/`zero_torque` are gone.
- **`squat2standup` verified on the real robot by the operator** — the corrected
  `Damp` → `Squat2StandUp` sequence stands G1 up from a collapsed squat, which is the
  exact failure this PR started from.

**Unit tests** — `unitree/g1/tests/test_fsm_posture.py`, following the existing
`engineai/t800/tests` stubbing convention:

```
python3 unitree/g1/tests/test_fsm_posture.py
Ran 38 tests in 4.0s — OK
```

Covers the FSM table, the posture estimator (including the exact values measured
on hardware), every transition's step sequence and target ids asserted against the
documented startup flows, the `fsm_mode` gate, and that the removed actions reach
no client method while the internal damp steps survive.

## Not covered

- `lie2standup` (躺倒开机流程, `Damp` → `Lie2StandUp`→702 → `Start`→主运控) has not
  been run on hardware. Only `squat2standup` was exercised; the 702 path is still
  covered by unit test and the vendor doc alone.
- Posture thresholds: the `squat` bound is calibrated against real measurements;
  `standing` and `lying` are derived from kinematics, not measured. Raw joint values
  are always returned so a caller can second-guess the label.
- A pre-existing, unrelated startup race in the SDK surfaces intermittently and is
  not addressed here — `unitree_sdk2py/core/channel.py:91`,
  `AttributeError: 'NoneType' object has no attribute 'take'` when data arrives
  before the DDS reader is ready. Plugin loading continues past it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
