### PR TITLE
feat(booster): add Booster K1 humanoid driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Each driver is a standalone [MCP](https://modelcontextprotocol.io) HTTP server t
 | `x-humanoid/tianyi2.0` | Tianyi 2.0 Pro Humanoid | 15707 | 35DOF (wheeled chassis + dual arms + dexterous hands + head + navigation) |
 | `deep_robotics/lynx_m20` | DEEPRobotics Lynx M20 | 15716 | Official ROS 2/Fast DDS interfaces and basic_server TCP/UDP native control, with Standard/Pro capability isolation |
 | `pndbotics/adam` | PNDbotics Adam Humanoid | 15702 | State, locomotion (gRPC), upper body control, dexterous hands, 3D model |
+| `booster/k1` | Booster K1 Humanoid | 15705 | State (IMU/joints/battery/odom/fall-detection + URDF), camera, locomotion, upper-body joint control, actions/get-up (ACP), audio |
 
 ## Quick Start
 

--- a/booster/k1/.dockerignore
+++ b/booster/k1/.dockerignore
@@ -1,0 +1,1 @@
+reference/

--- a/booster/k1/Dockerfile
+++ b/booster/k1/Dockerfile
@@ -1,0 +1,40 @@
+ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base:latest
+ARG PYPI_MIRROR=https://pypi.org/simple/
+FROM ${ROS_BASE_IMAGE}
+ARG PYPI_MIRROR
+
+WORKDIR /work
+
+RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
+    apt-get install -y --no-install-recommends --allow-unauthenticated \
+        python3-pip \
+        curl && \
+    rm -rf /var/lib/apt/lists/*
+
+# boosteros pulls in booster-robotics-sdk-python (its low-level RPC/DDS
+# binding) as a normal transitive pip dependency — no vendoring needed, unlike
+# unitree_sdk2py. Pinned <1.1.3: newer releases require Python >=3.12, which
+# the ROS humble base (Ubuntu 22.04, Python 3.10) does not have.
+RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} \
+    boosteros==1.1.1 pyyaml netifaces opencv-python-headless numpy
+
+ENV ROS_DOMAIN_ID=42
+ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+ENV FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
+
+COPY resource/ /work/resource/
+COPY common/   /work/common/
+COPY main.py   /work/main.py
+COPY device.py /work/device.py
+COPY config.yaml /work/config.yaml
+COPY deploy/   /deploy/
+
+ENV PYTHONPATH=/work
+ENV PYTHONUNBUFFERED=1
+# ANSI colour codes are control bytes; in a non-tty container log they are
+# exactly the "garbage characters" that make `docker logs` unreadable.
+ENV RCUTILS_COLORIZED_OUTPUT=0
+
+EXPOSE 15705
+
+CMD ["/bin/bash", "-c", "source /opt/ros/humble/setup.bash && source /ros_ws/install/setup.bash && python3 /work/main.py"]

--- a/booster/k1/config.yaml
+++ b/booster/k1/config.yaml
@@ -1,0 +1,25 @@
+mcp_port: 15705
+ros_namespace: ""   # 留空则自动使用 hostname
+
+plugins:
+  state:
+    enabled: true
+  camera:
+    enabled: true
+  loco:
+    enabled: true
+  upper_body:
+    enabled: true
+  action:
+    enabled: true
+  audio:
+    enabled: true
+  # brain 扩展能力（需要 requirements.txt 装 boosteros[brain]），默认关闭：
+  # 语音识别/对话/音色列表、目标检测——不是每台 K1 都装了 brain 依赖。
+  speech:
+    enabled: false
+  detection:
+    enabled: false
+
+# 未接入的 boosteros 能力（示教管理器 hand_guiding_manager、自动踢球管理器
+# soccer_kick_manager）——RoboCup/示教场景专用，不是核心遥测/控制，先不做成卡片。

--- a/booster/k1/deploy/service.yml
+++ b/booster/k1/deploy/service.yml
@@ -1,0 +1,21 @@
+booster-k1:
+  image: __IMAGE__
+  container_name: embodied-booster-k1
+  network_mode: host
+  ipc: host
+  pid: host
+  privileged: true
+  volumes:
+    - /dev:/dev
+    - /opt/phanthy-motus/data:/opt/phanthy-motus/data
+  environment:
+    - ROS_DOMAIN_ID=42
+    - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+    - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
+    - PYTHONUNBUFFERED=1
+  logging:
+    driver: local
+    options:
+      max-size: "10m"
+      max-file: "3"
+  restart: unless-stopped

--- a/booster/k1/device.py
+++ b/booster/k1/device.py
@@ -1,0 +1,866 @@
+#!/usr/bin/env python3
+"""
+drivers/booster/k1/device.py — Booster K1 设备插件。
+
+K1 只有一个 SDK 入口：boosteros.robots.booster.BoosterRobot（官方要求单例，见 main.py）。
+每个插件构造时接收同一个 `robot` 实例，而不是像 unitree/g1 那样各自持有独立 SDK client。
+
+`robot` 为 None 表示 main.py 未能连上真机/虚拟机（LocoClientInitError 或本环境本来就没有
+K1 可连）——所有插件必须优雅降级：sensor 插件跳过订阅（topic 不发数据），actuator 插件在
+dispatch 里对每个真实动作 action 返回 {"state": "error", "error": "robot not connected"}，
+而不是抛异常把 MCP handler 打挂。
+
+插件：
+  StatePlugin    (sensor + resource) — imu/battery/joints(skeleton)/odom/fall_down_state + URDF
+  CameraPlugin   (sensor)            — RGB 图像
+  LocoPlugin     (actuator)          — 行走模式/步态/速度/头部朝向/里程计复位
+  UpperBodyPlugin(actuator)          — 上身自定义关节控制（walk 模式下接管头+双臂）
+  ActionPlugin   (actuator, ACP)     — 预定义动作 / 起身 / 轨迹回放，异步任务走 ACP
+  AudioPlugin    (actuator + sensor) — 音频播放（ACP）、系统音量、录音
+  SpeechPlugin   (processor, 可选)   — 语音识别 / 对话 / 音色列表 (boosteros[brain])
+  DetectionPlugin(processor, 可选)   — 目标检测 (boosteros[brain])
+"""
+
+import json
+import os as _os
+import ssl as _ssl
+import threading
+import time
+import urllib.request as _urllib
+from pathlib import Path
+from uuid import uuid4
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy, DurabilityPolicy
+from std_msgs.msg import String
+from sensor_msgs.msg import CompressedImage
+
+_LOW_LAT_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    history=HistoryPolicy.KEEP_LAST,
+    depth=200,
+    durability=DurabilityPolicy.VOLATILE,
+)
+
+
+def _not_connected() -> dict:
+    return {"state": "error", "error": "robot not connected"}
+
+
+def _normalize_joint_key(name: str) -> str:
+    return "".join(ch for ch in name.lower() if ch.isalnum())
+
+
+def _load_urdf_joint_name_map() -> dict:
+    """normalized-name -> exact URDF <joint name="..."> string.
+
+    boosteros' get_joint_states() names (e.g. "AAHead_Yaw") and the
+    booster_assets K1_22dof.urdf joint names (e.g. "aahead_yaw_joint") use
+    different casing/suffix conventions from two independently generated
+    artifacts — confirmed by spot-checking booster_assets against the SDK
+    quick-start example, where they didn't even agree with each other on a
+    couple of head joints. Match by a case/underscore/suffix-insensitive key
+    instead of hardcoding a guessed table; unmapped joints fall back to their
+    raw boosteros name and simply won't render until this is re-verified
+    against a real K1.
+    """
+    urdf_path = Path(__file__).parent / "resource" / "k1_model.urdf"
+    mapping: dict = {}
+    try:
+        import xml.etree.ElementTree as ET
+        root = ET.parse(urdf_path).getroot()
+        for joint in root.findall("joint"):
+            name = joint.get("name", "")
+            key = _normalize_joint_key(name.removesuffix("_joint"))
+            mapping[key] = name
+    except Exception:
+        pass
+    return mapping
+
+
+def _acp_callback(action_id: str, status: str, result: dict, tool: str) -> None:
+    """POST action completion to Agent Core. See README_dev.md § Action Completion Protocol."""
+    agent_core_url = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+    ctx = _ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = _ssl.CERT_NONE
+    payload = json.dumps({
+        "action_id": action_id,
+        "status": status,       # "completed" | "error" | "cancelled"
+        "result": result,
+        "tool": tool,
+        "ts": time.time(),
+    }).encode()
+    try:
+        req = _urllib.Request(
+            f"{agent_core_url}/api/acp/complete",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        _urllib.urlopen(req, timeout=5, context=ctx)
+    except Exception as e:
+        import sys
+        print(f"[ACP] callback failed for {action_id}: {e}", file=sys.stderr)
+
+
+_TASK_STATUS_TO_ACP = {
+    "SUCCEEDED": "completed",
+    "FAILED": "error",
+    "CANCELLED": "cancelled",
+}
+
+
+def _bind_task_acp(handle, tool: str) -> str:
+    """Register handle.add_done_callback() -> ACP completion POST. Returns action_id (= trace_id)."""
+    action_id = handle.trace_id
+
+    def _on_done(h):
+        status = _TASK_STATUS_TO_ACP.get(str(h.status), "error")
+        result = {}
+        if h.error is not None:
+            result["error"] = str(h.error)
+        _acp_callback(action_id, status, result, tool)
+
+    handle.add_done_callback(_on_done)
+    return action_id
+
+
+# ── StatePlugin (sensor + resource) ──────────────────────────────────────────
+
+class _K1StateNode(Node):
+    """Bridges boosteros push/poll telemetry onto ROS2 topics for Agent Core's ros2_bridge."""
+
+    _JOINTS_INTERVAL = 0.1  # 10 Hz poll (boosteros has no subscribe_joint_states)
+
+    def __init__(self, robot, imu_topic, battery_topic, joints_topic, odom_topic, fall_topic):
+        super().__init__("k1_state")
+        self._robot = robot
+        self._imu_pub     = self.create_publisher(String, imu_topic,     _LOW_LAT_QOS)
+        self._battery_pub = self.create_publisher(String, battery_topic, _LOW_LAT_QOS)
+        self._joints_pub  = self.create_publisher(String, joints_topic,  _LOW_LAT_QOS)
+        self._odom_pub    = self.create_publisher(String, odom_topic,    _LOW_LAT_QOS)
+        self._fall_pub    = self.create_publisher(String, fall_topic,    _LOW_LAT_QOS)
+
+        self._lock = threading.Lock()
+        self._last_imu: dict = {}
+        self._last_battery: dict = {}
+        self._last_fall: dict = {}
+        self._last_imu_quat = [1.0, 0.0, 0.0, 0.0]
+        self._subs = []
+        self._urdf_joint_map = _load_urdf_joint_name_map()
+
+        if robot is None:
+            self.get_logger().warn("K1StateNode: robot not connected, topics will stay empty")
+            return
+
+        try:
+            self._subs.append(robot.subscribe_imu(self._on_imu))
+            self._subs.append(robot.subscribe_battery(self._on_battery))
+            self._subs.append(robot.subscribe_odom(self._on_odom))
+            self._subs.append(robot.subscribe_fall_down_state(self._on_fall))
+        except Exception as e:
+            self.get_logger().warn(f"K1StateNode: subscribe failed: {e}")
+
+        # No subscribe_joint_states in boosteros — poll get_joint_states() instead.
+        self.create_timer(self._JOINTS_INTERVAL, self._poll_joints)
+
+    def _on_imu(self, imu) -> None:
+        # boosteros IMUState.orientation is [x,y,z,w]; skeleton spec wants [w,x,y,z].
+        quat = list(imu.orientation) if imu.orientation is not None else None
+        imu_quat = [quat[3], quat[0], quat[1], quat[2]] if quat else [1.0, 0.0, 0.0, 0.0]
+        data = {
+            "linear_acceleration": list(imu.linear_acceleration),
+            "angular_velocity": list(imu.angular_velocity),
+            "rpy": list(imu.rpy) if imu.rpy is not None else None,
+            "timestamp": imu.timestamp,
+        }
+        with self._lock:
+            self._last_imu = data
+            self._last_imu_quat = imu_quat
+        out = String()
+        out.data = json.dumps(data)
+        self._imu_pub.publish(out)
+
+    def _on_battery(self, battery) -> None:
+        data = {
+            "percentage": getattr(battery, "percentage", None),
+            "voltage": getattr(battery, "voltage", None),
+            "current": getattr(battery, "current", None),
+            "charging": getattr(battery, "charging", None),
+            "timestamp": getattr(battery, "timestamp", None),
+        }
+        with self._lock:
+            self._last_battery = data
+        out = String()
+        out.data = json.dumps(data)
+        self._battery_pub.publish(out)
+
+    def _on_odom(self, odom) -> None:
+        out = String()
+        out.data = json.dumps({
+            "position": list(getattr(odom, "position", [])),
+            "orientation": list(getattr(odom, "orientation", [])),
+            "linear_velocity": list(getattr(odom, "linear_velocity", [])),
+            "angular_velocity": list(getattr(odom, "angular_velocity", [])),
+            "timestamp": getattr(odom, "timestamp", None),
+        })
+        self._odom_pub.publish(out)
+
+    def _on_fall(self, fall) -> None:
+        data = {"fallen": getattr(fall, "fallen", None), "timestamp": getattr(fall, "timestamp", None)}
+        with self._lock:
+            self._last_fall = data
+        out = String()
+        out.data = json.dumps(data)
+        self._fall_pub.publish(out)
+
+    def _poll_joints(self) -> None:
+        try:
+            states = self._robot.get_joint_states()
+        except Exception:
+            return
+        joints = [
+            {"idx": i, "name": self._urdf_joint_map.get(_normalize_joint_key(j.name), j.name),
+             "q": round(float(j.position), 4),
+             "dq": round(float(j.velocity), 4) if j.velocity is not None else 0.0,
+             "tau": round(float(j.effort), 3) if j.effort is not None else 0.0}
+            for i, j in enumerate(states.joints)
+        ]
+        with self._lock:
+            imu_quat = list(self._last_imu_quat)
+        out = String()
+        out.data = json.dumps({"joints": joints, "imu_quat": imu_quat})
+        self._joints_pub.publish(out)
+
+    def snapshot(self, key: str) -> dict:
+        with self._lock:
+            return dict({"imu": self._last_imu, "battery": self._last_battery,
+                         "fall_down_state": self._last_fall}.get(key, {}))
+
+
+class StatePlugin:
+    PREFIX = "state"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, robot):
+        self._robot = robot
+        self._imu_topic     = f"/{namespace}/state/imu"
+        self._battery_topic = f"/{namespace}/state/battery"
+        self._joints_topic  = f"/{namespace}/state/joints"
+        self._odom_topic    = f"/{namespace}/state/odom"
+        self._fall_topic    = f"/{namespace}/state/fall_down_state"
+        self._node = _K1StateNode(robot, self._imu_topic, self._battery_topic,
+                                   self._joints_topic, self._odom_topic, self._fall_topic)
+        executor.add_node(self._node)
+
+    def get_tools(self) -> list:
+        return [self._imu_tool(), self._battery_tool(), self._joints_tool(),
+                self._odom_tool(), self._fall_tool(), self._model_tool()]
+
+    def _imu_tool(self) -> dict:
+        return {
+            "name": "imu", "type": "sensor", "multiInstance": False,
+            "description": f"K1 IMU — linear acceleration, angular velocity, rpy. Publishes to {self._imu_topic}",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._imu_topic, "format": "data/json"}],
+        }
+
+    def _battery_tool(self) -> dict:
+        return {
+            "name": "battery", "type": "sensor", "multiInstance": False,
+            "description": f"K1 battery — percentage, voltage, current, charging state. Publishes to {self._battery_topic}",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._battery_topic, "format": "data/json"}],
+        }
+
+    def _joints_tool(self) -> dict:
+        return {
+            "name": "joints", "type": "sensor", "multiInstance": False,
+            "description": f"K1 joint states — 22 motors (neck + arms + legs), position(q)/velocity(dq)/effort(tau) at 10Hz. Publishes to {self._joints_topic}",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._joints_topic, "format": "sensor/skeleton"}],
+        }
+
+    def _odom_tool(self) -> dict:
+        return {
+            "name": "odom", "type": "sensor", "multiInstance": False,
+            "description": f"K1 odometry — position/orientation/velocity. Publishes to {self._odom_topic}",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._odom_topic, "format": "data/json"}],
+        }
+
+    def _fall_tool(self) -> dict:
+        return {
+            "name": "fall_down_state", "type": "sensor", "multiInstance": False,
+            "description": f"K1 fall-detection state. Publishes to {self._fall_topic}",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._fall_topic, "format": "data/json"}],
+        }
+
+    def _model_tool(self) -> dict:
+        return {
+            "name": "model", "type": "resource", "multiInstance": False,
+            "description": "K1 robot URDF model (22DOF) for 3D skeleton visualization",
+            "inputSchema": {"type": "object", "properties": {}},
+        }
+
+    def start(self) -> None:
+        pass  # subscriptions/timer started in __init__
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "running"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "info":
+            tool_name = args.get('_tool_name', '')
+            topic_map = {
+                'imu':             (self._imu_topic,     'data/json'),
+                'battery':         (self._battery_topic, 'data/json'),
+                'joints':          (self._joints_topic,  'sensor/skeleton'),
+                'odom':            (self._odom_topic,    'data/json'),
+                'fall_down_state': (self._fall_topic,    'data/json'),
+            }
+            if tool_name in topic_map:
+                topic, fmt = topic_map[tool_name]
+                return {"state": "running", "topic_out": [{"topic": topic, "format": fmt}]}
+            return {"state": "running"}
+        if action == "model":
+            urdf_path = Path(__file__).parent / "resource" / "k1_model.urdf"
+            if urdf_path.exists():
+                return {"urdf": urdf_path.read_text()}
+            return {"error": "URDF model file not found"}
+        return None
+
+
+# ── CameraPlugin (sensor) ─────────────────────────────────────────────────────
+
+class _K1CameraNode(Node):
+    def __init__(self, robot, color_topic: str):
+        super().__init__("k1_camera")
+        self._pub = self.create_publisher(CompressedImage, color_topic, _LOW_LAT_QOS)
+        self._sub = None
+        if robot is None:
+            self.get_logger().warn("K1CameraNode: robot not connected, no image will publish")
+            return
+        try:
+            self._sub = robot.subscribe_image(self._on_image, img_type="rgb")
+        except Exception as e:
+            self.get_logger().warn(f"K1CameraNode: subscribe_image failed: {e}")
+
+    def _on_image(self, image) -> None:
+        import cv2
+        import numpy as np
+        try:
+            if hasattr(image, "format"):  # already CompressedImage (e.g. jpeg)
+                jpeg_bytes = image.to_bytes()
+            else:
+                arr = image.to_numpy()
+                ok, buf = cv2.imencode(".jpg", arr)
+                if not ok:
+                    return
+                jpeg_bytes = buf.tobytes()
+        except Exception:
+            return
+        msg = CompressedImage()
+        msg.format = "jpeg"
+        msg.data = jpeg_bytes
+        self._pub.publish(msg)
+
+
+class CameraPlugin:
+    PREFIX = "camera"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, robot):
+        self._color_topic = f"/{namespace}/camera/rgb"
+        self._node = _K1CameraNode(robot, self._color_topic)
+        executor.add_node(self._node)
+
+    def get_tools(self) -> list:
+        return [self._color_tool()]
+
+    def _color_tool(self) -> dict:
+        return {
+            "name": "camera", "type": "sensor", "multiInstance": False,
+            "description": f"K1 head camera — JPEG frames. Publishes to {self._color_topic}",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._color_topic, "format": "image/jpeg"}],
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "running"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action == "info":
+            return {"state": "running", "topic_out": [{"topic": self._color_topic, "format": "image/jpeg"}]}
+        return None
+
+
+# ── LocoPlugin (actuator) ─────────────────────────────────────────────────────
+
+class LocoPlugin:
+    PREFIX = "loco"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, robot):
+        self._robot = robot
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "loco", "type": "actuator", "multiInstance": False,
+            "description": "K1 locomotion — mode/gait switching, planar velocity, head orientation, odometry reset",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["move", "stop", "set_mode", "set_gait", "get_mode",
+                                  "list_gaits", "set_head_angle", "reset_odom"],
+                        "description": "Action to perform",
+                    },
+                    "vx":    {"type": "number", "description": "Forward velocity m/s, positive = forward"},
+                    "vy":    {"type": "number", "description": "Lateral velocity m/s, positive = left"},
+                    "vyaw":  {"type": "number", "description": "Yaw rate rad/s, positive = counter-clockwise"},
+                    "mode":  {"type": "string", "description": "Target mode, e.g. 'walk', 'prepare', 'custom'"},
+                    "gait":  {"type": "string", "description": "Target gait name (see list_gaits)"},
+                    "pitch": {"type": "number", "description": "Head pitch rad, positive = down"},
+                    "yaw":   {"type": "number", "description": "Head yaw rad, positive = left"},
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "move":            {"params": ["vx", "vy", "vyaw"], "description": "Move with planar velocities (robot must be in 'walk' mode)"},
+                    "stop":            {"params": [],                  "description": "Zero all planar velocity"},
+                    "set_mode":        {"params": ["mode"],            "description": "Switch robot mode (walk / prepare / custom / ...)"},
+                    "set_gait":        {"params": ["gait"],            "description": "Switch gait"},
+                    "get_mode":        {"params": [],                  "description": "Get current mode"},
+                    "list_gaits":      {"params": [],                  "description": "List supported gaits"},
+                    "set_head_angle":  {"params": ["pitch", "yaw"],    "description": "Set head pitch/yaw (robot must be in 'walk' mode)"},
+                    "reset_odom":      {"params": [],                  "description": "Reset odometry to origin"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        if self._robot is not None:
+            try:
+                self._robot.set_velocity(0.0, 0.0, 0.0)
+            except Exception:
+                pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "stop":
+            return {"state": "idle"}
+        if self._robot is None:
+            return _not_connected()
+        try:
+            if action == "move":
+                vx, vy, vyaw = float(args.get("vx", 0.0)), float(args.get("vy", 0.0)), float(args.get("vyaw", 0.0))
+                self._robot.set_velocity(vx, vy, vyaw)
+                return {"state": "moving", "vx": vx, "vy": vy, "vyaw": vyaw}
+            if action == "stop":
+                self._robot.set_velocity(0.0, 0.0, 0.0)
+                return {"state": "stopped"}
+            if action == "set_mode":
+                mode = args.get("mode", "")
+                self._robot.set_mode(mode)
+                return {"state": "ok", "mode": mode}
+            if action == "set_gait":
+                gait = args.get("gait", "")
+                self._robot.set_gait(gait)
+                return {"state": "ok", "gait": gait}
+            if action == "get_mode":
+                return {"mode": self._robot.get_mode()}
+            if action == "list_gaits":
+                return {"gaits": list(self._robot.list_gaits())}
+            if action == "set_head_angle":
+                pitch, yaw = float(args.get("pitch", 0.0)), float(args.get("yaw", 0.0))
+                self._robot.set_head_angle(pitch=pitch, yaw=yaw)
+                return {"state": "ok", "pitch": pitch, "yaw": yaw}
+            if action == "reset_odom":
+                self._robot.reset_odom()
+                return {"state": "ok"}
+        except Exception as e:
+            return {"state": "error", "error": str(e)}
+        return None
+
+
+# ── UpperBodyPlugin (actuator) ────────────────────────────────────────────────
+
+class UpperBodyPlugin:
+    PREFIX = "upper_body"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, robot):
+        self._robot = robot
+        self._enabled = False
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "upper_body", "type": "actuator", "multiInstance": False,
+            "description": (
+                "K1 upper-body custom control — in 'walk' mode, hand control of head + both "
+                "arms (first 10 joints) to the caller while legs keep walking under the system"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["enable", "disable", "set_joints"],
+                        "description": "Action to perform",
+                    },
+                    "joints": {
+                        "type": "array",
+                        "description": "Joint commands: [{name, position, kp, kd}], names from state/joints",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "position": {"type": "number", "description": "Target position, rad"},
+                                "kp": {"type": "number", "description": "Position gain"},
+                                "kd": {"type": "number", "description": "Velocity gain"},
+                            },
+                            "required": ["name", "position"],
+                        },
+                    },
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "enable":     {"params": [],         "description": "Take over head + arm control (must be in 'walk' mode)"},
+                    "disable":    {"params": [],         "description": "Return upper-body control to the system"},
+                    "set_joints": {"params": ["joints"], "description": "Send target position/kp/kd for the upper-body joints"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        if self._robot is not None and self._enabled:
+            try:
+                self._robot.upper_body_control(False)
+            except Exception:
+                pass
+        self._enabled = False
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "stop":
+            self.stop()
+            return {"state": "idle"}
+        if self._robot is None:
+            return _not_connected()
+        try:
+            if action == "enable":
+                self._robot.upper_body_control(True)
+                self._enabled = True
+                return {"state": "ok", "upper_body_control": True}
+            if action == "disable":
+                self._robot.upper_body_control(False)
+                self._enabled = False
+                return {"state": "ok", "upper_body_control": False}
+            if action == "set_joints":
+                from boosteros.types import JointCommand
+                commands = [
+                    JointCommand(name=j["name"], position=float(j["position"]),
+                                 kp=float(j.get("kp", 20.0)), kd=float(j.get("kd", 1.0)))
+                    for j in args.get("joints", [])
+                ]
+                self._robot.set_joints(commands)
+                return {"state": "ok", "count": len(commands)}
+        except Exception as e:
+            return {"state": "error", "error": str(e)}
+        return None
+
+
+# ── ActionPlugin (actuator, ACP) ──────────────────────────────────────────────
+
+class ActionPlugin:
+    PREFIX = "action"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, robot):
+        self._robot = robot
+        self._handles: dict = {}  # trace_id -> TaskHandle
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "action", "type": "actuator", "multiInstance": False,
+            "description": "K1 predefined actions, get-up, and trajectory playback — long-running, tracked via ACP",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["list_actions", "do_action", "get_up", "execute_trajectory", "cancel"],
+                        "description": "Action to perform",
+                    },
+                    "action_id":       {"type": "string", "description": "Predefined action ID from list_actions"},
+                    "trajectory_path": {"type": "string", "description": "Path to a .btraj trajectory file, already present on the robot's filesystem"},
+                    "task_trace_id":   {"type": "string", "description": "trace_id of a running task to cancel"},
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "list_actions":       {"params": [],                  "description": "List predefined action IDs supported by this robot"},
+                    "do_action":          {"params": ["action_id"],       "description": "Asynchronously perform a predefined action"},
+                    "get_up":             {"params": [],                  "description": "Asynchronously trigger the get-up routine"},
+                    "execute_trajectory": {"params": ["trajectory_path"], "description": "Asynchronously replay a recorded joint trajectory (.btraj)"},
+                    "cancel":             {"params": ["task_trace_id"],   "description": "Cancel a running action/get-up/trajectory task"},
+                },
+                "x-completion": {
+                    "actions": ["do_action", "get_up", "execute_trajectory"],
+                    "timeout": 60,
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        for handle in list(self._handles.values()):
+            try:
+                handle.cancel()
+            except Exception:
+                pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "stop":
+            self.stop()
+            return {"state": "idle"}
+        if self._robot is None:
+            return _not_connected()
+        try:
+            if action == "list_actions":
+                return {"actions": [a.id if hasattr(a, "id") else str(a) for a in self._robot.list_actions()]}
+            if action == "do_action":
+                handle = self._robot.do_action(args["action_id"])
+                action_id = _bind_task_acp(handle, self.PREFIX)
+                self._handles[action_id] = handle
+                return {"state": "running", "action_id": action_id}
+            if action == "get_up":
+                handle = self._robot.get_up()
+                action_id = _bind_task_acp(handle, self.PREFIX)
+                self._handles[action_id] = handle
+                return {"state": "running", "action_id": action_id}
+            if action == "execute_trajectory":
+                from boosteros.types import TrajectoryData
+                trajectory = TrajectoryData.load(args["trajectory_path"])
+                handle = self._robot.execute_trajectory(trajectory)
+                action_id = _bind_task_acp(handle, self.PREFIX)
+                self._handles[action_id] = handle
+                return {"state": "running", "action_id": action_id}
+            if action == "cancel":
+                handle = self._handles.get(args.get("task_trace_id", ""))
+                if handle is None:
+                    return {"state": "error", "error": "unknown task_trace_id"}
+                return {"state": "ok", "cancelled": bool(handle.cancel())}
+        except Exception as e:
+            return {"state": "error", "error": str(e)}
+        return None
+
+
+# ── AudioPlugin (actuator + sensor) ───────────────────────────────────────────
+
+class AudioPlugin:
+    PREFIX = "audio"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, robot):
+        self._robot = robot
+        self._handles: dict = {}
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "audio", "type": "actuator", "multiInstance": False,
+            "description": "K1 audio — play a local sound file, system volume, mic recording",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["play_sound", "get_volume", "set_volume",
+                                  "start_recording", "stop_recording", "is_recording"],
+                        "description": "Action to perform",
+                    },
+                    "audio_path": {"type": "string", "description": "Path to a .wav/.mp3/.pcm file already on the robot's filesystem"},
+                    "volume":     {"type": "number", "description": "Volume 0.0-1.0"},
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "play_sound":      {"params": ["audio_path", "volume"], "description": "Asynchronously play a local audio file"},
+                    "get_volume":      {"params": [],                       "description": "Get system output volume"},
+                    "set_volume":      {"params": ["volume"],               "description": "Set system output volume (0.0-1.0)"},
+                    "start_recording": {"params": [],                       "description": "Start microphone recording"},
+                    "stop_recording":  {"params": [],                       "description": "Stop recording and return the captured audio"},
+                    "is_recording":    {"params": [],                       "description": "Whether a recording is currently in progress"},
+                },
+                "x-completion": {
+                    "actions": ["play_sound"],
+                    "timeout": 60,
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        for handle in list(self._handles.values()):
+            try:
+                handle.cancel()
+            except Exception:
+                pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "stop":
+            return {"state": "idle"}
+        if self._robot is None:
+            return _not_connected()
+        try:
+            if action == "play_sound":
+                volume = args.get("volume")
+                handle = self._robot.play_sound(args["audio_path"], volume=float(volume) if volume is not None else None)
+                action_id = _bind_task_acp(handle, self.PREFIX)
+                self._handles[action_id] = handle
+                return {"state": "playing", "action_id": action_id}
+            if action == "get_volume":
+                return {"volume": self._robot.audio_manager.get_system_volume()}
+            if action == "set_volume":
+                volume = float(args.get("volume", 0.5))
+                self._robot.audio_manager.set_system_volume(volume)
+                return {"state": "ok", "volume": volume}
+            if action == "start_recording":
+                self._robot.audio_manager.start_recording()
+                return {"state": "recording"}
+            if action == "stop_recording":
+                audio = self._robot.audio_manager.stop_recording()
+                duration = getattr(getattr(audio, "duration", None), "seconds", None)
+                return {"state": "ok", "duration_s": duration}
+            if action == "is_recording":
+                return {"recording": bool(self._robot.audio_manager.is_recording())}
+        except Exception as e:
+            return {"state": "error", "error": str(e)}
+        return None
+
+
+# ── SpeechPlugin (processor, optional — requires boosteros[brain]) ───────────
+
+class SpeechPlugin:
+    PREFIX = "speech"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, robot):
+        self._robot = robot
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "speech", "type": "processor", "multiInstance": False,
+            "description": "K1 brain speech — chat and available voices (requires boosteros[brain])",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string", "enum": ["chat", "list_voices"], "description": "Action to perform"},
+                    "text":   {"type": "string", "description": "User text to send to the chat interface"},
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "chat":        {"params": ["text"], "description": "Send text to the robot's brain chat interface"},
+                    "list_voices": {"params": [],       "description": "List available TTS voices"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "stop":
+            return {"state": "idle"}
+        if self._robot is None:
+            return _not_connected()
+        try:
+            if action == "chat":
+                return {"reply": self._robot.speech.chat(args.get("text", ""))}
+            if action == "list_voices":
+                return {"voices": list(self._robot.speech.list_voices())}
+        except Exception as e:
+            return {"state": "error", "error": str(e)}
+        return None
+
+
+# ── DetectionPlugin (processor, optional — requires boosteros[brain]) ────────
+
+class DetectionPlugin:
+    PREFIX = "detection"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, robot):
+        self._robot = robot
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "detection", "type": "processor", "multiInstance": False,
+            "description": "K1 brain vision detection (requires boosteros[brain])",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string", "enum": ["list_models", "load_model", "detect"], "description": "Action to perform"},
+                    "model":  {"type": "string", "description": "Model name from list_models"},
+                },
+                "required": ["action"],
+                "x-action-params": {
+                    "list_models": {"params": [],        "description": "List available detection models"},
+                    "load_model":  {"params": ["model"], "description": "Load a detection model by name"},
+                    "detect":      {"params": [],        "description": "Run detection on the current camera frame"},
+                },
+            },
+        }
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        if action == "start":
+            return {"state": "ready"}
+        if action == "stop":
+            return {"state": "idle"}
+        if self._robot is None:
+            return _not_connected()
+        try:
+            if action == "list_models":
+                return {"models": list(self._robot.detection.list_models())}
+            if action == "load_model":
+                self._robot.detection.load_model(args["model"])
+                return {"state": "ok", "model": args["model"]}
+            if action == "detect":
+                image = self._robot.get_image(img_type="rgb")
+                result = self._robot.detection.detect(image)
+                return {"detections": [d.__dict__ if hasattr(d, "__dict__") else str(d) for d in result]}
+        except Exception as e:
+            return {"state": "error", "error": str(e)}
+        return None

--- a/booster/k1/driver.yaml
+++ b/booster/k1/driver.yaml
@@ -1,0 +1,11 @@
+id: booster-k1-driver
+name: Booster K1 Bundle
+category: driver
+hardware_provider: booster
+hardware_model: "k1"
+image_name: booster-k1
+port: 15705
+mcp_url: "http://localhost:15705/mcp"
+description: "Booster K1 — 22DOF 双足人形机器人，IMU/关节/电池/跌倒/里程计感知、相机、行走与上身关节控制、动作/起身/轨迹/音频异步任务"
+build_context_extras:
+  - ../../common

--- a/booster/k1/main.py
+++ b/booster/k1/main.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""
+drivers/booster/k1/main.py — Booster K1 设备 bundle 统一入口。
+
+读取 config.yaml，按插件配置加载插件，聚合成一个 MCP HTTP server 对外暴露。
+驱动启动时自动 start 所有插件，关闭时自动 stop。
+
+与 unitree/g1 的差异：K1 只有一个官方 SDK 入口 —— boosteros.robots.booster.BoosterRobot。
+官方文档明确要求同一台机器人只创建一个实例（每个实例各开一条 ROS 节点/订阅/控制发布通道，
+多开会导致指令冲突），所以这里构造单个 `robot`，所有插件共享它，而不是像 G1 那样为每个
+能力分别持有一个 SDK client。
+
+用法：
+    python3 main.py
+
+环境变量：
+    CONFIG_PATH — config.yaml 路径（默认同目录下）
+"""
+
+from __future__ import annotations
+
+try:
+    from common import logsafe
+    logsafe.install()
+except ImportError as _e:  # running outside the container image
+    import sys as _sys
+    _sys.stderr.write(f"[bundle] logsafe unavailable ({_e}); stdout unprotected\n")
+
+import json
+import os
+import re
+import signal
+import socket
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import yaml
+
+import rclpy
+import rclpy.executors
+
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+def _load_config() -> dict:
+    config_path = os.environ.get("CONFIG_PATH", str(Path(__file__).parent / "config.yaml"))
+    with open(config_path) as f:
+        return yaml.safe_load(f)
+
+
+def _resolve_namespace(cfg: dict) -> str:
+    ns = cfg.get("ros_namespace", "").strip()
+    if ns:
+        return re.sub(r"[^a-zA-Z0-9_]", "_", ns)
+    return re.sub(r"[^a-zA-Z0-9_]", "_", socket.gethostname())
+
+
+# ── Bundle ────────────────────────────────────────────────────────────────────
+
+class K1DeviceBundle:
+    def __init__(self, cfg: dict, namespace: str, executor, robot):
+        self._plugins: list = []
+        plugins_cfg = cfg.get("plugins", {})
+
+        if plugins_cfg.get("state", {}).get("enabled", False):
+            from device import StatePlugin
+            self._plugins.append(StatePlugin(plugins_cfg["state"], namespace, executor, robot))
+            print("[bundle] StatePlugin loaded")
+
+        if plugins_cfg.get("camera", {}).get("enabled", False):
+            from device import CameraPlugin
+            self._plugins.append(CameraPlugin(plugins_cfg["camera"], namespace, executor, robot))
+            print("[bundle] CameraPlugin loaded")
+
+        if plugins_cfg.get("loco", {}).get("enabled", False):
+            from device import LocoPlugin
+            self._plugins.append(LocoPlugin(plugins_cfg["loco"], namespace, executor, robot))
+            print("[bundle] LocoPlugin loaded")
+
+        if plugins_cfg.get("upper_body", {}).get("enabled", False):
+            from device import UpperBodyPlugin
+            self._plugins.append(UpperBodyPlugin(plugins_cfg["upper_body"], namespace, executor, robot))
+            print("[bundle] UpperBodyPlugin loaded")
+
+        if plugins_cfg.get("action", {}).get("enabled", False):
+            from device import ActionPlugin
+            self._plugins.append(ActionPlugin(plugins_cfg["action"], namespace, executor, robot))
+            print("[bundle] ActionPlugin loaded")
+
+        if plugins_cfg.get("audio", {}).get("enabled", False):
+            from device import AudioPlugin
+            self._plugins.append(AudioPlugin(plugins_cfg["audio"], namespace, executor, robot))
+            print("[bundle] AudioPlugin loaded")
+
+        if plugins_cfg.get("speech", {}).get("enabled", False):
+            from device import SpeechPlugin
+            self._plugins.append(SpeechPlugin(plugins_cfg["speech"], namespace, executor, robot))
+            print("[bundle] SpeechPlugin loaded")
+
+        if plugins_cfg.get("detection", {}).get("enabled", False):
+            from device import DetectionPlugin
+            self._plugins.append(DetectionPlugin(plugins_cfg["detection"], namespace, executor, robot))
+            print("[bundle] DetectionPlugin loaded")
+
+    def start_all(self) -> None:
+        for i, p in enumerate(self._plugins):
+            try:
+                p.start()
+            except Exception as e:
+                print(f"[bundle] Plugin {i} ({type(p).__name__}) start() FAILED: {e}", flush=True)
+                import traceback
+                traceback.print_exc()
+        print(f"[bundle] All {len(self._plugins)} plugins started", flush=True)
+
+    def stop_all(self) -> None:
+        for p in self._plugins:
+            p.stop()
+        print("[bundle] All plugins stopped")
+
+    def get_all_tools(self) -> list:
+        tools = []
+        for p in self._plugins:
+            if hasattr(p, 'get_tools'):
+                tools.extend(p.get_tools())
+            else:
+                tools.append(p.get_tool())
+        return tools
+
+    def dispatch(self, tool_name: str, args: dict) -> dict | None:
+        for p in self._plugins:
+            plugin_tools = p.get_tools() if hasattr(p, 'get_tools') else [p.get_tool()]
+            for tool_def in plugin_tools:
+                if tool_def["name"] == tool_name:
+                    if tool_def["type"] == "resource":
+                        return p.dispatch(tool_name, args)
+                    action = args.pop("action", tool_name)
+                    args['_tool_name'] = tool_name  # let multi-tool plugins know which tool was called
+                    result = p.dispatch(action, args)
+                    return result
+        return None
+
+
+# ── MCP HTTP server ───────────────────────────────────────────────────────────
+
+_bundle: K1DeviceBundle | None = None
+
+
+def make_handler():
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):
+            msg = fmt % args
+            if '"POST /mcp' in msg and '200' in msg:
+                return
+            # Escape and cap: msg embeds the raw request line, which on host
+            # networking is remote-controlled bytes going straight into the
+            # Docker log framer (log injection / control-byte corruption).
+            safe = msg.encode("unicode_escape").decode("ascii")[:200]
+            print(f"[mcp] {self.address_string()} {safe}")
+
+        def _send(self, status: int, body: str):
+            encoded = body.encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type, Accept")
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def do_GET(self):
+            self.send_response(404)
+            self.end_headers()
+
+        def do_OPTIONS(self):
+            self.send_response(204)
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type, Accept")
+            self.end_headers()
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0))
+            raw = self.rfile.read(length)
+            try:
+                rpc = json.loads(raw)
+            except Exception:
+                self._send(400, json.dumps({"jsonrpc": "2.0", "id": None,
+                                             "error": {"code": -32700, "message": "Parse error"}}))
+                return
+
+            rid    = rpc.get("id")
+            method = rpc.get("method", "")
+            params = rpc.get("params") or {}
+
+            if rid is None:
+                self.send_response(202)
+                self.end_headers()
+                return
+
+            def ok(result):
+                self._send(200, json.dumps({"jsonrpc": "2.0", "id": rid, "result": result}))
+
+            def err(code, msg):
+                self._send(200, json.dumps({"jsonrpc": "2.0", "id": rid,
+                                             "error": {"code": code, "message": msg}}))
+
+            try:
+                if method == "initialize":
+                    ok({
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "k1-device-bundle", "version": "1.0.0"},
+                    })
+                elif method == "tools/list":
+                    ok({"tools": _bundle.get_all_tools()})
+                elif method == "tools/call":
+                    name   = params.get("name", "")
+                    args   = params.get("arguments") or {}
+                    result = _bundle.dispatch(name, args)
+                    if result is None:
+                        err(-32601, f"Unknown tool: {name}")
+                    else:
+                        ok({"content": [{"type": "text", "text": json.dumps(result)}]})
+                else:
+                    err(-32601, f"Method not found: {method}")
+            except Exception as e:
+                err(-32603, str(e))
+
+    return Handler
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+
+def _start_registration(mcp_port: int, name: str, category: str):
+    """Register this driver with agent-core in a background thread, then heartbeat every 30s."""
+    import urllib.request as _urllib
+    import ssl as _ssl
+    agent_core_url = os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+    payload = json.dumps({
+        "name": name,
+        "url":  f"http://localhost:{mcp_port}/mcp",
+        "category": category,
+    }).encode()
+    _ctx = _ssl.create_default_context()
+    _ctx.check_hostname = False
+    _ctx.verify_mode = _ssl.CERT_NONE
+    def _run():
+        import time as _t
+        while True:
+            try:
+                req = _urllib.Request(
+                    f"{agent_core_url}/api/mcp", data=payload,
+                    headers={"Content-Type": "application/json"}, method="POST",
+                )
+                with _urllib.urlopen(req, timeout=3, context=_ctx):
+                    pass  # heartbeat ok, suppress log
+                _t.sleep(30)
+            except Exception as e:
+                print(f"[register] failed: {e}, retrying in 5s")
+                _t.sleep(5)
+    threading.Thread(target=_run, daemon=True, name="register").start()
+
+
+def _connect_robot(cfg: dict):
+    """Construct the single shared BoosterRobot instance.
+
+    boosteros raises LocoClientInitError when no robot/virtual-robot is
+    discoverable within `timeout`. Real deploys can start this container
+    before the robot's motion service is up, and this environment has no
+    K1/Booster Studio reachable at all — either way the MCP server must still
+    come up and answer tools/list, just with every plugin reporting a
+    disconnected state instead of crashing the process.
+    """
+    from boosteros.robots.booster import BoosterRobot
+    try:
+        robot = BoosterRobot(
+            timeout=float(cfg.get("connect_timeout", 5.0)),
+            callback_workers=int(cfg.get("callback_workers", 4)),
+        )
+        print(f"[bundle] BoosterRobot connected: {robot.robot_info}")
+        return robot
+    except Exception as e:
+        print(f"[bundle] BoosterRobot connect FAILED ({e}); "
+              f"plugins will start in a disconnected state", flush=True)
+        return None
+
+
+def main():
+    global _bundle
+
+    cfg       = _load_config()
+    namespace = _resolve_namespace(cfg)
+    mcp_port  = int(cfg.get("mcp_port", 15705))
+
+    print(f"[bundle] namespace={namespace} mcp_port={mcp_port}")
+
+    robot = _connect_robot(cfg)
+
+    # ROS2 — used only for this driver's own outbound topics (imu/battery/
+    # joints/...); boosteros manages its own internal rclpy node/executor for
+    # talking to the robot.
+    rclpy.init()
+    executor = rclpy.executors.MultiThreadedExecutor()
+
+    _bundle = K1DeviceBundle(cfg, namespace, executor, robot)
+    _bundle.start_all()
+
+    def _spin():
+        while rclpy.ok():
+            executor.spin_once(timeout_sec=0.1)
+
+    spin_thread = threading.Thread(target=_spin, daemon=True, name="bundle_spin")
+    spin_thread.start()
+
+    _start_registration(mcp_port, cfg.get("name", "Booster K1 Bundle"), "driver")
+
+    server = ThreadingHTTPServer(("", mcp_port), make_handler())
+    print(f"[bundle] MCP server → http://localhost:{mcp_port}")
+
+    def _shutdown(signum, frame):
+        print(f"[bundle] signal {signum}, shutting down")
+        _bundle.stop_all()
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    try:
+        server.serve_forever()
+    finally:
+        _bundle.stop_all()
+        executor.shutdown()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/booster/k1/reference/docs/cpp-sdk/README.md
+++ b/booster/k1/reference/docs/cpp-sdk/README.md
@@ -1,0 +1,93 @@
+# Booster Robotics C++ SDK — reference notes
+
+Full source was downloaded via `codeload.github.com` (not `git clone` — the task asked to avoid
+the slow full-history clone; `raw.githubusercontent.com` was also unreachable from the dev
+environment, so `codeload.github.com`/`api.github.com` were used instead) and is mirrored on COS
+rather than committed to this repo (git isn't a great home for an 18MB binary blob):
+
+```bash
+curl -fsSL -o booster_robotics_sdk-main.zip \
+  https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/booster/booster_robotics_sdk-main.zip
+curl -fsSL -o booster_robotics_sdk_ros2-main.zip \
+  https://agi-phanthy-dev-1252788780.cos.ap-beijing.myqcloud.com/public/booster/booster_robotics_sdk_ros2-main.zip
+```
+
+`booster_robotics_sdk_ros2-main.zip` is the ROS2 message/service package
+(`BoosterApiReqMsg`/`RespMsg`, `AgentService`, `RpcService`, plus IDL for
+`ImuState`/`LowCmd`/`LowState`/`MotorCmd`/`MotorState`/`Odometer`/etc — build with `colcon`,
+depends on `rclcpp`/`ament_cmake`/`rosidl_default_generators`).
+
+This driver does **not** build against either repo directly — `boosteros`/
+`booster_robotics_sdk_python` (both pip-installable, see `../python-sdk/README.md`) are the
+actual runtime dependency. These zips exist purely as offline reference for the underlying
+RPC/DDS surface (useful if a future card needs something `boosteros` doesn't expose).
+
+## Repo layout (`booster_robotics_sdk`)
+
+```
+example/high_level/   b1_loco_example_client.cpp, b1_arm_sdk_example.cpp, b1_7dof_arm_sdk_example.cpp
+example/low_level/    b1_low_sdk_example.cpp, low_level_publisher/subscriber.cpp,
+                      battery_state_subscriber.cpp, odometer_example.cpp,
+                      low_level_hand_data_subscriber.cpp, b1_7dof_arm_low_sdk_example.cpp
+include/booster/common/dds/       DDS entity/topic-channel/callback plumbing
+include/booster/idl/              IDL message headers: ai/, audio/, b1/ (LowCmd, LowState,
+                                   MotorCmd/State, ImuState, Odometer, BatteryState,
+                                   FallDownState, RemoteControllerState, Hand*, Kick,
+                                   LightControlMsg, RobocupBehaviorStatus, ...),
+                                   camera/, geometry_msgs/, builtin_interfaces/
+include/booster/robot/            High-level client headers:
+    ai/            api.hpp, client.hpp, const.hpp
+    audio/         audio_manager.h, audio_player.h, audio_recorder.h, audio_localizer.h, ...
+    b1/            b1_loco_client.hpp, b1_loco_api.hpp, move_controller.hpp,
+                   arm_controller.hpp, b1_api_const.hpp
+    camera/        camera_client.hpp, camera_api.hpp
+    channel/       channel_factory.hpp, channel_publisher.hpp, channel_subscriber.hpp
+    common/        device_info(_parser).hpp, camera_info_parser.hpp, entities.hpp, robot_shared.hpp
+    device/light/  light_control_client.hpp, light_control_api.hpp
+    rpc/           rpc_client.hpp, rpc_server.hpp, request(_header).hpp, response(_header).hpp, error.hpp
+    vision/        vision_client.hpp, handeye_calib_client.hpp
+    x5_camera/     x5_camera_client.hpp
+include/booster_fastdds/          Vendored FastDDS/FastCDR C++ headers (their own DDS layer,
+                                   not ROS2's rmw — this is why `boosteros`'s "ROS 2 域 ID"
+                                   terminology in the Python docs doesn't necessarily mean a real
+                                   rclpy dependency at the wire level)
+```
+
+## Communication model (from the top-level README + doc site nav)
+
+Two interface families, mirrored in `boosteros`:
+
+- **High-level RPC** (`include/booster/robot/*/*_client.hpp`) — request/response calls: loco
+  (`b1_loco_client.hpp`), arm (`arm_controller.hpp`), camera, vision, audio, device/light, AI/LUI.
+  `boosteros.robots.booster.BoosterRobot` wraps these as `set_velocity`/`set_mode`/`do_action`/
+  `get_up`/etc.
+- **Low-level Topic** (DDS publish/subscribe via `channel_publisher.hpp`/`channel_subscriber.hpp`)
+  — direct sensor/motor IDL messages (`LowCmd`/`LowState`/`MotorCmd`/`MotorState`/`ImuState`/
+  `Odometer`/`BatteryState`/`FallDownState`) for full joint-level control, matching what
+  `example/low_level/*.cpp` demonstrates. `boosteros.get_joint_states()`/`set_joints()` are the
+  Python-level equivalent of subscribing/publishing these directly.
+
+## Python bindings
+
+`booster_robotics_sdk_python` (pip, manylinux wheels for cp310–cp314, x86_64+aarch64) is the
+pybind11 binding of this same C++ SDK — 1:1 API parity with the RPC/Topic split above. The repo
+README states this explicitly: "This release package provides the C++ SDK. Python SDK delivery
+is handled by the pip package." `boosteros` is declared as depending on
+`booster-robotics-sdk-python>=1.6.0,<1.7.0` — i.e. it's a higher-level wrapper on top, not a
+separate implementation.
+
+## K1 URDF / assets
+
+`resource/k1_model.urdf` in this driver was copied from
+`BoosterRobotics/booster_assets` → `robots/K1/K1_22dof.urdf` (fetched via the GitHub contents
+API, base64-decoded — `raw.githubusercontent.com` was unreachable). That repo also has
+`K1_locomotion.urdf`, `K1_22dof.xml`/`K1_22dof_parallel.xml` (MuJoCo), and `motions/K1/*.csv`
+(reference motion clips) not pulled in here.
+
+**Known joint-name mismatch**: `K1_22dof.urdf`'s joint names are SolidWorks-exporter style —
+lowercase, `_joint` suffix (e.g. `aahead_yaw_joint`, `left_shoulder_roll_joint`) — while
+`boosteros.get_joint_states()` returns SDK-style names (e.g. `AAHead_Yaw`, `Left_Shoulder_Roll`,
+and inconsistently `Head_Pitch` in the SDK's own quick-start example output, which doesn't even
+match its neighboring `AAHead_Yaw` naming pattern). `device.py::_load_urdf_joint_name_map()`
+matches by a case/underscore/suffix-normalized key rather than a hardcoded table; **this needs
+re-verification against a real K1** once one is reachable — see the plan's verification section.

--- a/booster/k1/reference/docs/python-sdk/README.md
+++ b/booster/k1/reference/docs/python-sdk/README.md
@@ -1,0 +1,164 @@
+# BoosterOS Python SDK (`boosteros`) — reference notes
+
+Fetched from https://docs.booster.tech/zh-CN/docs/developer-guide/booster-os-python-sdk/ via
+playwright/curl during driver implementation. This is a condensed reference, not a full mirror —
+see `reference/sdk/` for the full C++ SDK + ROS2 IDL source, and the live docs site for anything
+not covered here.
+
+## SDK overview
+
+- PyPI package: `boosteros` (also `booster_robotics_sdk_python` as its low-level dependency,
+  both public on PyPI).
+- Supports Booster K1 / T1 / T2. Requires Python >= 3.10 (boosteros==1.1.1) — **note:**
+  boosteros>=1.1.3 requires Python >=3.12, incompatible with the ROS humble base image
+  (Ubuntu 22.04 / Python 3.10) used by this driver; pinned to 1.1.1 in `requirements.txt`.
+- Runs against a real K1/T1/T2 or a Booster Studio virtual robot only — no other environment.
+- Firmware >= v1.7 required.
+
+## Install & quick start
+
+```bash
+python3 -m pip install boosteros            # base
+python3 -m pip install "boosteros[brain]"   # + Speech/Detection deps (matplotlib, ultralytics, onnx...)
+```
+
+```python
+from boosteros.robots.booster import BoosterRobot
+
+robot = BoosterRobot()
+info = robot.robot_info
+# RobotInfo(manufacturer='Booster Robotics', model='Booster K1', name='vr1', serial_number='rivt9', ...)
+
+mode = robot.get_mode()          # e.g. 'prepare'
+joints = robot.list_joints()     # 22 for K1
+
+joint_states = robot.get_joint_states()
+imu = robot.get_imu()
+img = robot.get_image(img_type="rgb")
+```
+
+## BoosterRobot(...) — initialization
+
+```python
+BoosterRobot(
+    network_interface: str = "",       # reserved, always ""
+    virtual_robot_name: str = "",       # only for multi-virtual-robot mode
+    *,
+    timeout: float = 5.0,               # init/service-discovery timeout (s)
+    callback_workers: int = 4,          # sensor-callback worker threads, >= 1
+    enable_tf_listener: bool = True,    # get_transform() needs this
+    **kwargs,                           # domain_id: int, dds_profile: str (advanced/rare)
+) -> BoosterRobot
+```
+
+**Must be a singleton per robot** — each instance opens its own ROS node, subscriptions, and
+control publisher; more than one causes command conflicts. Raises `LocoClientInitError` if no
+motion service is discovered within `timeout`.
+
+## Info / state retrieval
+
+`robot_info` (property) · `get_mode()` · `list_gaits()` · `get_gait()` · `list_frames()` ·
+`list_joints()` · `list_actions()` · `list_sensors()`
+
+## Sensor snapshot + subscription APIs
+
+Snapshot (blocking, one-shot): `get_image(img_type=...)` · `get_camera_info()` · `get_imu()` ·
+`get_odom()` · `get_joint_states()` · `get_battery()` · `get_fall_down_state()` ·
+`get_transform(...)`
+
+Subscription (push callback, returns a `SensorSubscription` with `.unsubscribe()`):
+`subscribe_image(callback, *, img_type=..., queue_size=0, overflow="drop_oldest")` ·
+`subscribe_imu(callback, *, imu_id="", queue_size=0, overflow=...)` ·
+`subscribe_odom(callback, ...)` · `subscribe_battery(callback, ...)` ·
+`subscribe_fall_down_state(callback, ...)`
+
+**No `subscribe_joint_states`** — this driver polls `get_joint_states()` on a 10 Hz ROS2 timer
+instead (see `device.py::_K1StateNode._poll_joints`).
+
+### IMUState
+
+`linear_acceleration` [x,y,z] m/s², `angular_velocity` [x,y,z] rad/s, `orientation` [x,y,z,w]
+quaternion (**note the order** — CLAUDE.md's `sensor/skeleton` spec wants `imu_quat` as
+`[w,x,y,z]`, so `device.py` reorders it), `rpy` [roll,pitch,yaw] rad, `timestamp`, `frame_id`.
+
+### JointState / JointStates
+
+Per-joint: `name`, `position`, `velocity`, `effort`, `acceleration`, `temperature`.
+`JointStates` is an ordered collection with `.joints`, `.names`, `.get_joint(name)`,
+`__getitem__`, `.to_numpy()`.
+
+### JointCommand (for `set_joints`)
+
+`JointCommand(name: str, position: float, kp: float | None, kd: float | None, ...)` — at least
+`name`+`position`; explicit `kp`/`kd` recommended for position control. K1 has 22 joints
+(2 neck + 4×2 arm + 6×2 leg); T1 has 23 (extra waist joint inserted at index 10).
+
+## Motion control APIs
+
+- `set_mode(mode: str) -> None` — e.g. `"prepare"`, `"walk"`, `"custom"`.
+- `set_gait(gait: str) -> None`
+- `set_velocity(vx: float, vy: float, vyaw: float) -> None` — robot-frame planar velocity,
+  must be in `"walk"` mode first. Start small (<=0.3 m/s vx for first tests).
+- `upper_body_control(enable: bool) -> None` — in `"walk"` mode, hand head+both-arms (first 10
+  joints) to the caller while legs keep walking under the system. Differs from `"custom"` mode,
+  which also takes over the legs.
+- `set_joints(joint_commands: list[JointCommand]) -> None` — batch joint command; the name set
+  must be either *all* joints or exactly the first 10 (upper body).
+- `set_head_angle(pitch: float, yaw: float) -> None` — rad; pitch positive = down, yaw positive
+  = left; out-of-limit does not raise, the robot just stops responding.
+- `reset_odom() -> None`
+
+## Advanced task APIs (all async, return `TaskHandle`)
+
+- `get_active_tasks()`
+- `do_action(action_id: str, *, on_done=None, on_status_change=None) -> TaskHandle[None]` —
+  `action_id` from `list_actions()`.
+- `get_up(*, on_done=None, on_status_change=None) -> TaskHandle[None]` — not cancellable.
+- `execute_trajectory(trajectory: TrajectoryData, *, on_done=None, on_status_change=None)` —
+  `TrajectoryData.load("/path/to/demo.btraj")`, a file produced by the hand-guiding (teach-mode)
+  recorder — out of scope for this driver's initial card set (see config.yaml comment), so
+  `action.execute_trajectory` here only accepts a path already on the robot's filesystem.
+- `play_sound(audio: str | PathLike | AudioData | Iterable[AudioData], *, volume=None, on_done=None, on_status_change=None)`
+  — `audio` is a **local path on the robot** (`.wav`/`.mp3`/`.pcm`) or an in-memory `AudioData`;
+  there is no over-the-wire byte upload in the SDK itself.
+
+### TaskHandle
+
+`.trace_id` (unique per call — used as the ACP `action_id`), `.task_id`, `.type`, `.group`,
+`.status` (`TaskStatus`: RUNNING/SUCCEEDED/FAILED/CANCELLED), `.error`, `.wait(timeout=None)`,
+`.cancel() -> bool`, `.done()`, `.running()`, `.task_info()`,
+`.add_done_callback(fn)` / `.add_status_change_callback(fn)` — used here to bridge into this
+platform's Action Completion Protocol (`device.py::_bind_task_acp`).
+
+## Audio manager (`robot.audio_manager`)
+
+`get_system_volume()` / `set_system_volume(volume: float)` (0.0–1.0, system-wide output, distinct
+from `play_sound(..., volume=)`'s per-call volume) · `start_recording()` / `stop_recording()` /
+`is_recording()` / `get_recording_duration()` · `record_stream()` / `play_stream()` (real-time
+streaming — not exposed as MCP tools here, out of scope for a one-shot JSON-RPC call).
+
+## Vision & speech (`boosteros[brain]`, optional)
+
+`robot.speech`: `recognize_stream(...)`, `chat(text)`, `list_voices()`.
+`robot.detection`: `list_models()`, `load_model(name)`, `detect(image)`, `plot(...)`.
+Gated behind `config.yaml`'s `plugins.speech.enabled` / `plugins.detection.enabled` (default
+`false`) since they require the `[brain]` extra (matplotlib/ultralytics/onnx/onnxruntime).
+
+## Excluded from this driver (see config.yaml comment)
+
+- `robot.hand_guiding_manager` (teach-mode recording) — niche, and `execute_trajectory`'s
+  `.btraj` input already depends on it.
+- `robot.soccer_kick_manager` (auto soccer-kick task) — RoboCup-specific demo feature.
+
+## Common data types index
+
+Time/Header: `Time`, `Duration`, `Header`.
+Sensor/state: `AnyImage` (`Image` | `CompressedImage`), `BoundingBox2D`, `DetectionResult`,
+`CameraInfo`, `RegionOfInterest`, `IMUState`, `OdomState`, `Transform`, `BatteryState`,
+`FallDownState`, `AudioData`, `ImageType`, `PcmSampleFormat`.
+Joints: `JointState`, `JointStates`, `JointCommand`.
+Robot metadata: `RobotInfo`, `JointLimits`, `JointInfo`, `ActionInfo`, `RobotModeName`,
+`RobotGaitName`, `SensorInfo`, `SensorType`.
+Tasks/subscriptions: `TaskHandle`, `TaskInfo`, `TaskStatus`, `OverflowPolicy`,
+`SensorSubscription`, `AudioPlaybackStreamHandle`.
+Trajectory: `TrajectoryMeta`, `JointTrajectoryPoint`, `TrajectoryData`.

--- a/booster/k1/requirements.txt
+++ b/booster/k1/requirements.txt
@@ -1,0 +1,8 @@
+# boosteros>=1.1.3 requires Python >=3.12; the ROS2 humble base image (Ubuntu
+# 22.04) ships Python 3.10, and rclpy's compiled extension is tied to that
+# interpreter — pin below the 3.12 floor instead of juggling a second Python.
+boosteros==1.1.1
+pyyaml>=6.0
+netifaces>=0.11.0
+opencv-python-headless>=4.8
+numpy>=1.24

--- a/booster/k1/resource/k1_model.urdf
+++ b/booster/k1/resource/k1_model.urdf
@@ -1,0 +1,1349 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This URDF was automatically created by SolidWorks to URDF Exporter! Originally created by Stephen Brawner (brawner@gmail.com) 
+     Commit Version: 1.6.0-4-g7f85cfe  Build Version: 1.6.7995.38578
+     For more information, please see http://wiki.ros.org/sw_urdf_exporter -->
+<robot
+  name="K1">
+
+  <!-- <mujoco>
+    <compiler meshdir="meshes/" balanceinertia="true" discardvisual="false"/>
+  </mujoco> -->
+  <!-- for convert to mujoco -->
+  <!-- <link name="world"/>
+  <joint name="world_joint" type="floating">
+    <origin xyz="0 0 0"/>
+    <parent link="world"/>
+    <child link="trunk"/>
+  </joint> -->
+
+  <link
+    name="trunk">
+    <inertial>
+      <origin
+        xyz="-0.0043392 -0.00065534 0.065686"
+        rpy="0 0 0" />
+      <mass
+        value="6.50" />
+      <inertia
+        ixx="0.096159"
+        ixy="-0.000039"
+        ixz="-0.002091"
+        iyy="0.089512"
+        iyz="-0.000567"
+        izz="0.020187" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Trunk.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/K1logo.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.792156862745098 0.819607843137255 0.933333333333333 1" />
+      </material>
+    </visual>      
+    <collision>
+      <origin
+        xyz="0 0 0.1"
+        rpy="0 0 0" />
+      <geometry>
+        <box size="0.12 0.18 0.2" />
+      </geometry>
+    </collision>
+    <collision>
+      <origin
+        xyz="0 0 -0.06"
+        rpy="1.5708 0 0" />
+      <geometry>
+        <cylinder radius="0.05" length="0.1" />
+      </geometry>
+    </collision>
+  </link>
+  <link
+    name="aahead_yaw_link">
+    <inertial>
+      <origin
+        xyz="-0.00069503 -0.00038527 0.031688"
+        rpy="0 0 0" />
+      <mass
+        value="0.30" />
+      <inertia
+        ixx="0.000429"
+        ixy="-0.000002"
+        ixz="-0.000006"
+        iyy="0.000421"
+        iyz="-0.000005"
+        izz="0.000126" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Head_1.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Head_1.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="aahead_yaw_joint"
+    type="revolute">
+    <origin
+      xyz="0.0056 0 0.2149"
+      rpy="0 0 0" />
+    <parent
+      link="trunk" />
+    <child
+      link="aahead_yaw_link" />
+    <axis
+      xyz="0 0 1" />
+    <limit
+      lower="-1.012"
+      upper="1.012"
+      effort="6.0"
+      velocity="7.85"
+    />
+  </joint>
+  <link
+    name="aahead_pitch_link">
+    <inertial>
+      <origin
+        xyz="0.011042 -0.00092871 0.080698"
+        rpy="0 0 0" />
+      <mass
+        value="0.70" />
+      <inertia
+        ixx="0.005927"
+        ixy="-0.000012"
+        ixz="0.000664"
+        iyy="0.005776"
+        iyz="-0.000033"
+        izz="0.001807" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Head_2.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Head_2.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="aahead_pitch_joint"
+    type="revolute">
+    <origin
+      xyz="0 0 0.033"
+      rpy="0 0 0" />
+    <parent
+      link="aahead_yaw_link" />
+    <child
+      link="aahead_pitch_link" />
+    <axis
+      xyz="0 1 0" />
+    <limit
+      lower="-0.314"
+      upper="0.794"
+      effort="6.0"
+      velocity="7.85"
+    />
+  </joint>
+  <link
+    name="aaleft_shoulder_pitch_link">
+    <inertial>
+      <origin
+        xyz="-0.002701 0.062383 -0.011965"
+        rpy="0 0 0" />
+      <mass
+        value="0.50" />
+      <inertia
+        ixx="0.002194"
+        ixy="-0.000084"
+        ixz="0.000017"
+        iyy="0.000331"
+        iyz="-0.000372"
+        izz="0.002139" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Left_Arm_1.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+  </link>
+  <joint
+    name="aaleft_shoulder_pitch_joint"
+    type="revolute">
+    <origin
+      xyz="0 0.077 0.1845"
+      rpy="0 0 0" />
+    <parent
+      link="trunk" />
+    <child
+      link="aaleft_shoulder_pitch_link" />
+    <axis
+      xyz="0 1 0" />
+    <limit
+      lower="-2.932"
+      upper="1.196"
+      effort="14.0"
+      velocity="33.51"
+    />
+  </joint>
+  <link
+    name="left_shoulder_roll_link">
+    <inertial>
+      <origin
+        xyz="0.01729 0.018221 -4.329E-05"
+        rpy="0 0 0" />
+      <mass
+        value="0.09" />
+      <inertia
+        ixx="0.000092"
+        ixy="0.000009"
+        ixz="0.000000"
+        iyy="0.000068"
+        iyz="0.000000"
+        izz="0.000113" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Left_Arm_2.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="-0.007 0 0"
+        rpy="0 1.5708 0" />
+      <geometry>
+        <cylinder radius="0.035" length="0.068" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="left_shoulder_roll_joint"
+    type="revolute">
+    <origin
+      xyz="0.0025 0.068 -0.0135"
+      rpy="0 0 0" />
+    <parent
+      link="aaleft_shoulder_pitch_link" />
+    <child
+      link="left_shoulder_roll_link" />
+    <axis
+      xyz="1 0 0" />
+    <limit
+      lower="-1.642"
+      upper="1.629"
+      effort="14.0"
+      velocity="33.51"
+    />
+  </joint>
+  <link
+    name="left_elbow_pitch_link">
+    <inertial>
+      <origin
+        xyz="-0.0003979 0.072617 -0.00066218"
+        rpy="0 0 0" />
+      <mass
+        value="0.80" />
+      <inertia
+        ixx="0.006069"
+        ixy="-0.000017"
+        ixz="-0.000001"
+        iyy="0.000387"
+        iyz="-0.000079"
+        izz="0.006067" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Left_Arm_3.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Left_Arm_3.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="left_elbow_pitch_joint"
+    type="revolute">
+    <origin
+      xyz="0 0.044428 0"
+      rpy="0 0 0" />
+    <parent
+      link="left_shoulder_roll_link" />
+    <child
+      link="left_elbow_pitch_link" />
+    <axis
+      xyz="0 1 0" />
+    <limit
+      lower="-1.885"
+      upper="1.885"
+      effort="14.0"
+      velocity="33.51"
+    />
+  </joint>
+  <link
+    name="left_elbow_yaw_link">
+    <inertial>
+      <origin
+        xyz="-0.0015751 0.084637 0.0087033"
+        rpy="0 0 0" />
+      <mass
+        value="0.19" />
+      <inertia
+        ixx="0.002056"
+        ixy="-0.000007"
+        ixz="-0.000002"
+        iyy="0.000082"
+        iyz="0.000031"
+        izz="0.002029" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Left_Arm_4.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Left_Arm_4.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="left_elbow_yaw_joint"
+    type="revolute">
+    <origin
+      xyz="0 0.1215 0"
+      rpy="0 0 0" />
+    <parent
+      link="left_elbow_pitch_link" />
+    <child
+      link="left_elbow_yaw_link" />
+    <axis
+      xyz="0 0 1" />
+    <limit
+      lower="-2.242"
+      upper="0.816"
+      effort="14.0"
+      velocity="33.51"
+    />
+  </joint>
+
+  <link
+    name="aaright_shoulder_pitch_link">
+    <inertial>
+      <origin
+        xyz="-0.0026302 -0.06251 -0.01199"
+        rpy="0 0 0" />
+      <mass
+        value="0.50" />
+      <inertia
+        ixx="0.002200"
+        ixy="0.000082"
+        ixz="0.000017"
+        iyy="0.000332"
+        iyz="0.000373"
+        izz="0.002145" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Right_Arm_1.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+  </link>
+  <joint
+    name="aaright_shoulder_pitch_joint"
+    type="revolute">
+    <origin
+      xyz="0 -0.077 0.1845"
+      rpy="0 0 0" />
+    <parent
+      link="trunk" />
+    <child
+      link="aaright_shoulder_pitch_link" />
+    <axis
+      xyz="0 1 0" />
+    <limit
+      lower="-2.932"
+      upper="1.196"
+      effort="14.0"
+      velocity="33.51"
+    />
+  </joint>
+  <link
+    name="right_shoulder_roll_link">
+    <inertial>
+      <origin
+        xyz="0.017229 -0.018428 4.3784E-05"
+        rpy="0 0 0" />
+      <mass
+        value="0.09" />
+      <inertia
+        ixx="0.000092"
+        ixy="-0.000009"
+        ixz="0.000000"
+        iyy="0.000068"
+        iyz="0.000000"
+        izz="0.000113" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Right_Arm_2.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="-0.007 0 0"
+        rpy="0 1.5708 0" />
+      <geometry>
+        <cylinder radius="0.035" length="0.068" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="right_shoulder_roll_joint"
+    type="revolute">
+    <origin
+      xyz="0.0025 -0.068 -0.0135"
+      rpy="0 0 0" />
+    <parent
+      link="aaright_shoulder_pitch_link" />
+    <child
+      link="right_shoulder_roll_link" />
+    <axis
+      xyz="1 0 0" />
+    <limit
+      lower="-1.642"
+      upper="1.629"
+      effort="14.0"
+      velocity="33.51"
+    />
+  </joint>
+  <link
+    name="right_elbow_pitch_link">
+    <inertial>
+      <origin
+        xyz="-0.00039919 -0.072601 -0.00065629"
+        rpy="0 0 0" />
+      <mass
+        value="0.80" />
+      <inertia
+        ixx="0.006070"
+        ixy="0.000017"
+        ixz="-0.000001"
+        iyy="0.000388"
+        iyz="0.000079"
+        izz="0.006068" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Right_Arm_3.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Right_Arm_3.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="right_elbow_pitch_joint"
+    type="revolute">
+    <origin
+      xyz="0 -0.044428 0"
+      rpy="0 0 0" />
+    <parent
+      link="right_shoulder_roll_link" />
+    <child
+      link="right_elbow_pitch_link" />
+    <axis
+      xyz="0 1 0" />
+    <limit
+      lower="-1.885"
+      upper="1.885"
+      effort="14.0"
+      velocity="33.51"
+    />
+  </joint>
+  <link
+    name="right_elbow_yaw_link">
+    <inertial>
+      <origin
+        xyz="-0.0015177 -0.084536 0.0086733"
+        rpy="0 0 0" />
+      <mass
+        value="0.19" />
+      <inertia
+        ixx="0.002056"
+        ixy="0.000005"
+        ixz="-0.000002"
+        iyy="0.000082"
+        iyz="-0.000031"
+        izz="0.002030" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Right_Arm_4.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Right_Arm_4.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="right_elbow_yaw_joint"
+    type="revolute">
+    <origin
+      xyz="0 -0.1215 0"
+      rpy="0 0 0" />
+    <parent
+      link="right_elbow_pitch_link" />
+    <child
+      link="right_elbow_yaw_link" />
+    <axis
+      xyz="0 0 1" />
+    <limit
+      lower="-0.816"
+      upper="2.242"
+      effort="14.0"
+      velocity="33.51"
+    />
+  </joint>
+
+  <link
+    name="left_hip_pitch_link">
+    <inertial>
+      <origin
+        xyz="-0.010093 -0.0019934 -0.024713"
+        rpy="0 0 0" />
+      <mass
+        value="0.69" />
+      <inertia
+        ixx="0.000781"
+        ixy="0.000004"
+        ixz="0.000167"
+        iyy="0.000987"
+        iyz="0.000008"
+        izz="0.000604" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Left_Hip_Pitch.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+  </link>
+  <joint
+    name="left_hip_pitch_joint"
+    type="revolute">
+    <origin
+      xyz="0 0.096 -0.077"
+      rpy="0 0 0" />
+    <parent
+      link="trunk" />
+    <child
+      link="left_hip_pitch_link" />
+    <axis
+      xyz="0 1 0" />
+    <limit
+      lower="-2.958"
+      upper="2.226"
+      effort="68.0"
+      velocity="14.66"
+    />
+  </joint>
+  <link
+    name="left_hip_roll_link">
+    <inertial>
+      <origin
+        xyz="0.023585 0.000049 -0.024996"
+        rpy="0 0 0" />
+      <mass
+        value="0.13" />
+      <inertia
+        ixx="0.000191"
+        ixy="0.000000"
+        ixz="-0.000048"
+        iyy="0.000262"
+        iyz="0.000000"
+        izz="0.000150" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Left_Hip_Roll.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="0 0 0"
+        rpy="0 1.5708 0" />
+      <geometry>
+        <cylinder radius="0.036" length="0.094" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="left_hip_roll_joint"
+    type="revolute">
+    <origin
+      xyz="0 0 -0.026"
+      rpy="0 0 0" />
+    <parent
+      link="left_hip_pitch_link" />
+    <child
+      link="left_hip_roll_link" />
+    <axis
+      xyz="1 0 0" />
+    <limit
+      lower="-0.375"
+      upper="1.536"
+      effort="43.0"
+      velocity="12.57"
+    />
+  </joint>
+  <link
+    name="left_hip_yaw_link">
+    <inertial>
+      <origin
+        xyz="-0.0084744 -0.0040494 -0.087906"
+        rpy="0 0 0" />
+      <mass
+        value="1.65" />
+      <inertia
+        ixx="0.015786"
+        ixy="0.000096"
+        ixz="0.001546"
+        iyy="0.016140"
+        iyz="0.000745"
+        izz="0.001551" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Left_Hip_Yaw.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="0 0 -0.03"
+        rpy="0 0 0" />
+      <geometry>
+        <cylinder radius="0.04" length="0.066" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="left_hip_yaw_joint"
+    type="revolute">
+    <origin
+      xyz="0.012 0 -0.0485"
+      rpy="0 0 0" />
+    <parent
+      link="left_hip_roll_link" />
+    <child
+      link="left_hip_yaw_link" />
+    <axis
+      xyz="0 0 1" />
+    <limit
+      lower="-1.012"
+      upper="1.012"
+      effort="38.3"
+      velocity="17.59"
+    />
+  </joint>
+  <link
+    name="left_knee_pitch_link">
+    <inertial>
+      <origin
+        xyz="-0.00081083 0.0031459 -0.10922"
+        rpy="0 0 0" />
+      <mass
+        value="1.50" />
+      <inertia
+        ixx="0.023681"
+        ixy="0.000035"
+        ixz="0.000222"
+        iyy="0.023670"
+        iyz="-0.000105"
+        izz="0.001240" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Left_Shank.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="0 0 0"
+        rpy="1.5708 0 0" />
+      <geometry>
+        <cylinder radius="0.045" length="0.07" />
+      </geometry>
+    </collision>
+    <collision>
+      <origin
+        xyz="0 0 -0.13"
+        rpy="0 0 0" />
+      <geometry>
+        <box size="0.06 0.06 0.10" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="left_knee_pitch_joint"
+    type="revolute">
+    <origin
+      xyz="-0.014 0 -0.117"
+      rpy="0 0 0" />
+    <parent
+      link="left_hip_yaw_link" />
+    <child
+      link="left_knee_pitch_link" />
+    <axis
+      xyz="0 1 0" />
+    <limit
+      lower="0."
+      upper="2.321"
+      effort="112.0"
+      velocity="12.57"
+    />
+  </joint>
+  <link
+    name="left_ankle_pitch_link">
+    <inertial>
+      <origin
+        xyz="0.000000 0.000000 0.000000"
+        rpy="0 0 0" />
+      <mass
+        value="0.039" />
+      <inertia
+        ixx="0.000002"
+        ixy="0.000000"
+        ixz="0.000000"
+        iyy="0.000004"
+        iyz="0.000000"
+        izz="0.000004" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Left_Ankle_Cross.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+  </link>
+  <joint
+    name="left_ankle_pitch_joint"
+    type="revolute">
+    <origin
+      xyz="0.00019706 0.0002 -0.24519"
+      rpy="0 0 0" />
+    <parent
+      link="left_knee_pitch_link" />
+    <child
+      link="left_ankle_pitch_link" />
+    <axis
+      xyz="0 1 0" />
+    <limit
+      lower="-0.87"
+      upper="0.345"
+      effort="38.3"
+      velocity="17.59"
+    />
+  </joint>
+  <link
+    name="left_ankle_roll_link">
+    <inertial>
+      <origin
+        xyz="0.011662 0.000244 -0.014364"
+        rpy="0 0 0" />
+      <mass
+        value="0.494" />
+      <inertia
+        ixx="0.000261"
+        ixy="0.0000003"
+        ixz="-0.000115"
+        iyy="0.001170"
+        iyz="-0.0000002"
+        izz="0.001213" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Left_Foot.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Left_Foot.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="left_ankle_roll_joint"
+    type="revolute">
+    <origin
+      xyz="0 0 0"
+      rpy="0 0 0" />
+    <parent
+      link="left_ankle_pitch_link" />
+    <child
+      link="left_ankle_roll_link" />
+    <axis
+      xyz="1 0 0" />
+    <limit
+      lower="-0.345"
+      upper="0.345"
+      effort="38.3"
+      velocity="17.59"
+    />
+  </joint>
+
+  <link
+    name="right_hip_pitch_link">
+    <inertial>
+      <origin
+        xyz="-0.010065 0.0020086 -0.024739"
+        rpy="0 0 0" />
+      <mass
+        value="0.69" />
+      <inertia
+        ixx="0.000782"
+        ixy="-0.000004"
+        ixz="0.000166"
+        iyy="0.000988"
+        iyz="-0.000009"
+        izz="0.000604" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Right_Hip_Pitch.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+  </link>
+  <joint
+    name="right_hip_pitch_joint"
+    type="revolute">
+    <origin
+      xyz="0 -0.096 -0.077"
+      rpy="0 0 0" />
+    <parent
+      link="trunk" />
+    <child
+      link="right_hip_pitch_link" />
+    <axis
+      xyz="0 1 0" />
+    <limit
+      lower="-2.958"
+      upper="2.226"
+      effort="68.0"
+      velocity="14.66"
+    />
+  </joint>
+  <link
+    name="right_hip_roll_link">
+    <inertial>
+      <origin
+        xyz="0.023585 0.000049 -0.024996"
+        rpy="0 0 0" />
+      <mass
+        value="0.13" />
+      <inertia
+        ixx="0.000191"
+        ixy="0.000000"
+        ixz="-0.000048"
+        iyy="0.000262"
+        iyz="0.000000"
+        izz="0.000150" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Right_Hip_Roll.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="0 0 0"
+        rpy="0 1.5708 0" />
+      <geometry>
+        <cylinder radius="0.036" length="0.094" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="right_hip_roll_joint"
+    type="revolute">
+    <origin
+      xyz="0 0 -0.026"
+      rpy="0 0 0" />
+    <parent
+      link="right_hip_pitch_link" />
+    <child
+      link="right_hip_roll_link" />
+    <axis
+      xyz="1 0 0" />
+    <limit
+      lower="-1.536"
+      upper="0.375"
+      effort="43.0"
+      velocity="12.57"
+  />
+  </joint>
+  <link
+    name="right_hip_yaw_link">
+    <inertial>
+      <origin
+        xyz="-0.008475 0.0040392 -0.087906"
+        rpy="0 0 0" />
+      <mass
+        value="1.65" />
+      <inertia
+        ixx="0.015786"
+        ixy="-0.000096"
+        ixz="0.001546"
+        iyy="0.016140"
+        iyz="-0.000745"
+        izz="0.001551" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Right_Hip_Yaw.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="0 0 -0.03"
+        rpy="0 0 0" />
+      <geometry>
+        <cylinder radius="0.04" length="0.066" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="right_hip_yaw_joint"
+    type="revolute">
+    <origin
+      xyz="0.012 0 -0.0485"
+      rpy="0 0 0" />
+    <parent
+      link="right_hip_roll_link" />
+    <child
+      link="right_hip_yaw_link" />
+    <axis
+      xyz="0 0 1" />
+    <limit
+      lower="-1.012"
+      upper="1.012"
+      effort="38.3"
+      velocity="17.59"
+    />
+  </joint>
+  <link
+    name="right_knee_pitch_link">
+    <inertial>
+      <origin
+        xyz="-0.000805 -0.003146 -0.109215"
+        rpy="0 0 0" />
+      <mass
+        value="1.50" />
+      <inertia
+        ixx="0.023681"
+        ixy="-0.000035"
+        ixz="0.000221"
+        iyy="0.023670"
+        iyz="0.000105"
+        izz="0.001240" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Right_Shank.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="0 0 0"
+        rpy="1.5708 0 0" />
+      <geometry>
+        <cylinder radius="0.045" length="0.07" />
+      </geometry>
+    </collision>
+    <collision>
+      <origin
+        xyz="0 0 -0.13"
+        rpy="0 0 0" />
+      <geometry>
+        <box size="0.06 0.06 0.1" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="right_knee_pitch_joint"
+    type="revolute">
+    <origin
+      xyz="-0.014 0 -0.117"
+      rpy="0 0 0" />
+    <parent
+      link="right_hip_yaw_link" />
+    <child
+      link="right_knee_pitch_link" />
+    <axis
+      xyz="0 1 0" />
+    <limit
+      lower="0."
+      upper="2.321"
+      effort="112.0"
+      velocity="12.57"
+    />
+  </joint>
+  <link
+    name="right_ankle_pitch_link">
+    <inertial>
+      <origin
+        xyz="0.000000 0.000000 0.000000"
+        rpy="0 0 0" />
+      <mass
+        value="0.039" />
+      <inertia
+        ixx="0.000002"
+        ixy="0.000000"
+        ixz="0.000000"
+        iyy="0.000004"
+        iyz="0.000000"
+        izz="0.000004" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Right_Ankle_Cross.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+  </link>
+  <joint
+    name="right_ankle_pitch_joint"
+    type="revolute">
+    <origin
+      xyz="0.00019706 -0.0002 -0.24519"
+      rpy="0 0 0" />
+    <parent
+      link="right_knee_pitch_link" />
+    <child
+      link="right_ankle_pitch_link" />
+    <axis
+      xyz="0 1 0" />
+    <limit
+      lower="-0.87"
+      upper="0.345"
+      effort="38.3"
+      velocity="17.59"
+    />
+  </joint>
+  <link
+    name="right_ankle_roll_link">
+    <inertial>
+      <origin
+        xyz="0.011662 -0.000244 -0.014364"
+        rpy="0 0 0" />
+      <mass
+        value="0.494" />
+      <inertia
+        ixx="0.000261"
+        ixy="-0.0000003"
+        ixz="-0.000115"
+        iyy="0.001170"
+        iyz="0.0000002"
+        izz="0.001213" />
+    </inertial>
+    <visual>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Right_Foot.STL" />
+      </geometry>
+      <material
+        name="">
+        <color
+          rgba="0.75294 0.75294 0.75294 1" />
+      </material>
+    </visual>
+    <collision>
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <geometry>
+        <mesh
+          filename="meshes/Right_Foot.STL" />
+      </geometry>
+    </collision>
+  </link>
+  <joint
+    name="right_ankle_roll_joint"
+    type="revolute">
+    <origin
+      xyz="0 0 0"
+      rpy="0 0 0" />
+    <parent
+      link="right_ankle_pitch_link" />
+    <child
+      link="right_ankle_roll_link" />
+    <axis
+      xyz="1 0 0" />
+    <limit
+      lower="-0.345"
+      upper="0.345"
+      effort="38.3"
+      velocity="17.59"
+    />
+  </joint>
+ 
+  <link name="head_realsense_rgb_link" />
+  <joint name="head_realsense_rgb_joint" type="fixed">
+    <origin xyz="0.053617 -0.0115 0.10231" rpy="-1.835388 0 -1.570796" />
+    <parent link="aahead_pitch_link" />
+    <child link="head_realsense_rgb_link" />
+  </joint>
+
+  <link name="head_booster_stereo_rgb_link" />
+  <joint name="head_booster_stereo_rgb_joint" type="fixed">
+    <origin xyz="0.060138 0.0351 0.092774" rpy="-1.570796 0 -1.570796" />
+    <parent link="aahead_pitch_link" />
+    <child link="head_booster_stereo_rgb_link" />
+  </joint>
+</robot>


### PR DESCRIPTION
## Summary
- New MCP driver for the Booster K1 (22DOF biped) at `booster/k1/`, modeled on `unitree/g1`'s plugin/dispatch skeleton but built around `boosteros` — K1's official pip-installable Python SDK — instead of a vendored SDK.
- Cards: `state` (imu/battery/joints-skeleton/odom/fall_down_state + URDF resource), `camera`, `loco` (mode/gait/velocity/head/odom-reset), `upper_body` (custom joint control), `action` (do_action/get_up/execute_trajectory via ACP), `audio` (play_sound via ACP + volume/recording). `speech`/`detection` are present but disabled by default (require `boosteros[brain]`). Teach-mode and auto-soccer-kick were intentionally left out as niche/RoboCup-specific.
- `resource/k1_model.urdf` (K1_22dof) pulled from `booster_assets`, with a normalization-based joint-name lookup in `device.py` to bridge a real naming mismatch between the URDF and `boosteros.get_joint_states()` names (documented in `reference/docs/cpp-sdk/README.md`).
- `reference/` holds condensed SDK docs plus zip snapshots of the two BoosterRobotics SDK repos (fetched via `codeload.github.com`/GitHub's contents API, not `git clone` — faster and worked around `raw.githubusercontent.com` being unreachable from the dev environment). Excluded from the Docker image via `.dockerignore`.
- Port 15705 (next free slot in 15700–15799), added to the README driver table.
- `boosteros` pinned to `1.1.1` in `requirements.txt`/`Dockerfile`: 1.1.3+ requires Python ≥3.12, incompatible with the ROS humble base image's Python 3.10.

## Test plan
- [x] `python3 -m py_compile main.py device.py`
- [x] YAML validity of `config.yaml`/`driver.yaml`
- [x] Stubbed `rclpy`/ROS2 message types locally and exercised every plugin's `get_tool()`/`get_tools()` schema plus `start`/`stop`/`info`/`model` dispatch with a disconnected robot — confirms valid, JSON-serializable tool schemas and graceful degradation when `BoosterRobot()` can't connect
- [ ] Docker image build (not run — no reachable Docker daemon in the dev environment)
- [ ] End-to-end against a real K1 or Booster Studio virtual robot (none reachable in the dev environment) — actuator/motion behavior and the joint-name mapping are **unverified against real hardware** and should be checked before relying on them

🤖 Generated with [Claude Code](https://claude.com/claude-code)