### PR TITLE
perf(r1): switch_mode FSM 序列改异步 + ACP 回调

### DIFF
--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -1837,8 +1837,16 @@ class LocoPlugin:
         return {"status": "executing", "mode": mode, "action_id": action_id}
 
     def _acp_fsm_sequence(self, action_id: str, mode: str, steps: list):
-        """Background thread: execute FSM sequence, then fire ACP callback."""
-        result = self._run_fsm_sequence(steps)
+        """Background thread: execute FSM sequence, then fire ACP callback.
+
+        The callback must go out on every path. An exception escaping here would
+        leave agent-core's barrier waiting out the full 150s x-completion timeout
+        for a sequence that already died.
+        """
+        try:
+            result = self._run_fsm_sequence(steps)
+        except Exception as e:
+            result = {"error": f"{type(e).__name__}: {e}"}
         status = "error" if result.get("error") else "completed"
         _loco_acp_notify(action_id, status, {"mode": mode, **result}, tool="switch_mode")
 

--- a/unitree/r1/device.py
+++ b/unitree/r1/device.py
@@ -1048,6 +1048,13 @@ class LocoPlugin:
     def __init__(self, plugin_config: dict, namespace: str, executor, loco_client):
         self._client = loco_client
         self._namespace = namespace
+        # Only one FSM sequence may be in flight. Async dispatch means the robot
+        # now spends 6-13s mid-transition while the agent is free to send more
+        # posture commands, and a second sequence starting on a half-standing robot
+        # is how a "safe" call becomes a fall.
+        self._fsm_busy = threading.Lock()
+        self._fsm_active: str | None = None
+        self._stop_move_ret: int | None = None
 
     def get_tools(self) -> list:
         return [self._loco_tool(), self._switch_mode_tool(), self._arm_tool()]
@@ -1083,6 +1090,29 @@ class LocoPlugin:
     _GROUND_STATES = {0, 1}       # zero_torque, damp — robot is on the ground
     _STANDING_STATES = {811}      # loco_mode — fully operational standing
     # FSM=4 (stance) is intermediate: allow both standup (continue) and lie-down (retreat)
+
+    # 701/702 are the *motion in progress* states: the robot is physically moving
+    # between postures and is neither down nor up. Measured on hardware: a healthy
+    # standup2lie sits in 702 for ~6s, a healthy lie2standup sits in 701 for ~3s.
+    #
+    # Every guard used to ignore them, and `fsm_to_start` below defaulted unknown
+    # readings to "start from step 0" -- i.e. ZeroTorque() on a robot that is
+    # halfway through standing up. While switch_mode was synchronous the window
+    # could not be observed (dispatch blocked, and the ACP barrier held back the
+    # next actuator); async dispatch opens it for the full 6-9s.
+    _TRANSITIONAL_STATES = {701, 702}
+
+    # Which transitional state a posture change must pass through. Reaching the
+    # target without ever seeing it means the robot got there by falling, not by
+    # lowering/raising itself -- both transitions last several seconds, so 1s
+    # polling cannot miss them.
+    _EXPECTED_TRANSIT = {"standup2lie": 702, "lie2standup": 701}
+
+    _FSM_NAMES = {
+        0: "zero_torque", 1: "damp", 4: "stance",
+        701: "lie2standup (in progress)", 702: "standup2lie (in progress)",
+        811: "loco_mode",
+    }
 
     def _switch_mode_tool(self) -> dict:
         return {
@@ -1205,7 +1235,25 @@ class LocoPlugin:
                 return {"ret": ret, "mode": "emergency_stop",
                         "warning": "Emergency damp executed regardless of state"}
 
-            elif mode == "lie2standup":
+            # Everything below moves the robot between postures. None of it is safe
+            # to start while a previous transition is still running, so both the
+            # measured FSM and our own in-flight flag have to be clear first.
+            if mode in ("lie2standup", "standup2lie"):
+                if current_fsm in self._TRANSITIONAL_STATES:
+                    print(f"[fsm] {mode}: REFUSED, robot is mid-transition "
+                          f"(fsm={current_fsm})", flush=True)
+                    return {"error": f"Robot is still changing posture "
+                                     f"(fsm={current_fsm}: "
+                                     f"{self._FSM_NAMES.get(current_fsm)}). "
+                                     f"Wait for the current action to report完成 "
+                                     f"before switching again."}
+                if self._fsm_busy.locked():
+                    print(f"[fsm] {mode}: REFUSED, a sequence is already running "
+                          f"({self._fsm_active})", flush=True)
+                    return {"error": f"A posture change ({self._fsm_active}) is already "
+                                     f"running. Wait for its completion callback."}
+
+            if mode == "lie2standup":
                 if current_fsm == 811:
                     print("[fsm] lie2standup: already standing, no-op", flush=True)
                     return {"info": "Robot is already in loco mode (standing)", "fsm_id": 811}
@@ -1216,9 +1264,22 @@ class LocoPlugin:
                     ("Stance",      4, "stance"),
                     ("Lie2StandUp", 811, "lie2standup"),
                 ]
-                # Skip completed steps based on current FSM
+                # Skip completed steps based on current FSM.
+                #
+                # This used to be `fsm_to_start.get(current_fsm, 0)` -- any FSM the
+                # table did not recognise fell through to "start at step 0", i.e.
+                # ZeroTorque() on a robot whose posture we did not understand. 701
+                # and 702 (transition in progress) are exactly such values, and they
+                # are caught above; anything else is a state we have no plan for, so
+                # refuse rather than guess and drop the robot.
                 fsm_to_start = {0: 1, 1: 2, 4: 3}
-                start_idx = fsm_to_start.get(current_fsm, 0)
+                if current_fsm not in fsm_to_start:
+                    print(f"[fsm] lie2standup: REFUSED, unrecognised fsm={current_fsm}",
+                          flush=True)
+                    return {"error": f"Unrecognised FSM state {current_fsm} "
+                                     f"({self._FSM_NAMES.get(current_fsm, 'unknown')}). "
+                                     f"Refusing to run the stand-up sequence from here."}
+                start_idx = fsm_to_start[current_fsm]
                 steps = all_steps[start_idx:]
                 print(f"[fsm] lie2standup: from fsm={current_fsm}, skipping {start_idx} step(s), "
                       f"running {[s[2] for s in steps]}", flush=True)
@@ -1234,6 +1295,12 @@ class LocoPlugin:
                     print(f"[fsm] standup2lie: from stance (fsm=4), running "
                           f"{[s[2] for s in steps]}", flush=True)
                     return self._async_fsm(mode, steps)
+                if current_fsm not in self._STANDING_STATES:
+                    print(f"[fsm] standup2lie: REFUSED, unrecognised fsm={current_fsm}",
+                          flush=True)
+                    return {"error": f"Unrecognised FSM state {current_fsm} "
+                                     f"({self._FSM_NAMES.get(current_fsm, 'unknown')}). "
+                                     f"Refusing to run the lie-down sequence from here."}
                 # From 811 (loco mode): stop movement first, then lie down safely.
                 # StopMove + the settle sleep run inside the worker thread too --
                 # leaving them here would keep dispatch blocked for a second and
@@ -1298,28 +1365,45 @@ class LocoPlugin:
     def _async_fsm(self, mode: str, steps: list, stop_first: bool = False) -> dict:
         """Launch an FSM sequence in the background, return an action_id immediately.
 
-        The sequence takes ~12s (4 steps, 1s apart). Running it synchronously froze
-        the whole agent turn for that long -- no reasoning, no speech, nothing.
-        Now dispatch returns at once and the ACP callback reports the outcome.
+        The sequence takes ~10-13s. Running it synchronously froze the whole agent
+        turn for that long -- no reasoning, no speech, nothing. Now dispatch returns
+        at once and the ACP callback reports the outcome.
+
+        Claiming _fsm_busy here rather than in the worker closes the window between
+        "dispatch decided to go" and "the thread got scheduled": two calls arriving
+        together would both pass the check in dispatch and both start moving the
+        robot.
         """
         from uuid import uuid4
+        if not self._fsm_busy.acquire(blocking=False):
+            print(f"[fsm] {mode}: REFUSED at launch, {self._fsm_active} still running",
+                  flush=True)
+            return {"error": f"A posture change ({self._fsm_active}) is already running. "
+                             f"Wait for its completion callback."}
         action_id = f"r1_fsm_{uuid4().hex[:8]}"
+        self._fsm_active = action_id
         print(f"[fsm] {action_id}: dispatching async, mode={mode} "
               f"steps={[s[2] for s in steps]} stop_first={stop_first}", flush=True)
-        threading.Thread(
-            target=self._acp_fsm_sequence,
-            args=(action_id, mode, steps, stop_first),
-            daemon=True,
-        ).start()
+        try:
+            threading.Thread(
+                target=self._acp_fsm_sequence,
+                args=(action_id, mode, steps, stop_first),
+                daemon=True,
+            ).start()
+        except Exception:
+            self._fsm_active = None
+            self._fsm_busy.release()
+            raise
         return {"status": "executing", "mode": mode, "action_id": action_id}
 
     def _acp_fsm_sequence(self, action_id: str, mode: str, steps: list,
                           stop_first: bool = False):
         """Worker: run the sequence, then fire the ACP callback.
 
-        The callback must go out on every path. Swallowing an exception here would
-        leave agent-core's barrier waiting out the full 90s timeout for a sequence
-        that already died.
+        The callback must go out on every path, and _fsm_busy must be released on
+        every path. Swallowing an exception here would leave agent-core's barrier
+        waiting out the full 90s timeout for a sequence that already died, and would
+        wedge the plugin against every future posture change.
         """
         t0 = time.monotonic()
         print(f"[fsm] {action_id}: worker started (thread={threading.current_thread().name})",
@@ -1327,7 +1411,17 @@ class LocoPlugin:
         try:
             if stop_first:
                 ret = self._client.StopMove()
-                print(f"[fsm] {action_id}: StopMove() -> ret={ret}, settling 1.0s", flush=True)
+                if ret != 0:
+                    # StopMove is what clears residual motion before the lie-down.
+                    # It is not fatal on its own (it returns non-zero on healthy runs
+                    # too), but "lie down while still moving" is the leading theory
+                    # for a controlled descent degrading into a collapse, so carry it
+                    # into the result rather than dropping it.
+                    print(f"[fsm] {action_id}: WARNING StopMove() -> ret={ret} (non-zero)",
+                          flush=True)
+                else:
+                    print(f"[fsm] {action_id}: StopMove() -> ret={ret}", flush=True)
+                self._stop_move_ret = ret
                 time.sleep(1.0)
             print(f"[fsm] {action_id}: entering RunFsmSequence at t={time.monotonic()-t0:.2f}s",
                   flush=True)
@@ -1335,8 +1429,38 @@ class LocoPlugin:
         except Exception as e:
             print(f"[fsm] {action_id}: worker raised {type(e).__name__}: {e}", flush=True)
             result = {"error": f"{type(e).__name__}: {e}"}
+        finally:
+            self._fsm_active = None
+            self._fsm_busy.release()
+
         status = "error" if result.get("error") else "completed"
         elapsed = time.monotonic() - t0
+
+        # Did the robot actually move through the posture, or just arrive at the
+        # target? A healthy standup2lie sits in 702 for ~6s and lie2standup in 701
+        # for ~3s, so 1s polling cannot miss them. Reaching damp without ever seeing
+        # 702 means the robot got down by falling -- which is what happened on
+        # 2026-09-02 and was reported as a clean "completed".
+        expected = self._EXPECTED_TRANSIT.get(mode)
+        seen = result.get("fsm_seen") or {}
+        if status == "completed" and expected is not None:
+            observed = seen.get(mode, [])
+            if expected not in observed:
+                status = "error"
+                result = {**result,
+                          "error": f"{mode} reached its target without ever passing "
+                                   f"through {expected} "
+                                   f"({self._FSM_NAMES.get(expected)}). The robot did "
+                                   f"not perform a controlled transition.",
+                          "anomaly": "missing_transitional_state",
+                          "expected_transitional": expected,
+                          "fsm_observed": observed}
+                print(f"[fsm] {action_id}: ANOMALY {mode} never entered {expected}; "
+                      f"observed={observed} -- treating as error, not completion",
+                      flush=True)
+
+        if stop_first:
+            result = {**result, "stop_move_ret": self._stop_move_ret}
         print(f"[fsm] {action_id}: {status} after {elapsed:.2f}s -> {result}", flush=True)
         if status == "completed" and not result.get("fsm_measured", True):
             # The final FSM could not be read, so "completed" is the target we aimed

--- a/unitree/r1/device.py
+++ b/unitree/r1/device.py
@@ -978,6 +978,35 @@ class LocoStatePlugin:
 
 # ── LocoPlugin (actuator) ────────────────────────────────────────────────────
 
+import os as _os
+
+_LOCO_AGENT_CORE_URL = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+
+
+def _loco_acp_notify(action_id: str, status: str, result: dict, tool: str = "loco"):
+    """POST ACP completion callback to Agent Core."""
+    import urllib.request as _urllib
+    import ssl as _ssl
+
+    ctx = _ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = _ssl.CERT_NONE
+    payload = json.dumps({
+        "action_id": action_id, "status": status,
+        "result": result, "tool": tool, "ts": time.time(),
+    }).encode()
+    try:
+        req = _urllib.Request(
+            f"{_LOCO_AGENT_CORE_URL}/api/acp/complete",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        _urllib.urlopen(req, timeout=5, context=ctx)
+    except Exception as e:
+        print(f"[Loco] ACP notify failed: {e}", flush=True)
+
+
 class LocoPlugin:
     """R1 locomotion control via LocoClient RPC (sport service) + ArmClient (arm service).
 
@@ -1071,6 +1100,23 @@ class LocoPlugin:
                     },
                 },
                 "required": ["mode"],
+                # lie2standup / standup2lie run a multi-step FSM sequence that takes
+                # ~12s. They return immediately with an action_id and fire the ACP
+                # callback when the sequence ends, so the agent can keep reasoning
+                # (and keep talking) while the robot moves.
+                #
+                # No "actions" filter here: agent-core matches it against
+                # args["action"] (mcp_client.py:504), and this tool's parameter is
+                # named "mode" -- a filter would never match. Without one every
+                # dispatch is eligible, and the real gate becomes whether the
+                # response carries an action_id (mcp_client.py:511). The synchronous
+                # modes (damp, zero_torque, emergency_stop, get_current_mode) are
+                # single RPCs that return in milliseconds and deliberately return no
+                # action_id, so they stay synchronous.
+                #
+                # timeout mirrors _run_fsm_sequence's worst case: 4 steps x 15s
+                # step_timeout plus interval, with margin.
+                "x-completion": {"timeout": 90},
             },
         }
 
@@ -1151,7 +1197,7 @@ class LocoPlugin:
                 # Skip completed steps based on current FSM
                 fsm_to_start = {0: 1, 1: 2, 4: 3}
                 start_idx = fsm_to_start.get(current_fsm, 0)
-                return self._run_fsm_sequence(all_steps[start_idx:])
+                return self._async_fsm(mode, all_steps[start_idx:])
 
             elif mode == "standup2lie":
                 if current_fsm in self._GROUND_STATES:
@@ -1159,12 +1205,13 @@ class LocoPlugin:
                 if current_fsm == 4:
                     # From stance: enter loco first, then lie down
                     steps = [("Start", 811, "start"), ("StandUp2Lie", 1, "standup2lie")]
-                else:
-                    # From 811 (loco mode): stop movement first, then lie down safely
-                    self._client.StopMove()
-                    import time as _time; _time.sleep(1.0)
-                    steps = [("StandUp2Lie", 1, "standup2lie")]
-                return self._run_fsm_sequence(steps)
+                    return self._async_fsm(mode, steps)
+                # From 811 (loco mode): stop movement first, then lie down safely.
+                # StopMove + the settle sleep run inside the worker thread too --
+                # leaving them here would keep dispatch blocked for a second and
+                # defeat the point of going async.
+                steps = [("StandUp2Lie", 1, "standup2lie")]
+                return self._async_fsm(mode, steps, stop_first=True)
 
             elif mode in ("zero_torque", "damp"):
                 if current_fsm in self._STANDING_STATES or current_fsm == 4:
@@ -1216,6 +1263,41 @@ class LocoPlugin:
         if result is None:
             return {"error": "RPC timeout during sequence execution"}
         return result
+
+    def _async_fsm(self, mode: str, steps: list, stop_first: bool = False) -> dict:
+        """Launch an FSM sequence in the background, return an action_id immediately.
+
+        The sequence takes ~12s (4 steps, 1s apart). Running it synchronously froze
+        the whole agent turn for that long -- no reasoning, no speech, nothing.
+        Now dispatch returns at once and the ACP callback reports the outcome.
+        """
+        from uuid import uuid4
+        action_id = f"r1_fsm_{uuid4().hex[:8]}"
+        threading.Thread(
+            target=self._acp_fsm_sequence,
+            args=(action_id, mode, steps, stop_first),
+            daemon=True,
+        ).start()
+        return {"status": "executing", "mode": mode, "action_id": action_id}
+
+    def _acp_fsm_sequence(self, action_id: str, mode: str, steps: list,
+                          stop_first: bool = False):
+        """Worker: run the sequence, then fire the ACP callback.
+
+        The callback must go out on every path. Swallowing an exception here would
+        leave agent-core's barrier waiting out the full 90s timeout for a sequence
+        that already died.
+        """
+        try:
+            if stop_first:
+                self._client.StopMove()
+                time.sleep(1.0)
+            result = self._run_fsm_sequence(steps)
+        except Exception as e:
+            result = {"error": f"{type(e).__name__}: {e}"}
+        status = "error" if result.get("error") else "completed"
+        _loco_acp_notify(action_id, status, {"mode": mode, **result},
+                         tool="switch_mode")
 
     # ── Arm helpers ───────────────────────────────────────────────────────────
 

--- a/unitree/r1/device.py
+++ b/unitree/r1/device.py
@@ -1002,9 +1002,14 @@ def _loco_acp_notify(action_id: str, status: str, result: dict, tool: str = "loc
             headers={"Content-Type": "application/json"},
             method="POST",
         )
-        _urllib.urlopen(req, timeout=5, context=ctx)
+        resp = _urllib.urlopen(req, timeout=5, context=ctx)
+        print(f"[Loco] ACP notify {action_id} -> {resp.status} "
+              f"({_LOCO_AGENT_CORE_URL})", flush=True)
     except Exception as e:
-        print(f"[Loco] ACP notify failed: {e}", flush=True)
+        # agent-core's barrier is now waiting on this callback. If it never lands the
+        # turn stalls until x-completion times out, so make the failure loud.
+        print(f"[Loco] ACP notify FAILED for {action_id} -> {_LOCO_AGENT_CORE_URL}: "
+              f"{type(e).__name__}: {e}", flush=True)
 
 
 class LocoPlugin:
@@ -1084,19 +1089,26 @@ class LocoPlugin:
             "name": "switch_mode",
             "type": "actuator",
             "multiInstance": False,
-            "description": "R1 locomotion mode switch (safe). "
-                           "damp=阻尼(ground only), zero_torque=零力矩(ground only), "
-                           "lie2standup=安全起立序列(ground→运控), standup2lie=安全躺下序列(standing→阻尼), "
-                           "emergency_stop=紧急阻尼(any state, accepts fall risk)",
+            "description": "R1 posture switch. "
+                           "lie2standup=安全起立序列(躺→站), standup2lie=安全躺下序列(站→躺), "
+                           "emergency_stop=紧急阻尼(任何状态，接受摔倒风险), "
+                           "get_current_mode=查询当前姿态。"
+                           "起立/躺下是异步的：立即返回 action_id，动作完成后回调通知。",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "mode": {
                         "type": "string",
-                        "enum": ["damp", "zero_torque",
-                                 "lie2standup", "standup2lie",
+                        # damp / zero_torque used to be exposed here. They are the only
+                        # way for the model to go limp directly, they only ever made
+                        # sense on the ground, and having four ways to "lie down" in one
+                        # enum invited the model to pick a raw motor mode when it wanted
+                        # a posture change. The model only needs lie/stand; the internal
+                        # ZeroTorque/Damp steps still run inside lie2standup, and
+                        # emergency_stop remains the one explicit way to go limp.
+                        "enum": ["lie2standup", "standup2lie",
                                  "emergency_stop", "get_current_mode"],
-                        "description": "Target mode, or get_current_mode to query current state.",
+                        "description": "Target posture, or get_current_mode to query current state.",
                     },
                 },
                 "required": ["mode"],
@@ -1109,13 +1121,12 @@ class LocoPlugin:
                 # args["action"] (mcp_client.py:504), and this tool's parameter is
                 # named "mode" -- a filter would never match. Without one every
                 # dispatch is eligible, and the real gate becomes whether the
-                # response carries an action_id (mcp_client.py:511). The synchronous
-                # modes (damp, zero_torque, emergency_stop, get_current_mode) are
-                # single RPCs that return in milliseconds and deliberately return no
-                # action_id, so they stay synchronous.
+                # response carries an action_id (mcp_client.py:511). emergency_stop
+                # and get_current_mode are single RPCs that return in milliseconds and
+                # deliberately return no action_id, so they stay synchronous.
                 #
                 # timeout mirrors _run_fsm_sequence's worst case: 4 steps x 15s
-                # step_timeout plus interval, with margin.
+                # step_timeout plus interval and settle, with margin.
                 "x-completion": {"timeout": 90},
             },
         }
@@ -1178,14 +1189,25 @@ class LocoPlugin:
         elif action == "switch_mode":
             mode = args.get("mode", "")
             code, current_fsm = self._client.GetFsmId()
+            print(f"[fsm] switch_mode(mode={mode!r}): GetFsmId -> fsm={current_fsm} "
+                  f"(code={code})", flush=True)
+            if code != 0:
+                # Every guard below keys off current_fsm. Acting on a failed read is
+                # how a "safe" call turns into a collapse, so refuse instead.
+                print(f"[fsm] switch_mode: REFUSED, cannot read FSM (code={code})", flush=True)
+                return {"error": f"Cannot read current FSM state (code={code}). "
+                                 f"Refusing to switch posture."}
 
             if mode == "emergency_stop":
+                print("[fsm] emergency_stop: Damp() regardless of state", flush=True)
                 ret = self._client.Damp()
+                print(f"[fsm] emergency_stop: Damp() -> ret={ret}", flush=True)
                 return {"ret": ret, "mode": "emergency_stop",
                         "warning": "Emergency damp executed regardless of state"}
 
             elif mode == "lie2standup":
                 if current_fsm == 811:
+                    print("[fsm] lie2standup: already standing, no-op", flush=True)
                     return {"info": "Robot is already in loco mode (standing)", "fsm_id": 811}
                 # Full sequence: zero_torque(0) → damp(1) → stance(4) → start(811)
                 all_steps = [
@@ -1197,30 +1219,39 @@ class LocoPlugin:
                 # Skip completed steps based on current FSM
                 fsm_to_start = {0: 1, 1: 2, 4: 3}
                 start_idx = fsm_to_start.get(current_fsm, 0)
-                return self._async_fsm(mode, all_steps[start_idx:])
+                steps = all_steps[start_idx:]
+                print(f"[fsm] lie2standup: from fsm={current_fsm}, skipping {start_idx} step(s), "
+                      f"running {[s[2] for s in steps]}", flush=True)
+                return self._async_fsm(mode, steps)
 
             elif mode == "standup2lie":
                 if current_fsm in self._GROUND_STATES:
+                    print(f"[fsm] standup2lie: already down (fsm={current_fsm}), no-op", flush=True)
                     return {"info": "Robot is already lying down", "fsm_id": current_fsm}
                 if current_fsm == 4:
                     # From stance: enter loco first, then lie down
                     steps = [("Start", 811, "start"), ("StandUp2Lie", 1, "standup2lie")]
+                    print(f"[fsm] standup2lie: from stance (fsm=4), running "
+                          f"{[s[2] for s in steps]}", flush=True)
                     return self._async_fsm(mode, steps)
                 # From 811 (loco mode): stop movement first, then lie down safely.
                 # StopMove + the settle sleep run inside the worker thread too --
                 # leaving them here would keep dispatch blocked for a second and
                 # defeat the point of going async.
                 steps = [("StandUp2Lie", 1, "standup2lie")]
+                print(f"[fsm] standup2lie: from fsm={current_fsm}, StopMove first, then "
+                      f"{[s[2] for s in steps]}", flush=True)
                 return self._async_fsm(mode, steps, stop_first=True)
 
             elif mode in ("zero_torque", "damp"):
-                if current_fsm in self._STANDING_STATES or current_fsm == 4:
-                    return {"error": f"Cannot enter {mode} from upright state "
-                                     f"(FSM={current_fsm}). Robot will collapse. "
-                                     f"Use standup2lie first."}
-                fn = self._client.ZeroTorque if mode == "zero_torque" else self._client.Damp
-                ret = fn()
-                return {"ret": ret, "mode": mode}
+                # Removed from the tool enum: these are raw motor modes, not postures,
+                # and they were the only way for the model to go limp directly. Kept as
+                # an explicit refusal so a stale cached schema or a hand-made call gets
+                # a clear answer instead of silently dropping the robot.
+                print(f"[fsm] switch_mode: REFUSED removed mode {mode!r}", flush=True)
+                return {"error": f"'{mode}' is no longer available. "
+                                 f"Use standup2lie to lie down, or emergency_stop "
+                                 f"if the robot must go limp immediately."}
 
             elif mode == "get_current_mode":
                 code, fsm_id = self._client.GetFsmId()
@@ -1235,7 +1266,7 @@ class LocoPlugin:
 
             else:
                 return {"error": f"Unknown mode: {mode}. "
-                                 f"Available: damp, zero_torque, lie2standup, standup2lie, emergency_stop, get_current_mode"}
+                                 f"Available: lie2standup, standup2lie, emergency_stop, get_current_mode"}
         # ── Arm actions (tool_name="arm", action = gesture name) ────────────────
         elif action == "release":
             # release_arm (id=99) puts hands down
@@ -1273,6 +1304,8 @@ class LocoPlugin:
         """
         from uuid import uuid4
         action_id = f"r1_fsm_{uuid4().hex[:8]}"
+        print(f"[fsm] {action_id}: dispatching async, mode={mode} "
+              f"steps={[s[2] for s in steps]} stop_first={stop_first}", flush=True)
         threading.Thread(
             target=self._acp_fsm_sequence,
             args=(action_id, mode, steps, stop_first),
@@ -1288,16 +1321,32 @@ class LocoPlugin:
         leave agent-core's barrier waiting out the full 90s timeout for a sequence
         that already died.
         """
+        t0 = time.monotonic()
+        print(f"[fsm] {action_id}: worker started (thread={threading.current_thread().name})",
+              flush=True)
         try:
             if stop_first:
-                self._client.StopMove()
+                ret = self._client.StopMove()
+                print(f"[fsm] {action_id}: StopMove() -> ret={ret}, settling 1.0s", flush=True)
                 time.sleep(1.0)
+            print(f"[fsm] {action_id}: entering RunFsmSequence at t={time.monotonic()-t0:.2f}s",
+                  flush=True)
             result = self._run_fsm_sequence(steps)
         except Exception as e:
+            print(f"[fsm] {action_id}: worker raised {type(e).__name__}: {e}", flush=True)
             result = {"error": f"{type(e).__name__}: {e}"}
         status = "error" if result.get("error") else "completed"
-        _loco_acp_notify(action_id, status, {"mode": mode, **result},
+        elapsed = time.monotonic() - t0
+        print(f"[fsm] {action_id}: {status} after {elapsed:.2f}s -> {result}", flush=True)
+        if status == "completed" and not result.get("fsm_measured", True):
+            # The final FSM could not be read, so "completed" is the target we aimed
+            # at, not the state the robot is in. Say so rather than implying evidence.
+            print(f"[fsm] {action_id}: WARNING final FSM unreadable; "
+                  f"reporting target {result.get('fsm_target')} unverified", flush=True)
+        _loco_acp_notify(action_id, status,
+                         {"mode": mode, "elapsed_s": round(elapsed, 2), **result},
                          tool="switch_mode")
+        print(f"[fsm] {action_id}: ACP callback sent (status={status})", flush=True)
 
     # ── Arm helpers ───────────────────────────────────────────────────────────
 

--- a/unitree/r1/ext_devices.py
+++ b/unitree/r1/ext_devices.py
@@ -847,7 +847,12 @@ class ExtCameraPlugin:
 
     def dispatch(self, action: str, args: dict) -> dict | None:
         instance_id = args.get("instance_id", "")
-        print(f"[ext_camera] dispatch: action={action!r} instance_id={instance_id!r} args_keys={list(args.keys())}", flush=True)
+        # `info` is polled by the dashboard every couple of seconds and changes
+        # nothing, so logging it buries the lines that matter (posture changes,
+        # errors) in the driver log. Only trace state-changing actions.
+        if action not in ("info", "status"):
+            print(f"[ext_camera] dispatch: action={action!r} instance_id={instance_id!r} "
+                  f"args_keys={list(args.keys())}", flush=True)
 
         if action == 'config':
             if instance_id:

--- a/unitree/r1/main.py
+++ b/unitree/r1/main.py
@@ -181,6 +181,11 @@ def make_handler():
             msg = fmt % args
             if '"POST /mcp' in msg and '200' in msg:
                 return
+            # The dashboard probes for an SSE endpoint this server does not serve,
+            # every couple of seconds. A 404 there is expected, not news, and it
+            # drowns out the posture/error lines in the driver log.
+            if '"GET /mcp/sse' in msg and '404' in msg:
+                return
             # Escape and cap: msg embeds the raw request line, which on host
             # networking is remote-controlled bytes going straight into the
             # Docker log framer (log injection / control-byte corruption).

--- a/unitree/r1/rpc_proxy.py
+++ b/unitree/r1/rpc_proxy.py
@@ -69,6 +69,12 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
             if method == "__run_fsm_sequence":
                 steps_spec, interval, step_timeout, settle_delay = args
                 completed = []
+                # Every distinct FSM value seen while waiting, per step. The caller
+                # uses it to tell a controlled transition from a fall: a healthy
+                # standup2lie passes through 702 for ~6s, lie2standup through 701 for
+                # ~3s, so arriving at the target without them means the robot did not
+                # move through the posture.
+                fsm_seen: dict = {}
                 t_seq = time.monotonic()
                 code0, fsm0 = client.GetFsmId()
                 print(f"[RpcWorker] fsm_sequence start: steps={[s[2] for s in steps_spec]} "
@@ -87,15 +93,19 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                               flush=True)
                         result_queue.put({"seq": seq, "result": {
                             "error": f"Step '{step_name}' failed: code={ret}",
-                            "step": step_name, "completed": completed}})
+                            "step": step_name, "completed": completed,
+                            "fsm_seen": fsm_seen}})
                         break  # abort sequence on failure
                     # Poll FSM until target reached or timeout
                     elapsed = 0.0
                     ok = False
+                    seen = fsm_seen.setdefault(step_name, [])
                     while elapsed < step_timeout:
                         time.sleep(interval)
                         elapsed += interval
                         code, fsm_id = client.GetFsmId()
+                        if code == 0 and fsm_id not in seen:
+                            seen.append(fsm_id)
                         print(f"[RpcWorker] fsm_step '{step_name}': poll t={elapsed:.1f}s "
                               f"fsm={fsm_id} (code={code}) want={target_fsm}", flush=True)
                         if code == 0 and fsm_id == target_fsm:
@@ -107,12 +117,13 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                               f"fsm={current} want={target_fsm}", flush=True)
                         result_queue.put({"seq": seq, "result": {
                             "error": f"Timeout '{step_name}' (expected={target_fsm}, got={current})",
-                            "step": step_name, "fsm_id": current, "completed": completed}})
+                            "step": step_name, "fsm_id": current, "completed": completed,
+                            "fsm_seen": fsm_seen}})
                         break  # abort sequence on timeout
                     completed.append(step_name)
                     # Wait for physical motion to settle before next step
-                    print(f"[RpcWorker] fsm_step '{step_name}': reached target in {elapsed:.1f}s, "
-                          f"settling {settle_delay}s", flush=True)
+                    print(f"[RpcWorker] fsm_step '{step_name}': reached target in {elapsed:.1f}s "
+                          f"(saw {seen}), settling {settle_delay}s", flush=True)
                     time.sleep(settle_delay)
                 else:
                     # Only reached if loop completed without break (all steps succeeded)
@@ -127,6 +138,7 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                         "fsm_id": fsm_final if code_f == 0 else steps_spec[-1][1],
                         "fsm_target": steps_spec[-1][1],
                         "fsm_measured": code_f == 0,
+                        "fsm_seen": fsm_seen,
                         "elapsed_s": round(time.monotonic() - t_seq, 2)}})
                 continue  # next cmd
 

--- a/unitree/r1/rpc_proxy.py
+++ b/unitree/r1/rpc_proxy.py
@@ -60,6 +60,7 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
         method = cmd.get("method")
         args = cmd.get("args", [])
         kwargs = cmd.get("kwargs", {})
+        seq = cmd.get("seq")
 
         try:
             client = clients.get(client_name, loco)
@@ -68,11 +69,23 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
             if method == "__run_fsm_sequence":
                 steps_spec, interval, step_timeout, settle_delay = args
                 completed = []
+                t_seq = time.monotonic()
+                code0, fsm0 = client.GetFsmId()
+                print(f"[RpcWorker] fsm_sequence start: steps={[s[2] for s in steps_spec]} "
+                      f"fsm_now={fsm0} (code={code0}) interval={interval}s "
+                      f"step_timeout={step_timeout}s settle={settle_delay}s", flush=True)
                 for method_name, target_fsm, step_name in steps_spec:
                     fn = getattr(client, method_name)
+                    t_step = time.monotonic()
+                    print(f"[RpcWorker] fsm_step '{step_name}': calling {method_name}() "
+                          f"target_fsm={target_fsm}", flush=True)
                     ret = fn()
+                    print(f"[RpcWorker] fsm_step '{step_name}': {method_name}() -> ret={ret} "
+                          f"({time.monotonic() - t_step:.2f}s)", flush=True)
                     if ret != 0:
-                        result_queue.put({"result": {
+                        print(f"[RpcWorker] fsm_step '{step_name}': FAILED, aborting sequence",
+                              flush=True)
+                        result_queue.put({"seq": seq, "result": {
                             "error": f"Step '{step_name}' failed: code={ret}",
                             "step": step_name, "completed": completed}})
                         break  # abort sequence on failure
@@ -83,29 +96,47 @@ def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.
                         time.sleep(interval)
                         elapsed += interval
                         code, fsm_id = client.GetFsmId()
+                        print(f"[RpcWorker] fsm_step '{step_name}': poll t={elapsed:.1f}s "
+                              f"fsm={fsm_id} (code={code}) want={target_fsm}", flush=True)
                         if code == 0 and fsm_id == target_fsm:
                             ok = True
                             break
                     if not ok:
                         _, current = client.GetFsmId()
-                        result_queue.put({"result": {
+                        print(f"[RpcWorker] fsm_step '{step_name}': TIMEOUT after {elapsed:.1f}s, "
+                              f"fsm={current} want={target_fsm}", flush=True)
+                        result_queue.put({"seq": seq, "result": {
                             "error": f"Timeout '{step_name}' (expected={target_fsm}, got={current})",
                             "step": step_name, "fsm_id": current, "completed": completed}})
                         break  # abort sequence on timeout
                     completed.append(step_name)
                     # Wait for physical motion to settle before next step
+                    print(f"[RpcWorker] fsm_step '{step_name}': reached target in {elapsed:.1f}s, "
+                          f"settling {settle_delay}s", flush=True)
                     time.sleep(settle_delay)
                 else:
                     # Only reached if loop completed without break (all steps succeeded)
-                    result_queue.put({"result": {"ret": 0, "steps": completed,
-                                                 "fsm_id": steps_spec[-1][1]}})
+                    # Report the FSM we actually measure, not the target we aimed at --
+                    # otherwise "completed" carries no evidence about the real robot.
+                    code_f, fsm_final = client.GetFsmId()
+                    print(f"[RpcWorker] fsm_sequence done: steps={completed} "
+                          f"fsm_final={fsm_final} (code={code_f}) target={steps_spec[-1][1]} "
+                          f"total={time.monotonic() - t_seq:.2f}s", flush=True)
+                    result_queue.put({"seq": seq, "result": {
+                        "ret": 0, "steps": completed,
+                        "fsm_id": fsm_final if code_f == 0 else steps_spec[-1][1],
+                        "fsm_target": steps_spec[-1][1],
+                        "fsm_measured": code_f == 0,
+                        "elapsed_s": round(time.monotonic() - t_seq, 2)}})
                 continue  # next cmd
 
             fn = getattr(client, method)
             result = fn(*args, **kwargs)
-            result_queue.put({"result": result})
+            result_queue.put({"seq": seq, "result": result})
         except Exception as e:
-            result_queue.put({"error": str(e)})
+            print(f"[RpcWorker] {client_name}.{method} raised: {e}", flush=True)
+            result_queue.put({"seq": seq, "error": str(e)})
+
 
 
 class RpcProxy:
@@ -122,18 +153,49 @@ class RpcProxy:
         )
         self._proc.start()
         self._lock = threading.Lock()
+        self._seq = 0
 
     def _call(self, client: str, method: str, *args, timeout: float = 15.0, **kwargs):
+        # One lock over one command/result queue pair, shared by loco + arm + audio.
+        # A long call (RunFsmSequence holds it for the whole sequence) blocks every
+        # other plugin, so log the wait when it is long enough to matter.
+        t_want = time.monotonic()
         with self._lock:
-            self._cmd_q.put({"client": client, "method": method, "args": args, "kwargs": kwargs})
-            try:
-                r = self._result_q.get(timeout=timeout)
-            except Exception:
-                return None  # caller handles based on method type
+            waited = time.monotonic() - t_want
+            if waited > 0.5:
+                print(f"[RpcProxy] {client}.{method} waited {waited:.2f}s for the RPC lock",
+                      flush=True)
+            self._seq += 1
+            seq = self._seq
+            self._cmd_q.put({"client": client, "method": method, "args": args,
+                             "kwargs": kwargs, "seq": seq})
+            t0 = time.monotonic()
+            while True:
+                remaining = timeout - (time.monotonic() - t0)
+                if remaining <= 0:
+                    # The command is still in flight. Its reply will land in the queue
+                    # later and would be handed to the *next* caller, desyncing every
+                    # subsequent call by one -- which silently corrupts GetFsmId() and
+                    # therefore the "don't damp while standing" guard. The seq tag lets
+                    # the next caller drop it instead.
+                    print(f"[RpcProxy] {client}.{method} TIMEOUT after {timeout:.1f}s "
+                          f"(seq={seq}); its late reply will be discarded", flush=True)
+                    return None
+                try:
+                    r = self._result_q.get(timeout=remaining)
+                except Exception:
+                    continue  # re-check the deadline
+                r_seq = r.get("seq")
+                if r_seq is not None and r_seq != seq:
+                    print(f"[RpcProxy] discarding stale reply seq={r_seq} "
+                          f"while waiting for seq={seq}", flush=True)
+                    continue
+                break
             if "error" in r:
                 print(f"[RpcProxy] {client}.{method} error: {r['error']}", flush=True)
                 return None  # caller handles based on method type
             return r["result"]
+
 
     def _call_code(self, client: str, method: str, *args, **kwargs) -> int:
         """For methods that return a single int code."""

--- a/unitree/r1/tests/test_rpc_proxy_seq.py
+++ b/unitree/r1/tests/test_rpc_proxy_seq.py
@@ -1,0 +1,183 @@
+"""
+RpcProxy: one lock, one command/result queue pair, shared by loco + arm + audio.
+
+`RunFsmSequence` holds that lock for the whole posture change. While switch_mode
+was synchronous the ACP barrier guaranteed nothing else ran during that window;
+now that dispatch returns immediately the turn keeps going, so TTS / speaker / LED
+calls really do land on the proxy mid-sequence. That makes a latent bug reachable:
+
+    try:
+        r = self._result_q.get(timeout=timeout)
+    except Exception:
+        return None          # the command is STILL in flight
+
+The late reply used to stay in the queue and be handed to the *next* caller,
+desyncing every subsequent call by one. `GetFsmId()` would then return whatever
+the previous command produced -- and every posture guard keys off that reading.
+
+These tests drive the real RpcProxy._call against a fake queue pair; no subprocess,
+no robot.
+
+Run:  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest unitree/r1/tests -q
+"""
+
+import importlib.util
+import queue
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+spec = importlib.util.spec_from_file_location("r1_rpc_proxy_under_test", ROOT / "rpc_proxy.py")
+RP = importlib.util.module_from_spec(spec)
+sys.modules["r1_rpc_proxy_under_test"] = RP
+spec.loader.exec_module(RP)
+
+
+class FakeProxy(RP.RpcProxy):
+    """RpcProxy without the spawned subprocess -- plain queues stand in for it."""
+
+    def __init__(self):
+        self._cmd_q = queue.Queue()
+        self._result_q = queue.Queue()
+        self._proc = None
+        self._lock = threading.Lock()
+        self._seq = 0
+
+    def take_cmd(self, timeout=1.0):
+        return self._cmd_q.get(timeout=timeout)
+
+    def reply(self, seq, result):
+        self._result_q.put({"seq": seq, "result": result})
+
+
+def test_every_command_carries_a_sequence_number():
+    p = FakeProxy()
+    t = threading.Thread(target=lambda: p._call("loco", "GetFsmId"), daemon=True)
+    t.start()
+    cmd = p.take_cmd()
+    assert cmd["seq"] == 1
+    assert cmd["client"] == "loco" and cmd["method"] == "GetFsmId"
+    p.reply(cmd["seq"], (0, 811))
+    t.join(timeout=2)
+
+
+def test_normal_call_returns_its_own_result():
+    p = FakeProxy()
+    out = []
+    t = threading.Thread(target=lambda: out.append(p._call("loco", "GetFsmId")), daemon=True)
+    t.start()
+    cmd = p.take_cmd()
+    p.reply(cmd["seq"], (0, 811))
+    t.join(timeout=2)
+    assert out == [(0, 811)]
+
+
+def test_a_late_reply_does_not_poison_the_next_call(capsys):
+    """The regression. Call A times out; its reply arrives afterwards. Call B must
+    get B's result, not A's -- otherwise GetFsmId() returns an FSM sequence dict and
+    every posture guard is reading garbage."""
+    p = FakeProxy()
+
+    # Call A: times out with nothing in the queue.
+    assert p._call("loco", "__run_fsm_sequence", timeout=0.15) is None
+    cmd_a = p.take_cmd()
+
+    # A's reply lands late.
+    p.reply(cmd_a["seq"], {"ret": 0, "steps": ["standup2lie"], "fsm_id": 1})
+
+    # Call B must skip it.
+    out = []
+    t = threading.Thread(target=lambda: out.append(p._call("loco", "GetFsmId")), daemon=True)
+    t.start()
+    cmd_b = p.take_cmd()
+    assert cmd_b["seq"] != cmd_a["seq"]
+    p.reply(cmd_b["seq"], (0, 811))
+    t.join(timeout=2)
+
+    assert out == [(0, 811)], f'call B got a stale reply: {out}'
+    log = capsys.readouterr().out
+    assert 'TIMEOUT' in log
+    assert 'discarding stale reply' in log
+
+
+def test_timeout_is_logged_loudly(capsys):
+    p = FakeProxy()
+    assert p._call("loco", "Damp", timeout=0.1) is None
+    out = capsys.readouterr().out
+    assert 'loco.Damp TIMEOUT' in out
+    assert 'discarded' in out
+
+
+def test_several_stale_replies_are_all_skipped():
+    p = FakeProxy()
+    for _ in range(3):
+        assert p._call("audio", "TtsMaker", timeout=0.05) is None
+    stale = [p.take_cmd() for _ in range(3)]
+    for c in stale:
+        p.reply(c["seq"], "stale")
+
+    out = []
+    t = threading.Thread(target=lambda: out.append(p._call("loco", "GetFsmId")), daemon=True)
+    t.start()
+    cmd = p.take_cmd()
+    p.reply(cmd["seq"], (0, 4))
+    t.join(timeout=2)
+    assert out == [(0, 4)]
+
+
+def test_worker_errors_still_surface_as_none(capsys):
+    p = FakeProxy()
+    out = []
+    t = threading.Thread(target=lambda: out.append(p._call("loco", "Damp")), daemon=True)
+    t.start()
+    cmd = p.take_cmd()
+    p._result_q.put({"seq": cmd["seq"], "error": "boom"})
+    t.join(timeout=2)
+    assert out == [None]
+    assert 'loco.Damp error: boom' in capsys.readouterr().out
+
+
+def test_a_long_call_blocks_others_and_says_so(capsys):
+    """This is what changed: while switch_mode was synchronous nothing else reached
+    the proxy during a sequence. Now TTS can, and it waits behind the whole posture
+    change -- so the wait has to be visible."""
+    p = FakeProxy()
+    started = threading.Event()
+
+    def slow():
+        started.set()
+        p._call("loco", "__run_fsm_sequence", timeout=5)
+
+    t = threading.Thread(target=slow, daemon=True)
+    t.start()
+    started.wait(1)
+    cmd_slow = p.take_cmd()
+
+    out = []
+    t2 = threading.Thread(target=lambda: out.append(p._call("audio", "TtsMaker")), daemon=True)
+    t2.start()
+
+    time.sleep(0.7)                       # t2 is parked on the lock
+    assert out == [], 'the second caller should still be blocked'
+    p.reply(cmd_slow["seq"], {"ret": 0})
+    t.join(timeout=2)
+
+    cmd_fast = p.take_cmd(timeout=2)
+    p.reply(cmd_fast["seq"], 0)
+    t2.join(timeout=2)
+
+    assert out == [0]
+    assert 'waited' in capsys.readouterr().out
+
+
+def test_call_code_and_call_tuple_report_failure_codes():
+    """Callers unpack these; None would raise instead of being handled."""
+    p = FakeProxy()
+    assert p._call_code("loco", "Damp", timeout=0.05) == 3104
+    assert p._call_tuple("loco", "GetFsmId", timeout=0.05) == (3104, None)

--- a/unitree/r1/tests/test_switch_mode_acp.py
+++ b/unitree/r1/tests/test_switch_mode_acp.py
@@ -132,6 +132,14 @@ class FakeLocoClient:
         return self.seq_result
 
 
+def _healthy(mode):
+    """What the worker returns for a real, controlled transition."""
+    transit = {"standup2lie": 702, "lie2standup": 701}[mode]
+    target = {"standup2lie": 1, "lie2standup": 811}[mode]
+    return {"ret": 0, "steps": [mode], "fsm_id": target, "fsm_target": target,
+            "fsm_measured": True, "fsm_seen": {mode: [transit, target]}}
+
+
 @pytest.fixture
 def notified(monkeypatch):
     """Capture ACP callbacks instead of POSTing them."""
@@ -167,7 +175,8 @@ def wait_for(predicate, timeout=5.0):
 ])
 def test_sequence_modes_return_before_the_sequence_finishes(mode, start_fsm, notified):
     """dispatch returns while RunFsmSequence is still running -- that is the point."""
-    plugin, client = make_plugin(fsm_id=start_fsm, seq_delay=1.0)
+    plugin, client = make_plugin(fsm_id=start_fsm, seq_delay=1.0,
+                                 seq_result=_healthy(mode))
 
     import time
     t0 = time.monotonic()
@@ -187,7 +196,7 @@ def test_sequence_modes_return_before_the_sequence_finishes(mode, start_fsm, not
 
 
 def test_sequence_runs_off_the_dispatch_thread():
-    plugin, client = make_plugin(fsm_id=0)
+    plugin, client = make_plugin(fsm_id=0, seq_result=_healthy('lie2standup'))
     plugin.dispatch('switch_mode', {'mode': 'lie2standup'})
     assert wait_for(lambda: client.sequence_thread is not None)
     assert client.sequence_thread is not threading.current_thread()
@@ -196,7 +205,7 @@ def test_sequence_runs_off_the_dispatch_thread():
 def test_standup2lie_from_loco_stops_movement_in_the_worker(notified):
     """StopMove + the 1s settle used to run inline, so dispatch blocked a second
     even before the sequence started."""
-    plugin, client = make_plugin(fsm_id=811)
+    plugin, client = make_plugin(fsm_id=811, seq_result=_healthy('standup2lie'))
 
     import time
     t0 = time.monotonic()
@@ -210,7 +219,7 @@ def test_standup2lie_from_loco_stops_movement_in_the_worker(notified):
 
 def test_standup2lie_from_stance_does_not_stop_move(notified):
     """FSM 4 is not walking; StopMove there would be a spurious RPC."""
-    plugin, client = make_plugin(fsm_id=4)
+    plugin, client = make_plugin(fsm_id=4, seq_result=_healthy('standup2lie'))
     plugin.dispatch('switch_mode', {'mode': 'standup2lie'})
     assert wait_for(lambda: notified)
     assert 'StopMove' not in client.calls
@@ -340,3 +349,161 @@ def test_schema_declares_x_completion_without_an_action_filter():
     assert 'actions' not in completion
     assert completion['timeout'] >= 60, 'must outlast 4 steps x 15s step_timeout'
     assert 'action' not in schema['properties']
+
+
+# ── mid-transition and unknown states must be refused ────────────────────────
+#
+# 701/702 are "motion in progress". Every guard used to ignore them, and
+# lie2standup's `fsm_to_start.get(current_fsm, 0)` defaulted anything it did not
+# recognise to step 0 -- ZeroTorque() on a robot that may be halfway up.
+#
+# While switch_mode was synchronous the robot could not be caught in those states:
+# dispatch blocked for the whole sequence and the ACP barrier held back the next
+# actuator. Async dispatch leaves the window open for 6-13s.
+
+@pytest.mark.parametrize('mode', ['lie2standup', 'standup2lie'])
+@pytest.mark.parametrize('fsm', [701, 702])
+def test_transitional_states_are_refused(mode, fsm, notified):
+    plugin, client = make_plugin(fsm_id=fsm)
+    result = plugin.dispatch('switch_mode', {'mode': mode})
+    assert 'error' in result
+    assert str(fsm) in result['error']
+    assert 'action_id' not in result
+    assert client.calls == [], 'no motor RPC may be issued mid-transition'
+    assert not notified
+
+
+def test_lie2standup_no_longer_zero_torques_on_an_unknown_state(notified):
+    """The dangerous default. fsm=999 used to select step 0 = ZeroTorque()."""
+    plugin, client = make_plugin(fsm_id=999)
+    result = plugin.dispatch('switch_mode', {'mode': 'lie2standup'})
+    assert 'error' in result
+    assert 'Unrecognised' in result['error']
+    assert 'ZeroTorque' not in client.calls
+    assert client.calls == []
+    assert not notified
+
+
+def test_standup2lie_refuses_an_unknown_state(notified):
+    plugin, client = make_plugin(fsm_id=999)
+    result = plugin.dispatch('switch_mode', {'mode': 'standup2lie'})
+    assert 'error' in result
+    assert client.calls == []
+    assert not notified
+
+
+@pytest.mark.parametrize('fsm,expect_steps', [
+    (0, ['damp', 'stance', 'lie2standup']),   # from zero_torque, skip step 0
+    (1, ['stance', 'lie2standup']),
+    (4, ['lie2standup']),
+])
+def test_lie2standup_still_skips_completed_steps(fsm, expect_steps, notified):
+    """The recognised states must behave exactly as before."""
+    captured = {}
+    plugin, _ = make_plugin(fsm_id=fsm)
+
+    def fake_async(mode, steps, stop_first=False):
+        captured['steps'] = [s[2] for s in steps]
+        return {'status': 'executing', 'action_id': 'test'}
+
+    plugin._async_fsm = fake_async
+    plugin.dispatch('switch_mode', {'mode': 'lie2standup'})
+    assert captured['steps'] == expect_steps
+
+
+# ── only one sequence at a time ──────────────────────────────────────────────
+
+def test_a_second_posture_change_is_refused_while_one_runs(notified):
+    """Two sequences moving the robot at once is how a safe call becomes a fall."""
+    plugin, client = make_plugin(fsm_id=811, seq_delay=1.0,
+                                 seq_result=_healthy('standup2lie'))
+    first = plugin.dispatch('switch_mode', {'mode': 'standup2lie'})
+    assert first['status'] == 'executing'
+
+    # Same reading, so only the busy flag can stop the second one.
+    second = plugin.dispatch('switch_mode', {'mode': 'standup2lie'})
+    assert 'error' in second
+    assert 'already running' in second['error']
+    assert 'action_id' not in second
+
+    assert wait_for(lambda: notified)
+    assert client.calls.count('RunFsmSequence') == 1
+
+
+def test_the_lock_is_released_after_a_sequence_finishes(notified):
+    plugin, _ = make_plugin(fsm_id=811, seq_result=_healthy('standup2lie'))
+    plugin.dispatch('switch_mode', {'mode': 'standup2lie'})
+    assert wait_for(lambda: notified)
+    assert not plugin._fsm_busy.locked()
+    assert plugin._fsm_active is None
+
+
+def test_the_lock_is_released_after_a_crash(notified):
+    """A wedged lock would refuse every future posture change for the process life."""
+    plugin, _ = make_plugin(fsm_id=811, seq_raises=RuntimeError('sdk exploded'))
+    plugin.dispatch('switch_mode', {'mode': 'standup2lie'})
+    assert wait_for(lambda: notified)
+    assert notified[0]['status'] == 'error'
+    assert not plugin._fsm_busy.locked()
+
+
+# ── "arrived" is not the same as "moved there" ───────────────────────────────
+
+@pytest.mark.parametrize('mode,transit,target', [
+    ('standup2lie', 702, 1),
+    ('lie2standup', 701, 811),
+])
+def test_reaching_the_target_without_the_transitional_state_is_an_error(
+        mode, transit, target, notified):
+    """The 2026-09-02 signature: standup2lie hit damp at the first poll, having
+    never entered 702, and was reported as a clean "completed" -- so the model went
+    on to say it had lain down while the robot was on the floor.
+
+    A healthy transition sits in 702 for ~6s / 701 for ~3s, so 1s polling cannot
+    miss it.
+    """
+    start = 811 if mode == 'standup2lie' else 4
+    plugin, _ = make_plugin(fsm_id=start, seq_result={
+        "ret": 0, "steps": [mode], "fsm_id": target, "fsm_target": target,
+        "fsm_measured": True, "fsm_seen": {mode: [target]}})   # target only
+    plugin.dispatch('switch_mode', {'mode': mode})
+
+    assert wait_for(lambda: notified)
+    assert notified[0]['status'] == 'error', 'a fall must not report as completed'
+    r = notified[0]['result']
+    assert r['anomaly'] == 'missing_transitional_state'
+    assert r['expected_transitional'] == transit
+    assert str(transit) in r['error']
+
+
+@pytest.mark.parametrize('mode', ['standup2lie', 'lie2standup'])
+def test_a_controlled_transition_is_reported_as_completed(mode, notified):
+    start = 811 if mode == 'standup2lie' else 4
+    plugin, _ = make_plugin(fsm_id=start, seq_result=_healthy(mode))
+    plugin.dispatch('switch_mode', {'mode': mode})
+    assert wait_for(lambda: notified)
+    assert notified[0]['status'] == 'completed'
+    assert 'anomaly' not in notified[0]['result']
+
+
+def test_a_step_failure_is_not_relabelled_by_the_transit_check(notified):
+    """An error must keep its own message, not be overwritten by the anomaly text."""
+    plugin, _ = make_plugin(fsm_id=811, seq_result={
+        "error": "Step 'standup2lie' failed: code=7", "fsm_seen": {}})
+    plugin.dispatch('switch_mode', {'mode': 'standup2lie'})
+    assert wait_for(lambda: notified)
+    assert notified[0]['status'] == 'error'
+    assert 'code=7' in notified[0]['result']['error']
+    assert 'anomaly' not in notified[0]['result']
+
+
+def test_stop_move_return_code_reaches_the_acp_result(notified):
+    """StopMove clears residual motion before the lie-down. It returns non-zero on
+    healthy runs too, so it is reported rather than acted on -- but it must not be
+    silently dropped, since "lie down while still moving" is the leading theory for
+    a controlled descent degrading into a collapse."""
+    plugin, client = make_plugin(fsm_id=811, seq_result=_healthy('standup2lie'))
+    client.StopMove = lambda: 127
+    plugin.dispatch('switch_mode', {'mode': 'standup2lie'})
+    assert wait_for(lambda: notified)
+    assert notified[0]['result']['stop_move_ret'] == 127

--- a/unitree/r1/tests/test_switch_mode_acp.py
+++ b/unitree/r1/tests/test_switch_mode_acp.py
@@ -1,0 +1,300 @@
+"""
+R1 switch_mode: the standing/lying FSM sequences must not block the dispatch thread.
+
+Measured on R1 (agent-core log, 2026-09-02): a `switch_mode(lie2standup)` call held
+the MCP dispatch for 12.14s -- `_run_fsm_sequence` runs 4 steps 1s apart and waits
+for each. Because every MCP `tools/call` is what the agent turn is awaiting, the
+whole turn froze for those 12s: no reasoning, no speech, nothing overlapped.
+
+So the two sequence modes now return an action_id immediately and report via the
+ACP callback, the same shape G1 has used since it went async.
+
+The single-RPC modes (damp / zero_torque / emergency_stop / get_current_mode)
+deliberately stay synchronous and return *no* action_id -- that absence is what
+keeps agent-core from arming a barrier for them, since this tool's parameter is
+named `mode` and agent-core's x-completion filter matches on `action`
+(mcp_client.py:504).
+
+Run:  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest unitree/r1/tests -q
+"""
+
+import importlib.util
+import sys
+import threading
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+class Message:
+    def __init__(self):
+        self.header = types.SimpleNamespace(stamp=None, frame_id="")
+
+
+class FakeNode:
+    def __init__(self, name):
+        self._name = name
+
+    def create_publisher(self, *a, **kw):
+        return types.SimpleNamespace(publish=lambda msg: None)
+
+    def create_subscription(self, *a, **kw):
+        return object()
+
+    def get_logger(self):
+        return types.SimpleNamespace(info=lambda *a: None, warn=lambda *a: None,
+                                     error=lambda *a: None, debug=lambda *a: None)
+
+
+def install_stubs():
+    rclpy = types.ModuleType("rclpy")
+    sys.modules.setdefault("rclpy", rclpy)
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_node.Node = FakeNode
+    rclpy_qos = types.ModuleType("rclpy.qos")
+    rclpy_qos.QoSProfile = lambda **kw: types.SimpleNamespace(**kw)
+    rclpy_qos.ReliabilityPolicy = types.SimpleNamespace(BEST_EFFORT=1, RELIABLE=2)
+    rclpy_qos.HistoryPolicy = types.SimpleNamespace(KEEP_LAST=1)
+    rclpy_qos.DurabilityPolicy = types.SimpleNamespace(VOLATILE=1)
+    sys.modules["rclpy.node"] = rclpy_node
+    sys.modules["rclpy.qos"] = rclpy_qos
+
+    std_msgs = types.ModuleType("std_msgs.msg")
+    std_msgs.String = type("String", (Message,),
+                           {"__init__": lambda self: setattr(self, "data", "")})
+    sys.modules["std_msgs.msg"] = std_msgs
+
+    audio_msgs = types.ModuleType("audio_msgs.msg")
+    audio_msgs.AudioChunk = type("AudioChunk", (Message,), {})
+    sys.modules["audio_msgs.msg"] = audio_msgs
+
+    # device.py only needs AudioClient to exist at import time.
+    for name in ("unitree_sdk2py", "unitree_sdk2py.g1", "unitree_sdk2py.g1.audio"):
+        sys.modules.setdefault(name, types.ModuleType(name))
+    audio_mod = types.ModuleType("unitree_sdk2py.g1.audio.g1_audio_client")
+    audio_mod.AudioClient = type("AudioClient", (), {})
+    sys.modules["unitree_sdk2py.g1.audio.g1_audio_client"] = audio_mod
+
+
+def load_device():
+    install_stubs()
+    spec = importlib.util.spec_from_file_location("r1_device_under_test", ROOT / "device.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["r1_device_under_test"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+DEV = load_device()
+
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+
+class FakeLocoClient:
+    """Stands in for the R1 LocoClient. RunFsmSequence blocks like the real one."""
+
+    def __init__(self, fsm_id=0, seq_delay=0.0, seq_result=None, seq_raises=None):
+        self.fsm_id = fsm_id
+        self.seq_delay = seq_delay
+        self.seq_result = seq_result if seq_result is not None else {"ok": True}
+        self.seq_raises = seq_raises
+        self.calls = []
+        self.sequence_thread = None
+
+    def GetFsmId(self):
+        return 0, self.fsm_id
+
+    def StopMove(self):
+        self.calls.append("StopMove")
+        return 0
+
+    def Damp(self):
+        self.calls.append("Damp")
+        return 0
+
+    def ZeroTorque(self):
+        self.calls.append("ZeroTorque")
+        return 0
+
+    def RunFsmSequence(self, steps, interval=1.0, step_timeout=15.0):
+        self.calls.append("RunFsmSequence")
+        self.sequence_thread = threading.current_thread()
+        if self.seq_delay:
+            import time
+            time.sleep(self.seq_delay)
+        if self.seq_raises:
+            raise self.seq_raises
+        return self.seq_result
+
+
+@pytest.fixture
+def notified(monkeypatch):
+    """Capture ACP callbacks instead of POSTing them."""
+    seen = []
+    monkeypatch.setattr(DEV, '_loco_acp_notify',
+                        lambda aid, status, result, tool="loco":
+                        seen.append({'action_id': aid, 'status': status,
+                                     'result': result, 'tool': tool}))
+    return seen
+
+
+def make_plugin(**kw):
+    client = FakeLocoClient(**kw)
+    return DEV.LocoPlugin({}, "ubuntu", None, client), client
+
+
+def wait_for(predicate, timeout=5.0):
+    import time
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+# ── the regression: dispatch must not block ──────────────────────────────────
+
+@pytest.mark.parametrize('mode,start_fsm', [
+    ('lie2standup', 0),
+    ('standup2lie', 811),
+    ('standup2lie', 4),
+])
+def test_sequence_modes_return_before_the_sequence_finishes(mode, start_fsm, notified):
+    """dispatch returns while RunFsmSequence is still running -- that is the point."""
+    plugin, client = make_plugin(fsm_id=start_fsm, seq_delay=1.0)
+
+    import time
+    t0 = time.monotonic()
+    result = plugin.dispatch('switch_mode', {'mode': mode})
+    elapsed = time.monotonic() - t0
+
+    assert elapsed < 0.5, f'dispatch blocked for {elapsed:.2f}s'
+    assert result['status'] == 'executing'
+    assert result['mode'] == mode
+    assert result['action_id'].startswith('r1_fsm_')
+
+    assert wait_for(lambda: notified), 'ACP callback never fired'
+    assert notified[0]['action_id'] == result['action_id']
+    assert notified[0]['status'] == 'completed'
+    assert notified[0]['tool'] == 'switch_mode'
+    assert notified[0]['result']['mode'] == mode
+
+
+def test_sequence_runs_off_the_dispatch_thread():
+    plugin, client = make_plugin(fsm_id=0)
+    plugin.dispatch('switch_mode', {'mode': 'lie2standup'})
+    assert wait_for(lambda: client.sequence_thread is not None)
+    assert client.sequence_thread is not threading.current_thread()
+
+
+def test_standup2lie_from_loco_stops_movement_in_the_worker(notified):
+    """StopMove + the 1s settle used to run inline, so dispatch blocked a second
+    even before the sequence started."""
+    plugin, client = make_plugin(fsm_id=811)
+
+    import time
+    t0 = time.monotonic()
+    plugin.dispatch('switch_mode', {'mode': 'standup2lie'})
+    elapsed = time.monotonic() - t0
+
+    assert elapsed < 0.5, f'dispatch blocked for {elapsed:.2f}s on StopMove'
+    assert wait_for(lambda: notified)
+    assert client.calls == ['StopMove', 'RunFsmSequence']
+
+
+def test_standup2lie_from_stance_does_not_stop_move(notified):
+    """FSM 4 is not walking; StopMove there would be a spurious RPC."""
+    plugin, client = make_plugin(fsm_id=4)
+    plugin.dispatch('switch_mode', {'mode': 'standup2lie'})
+    assert wait_for(lambda: notified)
+    assert 'StopMove' not in client.calls
+
+
+# ── failures must still report ───────────────────────────────────────────────
+
+def test_sequence_error_is_reported_as_error(notified):
+    plugin, _ = make_plugin(fsm_id=0, seq_result={'error': 'step standup timed out'})
+    plugin.dispatch('switch_mode', {'mode': 'lie2standup'})
+    assert wait_for(lambda: notified)
+    assert notified[0]['status'] == 'error'
+    assert notified[0]['result']['error'] == 'step standup timed out'
+
+
+def test_rpc_timeout_is_reported_as_error(notified):
+    """RunFsmSequence returning None is the RPC-timeout path."""
+    plugin, client = make_plugin(fsm_id=0)
+    client.seq_result = None   # the default kwarg coerces None, so set it directly
+    plugin.dispatch('switch_mode', {'mode': 'lie2standup'})
+    assert wait_for(lambda: notified)
+    assert notified[0]['status'] == 'error'
+    assert 'RPC timeout' in notified[0]['result']['error']
+
+
+def test_exception_in_the_worker_still_fires_the_callback(notified):
+    """Without this the agent-core barrier waits out the full 90s x-completion
+    timeout for a sequence that already died."""
+    plugin, _ = make_plugin(fsm_id=0, seq_raises=RuntimeError('sdk exploded'))
+    plugin.dispatch('switch_mode', {'mode': 'lie2standup'})
+    assert wait_for(lambda: notified)
+    assert notified[0]['status'] == 'error'
+    assert 'RuntimeError: sdk exploded' in notified[0]['result']['error']
+
+
+# ── the synchronous modes must stay synchronous ──────────────────────────────
+
+@pytest.mark.parametrize('mode,fsm', [
+    ('emergency_stop', 811),
+    ('damp', 0),
+    ('zero_torque', 0),
+    ('get_current_mode', 811),
+])
+def test_single_rpc_modes_carry_no_action_id(mode, fsm, notified):
+    """agent-core arms a barrier iff the response has an action_id
+    (mcp_client.py:511). These must not get one, or every damp would block the
+    turn waiting for a callback that never comes."""
+    plugin, _ = make_plugin(fsm_id=fsm)
+    result = plugin.dispatch('switch_mode', {'mode': mode})
+    assert 'action_id' not in result
+    assert not notified
+
+
+@pytest.mark.parametrize('mode,fsm,key', [
+    ('lie2standup', 811, 'info'),    # already standing
+    ('standup2lie', 1, 'info'),      # already lying
+])
+def test_no_op_shortcuts_carry_no_action_id(mode, fsm, key, notified):
+    """Same reason: nothing runs, so nothing will ever call back."""
+    plugin, _ = make_plugin(fsm_id=fsm)
+    result = plugin.dispatch('switch_mode', {'mode': mode})
+    assert key in result
+    assert 'action_id' not in result
+    assert not notified
+
+
+def test_upright_guard_still_refuses_damp(notified):
+    """Going limp while standing drops the robot -- the guard predates this change
+    and must survive it."""
+    plugin, _ = make_plugin(fsm_id=811)
+    result = plugin.dispatch('switch_mode', {'mode': 'damp'})
+    assert 'error' in result
+    assert 'action_id' not in result
+    assert not notified
+
+
+# ── schema ───────────────────────────────────────────────────────────────────
+
+def test_schema_declares_x_completion_without_an_action_filter():
+    """An `actions` filter would be matched against args["action"]
+    (mcp_client.py:504), but this tool's parameter is named `mode` -- so a filter
+    would never match and the barrier would never arm."""
+    plugin, _ = make_plugin()
+    schema = plugin._switch_mode_tool()['inputSchema']
+    completion = schema['x-completion']
+    assert 'actions' not in completion
+    assert completion['timeout'] >= 60, 'must outlast 4 steps x 15s step_timeout'
+    assert 'action' not in schema['properties']

--- a/unitree/r1/tests/test_switch_mode_acp.py
+++ b/unitree/r1/tests/test_switch_mode_acp.py
@@ -99,6 +99,7 @@ class FakeLocoClient:
 
     def __init__(self, fsm_id=0, seq_delay=0.0, seq_result=None, seq_raises=None):
         self.fsm_id = fsm_id
+        self.fsm_code = 0
         self.seq_delay = seq_delay
         self.seq_result = seq_result if seq_result is not None else {"ok": True}
         self.seq_raises = seq_raises
@@ -106,7 +107,7 @@ class FakeLocoClient:
         self.sequence_thread = None
 
     def GetFsmId(self):
-        return 0, self.fsm_id
+        return self.fsm_code, self.fsm_id
 
     def StopMove(self):
         self.calls.append("StopMove")
@@ -249,13 +250,11 @@ def test_exception_in_the_worker_still_fires_the_callback(notified):
 
 @pytest.mark.parametrize('mode,fsm', [
     ('emergency_stop', 811),
-    ('damp', 0),
-    ('zero_torque', 0),
     ('get_current_mode', 811),
 ])
 def test_single_rpc_modes_carry_no_action_id(mode, fsm, notified):
     """agent-core arms a barrier iff the response has an action_id
-    (mcp_client.py:511). These must not get one, or every damp would block the
+    (mcp_client.py:511). These must not get one, or every query would block the
     turn waiting for a callback that never comes."""
     plugin, _ = make_plugin(fsm_id=fsm)
     result = plugin.dispatch('switch_mode', {'mode': mode})
@@ -276,13 +275,56 @@ def test_no_op_shortcuts_carry_no_action_id(mode, fsm, key, notified):
     assert not notified
 
 
-def test_upright_guard_still_refuses_damp(notified):
-    """Going limp while standing drops the robot -- the guard predates this change
-    and must survive it."""
-    plugin, _ = make_plugin(fsm_id=811)
-    result = plugin.dispatch('switch_mode', {'mode': 'damp'})
+# ── damp / zero_torque are gone from the model's surface ─────────────────────
+
+@pytest.mark.parametrize('mode', ['damp', 'zero_torque'])
+def test_raw_motor_modes_are_not_offered(mode):
+    """They were the only way for the model to go limp directly, and four ways to
+    'lie down' in one enum invited picking a motor mode for a posture change."""
+    plugin, _ = make_plugin()
+    assert mode not in plugin._switch_mode_tool()['inputSchema']['properties']['mode']['enum']
+
+
+@pytest.mark.parametrize('mode', ['damp', 'zero_torque'])
+@pytest.mark.parametrize('fsm', [0, 1, 4, 811])
+def test_raw_motor_modes_are_refused_from_every_state(mode, fsm, notified):
+    """A stale cached schema or a hand-made call must get a clear refusal, not a
+    silently dropped robot -- including from the ground states where they used to
+    be allowed."""
+    plugin, client = make_plugin(fsm_id=fsm)
+    result = plugin.dispatch('switch_mode', {'mode': mode})
+    assert 'error' in result
+    assert 'standup2lie' in result['error']
+    assert client.calls == [], 'no motor RPC may be issued'
+    assert not notified
+
+
+def test_the_posture_modes_survive():
+    enum = make_plugin()[0]._switch_mode_tool()['inputSchema']['properties']['mode']['enum']
+    assert enum == ['lie2standup', 'standup2lie', 'emergency_stop', 'get_current_mode']
+
+
+def test_emergency_stop_still_damps_from_standing(notified):
+    """The one remaining deliberate way to go limp. Must not be gated on state."""
+    plugin, client = make_plugin(fsm_id=811)
+    result = plugin.dispatch('switch_mode', {'mode': 'emergency_stop'})
+    assert result['mode'] == 'emergency_stop'
+    assert client.calls == ['Damp']
+
+
+# ── an unreadable FSM must not be acted on ───────────────────────────────────
+
+@pytest.mark.parametrize('mode', ['lie2standup', 'standup2lie'])
+def test_failed_fsm_read_refuses_instead_of_guessing(mode, notified):
+    """Every branch below keys off current_fsm. Acting on a failed read is how a
+    'safe' sequence turns into a collapse -- and RpcProxy returns (3104, None) for
+    a timed-out call, which used to fall straight through to the else branch."""
+    plugin, client = make_plugin(fsm_id=0)
+    client.fsm_code = 3104
+    result = plugin.dispatch('switch_mode', {'mode': mode})
     assert 'error' in result
     assert 'action_id' not in result
+    assert client.calls == []
     assert not notified
 
 


### PR DESCRIPTION
## 问题

R1 实测（agent-core 日志，2026-09-02，`core:release.260902.62ce187`）：

```
08:34:00.764  [acp] barrier cleared: ['speak-fe056349']
08:34:12.906  [decision] llm request: round=2      ← 中间 12.14s 什么都没发生
```

这 12.14 秒是 `switch_mode(lie2standup)` 的 dispatch。`_run_fsm_sequence` 跑 4 个 FSM 步骤、
每步间隔 1 秒并轮询目标状态，同步阻塞返回。

而每个 `tools/call` 正是 agent turn 在 await 的东西 —— **这 12 秒里 LLM 完全停摆，没有推理、
没有语音、什么都不并行**。整个 turn 24.28 秒，它占了一半。

## 改动

`lie2standup` / `standup2lie` 立即返回 `action_id`，序列在后台线程跑完后发 ACP 回调。
这正是 G1 早已在用的形态（`_async_fsm` / `_acp_fsm_sequence`），本 PR 把它移植到 R1。

`StopMove` 和它后面的 1 秒稳定等待也一并移进 worker —— 留在原地的话 dispatch 在序列开始前
就先阻塞一秒。

### 为什么 `x-completion` 不带 `actions` 过滤

agent-core 用 `args.get('action')` 去匹配 `x-completion.actions`（`mcp_client.py:504`），
而 R1 这个工具的参数叫 `mode`，写了过滤器永远匹配不上、barrier 永远不武装。

G1 能用过滤器是因为它有 `x-action-params` 拆分，`action` 本身就是模式名。

所以这里不写 `actions`：所有 dispatch 都算候选，真正的闸门是响应里有没有 `action_id`
（`mcp_client.py:511`）。单次 RPC 的模式（`damp` / `zero_torque` / `emergency_stop` /
`get_current_mode`）和"已经在目标状态"的短路分支都不返回 `action_id`，因此保持同步 —— 否则
每次 `damp` 都会让 turn 等一个永远不会来的回调。

`timeout: 90` 覆盖 `_run_fsm_sequence` 最坏情况（4 步 × 15s `step_timeout` + 间隔 + 余量）。

### 顺带加固 G1 和 R1 的 ACP worker

`_acp_fsm_sequence` 原本没有 try/except。线程里抛异常 → 回调发不出去 → agent-core 的 barrier
要等满整个 `x-completion` timeout（R1 90s、G1 150s）才放行，而序列其实早就死了。现在异常被
捕获并作为 `status=error` 回报。

## 测试

新建 `unitree/r1/tests/`（R1 此前没有测试），17 个测试：

- **dispatch 在序列跑完前就返回**（3 种起始 FSM 参数化）—— 这是本次回归的核心断言
- 序列跑在非 dispatch 线程上
- `standup2lie` 只在 loco 模式下调 `StopMove`，FSM=4 时不调
- error / RPC timeout（返回 `None`）/ worker 抛异常 —— 三条失败路径都仍然回报
- 同步模式和短路分支**不带** `action_id`
- 站立时 `damp` 的安全护栏仍然拒绝（这条守护先于本改动，不能被改坏）
- schema 断言：不能有 `actions` 过滤器、timeout 足够长、参数确实叫 `mode` 不叫 `action`

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest unitree/r1/tests unitree/g1/tests tests -q
106 passed
```

G1 原有 67 个测试全绿，未受影响。

## 实机验证（2026-09-02，扶持下完成）

两个方向都拿到了健康基线：

| | 序列 | 过渡态 | 总时长 |
|---|---|---|---|
| `lie2standup`（fsm=1 起） | stance 1s + settle 2s → **701 持续 3s** → 811 | `saw [701, 811]` | 9.02s |
| `lie2standup`（fsm=0 起） | damp → stance → **701 持续 3s** → 811 | | 13.11s |
| `standup2lie`（fsm=811 起） | **702 持续 6s** → 1 | `saw [702, 1]` | 9.03s |

- 701/702 判据**无误报**，两次都正确判为 `completed`；
- `fsm_to_start` 跳步正常（`from fsm=1, skipping 2 step(s)`），没有多余的 ZeroTorque；
- ACP 回调 `-> 200`，agent-core 侧 `barrier cleared`；
- 日志噪音清除后，静置 50 秒零输出。

### 由此确认的两件事

**1. 701/702 跟随物理动作，不是指令回执。** 这推翻了"FSM 一收到指令就报完成"的假设，也把 2026-09-02 那次摔倒的性质定死了：那次 4 秒完成，即第一次 poll 就读到 damp、从未进入 702 —— 机器人是**摔**到 damp 的，而驱动报了 `{"ret": 0, "fsm_id": 1}`，模型于是继续说"我已经躺好了"。这正是本 PR 第 4 项要拦的。

**2. `StopMove() -> ret=127` 是 R1 的常态，不是故障信号。** 两次健康的躺下都返回 127。因此"残余运动没停住导致受控下放退化成阻尼"这条嫌疑**不成立**，已从怀疑列表划掉。代码只上报、不据此中止，是对的。

### 新测到的问题（本 PR 不修）

```
[RpcProxy] audio.PlayStream waited 9.02s for the RPC lock
[speaker] drain finished: blocks=13 max_idle=1.5s
```

`RunFsmSequence` 握着 `RpcProxy` 那把全局锁整整 9 秒，期间 `audio.PlayStream` 完全阻塞 —— **姿态切换期间喇叭是哑的**。

这不是异步化引入的：同步版本里 dispatch 线程同样握满全程，只是以前没有日志看不见。同类问题见 G1 的 `b04b0da`。

要修需要动两处：父进程改成专用读线程按 seq 路由回复（seq 标记本 PR 已具备），子进程把长命令丢到独立线程（worker 现在是单线程顺序处理，光改父进程无效）。

**故意不在本 PR 做** —— 摔倒根因未定，此时翻改所有 RPC 的公共路径会给下次复现引入新变量。

## 未解决

`StandUp2Lie()` 为什么会跳过 702 直接进阻尼，仍无答案。事故窗口的容器日志已损坏（一条声称 1,007,289,971 字节的记录），现场取不回来。

本 PR 做的是：封掉驱动**自身**能放倒机器人的路径、给异步化引入的并发窗口上锁、并让失败在复现时可见。复现时的判据是：

```
[fsm] r1_fsm_xxxx: ANOMALY standup2lie never entered 702; observed=[1] -- treating as error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
