### PR TITLE
feat: add per-bundle MCP card manifests for resource-center marketplace

### DIFF
--- a/booster/k1/driver.yaml
+++ b/booster/k1/driver.yaml
@@ -9,3 +9,18 @@ mcp_url: "http://localhost:15705/mcp"
 description: "Booster K1 — 22DOF 双足人形机器人，IMU/关节/电池/跌倒/里程计感知、相机、行走与上身关节控制、动作/起身/轨迹/音频异步任务"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `plugins.*.enabled` — speech and
+# detection are disabled by default (require boosteros[brain]) and excluded.
+cards:
+  - { name: imu,             type: sensor }
+  - { name: battery,         type: sensor }
+  - { name: joints,          type: sensor }
+  - { name: odom,            type: sensor }
+  - { name: fall_down_state, type: sensor }
+  - { name: model,           type: resource }
+  - { name: camera,          type: sensor }
+  - { name: loco,            type: actuator }
+  - { name: upper_body,      type: actuator }
+  - { name: action,          type: actuator }
+  - { name: audio,           type: actuator }

--- a/brainco/revo2/driver.yaml
+++ b/brainco/revo2/driver.yaml
@@ -9,3 +9,11 @@ mcp_url: "http://localhost:15706/mcp"
 description: "BrainCo Revo 2 灵巧手 — 6主动关节/11自由度控制、状态遥测、预设手势、LED，触觉版附带指尖触觉数据"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `plugins.*.enabled`. hand_touch is
+# excluded: config.yaml has it enabled, but device.py's build_plugins() only
+# loads it when variant=="touch", and this config's variant is "basic".
+cards:
+  - { name: hand,       type: actuator }
+  - { name: hand_state, type: sensor }
+  - { name: model,      type: resource }

--- a/build.sh
+++ b/build.sh
@@ -90,6 +90,7 @@ declare -a DRIVER_CATS
 declare -a DRIVER_PROVIDERS
 declare -a DRIVER_MODELS
 declare -a DRIVER_BUILDABLE   # "yes" / "no (no Dockerfile)"
+declare -a DRIVER_CARDS       # JSON array, e.g. [{"name":"base_drive","type":"actuator"}]
 
 _parse_yaml_field() {
     local file="$1" field="$2" val
@@ -103,6 +104,34 @@ _parse_yaml_list() {
     # Extract items under a YAML list key (simple single-level list)
     local file="$1" field="$2"
     awk "/^${field}:/{found=1; next} found && /^  - /{print \$2; next} found && !/^  /{exit}" "${file}" 2>/dev/null || true
+}
+
+_parse_yaml_cards_json() {
+    # Extract the optional `cards:` list into a compact JSON array for
+    # resource-center's driver marketplace listing. Entries must be flow-style,
+    # one per line: `- { name: base_drive, type: actuator }` — no PyYAML
+    # dependency, kept in the same bash-parsing style as the helpers above.
+    # Absent/empty field -> "[]".
+    local file="$1" items
+    items=$(awk '
+        /^cards:/ { found=1; next }
+        found && /^[[:space:]]*-/ {
+            line=$0
+            name=""; type=""
+            if (match(line, /name:[[:space:]]*[A-Za-z0-9_]+/)) {
+                name=substr(line, RSTART, RLENGTH); sub(/^name:[[:space:]]*/, "", name)
+            }
+            if (match(line, /type:[[:space:]]*[A-Za-z0-9_]+/)) {
+                type=substr(line, RSTART, RLENGTH); sub(/^type:[[:space:]]*/, "", type)
+            }
+            if (name != "") {
+                printf "%s{\"name\":\"%s\",\"type\":\"%s\"}", (n++ ? "," : ""), name, type
+            }
+            next
+        }
+        found && !/^[[:space:]]*-/ { exit }
+    ' "${file}" 2>/dev/null) || true
+    echo "[${items}]"
 }
 
 for yaml_file in "${SCRIPT_DIR}"/*/*/driver.yaml "${SCRIPT_DIR}"/*/driver.yaml; do
@@ -122,6 +151,7 @@ for yaml_file in "${SCRIPT_DIR}"/*/*/driver.yaml "${SCRIPT_DIR}"/*/driver.yaml; 
     DRIVER_PROVIDERS+=("$(_parse_yaml_field "${yaml_file}" hardware_provider)")
     DRIVER_MODELS+=("$(_parse_yaml_field "${yaml_file}" hardware_model)")
     DRIVER_BUILDABLE+=("${has_dockerfile}")
+    DRIVER_CARDS+=("$(_parse_yaml_cards_json "${yaml_file}")")
 done
 
 if [ ${#DRIVER_DIRS[@]} -eq 0 ]; then
@@ -329,6 +359,7 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
             desc="${DRIVER_DESCS[$idx]}"
             hw_provider="${DRIVER_PROVIDERS[$idx]:-}"
             hw_model="${DRIVER_MODELS[$idx]:-}"
+            cards="${DRIVER_CARDS[$idx]:-[]}"
             FULL_IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/${hw_provider}/${hw_model}:${TAG}"
 
             # 架构 facet（resource-center 据此过滤目录，见 resource-center/lib/arch.ts）。
@@ -346,7 +377,8 @@ if ${PUSH_ENABLED} && [ -n "${RESOURCE_CENTER_API_KEY:-}" ]; then
   \"hardware_model\": \"${hw_model}\",
   \"name\": \"${name}\",
   \"description\": \"${desc}\",
-  \"port\": ${port:-null}
+  \"port\": ${port:-null},
+  \"cards\": ${cards}
 }"
 
             http_code=$(curl -s -o /tmp/rc_register_resp.json -w "%{http_code}" \

--- a/deep_robotics/lynx_m20/driver.yaml
+++ b/deep_robotics/lynx_m20/driver.yaml
@@ -9,3 +9,31 @@ mcp_url: "http://localhost:15716/mcp"
 description: "Lynx M20 official ROS 2/Fast DDS motion and perception interfaces, native basic_server TCP/UDP control, and Standard/Pro capability isolation"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `model_variant` — this bundle has no
+# per-plugin enabled flags; M20ProNavigationPlugin (tool: navigation) and the
+# Pro-only "odometry" sensor stream are gated purely by `model_variant: pro`
+# in device.py's build_plugins()/M20Nodes, and are excluded here because
+# config.yaml currently sets model_variant: "standard".
+cards:
+  - { name: state,                 type: sensor }
+  - { name: motion_info,           type: sensor }
+  - { name: imu,                   type: sensor }
+  - { name: lidar,                 type: sensor }
+  - { name: lidar_rear,            type: sensor }
+  - { name: hard_estop,            type: sensor }
+  - { name: charge_status,         type: sensor }
+  - { name: gps,                   type: sensor }
+  - { name: joints,                type: sensor }
+  - { name: camera_front,          type: sensor }
+  - { name: camera_rear,           type: sensor }
+  - { name: native_motion_status,  type: sensor }
+  - { name: native_device_status,  type: sensor }
+  - { name: native_basic_status,   type: sensor }
+  - { name: errors,                type: sensor }
+  - { name: capabilities,          type: sensor }
+  - { name: ros_graph,             type: sensor }
+  - { name: motion_events,         type: sensor }
+  - { name: motion,                type: actuator }
+  - { name: charging,              type: actuator }
+  - { name: device,                type: actuator }

--- a/dji/M300/driver.yaml
+++ b/dji/M300/driver.yaml
@@ -9,3 +9,16 @@ mcp_url: "http://localhost:15702/mcp"
 description: "DJI Matrice 300 RTK — 飞行控制 + 遥测 + 感知 + HMS + 飞机信息"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `plugins.*.enabled` — all six
+# plugins (telemetry, camera_stream, perception, hms, flight, time_sync) are
+# enabled. hms.py's hidden test-only tools (hms_inject, hms_eliminate) are
+# excluded since main.py filters `hidden: true` tools out of the visible
+# listing; time_sync's tool is named `aircraft_info` in device.py.
+cards:
+  - { name: telemetry,     type: sensor }
+  - { name: camera_stream, type: sensor }
+  - { name: perception,    type: sensor }
+  - { name: hms,           type: sensor }
+  - { name: flight,        type: actuator }
+  - { name: aircraft_info, type: actuator }

--- a/dji/mavic3e/driver.yaml
+++ b/dji/mavic3e/driver.yaml
@@ -9,3 +9,18 @@ mcp_url: "http://localhost:15702/mcp"
 description: "DJI Mavic 3E/3T — 飞行控制 + 相机(广角/变焦/红外) + 云台 + 航点任务 + 遥测 + 感知 + 红外测温"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `plugins.*.enabled` — all 9 plugins
+# are enabled here, each exposing exactly one tool; main.py always adds the
+# unconditional `model` resource tool regardless of plugin config.
+cards:
+  - { name: telemetry,      type: sensor }
+  - { name: camera_stream,  type: sensor }
+  - { name: perception,     type: sensor }
+  - { name: hms,            type: sensor }
+  - { name: flight,         type: actuator }
+  - { name: camera,         type: actuator }
+  - { name: gimbal,         type: actuator }
+  - { name: waypoint,       type: actuator }
+  - { name: aircraft_info,  type: actuator }
+  - { name: model,          type: resource }

--- a/dji/mavic4e/driver.yaml
+++ b/dji/mavic4e/driver.yaml
@@ -9,3 +9,20 @@ mcp_url: "http://localhost:15703/mcp"
 description: "DJI Mavic 4E/4T — 飞行控制 + 相机 + 云台 + 航点任务 + 遥测 + 感知"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `plugins.*.enabled` — all 9 plugins
+# are currently enabled there, plus main.py's always-on `model` resource tool.
+# Note: device.py's docstring/section header mention a SpeakerPlugin (喊话器)
+# but no such class exists in the file and main.py never loads it — dead
+# reference, intentionally excluded.
+cards:
+  - { name: telemetry,     type: sensor }
+  - { name: camera_stream, type: sensor }
+  - { name: perception,    type: sensor }
+  - { name: hms,           type: sensor }
+  - { name: flight,        type: actuator }
+  - { name: camera,        type: actuator }
+  - { name: gimbal,        type: actuator }
+  - { name: waypoint,      type: actuator }
+  - { name: aircraft_info, type: actuator }
+  - { name: model,         type: resource }

--- a/engineai/t800/driver.yaml
+++ b/engineai/t800/driver.yaml
@@ -9,3 +9,55 @@ mcp_url: "http://localhost:15708/mcp"
 description: "EngineAI T800 开发版 — speaker 音频播放、loco 安全运动、gait 步态切换、motion_recorder 录制回放、head 头部控制，以及 ROS2/Native SDK、全身状态、舞蹈/手势、虚拟手柄与 LED 控制"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `plugins.*.enabled` (all plugins are
+# currently enabled). One config key can gate several tool names when a
+# plugin class exposes multiple cards: `state` covers joints..mainboard plus
+# driver_health/model, and `vision` covers pointcloud/camera/depth.
+cards:
+  - { name: joints,                  type: sensor }
+  - { name: imu,                     type: sensor }
+  - { name: battery,                 type: sensor }
+  - { name: motor_health,            type: sensor }
+  - { name: motor_state,             type: sensor }
+  - { name: motor_command,           type: sensor }
+  - { name: joint_command_feedback,  type: sensor }
+  - { name: gamepad,                 type: sensor }
+  - { name: motion_state,            type: sensor }
+  - { name: robot_snapshot,          type: sensor }
+  - { name: fault_summary,           type: sensor }
+  - { name: stability,               type: sensor }
+  - { name: joint_groups,            type: sensor }
+  - { name: capabilities,            type: sensor }
+  - { name: ros_graph,               type: sensor }
+  - { name: mainboard,               type: sensor }
+  - { name: driver_health,           type: actuator }
+  - { name: model,                   type: resource }
+  - { name: motion_events,           type: actuator }
+  - { name: heartbeat_status,        type: sensor }
+  - { name: motion_command_trace,    type: sensor }
+  - { name: native_interface_probe,  type: sensor }
+  - { name: loco,                    type: actuator }
+  - { name: safe_motion_mode,        type: actuator }
+  - { name: dance,                   type: actuator }
+  - { name: joint_plan,              type: actuator }
+  - { name: gesture,                 type: actuator }
+  - { name: head,                    type: actuator }
+  - { name: joint_override,          type: actuator }
+  - { name: joint_bridge,            type: actuator }
+  - { name: led,                     type: actuator }
+  - { name: tts,                     type: actuator }
+  - { name: motor_power,             type: actuator }
+  - { name: native_node_control,     type: actuator }
+  - { name: virtual_gamepad,         type: actuator }
+  - { name: controlled_spatial,      type: actuator }
+  - { name: controlled_spatial_map,  type: sensor }
+  - { name: safety,                  type: actuator }
+  - { name: native_sdk,              type: actuator }
+  - { name: mic,                     type: sensor }
+  - { name: speaker,                 type: actuator }
+  - { name: pointcloud,              type: sensor }
+  - { name: camera,                  type: sensor }
+  - { name: depth,                   type: sensor }
+  - { name: gait,                    type: actuator }
+  - { name: motion_recorder,         type: actuator }

--- a/noetix/bumi/driver.yaml
+++ b/noetix/bumi/driver.yaml
@@ -9,3 +9,20 @@ mcp_url: "http://localhost:15704/mcp"
 description: "Noetix Bumi-EDU — 麦克风、扬声器、摄像头、整机运动遥测、移动、起身收纳、预设动作和动作示教"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `plugins.*.enabled` (all six are
+# currently enabled: state, loco, mic, speaker, camera, motion_state).
+cards:
+  - { name: imu,               type: sensor }
+  - { name: battery,           type: sensor }
+  - { name: joints,            type: sensor }
+  - { name: model,             type: resource }
+  - { name: loco,              type: actuator }
+  - { name: stand_up_lie_prone, type: actuator }
+  - { name: semantic_action,   type: actuator }
+  - { name: action_recording,  type: actuator }
+  - { name: mic,               type: sensor }
+  - { name: speaker,           type: actuator }
+  - { name: camera,            type: sensor }
+  - { name: depth,             type: sensor }
+  - { name: motion_state,      type: sensor }

--- a/pndbotics/adam/driver.yaml
+++ b/pndbotics/adam/driver.yaml
@@ -9,3 +9,20 @@ mcp_url: "http://localhost:15702/mcp"
 description: "PNDbotics Adam — 状态感知 + 手部状态 + 持续手部控制 + 步行运动 + 手臂控制 + 3D模型"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `plugins.*.enabled` — all six plugins
+# (state, loco, camera, arm, hand, model) are currently enabled, so every tool
+# they expose is listed. camera_pointcloud is included even though its nested
+# `camera.pointcloud.enabled` defaults to false — that only gates whether the
+# point-cloud stream auto-starts, not whether the card is discoverable.
+cards:
+  - { name: joints,             type: sensor }
+  - { name: imu,                type: sensor }
+  - { name: battery,            type: sensor }
+  - { name: loco,               type: actuator }
+  - { name: arm,                type: actuator }
+  - { name: hand,                type: actuator }
+  - { name: camera_head,         type: sensor }
+  - { name: camera_depth,        type: sensor }
+  - { name: camera_pointcloud,   type: sensor }
+  - { name: model,               type: resource }

--- a/robotera/q5_bundle/driver.yaml
+++ b/robotera/q5_bundle/driver.yaml
@@ -9,3 +9,30 @@ mcp_url: "http://localhost:15793/mcp"
 description: "RobotEra Q5 state driver with guarded runtime-locked control cards and action-specific canvas forms"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `plugins.*.enabled` — disabled/merged
+# plugins (robot_ready, system_health, estop, diagnostics, simple_action) are
+# intentionally excluded, and joints.py's extra `model` resource tool is included.
+cards:
+  - { name: base_drive,        type: actuator }
+  - { name: joints,            type: sensor }
+  - { name: joints_state,      type: sensor }
+  - { name: battery,           type: sensor }
+  - { name: hand_state,        type: sensor }
+  - { name: mic,               type: sensor }
+  - { name: speaker,           type: actuator }
+  - { name: audio,             type: actuator }
+  - { name: camera_rgb,        type: sensor }
+  - { name: camera_depth,      type: sensor }
+  - { name: camera_pointcloud, type: sensor }
+  - { name: arm_control,       type: actuator }
+  - { name: hand_control,      type: actuator }
+  - { name: hand_gesture,      type: actuator }
+  - { name: arm_gesture,       type: actuator }
+  - { name: head_control,      type: actuator }
+  - { name: leg_control,       type: actuator }
+  - { name: waist_control,     type: actuator }
+  - { name: odom,              type: sensor }
+  - { name: teleop_state,      type: sensor }
+  - { name: robot_status,      type: sensor }
+  - { name: model,             type: resource }

--- a/unitree/g1/driver.yaml
+++ b/unitree/g1/driver.yaml
@@ -9,3 +9,37 @@ mcp_url: "http://localhost:15701/mcp"
 description: "Unitree G1 — 麦克风 + 内置TTS + LED + 运动控制 + 手臂动作 + 状态感知"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `plugins.*.enabled` — `slam` is
+# disabled there (superseded by controlled_spatial/controlled_spatial_map) so
+# its tools (pos_tag, slam_mapping, slam_cloud, spatial) are excluded.
+# `smart_motion` and `safety_harness` are on by default even though absent
+# from config.yaml's plugins block (main.py defaults them to enabled=True).
+cards:
+  - { name: mic,                    type: sensor }
+  - { name: tts,                    type: actuator }
+  - { name: speaker,                type: actuator }
+  - { name: led,                    type: actuator }
+  - { name: loco_state,             type: sensor }
+  - { name: loco_motion_state,      type: sensor }
+  - { name: motion_events,          type: sensor }
+  - { name: loco,                   type: actuator }
+  - { name: switch_mode,            type: actuator }
+  - { name: switch_mode_expert,     type: actuator }
+  - { name: arm,                    type: actuator }
+  - { name: posture,                type: sensor }
+  - { name: imu,                    type: sensor }
+  - { name: battery,                type: sensor }
+  - { name: joints,                 type: sensor }
+  - { name: mainboard,              type: sensor }
+  - { name: model,                  type: resource }
+  - { name: camera_rgb,             type: sensor }
+  - { name: camera_depth,           type: sensor }
+  - { name: camera_distance,        type: sensor }
+  - { name: lidar_cloud,            type: sensor }
+  - { name: controlled_spatial,     type: actuator }
+  - { name: controlled_spatial_map, type: sensor }
+  - { name: motion_switcher,        type: actuator }
+  - { name: ext_mic,                type: sensor }
+  - { name: ext_camera,             type: sensor }
+  - { name: smart_motion,           type: actuator }

--- a/unitree/go1/driver.yaml
+++ b/unitree/go1/driver.yaml
@@ -9,3 +9,36 @@ mcp_url: "http://localhost:15715/mcp"
 description: "Unitree Go1 (EDU) 状态+控制驱动（原始 unitree_legged_sdk）。卡片实现聚合在 sensors.py、controllers.py、ext_devices.py 与 camera.py 四个文件中；camera.py 向 AgentCore 独立注册 camera_rgb、camera_depth、camera_pointcloud 三张五机位视觉卡，分别输出 RGB、彩色深度、XYZ 点云（点云保留 JPEG 俯视预览）。三种流在同一物理机位互斥。其余卡提供 Go1 状态、运动控制、外设和 URDF 资源；beep/speaker 与视觉 Nano 后端由容器首启自动部署。"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `plugins.*.enabled`. camera_depth and
+# camera_pointcloud are disabled (Nano needs DEPTH_ENABLE=1 / PCL_ENABLE=1) and
+# excluded. `system_health` is intentionally excluded too: config.yaml has a
+# YAML indentation bug (line ~18) that nests `system_health:` as a dead key
+# inside `face_light`'s mapping instead of a sibling plugin key, so
+# `pc.get("system_health", {})` in main.py never finds it and the card never
+# loads — confirmed by parsing config.yaml with PyYAML. Fix that indentation
+# bug first if system_health should ship. activity_monitor is listed as
+# `actuator` because that's what its own get_tool() declares in sensors.py,
+# even though the card is read-only (samples velocity/mode, action=report).
+cards:
+  - { name: loco_state,         type: sensor }
+  - { name: battery,            type: sensor }
+  - { name: face_light,         type: actuator }
+  - { name: camera_rgb,         type: sensor }
+  - { name: imu,                type: sensor }
+  - { name: feet,               type: sensor }
+  - { name: fall_alarm,         type: sensor }
+  - { name: odometry,           type: sensor }
+  - { name: obstacle_range,     type: sensor }
+  - { name: udp_diagnostics,    type: sensor }
+  - { name: joints,             type: sensor }
+  - { name: remote_controller,  type: sensor }
+  - { name: model,              type: resource }
+  - { name: activity_monitor,   type: actuator }
+  - { name: beep,               type: actuator }
+  - { name: speaker,            type: actuator }
+  - { name: loco,               type: actuator }
+  - { name: body_pose,          type: actuator }
+  - { name: gesture,            type: actuator }
+  - { name: switch_gait,        type: actuator }
+  - { name: special_motion,     type: actuator }

--- a/unitree/go2/driver.yaml
+++ b/unitree/go2/driver.yaml
@@ -9,3 +9,30 @@ mcp_url: "http://localhost:15703/mcp"
 description: "Unitree Go2 — 运动控制 + 避障 + 语音 + 视频 + 导航"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `plugins.*.enabled` — controlled_spatial
+# is disabled here (spatial plugin covers SLAM/nav instead), so its tool is excluded.
+cards:
+  - { name: mic,           type: sensor }
+  - { name: speaker,       type: actuator }
+  - { name: vui,           type: actuator }
+  - { name: loco_state,    type: sensor }
+  - { name: loco,          type: actuator }
+  - { name: switch_gait,   type: actuator }
+  - { name: gesture,       type: actuator }
+  - { name: acrobatics,    type: actuator }
+  - { name: obstacles_avoid, type: actuator }
+  - { name: camera_front,  type: sensor }
+  - { name: imu,           type: sensor }
+  - { name: battery,       type: sensor }
+  - { name: joints,        type: sensor }
+  - { name: motion_switcher, type: actuator }
+  - { name: lidar_cloud,   type: sensor }
+  - { name: pos_tag,       type: sensor }
+  - { name: slam_mapping,  type: sensor }
+  - { name: slam_cloud,    type: sensor }
+  - { name: grid_map,      type: sensor }
+  - { name: spatial,       type: actuator }
+  - { name: asr,           type: sensor }
+  - { name: ext_mic,       type: sensor }
+  - { name: ext_camera,    type: sensor }

--- a/unitree/r1/driver.yaml
+++ b/unitree/r1/driver.yaml
@@ -9,3 +9,30 @@ mcp_url: "http://localhost:15702/mcp"
 description: "Unitree R1-EDU — 麦克风 + TTS + LED + 运动控制 + 双目摄像头 + 状态感知"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `plugins.*.enabled` — one config key
+# (loco, state) gates several MCP tools implemented by separate plugin classes.
+# smart_motion is not in config.yaml but defaults to enabled=True in main.py
+# (R1DeviceBundle.__init__), so it is included too.
+cards:
+  - { name: mic,          type: sensor }
+  - { name: tts,          type: actuator }
+  - { name: speaker,      type: actuator }
+  - { name: led,          type: actuator }
+  - { name: loco_state,   type: sensor }
+  - { name: loco,         type: actuator }
+  - { name: switch_mode,  type: actuator }
+  - { name: arm,          type: actuator }
+  - { name: imu,          type: sensor }
+  - { name: battery,      type: sensor }
+  - { name: joints,       type: sensor }
+  - { name: mainboard,    type: sensor }
+  - { name: model,        type: resource }
+  - { name: asr,          type: sensor }
+  - { name: camera_main,  type: sensor }
+  - { name: camera_left,  type: sensor }
+  - { name: camera_right, type: sensor }
+  - { name: camera_depth, type: sensor }
+  - { name: ext_mic,      type: sensor }
+  - { name: ext_camera,   type: sensor }
+  - { name: smart_motion, type: actuator }

--- a/x-humanoid/tianyi2.0/driver.yaml
+++ b/x-humanoid/tianyi2.0/driver.yaml
@@ -9,3 +9,43 @@ mcp_url: "http://localhost:15707/mcp"
 description: "天轶2.0 Pro — 35DOF 人形机器人 (轮式底盘 + 双臂 + 灵巧手 + 头部 + 导航)"
 build_context_extras:
   - ../../common
+# Cards this bundle exposes, for resource-center's driver marketplace listing.
+# Kept in sync by hand with config.yaml's `plugins.*.enabled` (all plugins are
+# currently enabled) — joints_bridge is a standalone ROS process with no MCP
+# tool of its own, and ext_devices.py's ExtCameraPlugin is dead code (never
+# registered in main.py, no `ext_camera` key in config.yaml) so it is excluded.
+cards:
+  - { name: joints,             type: sensor }
+  - { name: battery,            type: sensor }
+  - { name: estop,              type: sensor }
+  - { name: force_sensor,       type: sensor }
+  - { name: model,              type: resource }
+  - { name: camera_head,        type: sensor }
+  - { name: imu,                type: sensor }
+  - { name: camera_depth,       type: sensor }
+  - { name: camera_pointcloud,  type: sensor }
+  - { name: asr,                type: sensor }
+  - { name: nav_state,          type: sensor }
+  - { name: power_board,        type: sensor }
+  - { name: motors,             type: sensor }
+  - { name: hand_state,         type: sensor }
+  - { name: remote_event,       type: sensor }
+  - { name: head,               type: actuator }
+  - { name: head_gesture,       type: actuator }
+  - { name: arm,                type: actuator }
+  - { name: arm_gesture,        type: actuator }
+  - { name: waist,              type: actuator }
+  - { name: hand,               type: actuator }
+  - { name: tts,                type: actuator }
+  - { name: voice_play,         type: actuator }
+  - { name: nav,                type: actuator }
+  - { name: home,               type: actuator }
+  - { name: chat,               type: actuator }
+  - { name: voice_chat,         type: actuator }
+  - { name: controlled_spatial, type: actuator }
+  - { name: spatial_map,        type: actuator }
+  - { name: health_check,       type: actuator }
+  - { name: laser_scan,         type: sensor }
+  - { name: chassis_raw,        type: actuator }
+  - { name: ext_mic,            type: sensor }
+  - { name: light,              type: actuator }


### PR DESCRIPTION
## Summary
- Adds `cards: [{name, type}]` to all 15 bundles' `driver.yaml` (flow-style, awk-parseable): q5, g1, go1, go2, r1, k1, revo2, lynx_m20, M300, mavic3e, mavic4e, t800, bumi, adam, tianyi2.0.
- `build.sh`: new `_parse_yaml_cards_json()` awk helper reads the field and adds it to the resource-center registration payload. No new dependency (no PyYAML) — matches the existing `_parse_yaml_field`/`_parse_yaml_list` bash-parsing style.
- Card lists were derived per-bundle from `config.yaml`'s enabled plugins cross-referenced against each tool's declared `type` in source (`device.py`/etc.), excluding disabled/merged/dead code.
- `realman` and `pc` bundles have no `driver.yaml` in this repo and are left without cards.

Flagged issues found while auditing (not fixed here, left as-is to match runtime behavior):
- `unitree/go1/config.yaml`: `system_health:` is accidentally YAML-nested inside `face_light`'s block (indentation bug) — never actually loads. Excluded from cards.
- A few bundles (`go1`'s `activity_monitor`, `tianyi2.0`'s `health_check`, DJI's `aircraft_info`) declare `type: actuator` in source for read-only diagnostic tools — kept as-declared.

Companion changes: `phanthymotus` (`core`/`perception`/`actucore` build scripts) and `resource-center` (schema/API/UI).

## Test plan
- [x] Ran the exact `_parse_yaml_cards_json` awk snippet against every edited `driver.yaml` — all parse to valid JSON, no bad `type` values, no duplicate names within a bundle.
- [x] Verified in resource-center (backfilling the same data into the DB) that every bundle renders its total card count + sensor/actuator/processor/resource breakdown correctly.