### PR TITLE
fix(tianyi): controlled_spatial 缺 config 分支导致开启控制报 Unknown tool

### DIFF
--- a/x-humanoid/tianyi2.0/controlled_spatial.py
+++ b/x-humanoid/tianyi2.0/controlled_spatial.py
@@ -670,6 +670,12 @@ class ControlledSpatialPlugin:
         return None
 
     def dispatch(self, action: str, args: dict) -> dict | None:
+        # Agent Core 在 start 前会自动下发一次 action:config（卡片里存过配置时），
+        # 少了这个分支就会 return None，被 main.py 翻译成 "Unknown tool"。
+        if action == "config":
+            if "password" in args:
+                self._password = str(args["password"])
+            return {"status": "configured"}
         if action == "start":
             return {"state": "ready"}
         if action == "stop":
@@ -685,7 +691,9 @@ class ControlledSpatialPlugin:
 
         # ── Mapping ────────────────────────────────────────────────────────
 
-        elif action == "start_mapping":
+        # 独立的 if（不是 elif）：上面的密码块只在校验失败时 return，
+        # 挂成 elif 会让所有通过校验的受保护操作直接跳过整条分支链。
+        if action == "start_mapping":
             map_name = args.get("map_name", "")
             if not map_name:
                 return {"error": "map_name is required"}

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -509,6 +509,11 @@ class TianyiDeviceBundle:
                             return {"error": f"start failed: {e}"}
                     args['_tool_name'] = tool_name
                     result = p.dispatch(action, args)
+                    # 工具存在但插件不认这个 action：别把 None 冒泡上去，
+                    # 否则 HTTP 层会报成 "Unknown tool"，把排查引向错误方向。
+                    if result is None:
+                        return {"state": "error",
+                                "error": f"Unknown action: {action} (tool={tool_name})"}
                     return result
         return None
 


### PR DESCRIPTION
## 问题

天翼 2.0 点「开启控制」报：

```
[controlled_spatial] 配置失败：Unknown tool: controlled_spatial
```

## 根因

1. Agent Core 在 `start` 前会自动下发一次 `action: config`（`mcp_manage.py` auto-config，条件是工具有 configSchema 且卡片存过配置）。
2. tianyi 的 `controlled_spatial` 声明了 configSchema（`password`），但 `dispatch()` 没有 `config` 分支 → 落到末尾 `return None`。
3. `main.py` 把插件返回的 `None` 和「工具不存在」混为一谈 → 回 `-32601 Unknown tool: controlled_spatial`。

go2 / g1 / t800 的同名插件都没有 configSchema，不会触发 config 调用，所以只有 tianyi 中招。已在机器上确认部署版本同样缺该分支（不是镜像旧的问题）。

## 顺带修掉的两个真问题

- **卡片里的 password 一直不生效**：`self._password` 只在构造时从 config.yaml 读一次，没有任何地方写回。config 分支补上后一并解决。
- **15 个受保护操作全部失效**：`elif action == "start_mapping"` 挂在 `if action in self._protected_actions` 后面，密码校验**通过**时不 return，于是直接跳过整条 if/elif 链返回 `None`。`start_mapping`、`delete_map`、`add_wall`/`remove_wall`/`clear_walls`、轨道/区域/POI 的增删等都中招（症状同样是 "Unknown tool"）。改成独立的 `if`。
- `main.py`：插件返回 `None` 时改报 `Unknown action: <action> (tool=...)`，不再误导成工具未注册。

## 验证

`agent-core`/驱动无测试套件，用 stub self 直接驱动 `dispatch()` 手工验证：

- `config` 落到 `self._password`（`{'status': 'configured'}`）
- 受保护操作在新密码下能进到各自分支（`start_mapping` 无 map_name 返回 `map_name is required`；`clear_walls` 走到 `_slamtec.clear_lines`）
- 密码错误仍被拦截
- 链尾的 `get_pose` / `get_localization_quality` 仍可达
- 未知 action 仍返回 `None`（由 `main.py` 转成 `Unknown action`）

**真机复测待做**：需重新构建天翼驱动镜像，在 `10.100.129.72` 上点「开启控制」确认无报错、且改密码后受保护操作按新密码校验。未在真机上跑任何 actuator 动作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)