### PR TITLE
fix: controlled_spatial 导航到达检测与 config 分支修复 + 多机型音频播放稳定性修复 + 新增 Booster K1 / BrainCo Revo2 驱动

### DIFF
--- a/unitree/g1/config.yaml
+++ b/unitree/g1/config.yaml
@@ -27,7 +27,7 @@ plugins:
     db_path: /opt/phanthy-motus/data/spatial.db
   controlled_spatial:
     enabled: true
-    isolated_process: true
+    isolated_process: false
     native_slam_pcd_dir: /home/unitree
     native_slam_db_path: /opt/phanthy-motus/data/controlled_spatial.db
   controlled_spatial_map:

--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -502,7 +502,7 @@ class ControlledSpatialPlugin:
 
     # ── ACP completion thread ────────────────────────────────────────────────
 
-    def _acp_wait_nav(self, action_id: str, target: str, stall_timeout: float = 90):
+    def _acp_wait_nav(self, action_id: str, target: str, stall_timeout: float = 90, target_xy=None):
         """Wait for navigation to complete, then fire ACP callback."""
         self._nav_action_id = action_id
         t0 = time.time()
@@ -537,11 +537,24 @@ class ControlledSpatialPlugin:
                 })
             return
 
-        # Fallback: no SmartMotion — poll local DDS callback + stall detection
+        # Fallback: no SmartMotion — pose-based arrival (dist < 0.3m) + stall detection
         last_pose = self._get_pose()
         last_move_time = time.time()
 
         while True:
+            # Pose-based arrival check before waiting for stale ctrl_info signal
+            if target_xy is not None:
+                current_pose = self._get_pose()
+                if current_pose:
+                    dx = current_pose["x"] - target_xy[0]
+                    dy = current_pose["y"] - target_xy[1]
+                    if math.sqrt(dx * dx + dy * dy) < 0.3:
+                        elapsed = round(time.time() - t0, 1)
+                        _acp_notify(action_id, "completed", {
+                            "target": target, "pose": current_pose, "elapsed": elapsed,
+                        })
+                        return
+
             if self._nav_arrived.wait(timeout=1.0):
                 elapsed = round(time.time() - t0, 1)
                 if self._nav_error:
@@ -769,7 +782,7 @@ class ControlledSpatialPlugin:
                 result["action_id"] = action_id
                 threading.Thread(
                     target=self._acp_wait_nav,
-                    args=(action_id, tag_name, float(args.get("stall_timeout", 90))),
+                    args=(action_id, tag_name, float(args.get("stall_timeout", 90)), (poi["x"], poi["y"])),
                     daemon=True,
                 ).start()
                 return result
@@ -789,7 +802,7 @@ class ControlledSpatialPlugin:
                 action_id = f"g1_nav_{uuid4().hex[:8]}"
                 threading.Thread(
                     target=self._acp_wait_nav,
-                    args=(action_id, tag_name, float(args.get("stall_timeout", 90))),
+                    args=(action_id, tag_name, float(args.get("stall_timeout", 90)), (poi["x"], poi["y"])),
                     daemon=True,
                 ).start()
                 return {"status": "navigating", "target": tag_name,
@@ -819,7 +832,7 @@ class ControlledSpatialPlugin:
                 result["action_id"] = action_id
                 threading.Thread(
                     target=self._acp_wait_nav,
-                    args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90))),
+                    args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90)), (x, y)),
                     daemon=True,
                 ).start()
                 return result
@@ -927,6 +940,7 @@ def _controlled_spatial_process(plugin_config: dict, namespace: str, command_que
         child_config = dict(plugin_config)
         child_config["isolated_process"] = False
         plugin = ControlledSpatialPlugin(child_config, namespace, None, slam_client=None, smart_motion=None)
+        print("[ControlledSpatial:subprocess] no smart_motion — using pose-based fallback for arrival detection", flush=True)
         plugin.start()
         tool_def = plugin.get_tools()
         result_queue.put({"ready": True, "tools": tool_def})

--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -593,20 +593,29 @@ class ControlledSpatialPlugin:
                 last_move_time = time.time()
 
             if time.time() - last_move_time > stall_timeout:
-                if self._client:
-                    self._client.PauseNav()
-                _acp_notify(action_id, "error", {
-                    "target": target,
-                    "error": f"stall_timeout ({stall_timeout}s)",
-                    "elapsed": round(time.time() - t0, 1),
-                })
+                # Guard: if superseded, don't PauseNav (would pause active nav) or post stale error
+                if self._nav_action_id == action_id:
+                    self._nav_action_id = None
+                    if self._client:
+                        self._client.PauseNav()
+                    _acp_notify(action_id, "error", {
+                        "target": target,
+                        "error": f"stall_timeout ({stall_timeout}s)",
+                        "elapsed": round(time.time() - t0, 1),
+                    })
+                else:
+                    print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping stall_timeout notify')
                 return
 
             if time.time() - t0 > 180:
-                _acp_notify(action_id, "error", {
-                    "target": target, "error": "timeout_180s",
-                    "elapsed": 180,
-                })
+                if self._nav_action_id == action_id:
+                    self._nav_action_id = None
+                    _acp_notify(action_id, "error", {
+                        "target": target, "error": "timeout_180s",
+                        "elapsed": 180,
+                    })
+                else:
+                    print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping timeout_180s notify')
                 return
 
     # ── Dispatch ─────────────────────────────────────────────────────────────

--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -517,13 +517,34 @@ class ControlledSpatialPlugin:
                 return True
             return False
 
-    def _supersede_nav(self, action_id: str) -> int:
-        """Replace the current navigation action and invalidate its local waiter."""
+    def _reserve_nav(self, action_id: str):
+        """Reserve action_id as the current navigation before sending the physical command.
+
+        Returns (old_action_id, old_generation, new_generation) for rollback.
+        Does NOT emit cancellation — the caller emits it only after the replacement
+        command is confirmed, so the old waiter is invalidated before the physical
+        motion can change.  Without this ordering, the old ACP waiter can claim its
+        action as terminal in the interval between navigate_to() submission and
+        _supersede_nav(), reporting completed/error for a motion that has already
+        been replaced.
+        """
         with self._lock:
             old_action_id = self._nav_action_id
+            old_generation = self._nav_generation
             self._nav_action_id = action_id
             self._nav_generation += 1
-            generation = self._nav_generation
+            return old_action_id, old_generation, self._nav_generation
+
+    def _rollback_nav(self, action_id: str, old_action_id: str | None, old_generation: int):
+        """Restore previous nav state if the replacement command failed and no newer nav exists."""
+        with self._lock:
+            if self._nav_action_id == action_id:
+                self._nav_action_id = old_action_id
+                self._nav_generation = old_generation
+
+    def _supersede_nav(self, action_id: str) -> int:
+        """Replace the current navigation action and invalidate its local waiter."""
+        old_action_id, _, generation = self._reserve_nav(action_id)
         if old_action_id:
             _acp_notify(old_action_id, "cancelled", {"reason": "superseded by new navigate"})
         return generation
@@ -821,12 +842,23 @@ class ControlledSpatialPlugin:
                 self._nav_error = None
                 from uuid import uuid4
                 action_id = f"g1_nav_{uuid4().hex[:8]}"
+                # Reserve the action ID BEFORE sending the physical command so the old
+                # waiter is invalidated before the motion can change.  If navigate_to
+                # fails, the old nav was already PauseNav'd in the subprocess, so we
+                # report it cancelled and clean up the failed reservation.
+                old_id, _, generation = self._reserve_nav(action_id)
                 result = self._smart_motion.navigate_to(poi["x"], poi["y"], yaw, tag_name,
                                                      speed=speed, mode=mode,
                                                      navigation_id=action_id)
                 if result.get("status") != "navigating":
+                    if old_id:
+                        _acp_notify(old_id, "cancelled", {"reason": "replacement navigation failed"})
+                    with self._lock:
+                        if self._nav_action_id == action_id:
+                            self._nav_action_id = None
                     return result
-                generation = self._supersede_nav(action_id)
+                if old_id:
+                    _acp_notify(old_id, "cancelled", {"reason": "superseded by new navigate"})
                 result["action_id"] = action_id
                 threading.Thread(
                     target=self._acp_wait_nav,
@@ -845,21 +877,26 @@ class ControlledSpatialPlugin:
                 mode = 1  # 强制停障模式，不允许绕障
             self._nav_arrived.clear()
             self._nav_error = None
+            from uuid import uuid4
+            action_id = f"g1_nav_{uuid4().hex[:8]}"
+            old_id, old_gen, generation = self._reserve_nav(action_id)
             code, resp = self._client.NavigateTo(poi["x"], poi["y"], 0, 0, 0, q_z, q_w, speed=speed, mode=mode)
-            if code == 0:
-                from uuid import uuid4
-                action_id = f"g1_nav_{uuid4().hex[:8]}"
-                generation = self._supersede_nav(action_id)
-                threading.Thread(
-                    target=self._acp_wait_nav,
-                    args=(action_id, tag_name, float(args.get("stall_timeout", 90)),
-                          (poi["x"], poi["y"]), generation),
-                    daemon=True,
-                ).start()
-                return {"status": "navigating", "target": tag_name,
-                        "pose": {"x": poi["x"], "y": poi["y"], "yaw": yaw},
-                        "action_id": action_id}
-            return _rpc_error("NavigateTo", code, resp)
+            if code != 0:
+                # Direct SLAM NavigateTo failed — old navigation likely still running.
+                # Roll back the reservation so the old waiter can continue.
+                self._rollback_nav(action_id, old_id, old_gen)
+                return _rpc_error("NavigateTo", code, resp)
+            if old_id:
+                _acp_notify(old_id, "cancelled", {"reason": "superseded by new navigate"})
+            threading.Thread(
+                target=self._acp_wait_nav,
+                args=(action_id, tag_name, float(args.get("stall_timeout", 90)),
+                      (poi["x"], poi["y"]), generation),
+                daemon=True,
+            ).start()
+            return {"status": "navigating", "target": tag_name,
+                    "pose": {"x": poi["x"], "y": poi["y"], "yaw": yaw},
+                    "action_id": action_id}
 
         elif action == "navigate_to_pose":
             x = float(args.get("x", 0))
@@ -875,11 +912,19 @@ class ControlledSpatialPlugin:
                 self._nav_error = None
                 from uuid import uuid4
                 action_id = f"g1_nav_{uuid4().hex[:8]}"
+                # Reserve before sending physical command — see navigate_to_tag for rationale.
+                old_id, _, generation = self._reserve_nav(action_id)
                 result = self._smart_motion.navigate_to(x, y, yaw, speed=speed, mode=mode,
                                                         navigation_id=action_id)
                 if result.get("status") != "navigating":
+                    if old_id:
+                        _acp_notify(old_id, "cancelled", {"reason": "replacement navigation failed"})
+                    with self._lock:
+                        if self._nav_action_id == action_id:
+                            self._nav_action_id = None
                     return result
-                generation = self._supersede_nav(action_id)
+                if old_id:
+                    _acp_notify(old_id, "cancelled", {"reason": "superseded by new navigate"})
                 result["action_id"] = action_id
                 threading.Thread(
                     target=self._acp_wait_nav,
@@ -895,20 +940,23 @@ class ControlledSpatialPlugin:
             mode = int(args.get("mode", 1))
             self._nav_arrived.clear()
             self._nav_error = None
+            from uuid import uuid4
+            action_id = f"g1_nav_{uuid4().hex[:8]}"
+            old_id, old_gen, generation = self._reserve_nav(action_id)
             code, resp = self._client.NavigateTo(x, y, 0, 0, 0, q_z, q_w, speed=speed, mode=mode)
-            if code == 0:
-                from uuid import uuid4
-                action_id = f"g1_nav_{uuid4().hex[:8]}"
-                generation = self._supersede_nav(action_id)
-                threading.Thread(
-                    target=self._acp_wait_nav,
-                    args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90)),
-                          (x, y), generation),
-                    daemon=True,
-                ).start()
-                return {"status": "navigating", "target_pose": {"x": x, "y": y, "yaw": yaw},
-                        "action_id": action_id}
-            return _rpc_error("NavigateTo", code, resp)
+            if code != 0:
+                self._rollback_nav(action_id, old_id, old_gen)
+                return _rpc_error("NavigateTo", code, resp)
+            if old_id:
+                _acp_notify(old_id, "cancelled", {"reason": "superseded by new navigate"})
+            threading.Thread(
+                target=self._acp_wait_nav,
+                args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90)),
+                      (x, y), generation),
+                daemon=True,
+            ).start()
+            return {"status": "navigating", "target_pose": {"x": x, "y": y, "yaw": yaw},
+                    "action_id": action_id}
 
         elif action == "wait_navigation_done":
             stall_timeout = float(args.get("stall_timeout", 60))
@@ -973,11 +1021,13 @@ class ControlledSpatialPlugin:
 def _controlled_spatial_process(plugin_config: dict, namespace: str, command_queue, result_queue):
     """Subprocess entry: runs ControlledSpatialPlugin with its own DDS + GIL."""
     # Spawned child: fresh interpreter, does not inherit the parent's sys.stdout.
-    try:
-        from common import logsafe
-        logsafe.install(check_fd=False)
-    except ImportError:
-        pass
+    # logsafe is a hard dependency — the driver requires atomic log writes to avoid
+    # torn records from multiple writers.  If common is absent from the image/build
+    # context, fail startup clearly rather than silently continuing as an
+    # unsynchronised writer.  The outer try/except below propagates the error via
+    # result_queue so ControlledSpatialIsolatedProxy reports a startup failure.
+    from common import logsafe
+    logsafe.install(check_fd=False)
 
     import os as _os
     _os.setsid()

--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -349,6 +349,7 @@ class ControlledSpatialPlugin:
         self._nav_arrived = threading.Event()
         self._nav_error: str | None = None
         self._nav_action_id: str | None = None  # current navigate ACP action_id
+        self._nav_generation = 0
         self._last_db_map_status: str | None = None
         self._lock = threading.Lock()
 
@@ -516,20 +517,19 @@ class ControlledSpatialPlugin:
                 return True
             return False
 
-    def _supersede_nav(self, action_id: str) -> None:
-        """Replace the current navigation action_id, cancelling the previous one.
-
-        The old action's ACP "cancelled" notification is posted outside the
-        lock so an Agent Core outage cannot block pose updates or other
-        navigation calls behind the network I/O.
-        """
+    def _supersede_nav(self, action_id: str) -> int:
+        """Replace the current navigation action and invalidate its local waiter."""
         with self._lock:
             old_action_id = self._nav_action_id
             self._nav_action_id = action_id
+            self._nav_generation += 1
+            generation = self._nav_generation
         if old_action_id:
             _acp_notify(old_action_id, "cancelled", {"reason": "superseded by new navigate"})
+        return generation
 
-    def _acp_wait_nav(self, action_id: str, target: str, stall_timeout: float = 90, target_xy=None):
+    def _acp_wait_nav(self, action_id: str, target: str, stall_timeout: float = 90,
+                      target_xy=None, generation: int | None = None):
         """Wait for navigation to complete, then fire ACP callback."""
         t0 = time.time()
 
@@ -538,7 +538,11 @@ class ControlledSpatialPlugin:
         # The main process DDS callback for ctrl_info.is_arrived is unreliable
         # (SLAM service never publishes ctrl_info in practice).
         if self._smart_motion:
-            result = self._smart_motion.wait_nav_done(stall_timeout=stall_timeout)
+            result = self._smart_motion.wait_nav_done(
+                stall_timeout=stall_timeout, navigation_id=action_id)
+            if result.get("status") == "superseded":
+                print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping notify')
+                return
             elapsed = round(time.time() - t0, 1)
             # Guard: if this nav was superseded, don't fire stale ACP
             if not self._try_claim_terminal(action_id):
@@ -567,6 +571,11 @@ class ControlledSpatialPlugin:
         last_move_time = time.time()
 
         while True:
+            with self._lock:
+                if generation is not None and self._nav_generation != generation:
+                    print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping notify')
+                    return
+
             # Pose-based arrival check before waiting for stale ctrl_info signal
             if target_xy is not None:
                 current_pose = self._get_pose()
@@ -810,17 +819,19 @@ class ControlledSpatialPlugin:
                     mode = 1  # 强制停障模式，不允许绕障
                 self._nav_arrived.clear()
                 self._nav_error = None
-                result = self._smart_motion.navigate_to(poi["x"], poi["y"], yaw, tag_name,
-                                                     speed=speed, mode=mode)
-                if result.get("status") != "navigating":
-                    return result
                 from uuid import uuid4
                 action_id = f"g1_nav_{uuid4().hex[:8]}"
-                self._supersede_nav(action_id)
+                result = self._smart_motion.navigate_to(poi["x"], poi["y"], yaw, tag_name,
+                                                     speed=speed, mode=mode,
+                                                     navigation_id=action_id)
+                if result.get("status") != "navigating":
+                    return result
+                generation = self._supersede_nav(action_id)
                 result["action_id"] = action_id
                 threading.Thread(
                     target=self._acp_wait_nav,
-                    args=(action_id, tag_name, float(args.get("stall_timeout", 90)), (poi["x"], poi["y"])),
+                    args=(action_id, tag_name, float(args.get("stall_timeout", 90)),
+                          (poi["x"], poi["y"]), generation),
                     daemon=True,
                 ).start()
                 return result
@@ -838,10 +849,11 @@ class ControlledSpatialPlugin:
             if code == 0:
                 from uuid import uuid4
                 action_id = f"g1_nav_{uuid4().hex[:8]}"
-                self._supersede_nav(action_id)
+                generation = self._supersede_nav(action_id)
                 threading.Thread(
                     target=self._acp_wait_nav,
-                    args=(action_id, tag_name, float(args.get("stall_timeout", 90)), (poi["x"], poi["y"])),
+                    args=(action_id, tag_name, float(args.get("stall_timeout", 90)),
+                          (poi["x"], poi["y"]), generation),
                     daemon=True,
                 ).start()
                 return {"status": "navigating", "target": tag_name,
@@ -861,16 +873,18 @@ class ControlledSpatialPlugin:
                     mode = 1  # 强制停障模式，不允许绕障
                 self._nav_arrived.clear()
                 self._nav_error = None
-                result = self._smart_motion.navigate_to(x, y, yaw, speed=speed, mode=mode)
-                if result.get("status") != "navigating":
-                    return result
                 from uuid import uuid4
                 action_id = f"g1_nav_{uuid4().hex[:8]}"
-                self._supersede_nav(action_id)
+                result = self._smart_motion.navigate_to(x, y, yaw, speed=speed, mode=mode,
+                                                        navigation_id=action_id)
+                if result.get("status") != "navigating":
+                    return result
+                generation = self._supersede_nav(action_id)
                 result["action_id"] = action_id
                 threading.Thread(
                     target=self._acp_wait_nav,
-                    args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90)), (x, y)),
+                    args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90)),
+                          (x, y), generation),
                     daemon=True,
                 ).start()
                 return result
@@ -885,10 +899,11 @@ class ControlledSpatialPlugin:
             if code == 0:
                 from uuid import uuid4
                 action_id = f"g1_nav_{uuid4().hex[:8]}"
-                self._supersede_nav(action_id)
+                generation = self._supersede_nav(action_id)
                 threading.Thread(
                     target=self._acp_wait_nav,
-                    args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90)), (x, y)),
+                    args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90)),
+                          (x, y), generation),
                     daemon=True,
                 ).start()
                 return {"status": "navigating", "target_pose": {"x": x, "y": y, "yaw": yaw},

--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -502,6 +502,20 @@ class ControlledSpatialPlugin:
 
     # ── ACP completion thread ────────────────────────────────────────────────
 
+    def _try_claim_terminal(self, action_id: str) -> bool:
+        """Atomically claim the terminal transition for action_id.
+
+        Returns True only if action_id is still the current navigation (and
+        clears it), so exactly one waiter posts the terminal ACP callback.
+        Must not call _acp_notify inside the lock — network I/O stays out of
+        the critical section.
+        """
+        with self._lock:
+            if self._nav_action_id == action_id:
+                self._nav_action_id = None
+                return True
+            return False
+
     def _acp_wait_nav(self, action_id: str, target: str, stall_timeout: float = 90, target_xy=None):
         """Wait for navigation to complete, then fire ACP callback."""
         t0 = time.time()
@@ -514,10 +528,9 @@ class ControlledSpatialPlugin:
             result = self._smart_motion.wait_nav_done(stall_timeout=stall_timeout)
             elapsed = round(time.time() - t0, 1)
             # Guard: if this nav was superseded, don't fire stale ACP
-            if self._nav_action_id != action_id:
+            if not self._try_claim_terminal(action_id):
                 print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping notify')
                 return
-            self._nav_action_id = None
             status = result.get("status", "error")
             if status == "arrived":
                 _acp_notify(action_id, "completed", {
@@ -549,10 +562,9 @@ class ControlledSpatialPlugin:
                     dy = current_pose["y"] - target_xy[1]
                     if math.sqrt(dx * dx + dy * dy) < 0.3:
                         # Guard: if this nav was superseded, don't fire stale ACP
-                        if self._nav_action_id != action_id:
+                        if not self._try_claim_terminal(action_id):
                             print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping notify')
                             return
-                        self._nav_action_id = None
                         elapsed = round(time.time() - t0, 1)
                         _acp_notify(action_id, "completed", {
                             "target": target, "pose": current_pose, "elapsed": elapsed,
@@ -561,10 +573,9 @@ class ControlledSpatialPlugin:
 
             if self._nav_arrived.wait(timeout=1.0):
                 # Guard: if this nav was superseded, don't fire stale ACP
-                if self._nav_action_id != action_id:
+                if not self._try_claim_terminal(action_id):
                     print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping notify')
                     return
-                self._nav_action_id = None
                 elapsed = round(time.time() - t0, 1)
                 if self._nav_error:
                     error = self._nav_error
@@ -593,28 +604,26 @@ class ControlledSpatialPlugin:
 
             if time.time() - last_move_time > stall_timeout:
                 # Guard: if superseded, don't PauseNav (would pause active nav) or post stale error
-                if self._nav_action_id == action_id:
-                    self._nav_action_id = None
-                    if self._client:
-                        self._client.PauseNav()
-                    _acp_notify(action_id, "error", {
-                        "target": target,
-                        "error": f"stall_timeout ({stall_timeout}s)",
-                        "elapsed": round(time.time() - t0, 1),
-                    })
-                else:
+                if not self._try_claim_terminal(action_id):
                     print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping stall_timeout notify')
+                    return
+                if self._client:
+                    self._client.PauseNav()
+                _acp_notify(action_id, "error", {
+                    "target": target,
+                    "error": f"stall_timeout ({stall_timeout}s)",
+                    "elapsed": round(time.time() - t0, 1),
+                })
                 return
 
             if time.time() - t0 > 180:
-                if self._nav_action_id == action_id:
-                    self._nav_action_id = None
-                    _acp_notify(action_id, "error", {
-                        "target": target, "error": "timeout_180s",
-                        "elapsed": 180,
-                    })
-                else:
+                if not self._try_claim_terminal(action_id):
                     print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping timeout_180s notify')
+                    return
+                _acp_notify(action_id, "error", {
+                    "target": target, "error": "timeout_180s",
+                    "elapsed": 180,
+                })
                 return
 
     # ── Dispatch ─────────────────────────────────────────────────────────────
@@ -772,12 +781,6 @@ class ControlledSpatialPlugin:
             tag_name = args.get("tag_name", "")
             if not tag_name:
                 return {"error": "tag_name is required"}
-            from uuid import uuid4
-            action_id = f"g1_nav_{uuid4().hex[:8]}"
-            with self._lock:
-                if self._nav_action_id:
-                    _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
-                self._nav_action_id = action_id
             active_map = self._active_map
             if not active_map:
                 return {"error": "No active map. Load a map first."}
@@ -796,6 +799,14 @@ class ControlledSpatialPlugin:
                 self._nav_error = None
                 result = self._smart_motion.navigate_to(poi["x"], poi["y"], yaw, tag_name,
                                                      speed=speed, mode=mode)
+                if result.get("status") != "navigating":
+                    return result
+                from uuid import uuid4
+                action_id = f"g1_nav_{uuid4().hex[:8]}"
+                with self._lock:
+                    if self._nav_action_id:
+                        _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
+                    self._nav_action_id = action_id
                 result["action_id"] = action_id
                 threading.Thread(
                     target=self._acp_wait_nav,
@@ -815,6 +826,12 @@ class ControlledSpatialPlugin:
             self._nav_error = None
             code, resp = self._client.NavigateTo(poi["x"], poi["y"], 0, 0, 0, q_z, q_w, speed=speed, mode=mode)
             if code == 0:
+                from uuid import uuid4
+                action_id = f"g1_nav_{uuid4().hex[:8]}"
+                with self._lock:
+                    if self._nav_action_id:
+                        _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
+                    self._nav_action_id = action_id
                 threading.Thread(
                     target=self._acp_wait_nav,
                     args=(action_id, tag_name, float(args.get("stall_timeout", 90)), (poi["x"], poi["y"])),
@@ -829,12 +846,6 @@ class ControlledSpatialPlugin:
             x = float(args.get("x", 0))
             y = float(args.get("y", 0))
             yaw = float(args.get("yaw", 0))
-            from uuid import uuid4
-            action_id = f"g1_nav_{uuid4().hex[:8]}"
-            with self._lock:
-                if self._nav_action_id:
-                    _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
-                self._nav_action_id = action_id
 
             if self._smart_motion:
                 speed = max(0.2, min(0.8, float(args.get("speed", 0.5))))
@@ -844,6 +855,14 @@ class ControlledSpatialPlugin:
                 self._nav_arrived.clear()
                 self._nav_error = None
                 result = self._smart_motion.navigate_to(x, y, yaw, speed=speed, mode=mode)
+                if result.get("status") != "navigating":
+                    return result
+                from uuid import uuid4
+                action_id = f"g1_nav_{uuid4().hex[:8]}"
+                with self._lock:
+                    if self._nav_action_id:
+                        _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
+                    self._nav_action_id = action_id
                 result["action_id"] = action_id
                 threading.Thread(
                     target=self._acp_wait_nav,
@@ -860,6 +879,12 @@ class ControlledSpatialPlugin:
             self._nav_error = None
             code, resp = self._client.NavigateTo(x, y, 0, 0, 0, q_z, q_w, speed=speed, mode=mode)
             if code == 0:
+                from uuid import uuid4
+                action_id = f"g1_nav_{uuid4().hex[:8]}"
+                with self._lock:
+                    if self._nav_action_id:
+                        _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
+                    self._nav_action_id = action_id
                 threading.Thread(
                     target=self._acp_wait_nav,
                     args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90)), (x, y)),

--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -504,7 +504,6 @@ class ControlledSpatialPlugin:
 
     def _acp_wait_nav(self, action_id: str, target: str, stall_timeout: float = 90, target_xy=None):
         """Wait for navigation to complete, then fire ACP callback."""
-        self._nav_action_id = action_id
         t0 = time.time()
 
         # Primary: delegate to SmartMotion subprocess which has reliable
@@ -773,10 +772,12 @@ class ControlledSpatialPlugin:
             tag_name = args.get("tag_name", "")
             if not tag_name:
                 return {"error": "tag_name is required"}
-            # Cancel any in-flight navigation ACP
-            if self._nav_action_id:
-                _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
-                self._nav_action_id = None
+            from uuid import uuid4
+            action_id = f"g1_nav_{uuid4().hex[:8]}"
+            with self._lock:
+                if self._nav_action_id:
+                    _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
+                self._nav_action_id = action_id
             active_map = self._active_map
             if not active_map:
                 return {"error": "No active map. Load a map first."}
@@ -795,9 +796,6 @@ class ControlledSpatialPlugin:
                 self._nav_error = None
                 result = self._smart_motion.navigate_to(poi["x"], poi["y"], yaw, tag_name,
                                                      speed=speed, mode=mode)
-                # ACP: spawn completion thread
-                from uuid import uuid4
-                action_id = f"g1_nav_{uuid4().hex[:8]}"
                 result["action_id"] = action_id
                 threading.Thread(
                     target=self._acp_wait_nav,
@@ -817,8 +815,6 @@ class ControlledSpatialPlugin:
             self._nav_error = None
             code, resp = self._client.NavigateTo(poi["x"], poi["y"], 0, 0, 0, q_z, q_w, speed=speed, mode=mode)
             if code == 0:
-                from uuid import uuid4
-                action_id = f"g1_nav_{uuid4().hex[:8]}"
                 threading.Thread(
                     target=self._acp_wait_nav,
                     args=(action_id, tag_name, float(args.get("stall_timeout", 90)), (poi["x"], poi["y"])),
@@ -833,10 +829,12 @@ class ControlledSpatialPlugin:
             x = float(args.get("x", 0))
             y = float(args.get("y", 0))
             yaw = float(args.get("yaw", 0))
-            # Cancel any in-flight navigation ACP
-            if self._nav_action_id:
-                _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
-                self._nav_action_id = None
+            from uuid import uuid4
+            action_id = f"g1_nav_{uuid4().hex[:8]}"
+            with self._lock:
+                if self._nav_action_id:
+                    _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
+                self._nav_action_id = action_id
 
             if self._smart_motion:
                 speed = max(0.2, min(0.8, float(args.get("speed", 0.5))))
@@ -846,8 +844,6 @@ class ControlledSpatialPlugin:
                 self._nav_arrived.clear()
                 self._nav_error = None
                 result = self._smart_motion.navigate_to(x, y, yaw, speed=speed, mode=mode)
-                from uuid import uuid4
-                action_id = f"g1_nav_{uuid4().hex[:8]}"
                 result["action_id"] = action_id
                 threading.Thread(
                     target=self._acp_wait_nav,
@@ -864,8 +860,6 @@ class ControlledSpatialPlugin:
             self._nav_error = None
             code, resp = self._client.NavigateTo(x, y, 0, 0, 0, q_z, q_w, speed=speed, mode=mode)
             if code == 0:
-                from uuid import uuid4
-                action_id = f"g1_nav_{uuid4().hex[:8]}"
                 threading.Thread(
                     target=self._acp_wait_nav,
                     args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90)), (x, y)),

--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -549,6 +549,11 @@ class ControlledSpatialPlugin:
                     dx = current_pose["x"] - target_xy[0]
                     dy = current_pose["y"] - target_xy[1]
                     if math.sqrt(dx * dx + dy * dy) < 0.3:
+                        # Guard: if this nav was superseded, don't fire stale ACP
+                        if self._nav_action_id != action_id:
+                            print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping notify')
+                            return
+                        self._nav_action_id = None
                         elapsed = round(time.time() - t0, 1)
                         _acp_notify(action_id, "completed", {
                             "target": target, "pose": current_pose, "elapsed": elapsed,
@@ -556,6 +561,11 @@ class ControlledSpatialPlugin:
                         return
 
             if self._nav_arrived.wait(timeout=1.0):
+                # Guard: if this nav was superseded, don't fire stale ACP
+                if self._nav_action_id != action_id:
+                    print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping notify')
+                    return
+                self._nav_action_id = None
                 elapsed = round(time.time() - t0, 1)
                 if self._nav_error:
                     error = self._nav_error
@@ -849,7 +859,7 @@ class ControlledSpatialPlugin:
                 action_id = f"g1_nav_{uuid4().hex[:8]}"
                 threading.Thread(
                     target=self._acp_wait_nav,
-                    args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90))),
+                    args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90)), (x, y)),
                     daemon=True,
                 ).start()
                 return {"status": "navigating", "target_pose": {"x": x, "y": y, "yaw": yaw},

--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -516,6 +516,19 @@ class ControlledSpatialPlugin:
                 return True
             return False
 
+    def _supersede_nav(self, action_id: str) -> None:
+        """Replace the current navigation action_id, cancelling the previous one.
+
+        The old action's ACP "cancelled" notification is posted outside the
+        lock so an Agent Core outage cannot block pose updates or other
+        navigation calls behind the network I/O.
+        """
+        with self._lock:
+            old_action_id = self._nav_action_id
+            self._nav_action_id = action_id
+        if old_action_id:
+            _acp_notify(old_action_id, "cancelled", {"reason": "superseded by new navigate"})
+
     def _acp_wait_nav(self, action_id: str, target: str, stall_timeout: float = 90, target_xy=None):
         """Wait for navigation to complete, then fire ACP callback."""
         t0 = time.time()
@@ -803,10 +816,7 @@ class ControlledSpatialPlugin:
                     return result
                 from uuid import uuid4
                 action_id = f"g1_nav_{uuid4().hex[:8]}"
-                with self._lock:
-                    if self._nav_action_id:
-                        _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
-                    self._nav_action_id = action_id
+                self._supersede_nav(action_id)
                 result["action_id"] = action_id
                 threading.Thread(
                     target=self._acp_wait_nav,
@@ -828,10 +838,7 @@ class ControlledSpatialPlugin:
             if code == 0:
                 from uuid import uuid4
                 action_id = f"g1_nav_{uuid4().hex[:8]}"
-                with self._lock:
-                    if self._nav_action_id:
-                        _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
-                    self._nav_action_id = action_id
+                self._supersede_nav(action_id)
                 threading.Thread(
                     target=self._acp_wait_nav,
                     args=(action_id, tag_name, float(args.get("stall_timeout", 90)), (poi["x"], poi["y"])),
@@ -859,10 +866,7 @@ class ControlledSpatialPlugin:
                     return result
                 from uuid import uuid4
                 action_id = f"g1_nav_{uuid4().hex[:8]}"
-                with self._lock:
-                    if self._nav_action_id:
-                        _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
-                    self._nav_action_id = action_id
+                self._supersede_nav(action_id)
                 result["action_id"] = action_id
                 threading.Thread(
                     target=self._acp_wait_nav,
@@ -881,10 +885,7 @@ class ControlledSpatialPlugin:
             if code == 0:
                 from uuid import uuid4
                 action_id = f"g1_nav_{uuid4().hex[:8]}"
-                with self._lock:
-                    if self._nav_action_id:
-                        _acp_notify(self._nav_action_id, "cancelled", {"reason": "superseded by new navigate"})
-                    self._nav_action_id = action_id
+                self._supersede_nav(action_id)
                 threading.Thread(
                     target=self._acp_wait_nav,
                     args=(action_id, f"pose({x},{y})", float(args.get("stall_timeout", 90)), (x, y)),

--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -352,6 +352,7 @@ class ControlledSpatialPlugin:
         self._nav_generation = 0
         self._last_db_map_status: str | None = None
         self._lock = threading.Lock()
+        self._nav_command_lock = threading.Lock()
 
         # Subscribe DDS for pose updates
         self._dds_subs = []
@@ -503,19 +504,29 @@ class ControlledSpatialPlugin:
 
     # ── ACP completion thread ────────────────────────────────────────────────
 
-    def _try_claim_terminal(self, action_id: str) -> bool:
+    def _nav_is_current(self, action_id: str, generation: int | None) -> bool:
+        # Wait until a provisional reservation commits or rolls back.
+        with self._nav_command_lock, self._lock:
+            return (self._nav_action_id == action_id and
+                    (generation is None or self._nav_generation == generation))
+
+    def _try_claim_terminal(self, action_id: str, pause: bool = False) -> bool:
         """Atomically claim the terminal transition for action_id.
 
         Returns True only if action_id is still the current navigation (and
         clears it), so exactly one waiter posts the terminal ACP callback.
-        Must not call _acp_notify inside the lock — network I/O stays out of
-        the critical section.
+        ACP callbacks stay outside both locks. Optional PauseNav holds only
+        the command lock so it cannot pause a newly submitted navigation.
         """
-        with self._lock:
-            if self._nav_action_id == action_id:
+        with self._nav_command_lock:
+            with self._lock:
+                if self._nav_action_id != action_id:
+                    return False
                 self._nav_action_id = None
-                return True
-            return False
+            # Prevent a replacement from starting before the old motion is paused.
+            if pause and self._client:
+                self._client.PauseNav()
+            return True
 
     def _reserve_nav(self, action_id: str):
         """Reserve action_id as the current navigation before sending the physical command.
@@ -559,11 +570,20 @@ class ControlledSpatialPlugin:
         # The main process DDS callback for ctrl_info.is_arrived is unreliable
         # (SLAM service never publishes ctrl_info in practice).
         if self._smart_motion:
-            result = self._smart_motion.wait_nav_done(
-                stall_timeout=stall_timeout, navigation_id=action_id)
-            if result.get("status") == "superseded":
-                print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping notify')
-                return
+            while True:
+                if not self._nav_is_current(action_id, generation):
+                    return
+                result = self._smart_motion.wait_nav_done(
+                    stall_timeout=stall_timeout, navigation_id=action_id)
+                if result.get("status") != "unknown":
+                    break
+                # Timeout does not confirm termination. Cancel only this ID, since
+                # a replacement may already be physically active.
+                result = self._smart_motion._call(
+                    "cancel_navigation", navigation_id=action_id)
+                if result.get("status") in ("stopped", "superseded"):
+                    break
+                time.sleep(0.5)
             elapsed = round(time.time() - t0, 1)
             # Guard: if this nav was superseded, don't fire stale ACP
             if not self._try_claim_terminal(action_id):
@@ -574,6 +594,8 @@ class ControlledSpatialPlugin:
                 _acp_notify(action_id, "completed", {
                     "target": target, "pose": result.get("pose"), "elapsed": elapsed,
                 })
+            elif status == "superseded":
+                _acp_notify(action_id, "cancelled", {"target": target, "reason": status})
             else:
                 # Validate: if status is unexpected (e.g. "navigating" from queue race),
                 # treat as error with full result for debugging
@@ -592,10 +614,9 @@ class ControlledSpatialPlugin:
         last_move_time = time.time()
 
         while True:
-            with self._lock:
-                if generation is not None and self._nav_generation != generation:
-                    print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping notify')
-                    return
+            if not self._nav_is_current(action_id, generation):
+                print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping notify')
+                return
 
             # Pose-based arrival check before waiting for stale ctrl_info signal
             if target_xy is not None:
@@ -647,11 +668,9 @@ class ControlledSpatialPlugin:
 
             if time.time() - last_move_time > stall_timeout:
                 # Guard: if superseded, don't PauseNav (would pause active nav) or post stale error
-                if not self._try_claim_terminal(action_id):
+                if not self._try_claim_terminal(action_id, pause=True):
                     print(f'[ControlledSpatial] _acp_wait_nav {action_id} superseded, skipping stall_timeout notify')
                     return
-                if self._client:
-                    self._client.PauseNav()
                 _acp_notify(action_id, "error", {
                     "target": target,
                     "error": f"stall_timeout ({stall_timeout}s)",
@@ -672,6 +691,15 @@ class ControlledSpatialPlugin:
     # ── Dispatch ─────────────────────────────────────────────────────────────
 
     def dispatch(self, action: str, args: dict) -> dict | None:
+        if action in ("navigate_to_tag", "navigate_to_pose",
+                      "pause_nav", "resume_nav", "stop_nav"):
+            # Serialize reservation through RPC and waiter setup, without holding
+            # the state lock needed by DDS callbacks and completion waiters.
+            with self._nav_command_lock:
+                return self._dispatch_serialized(action, args)
+        return self._dispatch_serialized(action, args)
+
+    def _dispatch_serialized(self, action: str, args: dict) -> dict | None:
         if action == "start":
             return {"state": "ready"}
         if action == "stop":
@@ -842,15 +870,18 @@ class ControlledSpatialPlugin:
                 self._nav_error = None
                 from uuid import uuid4
                 action_id = f"g1_nav_{uuid4().hex[:8]}"
-                # Reserve the action ID BEFORE sending the physical command so the old
-                # waiter is invalidated before the motion can change.  If navigate_to
-                # fails, the old nav was already PauseNav'd in the subprocess, so we
-                # report it cancelled and clean up the failed reservation.
-                old_id, _, generation = self._reserve_nav(action_id)
+                # Invalidate the old waiter before physical motion can change.
+                # Only expired guarantees that the replacement was not executed.
+                old_id, old_gen, generation = self._reserve_nav(action_id)
                 result = self._smart_motion.navigate_to(poi["x"], poi["y"], yaw, tag_name,
                                                      speed=speed, mode=mode,
                                                      navigation_id=action_id)
-                if result.get("status") != "navigating":
+                if result.get("status") == "expired":
+                    self._rollback_nav(action_id, old_id, old_gen)
+                    return result
+                # A timed-out submission may still be active. Keep its reservation
+                # and track the navigation ID until a terminal result is known.
+                if result.get("status") not in ("navigating", "unknown"):
                     if old_id:
                         _acp_notify(old_id, "cancelled", {"reason": "replacement navigation failed"})
                     with self._lock:
@@ -913,10 +944,15 @@ class ControlledSpatialPlugin:
                 from uuid import uuid4
                 action_id = f"g1_nav_{uuid4().hex[:8]}"
                 # Reserve before sending physical command — see navigate_to_tag for rationale.
-                old_id, _, generation = self._reserve_nav(action_id)
+                old_id, old_gen, generation = self._reserve_nav(action_id)
                 result = self._smart_motion.navigate_to(x, y, yaw, speed=speed, mode=mode,
                                                         navigation_id=action_id)
-                if result.get("status") != "navigating":
+                if result.get("status") == "expired":
+                    self._rollback_nav(action_id, old_id, old_gen)
+                    return result
+                # A timed-out submission may still be active. Keep its reservation
+                # and track the navigation ID until a terminal result is known.
+                if result.get("status") not in ("navigating", "unknown"):
                     if old_id:
                         _acp_notify(old_id, "cancelled", {"reason": "replacement navigation failed"})
                     with self._lock:

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -164,12 +164,10 @@ class G1DeviceBundle:
             controlled_cfg = dict(plugins_cfg["controlled_spatial"])
             controlled_cfg["network_iface"] = network_iface
             if controlled_cfg.get("isolated_process", False):
-                sm_enabled = plugins_cfg.get("smart_motion", {}).get("enabled", True)
-                if sm_enabled:
-                    print("[WARNING] controlled_spatial isolated_process=true with smart_motion enabled — "
-                          "navigation arrival detection uses pose-based fallback (dist<0.3m). "
-                          "If audio stutter reappears, set isolated_process=false and verify TTS latency.",
-                          flush=True)
+                print("[WARNING] controlled_spatial isolated_process=true — navigation arrival detection "
+                      "uses pose-based fallback (dist<0.3m). If audio stutter reappears, set "
+                      "isolated_process=false and verify TTS latency.",
+                      flush=True)
                 from controlled_spatial import ControlledSpatialIsolatedProxy
                 self._plugins.append(ControlledSpatialIsolatedProxy(controlled_cfg, namespace, executor, slam_client, smart_motion=smart_motion))
                 print("[bundle] ControlledSpatialPlugin loaded (isolated process)")

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -333,7 +333,7 @@ def make_handler():
                     args   = params.get("arguments") or {}
                     result = _bundle.dispatch(name, args)
                     if result is None:
-                        err(-32601, f"Unknown tool: {name}")
+                        err(-32601, f"Unknown action: {name}")
                     else:
                         ok({"content": [{"type": "text", "text": json.dumps(result)}]})
                 else:

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -164,6 +164,12 @@ class G1DeviceBundle:
             controlled_cfg = dict(plugins_cfg["controlled_spatial"])
             controlled_cfg["network_iface"] = network_iface
             if controlled_cfg.get("isolated_process", False):
+                sm_enabled = plugins_cfg.get("smart_motion", {}).get("enabled", True)
+                if sm_enabled:
+                    print("[WARNING] controlled_spatial isolated_process=true with smart_motion enabled — "
+                          "navigation arrival detection uses pose-based fallback (dist<0.3m). "
+                          "If audio stutter reappears, set isolated_process=false and verify TTS latency.",
+                          flush=True)
                 from controlled_spatial import ControlledSpatialIsolatedProxy
                 self._plugins.append(ControlledSpatialIsolatedProxy(controlled_cfg, namespace, executor, slam_client, smart_motion=smart_motion))
                 print("[bundle] ControlledSpatialPlugin loaded (isolated process)")

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -163,6 +163,14 @@ class G1DeviceBundle:
         if plugins_cfg.get("controlled_spatial", {}).get("enabled", False):
             controlled_cfg = dict(plugins_cfg["controlled_spatial"])
             controlled_cfg["network_iface"] = network_iface
+            # isolated_process defaults to false: the plugin runs in-process and shares
+            # the SmartMotion subprocess's reliable pose-based arrival detection
+            # (rt/slam_info DDS subscription, dist < 0.3m).  This trades process
+            # isolation for dependable nav completion and lower TTS latency (no extra
+            # spawned interpreter contending on the GIL / DDS).
+            # Set isolated_process=true only if you need strict process separation; in
+            # that mode arrival detection falls back to pose-based polling in the
+            # isolated child, which is less reliable and can reintroduce audio stutter.
             if controlled_cfg.get("isolated_process", False):
                 print("[WARNING] controlled_spatial isolated_process=true — navigation arrival detection "
                       "uses pose-based fallback (dist<0.3m). If audio stutter reappears, set "

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -239,6 +239,13 @@ class G1DeviceBundle:
                 tools.append(p.get_tool())
         return tools
 
+    def has_tool(self, tool_name: str) -> bool:
+        for p in self._plugins:
+            plugin_tools = p.get_tools() if hasattr(p, 'get_tools') else [p.get_tool()]
+            if any(tool_def["name"] == tool_name for tool_def in plugin_tools):
+                return True
+        return False
+
     def dispatch(self, tool_name: str, args: dict) -> dict | None:
         for p in self._plugins:
             plugin_tools = p.get_tools() if hasattr(p, 'get_tools') else [p.get_tool()]
@@ -331,9 +338,13 @@ def make_handler():
                 elif method == "tools/call":
                     name   = params.get("name", "")
                     args   = params.get("arguments") or {}
+                    if not _bundle.has_tool(name):
+                        err(-32601, f"Unknown tool: {name}")
+                        return
+                    requested_action = args.get("action", name)
                     result = _bundle.dispatch(name, args)
                     if result is None:
-                        err(-32601, f"Unknown action: {name}")
+                        err(-32601, f"Unknown action for tool {name}: {requested_action}")
                     else:
                         ok({"content": [{"type": "text", "text": json.dumps(result)}]})
                 else:

--- a/unitree/g1/main.py
+++ b/unitree/g1/main.py
@@ -163,18 +163,12 @@ class G1DeviceBundle:
         if plugins_cfg.get("controlled_spatial", {}).get("enabled", False):
             controlled_cfg = dict(plugins_cfg["controlled_spatial"])
             controlled_cfg["network_iface"] = network_iface
-            # isolated_process defaults to false: the plugin runs in-process and shares
-            # the SmartMotion subprocess's reliable pose-based arrival detection
-            # (rt/slam_info DDS subscription, dist < 0.3m).  This trades process
-            # isolation for dependable nav completion and lower TTS latency (no extra
-            # spawned interpreter contending on the GIL / DDS).
-            # Set isolated_process=true only if you need strict process separation; in
-            # that mode arrival detection falls back to pose-based polling in the
-            # isolated child, which is less reliable and can reintroduce audio stutter.
+            # 默认插件运行于主进程，通过 SmartMotionProxy 委托 SmartMotion
+            # 子进程进行位姿到达检测（dist < 0.3m），检测不在主进程执行。
+            # 独立模式则在 ControlledSpatial 子进程内使用位姿轮询 fallback。
             if controlled_cfg.get("isolated_process", False):
-                print("[WARNING] controlled_spatial isolated_process=true — navigation arrival detection "
-                      "uses pose-based fallback (dist<0.3m). If audio stutter reappears, set "
-                      "isolated_process=false and verify TTS latency.",
+                print("[WARNING] controlled_spatial 独立子进程使用位姿轮询 fallback "
+                      "(dist<0.3m)，不通过 SmartMotionProxy 使用 SmartMotion 子进程的到达检测。",
                       flush=True)
                 from controlled_spatial import ControlledSpatialIsolatedProxy
                 self._plugins.append(ControlledSpatialIsolatedProxy(controlled_cfg, namespace, executor, slam_client, smart_motion=smart_motion))

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -138,9 +138,9 @@ class SmartMotionProxy:
         return self._call("stop", reason=reason)
 
     def navigate_to(self, x: float, y: float, yaw: float, target_name: str = "",
-                    speed: float = 0.5, mode: int = 1) -> dict:
+                    speed: float = 0.5, mode: int = 1, navigation_id: str | None = None) -> dict:
         return self._call("navigate_to", x=x, y=y, yaw=yaw, target_name=target_name,
-                          speed=speed, mode=mode)
+                          speed=speed, mode=mode, navigation_id=navigation_id)
 
     def pause_nav(self, reason: str = "command") -> dict:
         return self._call("pause_nav", reason=reason)
@@ -151,9 +151,10 @@ class SmartMotionProxy:
     def stop_nav(self) -> dict:
         return self._call("stop_nav")
 
-    def wait_nav_done(self, stall_timeout: float = 60) -> dict:
+    def wait_nav_done(self, stall_timeout: float = 60,
+                      navigation_id: str | None = None) -> dict:
         return self._call("wait_nav_done", stall_timeout=stall_timeout,
-                          timeout=stall_timeout + 30)
+                          navigation_id=navigation_id, timeout=stall_timeout + 30)
 
     def get_state(self) -> dict:
         return self._call("get_state")
@@ -272,6 +273,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     nav_arrived_flag = False
     nav_arrived_error = None
     nav_current_pose = None
+    nav_generation = 0
 
     # ── Helpers ──
     def clamp(vx, vy, vyaw, zone):
@@ -660,16 +662,18 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         return {"ret": ret, "vx": clamped_vx, "vy": clamped_vy, "vyaw": clamped_vyaw,
                 "duration": duration, "state": state.value}
 
-    def handle_navigate_to(x, y, yaw, target_name, speed=0.5, mode=1, stall_timeout=60):
-        nonlocal state, nav_cmd, speed_zone, nav_arrived_flag, nav_arrived_error
+    def handle_navigate_to(x, y, yaw, target_name, speed=0.5, mode=1, stall_timeout=60,
+                           navigation_id=None):
+        nonlocal state, nav_cmd, speed_zone, nav_arrived_flag, nav_arrived_error, nav_generation
 
         if state == MotionState.MOVING:
             do_stop("command")
         elif state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
             do_stop_nav()
 
-        # Reset arrival state for this navigation session
+        # A new command invalidates all existing waits before resetting shared arrival state.
         with slam_info_lock:
+            nav_generation += 1
             nav_arrived_flag = False
             nav_arrived_error = None
 
@@ -689,7 +693,9 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             return {"error": f"NavigateTo failed, code={code}", "response": resp}
 
         label = target_name or f"({x:.1f}, {y:.1f})"
-        nav_cmd = {"target_name": label, "target_pose": {"x": x, "y": y, "yaw": yaw}, "start_time": time.time()}
+        nav_cmd = {"target_name": label, "target_pose": {"x": x, "y": y, "yaw": yaw},
+                   "start_time": time.time(), "navigation_id": navigation_id,
+                   "generation": nav_generation}
         state = MotionState.NAVIGATING
         speed_zone = SpeedZone.NORMAL
 
@@ -697,7 +703,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         # Return immediately — non-blocking. wait_navigation_done handles arrival detection.
         return {"status": "navigating", "target": label, "pose": {"x": x, "y": y, "yaw": yaw}}
 
-    def handle_wait_nav_done(stall_timeout=60):
+    def handle_wait_nav_done(stall_timeout=60, navigation_id=None):
         """Block until navigation completes or robot is stuck.
         Arrival detection: pose-based (distance to target < 0.3m).
         Also checks ctrl_info.is_arrived if SLAM service ever publishes it.
@@ -709,6 +715,10 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         wait_start = time.time()
 
         with slam_info_lock:
+            if not nav_cmd or (navigation_id is not None and
+                               nav_cmd.get("navigation_id") != navigation_id):
+                return {"status": "superseded"}
+            wait_generation = nav_cmd["generation"]
             last_pose = dict(nav_current_pose) if nav_current_pose else None
 
         if last_pose is None:
@@ -719,6 +729,10 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             elapsed = time.time() - wait_start
 
             with slam_info_lock:
+                if not nav_cmd or nav_cmd.get("generation") != wait_generation or \
+                        (navigation_id is not None and
+                         nav_cmd.get("navigation_id") != navigation_id):
+                    return {"status": "superseded"}
                 arrived = nav_arrived_flag
                 error = nav_arrived_error
                 pose = dict(nav_current_pose) if nav_current_pose else None
@@ -786,6 +800,12 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         # State changed externally (e.g., emergency stop)
         print(f"[SmartMotion] wait_nav_done: state changed to {state.value}", flush=True)
         return {"status": "stopped", "state": state.value}
+
+    def complete_wait_nav(cmd):
+        result = handle_wait_nav_done(cmd.get("stall_timeout", 60),
+                                      navigation_id=cmd.get("navigation_id"))
+        result["_req_id"] = cmd.get("_req_id")
+        result_queue.put(result)
 
     def handle_pause_nav(reason_str):
         nonlocal state
@@ -928,7 +948,8 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                                             cmd.get("target_name", ""),
                                             speed=cmd.get("speed", 0.5),
                                             mode=cmd.get("mode", 1),
-                                            stall_timeout=cmd.get("stall_timeout", 60))
+                                            stall_timeout=cmd.get("stall_timeout", 60),
+                                            navigation_id=cmd.get("navigation_id"))
             elif method == "pause_nav":
                 result = handle_pause_nav(cmd.get("reason", "command"))
             elif method == "resume_nav":
@@ -936,7 +957,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             elif method == "stop_nav":
                 result = do_stop_nav()
             elif method == "wait_nav_done":
-                result = handle_wait_nav_done(cmd.get("stall_timeout", 60))
+                threading.Thread(target=complete_wait_nav, args=(cmd,), daemon=True).start()
             elif method == "get_state":
                 result = handle_get_state()
             elif method == "start_mapping":

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -713,7 +713,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         """Block until navigation completes or robot is stuck.
         Arrival detection: pose-based (distance to target < 0.3m).
         Also checks ctrl_info.is_arrived if SLAM service ever publishes it.
-        Runs safety checks and ROS2 spin during the wait."""
+        ROS2 spinning and safety checks are handled by the main loop."""
         nonlocal state, nav_arrived_flag, nav_arrived_error, nav_cmd, speed_zone, stop_repeat_count
         poll_interval = 0.5
         last_pose = None
@@ -821,13 +821,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                         "error": f"No movement for {stall_timeout}s, navigation cancelled",
                         "pose": pose}
 
-            # Run safety checks and ROS2 spin during wait
-            process_safety_checks()
-            if stop_repeat_count > 0 and state == MotionState.IDLE:
-                loco_client.StopMove()
-                stop_repeat_count -= 1
-            executor.spin_once(timeout_sec=0)
-
+            # ROS2 spinning and safety checks are owned by the main loop.
             time.sleep(poll_interval)
 
         # State changed externally (e.g., emergency stop)
@@ -835,8 +829,12 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         return {"status": "stopped", "state": state.value}
 
     def complete_wait_nav(cmd):
-        result = handle_wait_nav_done(cmd.get("stall_timeout", 60),
-                                      navigation_id=cmd.get("navigation_id"))
+        try:
+            result = handle_wait_nav_done(cmd.get("stall_timeout", 60),
+                                          navigation_id=cmd.get("navigation_id"))
+        except Exception as exc:
+            print(f"[SmartMotion] wait_nav_done failed: {exc!r}", flush=True)
+            result = {"status": "error", "error": f"wait_nav_done failed: {exc}"}
         result["_req_id"] = cmd.get("_req_id")
         result_queue.put(result)
 

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -742,14 +742,23 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                 arrived = nav_arrived_flag
                 error = nav_arrived_error
                 pose = dict(nav_current_pose) if nav_current_pose else None
+                target_pose = dict(nav_cmd["target_pose"]) if nav_cmd else None
                 nav_arrived_flag = False
                 nav_arrived_error = None
 
             # ctrl_info-based arrival (secondary — SLAM service may not publish ctrl_info)
+            # Terminal transition must happen inside slam_info_lock and be conditional on
+            # the same generation/navigation_id, otherwise a newly queued navigate_to can
+            # install its nav_cmd in the gap and the old waiter will wipe it.
             if arrived:
-                state = MotionState.IDLE
-                nav_cmd = None
-                speed_zone = SpeedZone.NORMAL
+                with slam_info_lock:
+                    if not nav_cmd or nav_cmd.get("generation") != wait_generation or \
+                            (navigation_id is not None and
+                             nav_cmd.get("navigation_id") != navigation_id):
+                        return {"status": "superseded"}
+                    state = MotionState.IDLE
+                    nav_cmd = None
+                    speed_zone = SpeedZone.NORMAL
                 if error:
                     return {"status": "error", "error": error}
                 print(f"[SmartMotion] wait_nav_done: arrived via ctrl_info "
@@ -757,14 +766,21 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                 return {"status": "arrived", "pose": pose}
 
             # Pose-based arrival detection (primary mechanism)
-            if pose and nav_cmd:
-                tx = nav_cmd["target_pose"]["x"]
-                ty = nav_cmd["target_pose"]["y"]
+            # target_pose is snapshotted inside the lock above — never read nav_cmd
+            # outside the synchronization.
+            if pose and target_pose:
+                tx = target_pose["x"]
+                ty = target_pose["y"]
                 dist = math.sqrt((pose["x"] - tx)**2 + (pose["y"] - ty)**2)
                 if dist < 0.3:
-                    state = MotionState.IDLE
-                    nav_cmd = None
-                    speed_zone = SpeedZone.NORMAL
+                    with slam_info_lock:
+                        if not nav_cmd or nav_cmd.get("generation") != wait_generation or \
+                                (navigation_id is not None and
+                                 nav_cmd.get("navigation_id") != navigation_id):
+                            return {"status": "superseded"}
+                        state = MotionState.IDLE
+                        nav_cmd = None
+                        speed_zone = SpeedZone.NORMAL
                     print(f"[SmartMotion] wait_nav_done: arrived via pose "
                           f"after {elapsed:.1f}s, dist={dist:.3f}m, pose={pose}", flush=True)
                     return {"status": "arrived", "pose": pose}
@@ -787,7 +803,18 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     last_pose = pose
 
             if state == MotionState.NAVIGATING and time.time() - stall_start > stall_timeout:
-                do_stop_nav()
+                with slam_info_lock:
+                    if not nav_cmd or nav_cmd.get("generation") != wait_generation or \
+                            (navigation_id is not None and
+                             nav_cmd.get("navigation_id") != navigation_id):
+                        return {"status": "superseded"}
+                    state = MotionState.IDLE
+                    nav_cmd = None
+                    speed_zone = SpeedZone.NORMAL
+                try:
+                    slam_client.PauseNav()
+                except Exception:
+                    pass
                 print(f"[SmartMotion] wait_nav_done: TIMEOUT after {stall_timeout}s "
                       f"no movement, pose={pose}", flush=True)
                 return {"status": "timeout",

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -193,6 +193,12 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     Initializes its own DDS channel, RPC clients, ROS2 node, and LiDAR subscription.
     Runs independently from the main driver process — no GIL contention.
     """
+    try:
+        from common import logsafe
+        logsafe.install(check_fd=False)
+    except ImportError:
+        pass
+
     import numpy as np
     import rclpy
     from rclpy.node import Node

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -128,7 +128,7 @@ class SmartMotionProxy:
             result = result_q.get(timeout=timeout)
             return result
         except queue.Empty:
-            return {"error": f"SmartMotion subprocess timeout ({method})"}
+            return {"error": f"SmartMotion subprocess timeout ({method})", "status": "unknown"}
         finally:
             with self._dispatch_lock:
                 self._pending.pop(req_id, None)
@@ -141,8 +141,18 @@ class SmartMotionProxy:
 
     def navigate_to(self, x: float, y: float, yaw: float, target_name: str = "",
                     speed: float = 0.5, mode: int = 1, navigation_id: str | None = None) -> dict:
-        return self._call("navigate_to", x=x, y=y, yaw=yaw, target_name=target_name,
-                          speed=speed, mode=mode, navigation_id=navigation_id)
+        if navigation_id is None:
+            from uuid import uuid4
+            navigation_id = uuid4().hex
+        result = self._call("navigate_to", x=x, y=y, yaw=yaw, target_name=target_name,
+                            speed=speed, mode=mode, navigation_id=navigation_id,
+                            deadline=time.monotonic() + 15.0)
+        if result.get("status") == "unknown":
+            cancelled = self._call("cancel_navigation", navigation_id=navigation_id)
+            if cancelled.get("status") in ("stopped", "superseded"):
+                return {"status": "cancelled", "error": "Navigation submission timed out; cancellation confirmed"}
+            result["navigation_id"] = navigation_id
+        return result
 
     def pause_nav(self, reason: str = "command") -> dict:
         return self._call("pause_nav", reason=reason)
@@ -334,6 +344,23 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             slam_info_lock.notify_all()
         if was_nav:
             publish_event("nav_stopped", {"reason": "command"})
+        return {"status": "stopped"}
+
+    def cancel_navigation(navigation_id):
+        nonlocal state, nav_cmd, speed_zone
+        with slam_info_lock:
+            if not nav_cmd or nav_cmd.get("navigation_id") != navigation_id:
+                return {"status": "superseded"}
+            try:
+                code, _ = slam_client.PauseNav()
+            except Exception as exc:
+                return {"status": "unknown", "error": str(exc)}
+            if code != 0:
+                return {"status": "unknown", "error": f"PauseNav failed, code={code}"}
+            state = MotionState.IDLE
+            nav_cmd = None
+            speed_zone = SpeedZone.NORMAL
+            slam_info_lock.notify_all()
         return {"status": "stopped"}
 
     def duration_expired():
@@ -678,9 +705,11 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                 "duration": duration, "state": state.value}
 
     def handle_navigate_to(x, y, yaw, target_name, speed=0.5, mode=1, stall_timeout=60,
-                           navigation_id=None):
+                           navigation_id=None, deadline=None):
         nonlocal state, nav_cmd, speed_zone, nav_arrived_flag, nav_arrived_error, nav_generation
 
+        if deadline is not None and time.monotonic() >= deadline:
+            return {"status": "expired", "error": "Navigation expired before execution"}
         if state == MotionState.MOVING:
             do_stop("command")
         elif state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
@@ -702,12 +731,13 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             slam_client.ResumeNav()
         except Exception:
             pass
-        code, resp = slam_client.NavigateTo(x, y, 0, 0, 0, q_z, q_w,
-                                              speed=speed, mode=mode)
+        try:
+            code, resp = slam_client.NavigateTo(x, y, 0, 0, 0, q_z, q_w,
+                                               speed=speed, mode=mode)
+        except Exception as exc:
+            code, resp = -1, str(exc)
 
-        if code != 0:
-            return {"error": f"NavigateTo failed, code={code}", "response": resp}
-
+        # RPC 失败也可能是回包丢失；先登记目标，确保取消失败时仍可跟踪。
         label = target_name or f"({x:.1f}, {y:.1f})"
         with slam_info_lock:
             nav_cmd = {"target_name": label, "target_pose": {"x": x, "y": y, "yaw": yaw},
@@ -717,6 +747,11 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             speed_zone = SpeedZone.NORMAL
             slam_info_lock.notify_all()
 
+        if code != 0 or (deadline is not None and time.monotonic() >= deadline):
+            cancelled = cancel_navigation(navigation_id)
+            return {"status": "cancelled" if cancelled["status"] == "stopped" else "unknown",
+                    "error": f"Navigation unconfirmed or expired, code={code}",
+                    "navigation_id": navigation_id, "response": resp}
         publish_event("nav_start", {"target_name": label, "target_pose": {"x": x, "y": y, "yaw": yaw}})
         # Return immediately — non-blocking. wait_navigation_done handles arrival detection.
         return {"status": "navigating", "target": label, "pose": {"x": x, "y": y, "yaw": yaw}}
@@ -821,17 +856,9 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                             (navigation_id is not None and
                              nav_cmd.get("navigation_id") != navigation_id):
                         return {"status": "superseded"}
-                    state = MotionState.IDLE
-                    nav_cmd = None
-                    speed_zone = SpeedZone.NORMAL
-                try:
-                    slam_client.PauseNav()
-                except Exception:
-                    pass
-                print(f"[SmartMotion] wait_nav_done: TIMEOUT after {stall_timeout}s "
-                      f"no movement, pose={pose}", flush=True)
-                return {"status": "timeout",
-                        "error": f"No movement for {stall_timeout}s, navigation cancelled",
+                # 等待线程不执行物理 RPC；由代理经命令队列定向取消并确认。
+                return {"status": "unknown",
+                        "error": f"No movement for {stall_timeout}s; cancellation required",
                         "pose": pose}
 
             with slam_info_lock:
@@ -1000,7 +1027,10 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                                             speed=cmd.get("speed", 0.5),
                                             mode=cmd.get("mode", 1),
                                             stall_timeout=cmd.get("stall_timeout", 60),
-                                            navigation_id=cmd.get("navigation_id"))
+                                            navigation_id=cmd.get("navigation_id"),
+                                            deadline=cmd.get("deadline"))
+            elif method == "cancel_navigation":
+                result = cancel_navigation(cmd.get("navigation_id"))
             elif method == "pause_nav":
                 result = handle_pause_nav(cmd.get("reason", "command"))
             elif method == "resume_nav":

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -100,16 +100,18 @@ class SmartMotionProxy:
         while True:
             try:
                 item = self._result_queue.get(timeout=1.0)
-                req_id = item.pop("_req_id", None) if isinstance(item, dict) else None
-                if req_id and req_id in self._pending:
-                    self._pending[req_id].put(item)
-                else:
-                    # Fallback: shouldn't happen, but don't lose the result
-                    # Put it in any waiting queue (legacy behavior)
-                    with self._dispatch_lock:
-                        for q in self._pending.values():
-                            q.put(item)
-                            break
+                if not isinstance(item, dict):
+                    continue
+                req_id = item.pop("_req_id", None)
+                if not isinstance(req_id, str) or not req_id:
+                    continue
+                with self._dispatch_lock:
+                    result_q = self._pending.get(req_id)
+                    if result_q is not None:
+                        try:
+                            result_q.put_nowait(item)
+                        except queue.Full:
+                            pass
             except queue.Empty:
                 continue
             except Exception:
@@ -193,11 +195,8 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     Initializes its own DDS channel, RPC clients, ROS2 node, and LiDAR subscription.
     Runs independently from the main driver process — no GIL contention.
     """
-    try:
-        from common import logsafe
-        logsafe.install(check_fd=False)
-    except ImportError:
-        pass
+    from common import logsafe
+    logsafe.install(check_fd=False)
 
     import numpy as np
     import rclpy

--- a/unitree/g1/safety_harness.py
+++ b/unitree/g1/safety_harness.py
@@ -275,11 +275,14 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
     fwd_log_n = 0  # decel-zone log counter, reset on leaving the zone
 
     # Nav arrival state (updated by rt/slam_info DDS callback in this subprocess)
-    slam_info_lock = threading.Lock()
+    slam_info_lock = threading.Condition()
     nav_arrived_flag = False
     nav_arrived_error = None
     nav_current_pose = None
     nav_generation = 0
+    shutdown_event = threading.Event()
+    waiter_threads = set()
+    waiter_threads_lock = threading.Lock()
 
     # ── Helpers ──
     def clamp(vx, vy, vyaw, zone):
@@ -328,6 +331,8 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         state = MotionState.IDLE
         nav_cmd = None
         speed_zone = SpeedZone.NORMAL
+        with slam_info_lock:
+            slam_info_lock.notify_all()
         if was_nav:
             publish_event("nav_stopped", {"reason": "command"})
         return {"status": "stopped"}
@@ -478,6 +483,8 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         current_cmd = None
         speed_zone = SpeedZone.NORMAL
         stop_repeat_count = 3  # repeat StopMove in main loop to ensure it takes effect
+        with slam_info_lock:
+            slam_info_lock.notify_all()
         if was_active:
             event_data = {"reason": reason_str}
             if extra:
@@ -599,6 +606,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     nav_current_pose = {
                         "x": pose_data["x"], "y": pose_data["y"], "yaw": round(yaw, 3)
                     }
+                    slam_info_lock.notify_all()
                 # Debug: log first few pos_info to verify subprocess receives them
                 if slam_info_pos_count <= 3:
                     print(f"[SmartMotion] slam_info pos_info #{slam_info_pos_count}: "
@@ -610,11 +618,13 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             if ctrl_data.get("is_arrived"):
                 with slam_info_lock:
                     nav_arrived_flag = True
+                    slam_info_lock.notify_all()
             obs = ctrl_data.get("obsInfo", {})
             if obs.get("state") and obs.get("time", 0) > 10:
                 with slam_info_lock:
                     nav_arrived_error = "blocked by obstacle for >10s"
                     nav_arrived_flag = True
+                    slam_info_lock.notify_all()
 
     try:
         from unitree_sdk2py.idl.std_msgs.msg.dds_ import String_ as StringMsg_
@@ -682,6 +692,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             nav_generation += 1
             nav_arrived_flag = False
             nav_arrived_error = None
+            slam_info_lock.notify_all()
 
         q_z = math.sin(yaw / 2)
         q_w = math.cos(yaw / 2)
@@ -699,11 +710,13 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             return {"error": f"NavigateTo failed, code={code}", "response": resp}
 
         label = target_name or f"({x:.1f}, {y:.1f})"
-        nav_cmd = {"target_name": label, "target_pose": {"x": x, "y": y, "yaw": yaw},
-                   "start_time": time.time(), "navigation_id": navigation_id,
-                   "generation": nav_generation}
-        state = MotionState.NAVIGATING
-        speed_zone = SpeedZone.NORMAL
+        with slam_info_lock:
+            nav_cmd = {"target_name": label, "target_pose": {"x": x, "y": y, "yaw": yaw},
+                       "start_time": time.time(), "navigation_id": navigation_id,
+                       "generation": nav_generation}
+            state = MotionState.NAVIGATING
+            speed_zone = SpeedZone.NORMAL
+            slam_info_lock.notify_all()
 
         publish_event("nav_start", {"target_name": label, "target_pose": {"x": x, "y": y, "yaw": yaw}})
         # Return immediately — non-blocking. wait_navigation_done handles arrival detection.
@@ -714,8 +727,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         Arrival detection: pose-based (distance to target < 0.3m).
         Also checks ctrl_info.is_arrived if SLAM service ever publishes it.
         ROS2 spinning and safety checks are handled by the main loop."""
-        nonlocal state, nav_arrived_flag, nav_arrived_error, nav_cmd, speed_zone, stop_repeat_count
-        poll_interval = 0.5
+        nonlocal state, nav_arrived_flag, nav_arrived_error, nav_cmd, speed_zone
         last_pose = None
         stall_start = time.time()
         wait_start = time.time()
@@ -759,6 +771,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                     state = MotionState.IDLE
                     nav_cmd = None
                     speed_zone = SpeedZone.NORMAL
+                    slam_info_lock.notify_all()
                 if error:
                     return {"status": "error", "error": error}
                 print(f"[SmartMotion] wait_nav_done: arrived via ctrl_info "
@@ -781,6 +794,7 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                         state = MotionState.IDLE
                         nav_cmd = None
                         speed_zone = SpeedZone.NORMAL
+                        slam_info_lock.notify_all()
                     print(f"[SmartMotion] wait_nav_done: arrived via pose "
                           f"after {elapsed:.1f}s, dist={dist:.3f}m, pose={pose}", flush=True)
                     return {"status": "arrived", "pose": pose}
@@ -821,14 +835,19 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                         "error": f"No movement for {stall_timeout}s, navigation cancelled",
                         "pose": pose}
 
-            # ROS2 spinning and safety checks are owned by the main loop.
-            time.sleep(poll_interval)
+            with slam_info_lock:
+                if not shutdown_event.is_set():
+                    slam_info_lock.wait(timeout=0.5)
+
+        if shutdown_event.is_set():
+            return {"status": "stopped", "state": MotionState.IDLE.value}
 
         # State changed externally (e.g., emergency stop)
         print(f"[SmartMotion] wait_nav_done: state changed to {state.value}", flush=True)
         return {"status": "stopped", "state": state.value}
 
     def complete_wait_nav(cmd):
+        current_thread = threading.current_thread()
         try:
             result = handle_wait_nav_done(cmd.get("stall_timeout", 60),
                                           navigation_id=cmd.get("navigation_id"))
@@ -837,6 +856,8 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             result = {"status": "error", "error": f"wait_nav_done failed: {exc}"}
         result["_req_id"] = cmd.get("_req_id")
         result_queue.put(result)
+        with waiter_threads_lock:
+            waiter_threads.discard(current_thread)
 
     def handle_pause_nav(reason_str):
         nonlocal state
@@ -988,7 +1009,10 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
             elif method == "stop_nav":
                 result = do_stop_nav()
             elif method == "wait_nav_done":
-                threading.Thread(target=complete_wait_nav, args=(cmd,), daemon=True).start()
+                waiter = threading.Thread(target=complete_wait_nav, args=(cmd,), daemon=True)
+                with waiter_threads_lock:
+                    waiter_threads.add(waiter)
+                waiter.start()
             elif method == "get_state":
                 result = handle_get_state()
             elif method == "start_mapping":
@@ -1011,6 +1035,9 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
                 )
                 result = {"code": code, "response": resp}
             elif method == "shutdown":
+                shutdown_event.set()
+                with slam_info_lock:
+                    slam_info_lock.notify_all()
                 if state == MotionState.MOVING:
                     loco_client.StopMove()
                 elif state in (MotionState.NAVIGATING, MotionState.NAV_PAUSED):
@@ -1048,6 +1075,13 @@ def _run_smart_motion_process(namespace: str, config: dict, network_iface: str,
         executor.spin_once(timeout_sec=0)
 
     # Cleanup
+    shutdown_event.set()
+    with slam_info_lock:
+        slam_info_lock.notify_all()
+    with waiter_threads_lock:
+        waiters = list(waiter_threads)
+    for waiter in waiters:
+        waiter.join(timeout=1.0)
     if move_timer:
         move_timer.cancel()
     executor.shutdown()

--- a/unitree/g1/tests/test_controlled_spatial_supersede.py
+++ b/unitree/g1/tests/test_controlled_spatial_supersede.py
@@ -104,5 +104,118 @@ class ControlledSpatialSupersedeTests(unittest.TestCase):
         self.fail("condition was not satisfied before timeout")
 
 
+class RaceySmartMotion:
+    """Simulates the subprocess race: the second navigate_to RPC is in-flight
+    (blocked) when the old waiter's wait_nav_done returns a stale 'arrived'.
+
+    With the old code (navigate_to submitted before _supersede_nav), the old
+    waiter could _try_claim_terminal its action_id and fire 'completed' while
+    the new navigation was already physically underway.  With reserve-before-
+    submit, _nav_action_id is already the new id, so the old claim fails.
+    """
+
+    def __init__(self):
+        self.old_id = None
+        self.new_id = None
+        self.nav_in_flight = threading.Event()
+        self.nav_continue = threading.Event()
+        self.old_arrive = threading.Event()
+        self.new_arrive = threading.Event()
+
+    def navigate_to(self, *args, navigation_id=None, **kwargs):
+        if self.old_id is None:
+            self.old_id = navigation_id
+            return {"status": "navigating"}
+        # Second navigate_to: block to simulate an in-flight RPC.
+        self.new_id = navigation_id
+        self.nav_in_flight.set()
+        self.nav_continue.wait(timeout=5)
+        return {"status": "navigating"}
+
+    def wait_nav_done(self, stall_timeout=60, navigation_id=None):
+        if navigation_id == self.new_id:
+            self.new_arrive.wait(timeout=5)
+            return {"status": "arrived", "pose": {"x": 2.0, "y": 0.0}}
+        # Old navigation: wait for the test to inject a stale arrival.
+        self.old_arrive.wait(timeout=5)
+        return {"status": "arrived", "pose": {"x": 1.0, "y": 0.0}}
+
+
+class ArrivalInterleavingTests(unittest.TestCase):
+    """Regression: an arrival detected on the old navigation must not fire
+    'completed' for the old action when a replacement navigation has already
+    reserved its action_id (even if the replacement RPC is still in-flight)."""
+
+    def make_plugin(self, smart_motion):
+        db_file = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        db_file.close()
+        self.addCleanup(Path(db_file.name).unlink, missing_ok=True)
+        return CS.ControlledSpatialPlugin(
+            {"native_slam_db_path": db_file.name}, "g1", None, None, smart_motion)
+
+    def test_old_arrival_during_inflight_replacement_does_not_complete_old_action(self):
+        sm = RaceySmartMotion()
+        plugin = self.make_plugin(sm)
+        notifications = []
+
+        with patch.object(CS, "_acp_notify", side_effect=lambda *args: notifications.append(args)):
+            # 1. Start first navigation — old waiter blocks on wait_nav_done(old_id).
+            first = plugin.dispatch("navigate_to_pose", {"x": 1, "y": 0, "yaw": 0})
+            self.assertIsNotNone(first.get("action_id"))
+            # Give the old waiter thread time to enter wait_nav_done.
+            time.sleep(0.1)
+
+            # 2. Start second navigation in a background thread because navigate_to
+            #    blocks (simulating in-flight RPC).  reserve_nav(new_id) runs
+            #    BEFORE the blocking navigate_to call.
+            second_result = {}
+            def _start_second():
+                second_result["value"] = plugin.dispatch(
+                    "navigate_to_pose", {"x": 2, "y": 0, "yaw": 0})
+            t = threading.Thread(target=_start_second, daemon=True)
+            t.start()
+
+            # 3. Wait until the second navigate_to is blocked in-flight.
+            sm.nav_in_flight.wait(timeout=2)
+            # At this point _nav_action_id is already the new id (reserved before
+            # the blocking call).  Inject a stale arrival for the old navigation.
+            sm.old_arrive.set()
+            # Give the old waiter time to process the stale arrival.
+            time.sleep(0.2)
+
+            # The old waiter must NOT have fired 'completed' — its _try_claim_terminal
+            # should fail because _nav_action_id is the new id.
+            old_completed = [n for n in notifications
+                             if n[0] == first["action_id"] and n[1] == "completed"]
+            self.assertEqual(old_completed, [],
+                             f"old action must not complete during replacement; got {notifications}")
+
+            # 4. Release the blocking navigate_to so the second nav completes setup.
+            sm.nav_continue.set()
+            t.join(timeout=2)
+            second = second_result.get("value")
+            self.assertIsNotNone(second)
+            self.assertEqual(second.get("status"), "navigating")
+
+            # 5. Signal arrival for the new navigation.
+            sm.new_arrive.set()
+            # Wait for the new action to complete.
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                if any(n[0] == second["action_id"] and n[1] == "completed"
+                       for n in notifications):
+                    break
+                time.sleep(0.01)
+
+        # Final assertions: old action got exactly 'cancelled' (never 'completed'),
+        # new action got 'completed'.
+        old_events = [(n[0], n[1]) for n in notifications if n[0] == first["action_id"]]
+        new_events = [(n[0], n[1]) for n in notifications if n[0] == second["action_id"]]
+        self.assertEqual(old_events, [(first["action_id"], "cancelled")],
+                         f"old action should only be cancelled, got {old_events}")
+        self.assertIn((second["action_id"], "completed"), new_events,
+                      f"new action should complete, got {new_events}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/unitree/g1/tests/test_controlled_spatial_supersede.py
+++ b/unitree/g1/tests/test_controlled_spatial_supersede.py
@@ -1,0 +1,108 @@
+"""Regression tests for superseded controlled-spatial navigation waiters."""
+
+import importlib.util
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_controlled_spatial():
+    spec = importlib.util.spec_from_file_location(
+        "controlled_spatial_under_test", ROOT / "controlled_spatial.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CS = load_controlled_spatial()
+
+
+class FakeSmartMotion:
+    def __init__(self):
+        self._arrived = threading.Event()
+        self._active_navigation_id = None
+        self.wait_started = {}
+
+    def navigate_to(self, *args, navigation_id=None, **kwargs):
+        self._active_navigation_id = navigation_id
+        return {"status": "navigating"}
+
+    def wait_nav_done(self, stall_timeout=60, navigation_id=None):
+        self.wait_started.setdefault(navigation_id, threading.Event()).set()
+        self._arrived.wait(timeout=1)
+        if navigation_id != self._active_navigation_id:
+            return {"status": "superseded"}
+        return {"status": "arrived", "pose": {"x": 2.0, "y": 0.0}}
+
+    def arrive(self):
+        self._arrived.set()
+
+
+class FakeClient:
+    def NavigateTo(self, *args, **kwargs):
+        return 0, {}
+
+
+class ControlledSpatialSupersedeTests(unittest.TestCase):
+    def make_plugin(self, smart_motion):
+        db_file = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        db_file.close()
+        self.addCleanup(Path(db_file.name).unlink, missing_ok=True)
+        return CS.ControlledSpatialPlugin(
+            {"native_slam_db_path": db_file.name}, "g1", None, None, smart_motion)
+
+    def test_smart_motion_arrival_completes_only_latest_navigation(self):
+        smart_motion = FakeSmartMotion()
+        plugin = self.make_plugin(smart_motion)
+        notifications = []
+
+        with patch.object(CS, "_acp_notify", side_effect=lambda *args: notifications.append(args)):
+            first = plugin.dispatch("navigate_to_pose", {"x": 1, "y": 0, "yaw": 0})
+            self.assertTrue(smart_motion.wait_started[first["action_id"]].wait(timeout=1))
+            second = plugin.dispatch("navigate_to_pose", {"x": 2, "y": 0, "yaw": 0})
+            self.assertTrue(smart_motion.wait_started[second["action_id"]].wait(timeout=1))
+            smart_motion.arrive()
+            self.wait_for(lambda: any(item[0] == second["action_id"] and item[1] == "completed"
+                                      for item in notifications))
+
+        self.assertEqual(
+            [(item[0], item[1]) for item in notifications],
+            [(first["action_id"], "cancelled"), (second["action_id"], "completed")],
+        )
+
+    def test_fallback_arrival_completes_only_latest_navigation(self):
+        plugin = self.make_plugin(None)
+        plugin._client = FakeClient()
+        notifications = []
+
+        with patch.object(CS, "_acp_notify", side_effect=lambda *args: notifications.append(args)):
+            first = plugin.dispatch("navigate_to_pose", {"x": 1, "y": 0, "yaw": 0})
+            second = plugin.dispatch("navigate_to_pose", {"x": 2, "y": 0, "yaw": 0})
+            plugin._nav_arrived.set()
+            self.wait_for(lambda: any(item[0] == second["action_id"] and item[1] == "completed"
+                                      for item in notifications))
+
+        self.assertEqual(
+            [(item[0], item[1]) for item in notifications],
+            [(first["action_id"], "cancelled"), (second["action_id"], "completed")],
+        )
+
+    def wait_for(self, predicate, timeout=2):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            time.sleep(0.01)
+        self.fail("condition was not satisfied before timeout")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_controlled_spatial_supersede.py
+++ b/unitree/g1/tests/test_controlled_spatial_supersede.py
@@ -33,6 +33,7 @@ class FakeSmartMotion:
 
     def navigate_to(self, *args, navigation_id=None, **kwargs):
         self._active_navigation_id = navigation_id
+        self.wait_started[navigation_id] = threading.Event()
         return {"status": "navigating"}
 
     def wait_nav_done(self, stall_timeout=60, navigation_id=None):
@@ -56,8 +57,11 @@ class ControlledSpatialSupersedeTests(unittest.TestCase):
         db_file = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
         db_file.close()
         self.addCleanup(Path(db_file.name).unlink, missing_ok=True)
-        return CS.ControlledSpatialPlugin(
-            {"native_slam_db_path": db_file.name}, "g1", None, None, smart_motion)
+        with patch.object(CS, "_SlamRpcProxy", return_value=FakeClient()):
+            plugin = CS.ControlledSpatialPlugin(
+                {"native_slam_db_path": db_file.name}, "g1", None, None, smart_motion)
+        self.addCleanup(plugin._db._conn.close)
+        return plugin
 
     def test_smart_motion_arrival_completes_only_latest_navigation(self):
         smart_motion = FakeSmartMotion()
@@ -119,6 +123,7 @@ class RaceySmartMotion:
         self.new_id = None
         self.nav_in_flight = threading.Event()
         self.nav_continue = threading.Event()
+        self.old_wait_started = threading.Event()
         self.old_arrive = threading.Event()
         self.new_arrive = threading.Event()
 
@@ -137,6 +142,7 @@ class RaceySmartMotion:
             self.new_arrive.wait(timeout=5)
             return {"status": "arrived", "pose": {"x": 2.0, "y": 0.0}}
         # Old navigation: wait for the test to inject a stale arrival.
+        self.old_wait_started.set()
         self.old_arrive.wait(timeout=5)
         return {"status": "arrived", "pose": {"x": 1.0, "y": 0.0}}
 
@@ -150,20 +156,27 @@ class ArrivalInterleavingTests(unittest.TestCase):
         db_file = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
         db_file.close()
         self.addCleanup(Path(db_file.name).unlink, missing_ok=True)
-        return CS.ControlledSpatialPlugin(
-            {"native_slam_db_path": db_file.name}, "g1", None, None, smart_motion)
+        with patch.object(CS, "_SlamRpcProxy", return_value=FakeClient()):
+            plugin = CS.ControlledSpatialPlugin(
+                {"native_slam_db_path": db_file.name}, "g1", None, None, smart_motion)
+        self.addCleanup(plugin._db._conn.close)
+        return plugin
 
     def test_old_arrival_during_inflight_replacement_does_not_complete_old_action(self):
         sm = RaceySmartMotion()
         plugin = self.make_plugin(sm)
+        plugin._nav_command_lock = ObservedLock()
+        self.addCleanup(sm.nav_continue.set)
+        self.addCleanup(sm.old_arrive.set)
+        self.addCleanup(sm.new_arrive.set)
         notifications = []
 
         with patch.object(CS, "_acp_notify", side_effect=lambda *args: notifications.append(args)):
             # 1. Start first navigation — old waiter blocks on wait_nav_done(old_id).
             first = plugin.dispatch("navigate_to_pose", {"x": 1, "y": 0, "yaw": 0})
             self.assertIsNotNone(first.get("action_id"))
-            # Give the old waiter thread time to enter wait_nav_done.
-            time.sleep(0.1)
+            self.assertTrue(sm.old_wait_started.wait(timeout=2))
+            plugin._nav_command_lock.contended.clear()
 
             # 2. Start second navigation in a background thread because navigate_to
             #    blocks (simulating in-flight RPC).  reserve_nav(new_id) runs
@@ -176,15 +189,13 @@ class ArrivalInterleavingTests(unittest.TestCase):
             t.start()
 
             # 3. Wait until the second navigate_to is blocked in-flight.
-            sm.nav_in_flight.wait(timeout=2)
+            self.assertTrue(sm.nav_in_flight.wait(timeout=2))
             # At this point _nav_action_id is already the new id (reserved before
             # the blocking call).  Inject a stale arrival for the old navigation.
             sm.old_arrive.set()
-            # Give the old waiter time to process the stale arrival.
-            time.sleep(0.2)
+            self.assertTrue(plugin._nav_command_lock.contended.wait(timeout=2))
 
-            # The old waiter must NOT have fired 'completed' — its _try_claim_terminal
-            # should fail because _nav_action_id is the new id.
+            # Terminal claiming waits for the replacement to commit or roll back.
             old_completed = [n for n in notifications
                              if n[0] == first["action_id"] and n[1] == "completed"]
             self.assertEqual(old_completed, [],
@@ -215,6 +226,400 @@ class ArrivalInterleavingTests(unittest.TestCase):
                          f"old action should only be cancelled, got {old_events}")
         self.assertIn((second["action_id"], "completed"), new_events,
                       f"new action should complete, got {new_events}")
+
+
+class ObservedLock:
+    """Expose contention without relying on scheduler sleeps."""
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.contended = threading.Event()
+
+    def __enter__(self):
+        if not self.lock.acquire(blocking=False):
+            self.contended.set()
+            self.lock.acquire()
+
+    def __exit__(self, *args):
+        self.lock.release()
+
+
+class SubmissionContractTests(unittest.TestCase):
+    make_plugin = ControlledSpatialSupersedeTests.make_plugin
+
+    def prepare(self, smart_motion):
+        plugin = self.make_plugin(smart_motion)
+        plugin._active_map = "test"
+        plugin._db.add_poi("target", 1, 0, 0, "test")
+        return plugin
+
+    def test_navigation_commands_are_serialized(self):
+        for smart in (False, True):
+            for first_action in ("navigate_to_tag", "navigate_to_pose"):
+                for second_action in ("navigate_to_tag", "navigate_to_pose",
+                                      "pause_nav", "resume_nav", "stop_nav"):
+                    for barrier_at in ("reservation", "rpc", "waiter_setup"):
+                        with self.subTest(smart=smart, first=first_action,
+                                          second=second_action, barrier=barrier_at):
+                            self.check_serialized(smart, first_action, second_action, barrier_at)
+
+    def check_serialized(self, smart, first_action, second_action, barrier_at):
+        from unittest.mock import Mock
+
+        backend = Mock()
+        plugin = self.prepare(backend if smart else None)
+        if not smart:
+            plugin._client = backend
+        lock = ObservedLock()
+        plugin._nav_command_lock = lock
+        blocked = threading.Event()
+        release = threading.Event()
+        calls = []
+        results = {}
+        errors = []
+        waiters = []
+        real_thread = threading.Thread
+
+        def barrier():
+            blocked.set()
+            if not release.wait(timeout=5):
+                raise AssertionError("submission barrier was not released")
+
+        def rpc(name, *args, **kwargs):
+            # RPC must never hold the state lock.
+            self.assertTrue(plugin._lock.acquire(blocking=False))
+            plugin._lock.release()
+            calls.append((name, plugin._nav_action_id))
+            if barrier_at == "rpc" and len(calls) == 1:
+                barrier()
+            return {"status": "navigating"} if smart else (0, {})
+
+        names = (("navigate_to", "pause_nav", "resume_nav", "stop_nav") if smart
+                 else ("NavigateTo", "PauseNav", "ResumeNav"))
+        for name in names:
+            getattr(backend, name).side_effect = lambda *a, _name=name, **kw: rpc(_name, *a, **kw)
+
+        reserve = plugin._reserve_nav
+        reservations = []
+
+        def reserve_nav(action_id):
+            value = reserve(action_id)
+            reservations.append(action_id)
+            if barrier_at == "reservation" and len(reservations) == 1:
+                barrier()
+            return value
+
+        def waiter_thread(*args, **kwargs):
+            if barrier_at == "waiter_setup" and not waiters:
+                barrier()
+            thread = real_thread(*args, **kwargs)
+            waiters.append(thread)
+            return thread
+
+        def dispatch(key, action):
+            try:
+                results[key] = plugin.dispatch(action, {"tag_name": "target", "x": 2})
+            except BaseException as exc:
+                errors.append(exc)
+
+        first = real_thread(target=dispatch, args=("first", first_action), daemon=True)
+        second = real_thread(target=dispatch, args=("second", second_action), daemon=True)
+        with patch.object(plugin, "_reserve_nav", side_effect=reserve_nav), \
+                patch.object(plugin, "_acp_wait_nav"), \
+                patch.object(CS.threading, "Thread", side_effect=waiter_thread), \
+                patch.object(CS, "_acp_notify"):
+            try:
+                first.start()
+                self.assertTrue(blocked.wait(timeout=2))
+                reserved_id = plugin._nav_action_id
+                second.start()
+                self.assertTrue(lock.contended.wait(timeout=2))
+                self.assertEqual(reservations, [reserved_id])
+                self.assertEqual(len(calls), 0 if barrier_at == "reservation" else 1)
+                # Read-only dispatch and state access remain available during RPC.
+                self.assertEqual(plugin.dispatch("info", {}), {"state": "running"})
+                self.assertIsNone(plugin._get_pose())
+            finally:
+                release.set()
+                first.join(timeout=3)
+                if second.ident is not None:
+                    second.join(timeout=3)
+                for waiter in waiters:
+                    waiter.join(timeout=3)
+            self.assertFalse(first.is_alive())
+            self.assertFalse(second.is_alive())
+            self.assertEqual(errors, [])
+            self.assertEqual(len(calls), 2)
+            self.assertEqual(calls[0][1], results["first"]["action_id"])
+            expected_id = results["second"].get("action_id", results["first"]["action_id"])
+            self.assertEqual(plugin._nav_action_id, expected_id)
+            self.assertEqual(calls[1][1], expected_id)
+
+    def test_fallback_failed_replacement_preserves_waiter(self):
+        """The waiter must survive a provisional generation change and rollback."""
+        for action in ("navigate_to_tag", "navigate_to_pose"):
+            with self.subTest(action=action):
+                plugin = self.prepare(None)
+                _, _, generation = plugin._reserve_nav("old")
+                plugin._nav_command_lock = ObservedLock()
+                rpc_started = threading.Event()
+                release = threading.Event()
+                results = []
+
+                def fail_navigation(*args, **kwargs):
+                    rpc_started.set()
+                    if not release.wait(timeout=5):
+                        raise AssertionError("RPC barrier was not released")
+                    return 3204, {}
+
+                replacement = threading.Thread(
+                    target=lambda: results.append(plugin.dispatch(
+                        action, {"tag_name": "target", "x": 2})), daemon=True)
+                old_waiter = threading.Thread(
+                    target=plugin._acp_wait_nav,
+                    args=("old", "old target", 90, (10, 0), generation), daemon=True)
+                with patch.object(plugin._client, "NavigateTo", side_effect=fail_navigation), \
+                        patch.object(CS, "_acp_notify") as notify:
+                    try:
+                        replacement.start()
+                        self.assertTrue(rpc_started.wait(timeout=2))
+                        # Schedule the old waiter while the reservation is provisional.
+                        old_waiter.start()
+                        self.assertTrue(plugin._nav_command_lock.contended.wait(timeout=2))
+                        self.assertTrue(old_waiter.is_alive())
+                        notify.assert_not_called()
+                    finally:
+                        release.set()
+                        replacement.join(timeout=2)
+                    self.assertFalse(replacement.is_alive())
+                    self.assertIn("error", results[0])
+                    self.assertEqual(plugin._nav_action_id, "old")
+                    self.assertEqual(plugin._nav_generation, generation)
+                    notify.assert_not_called()
+                    plugin._nav_arrived.set()
+                    old_waiter.join(timeout=2)
+                    self.assertFalse(old_waiter.is_alive())
+                    self.assertEqual([c.args[:2] for c in notify.call_args_list],
+                                     [("old", "completed")])
+                    self.assertIsNone(plugin._nav_action_id)
+
+    def test_smart_motion_arrival_survives_expired_replacement(self):
+        from unittest.mock import Mock
+
+        for action in ("navigate_to_tag", "navigate_to_pose"):
+            with self.subTest(action=action):
+                backend = Mock()
+                plugin = self.prepare(backend)
+                _, _, generation = plugin._reserve_nav("old")
+                plugin._nav_command_lock = ObservedLock()
+                entered = threading.Event()
+                release = threading.Event()
+                arrival = threading.Event()
+
+                def wait(**kwargs):
+                    entered.set()
+                    self.assertTrue(arrival.wait(timeout=3))
+                    return {"status": "arrived"}
+
+                def navigate(*args, **kwargs):
+                    arrival.set()
+                    self.assertTrue(release.wait(timeout=3))
+                    return {"status": "expired"}
+
+                backend.wait_nav_done.side_effect = wait
+                backend.navigate_to.side_effect = navigate
+                waiter = threading.Thread(target=plugin._acp_wait_nav,
+                                          args=("old", "target", 90, None, generation))
+                replacement = threading.Thread(target=plugin.dispatch,
+                                               args=(action, {"tag_name": "target", "x": 2}))
+                with patch.object(CS, "_acp_notify") as notify:
+                    try:
+                        waiter.start()
+                        self.assertTrue(entered.wait(timeout=2))
+                        replacement.start()
+                        self.assertTrue(plugin._nav_command_lock.contended.wait(timeout=2))
+                        self.assertTrue(waiter.is_alive())
+                        notify.assert_not_called()
+                    finally:
+                        release.set()
+                        arrival.set()
+                        replacement.join(timeout=3)
+                        waiter.join(timeout=3)
+                    self.assertFalse(waiter.is_alive())
+                    self.assertFalse(replacement.is_alive())
+                    self.assertEqual([c.args[:2] for c in notify.call_args_list],
+                                     [("old", "completed")])
+
+    def test_unknown_wait_retains_tracking_until_confirmed(self):
+        from unittest.mock import Mock
+
+        for terminal in ("stopped", "superseded", "arrived"):
+            with self.subTest(terminal=terminal):
+                backend = Mock()
+                plugin = self.prepare(backend)
+                _, _, generation = plugin._reserve_nav("old")
+                backend.wait_nav_done.side_effect = [
+                    {"status": "unknown"},
+                    {"status": "arrived" if terminal == "arrived" else "unknown"}]
+                backend._call.side_effect = [{"status": "unknown"}, {"status": terminal}]
+                with patch.object(CS, "_acp_notify") as notify:
+                    def retry_delay(seconds):
+                        self.assertGreaterEqual(seconds, 0.1)
+                        self.assertEqual(plugin._nav_action_id, "old")
+                        notify.assert_not_called()
+
+                    with patch.object(CS.time, "sleep", side_effect=retry_delay) as sleep:
+                        plugin._acp_wait_nav("old", "target", generation=generation)
+                    sleep.assert_called_once()
+                    self.assertEqual(backend.wait_nav_done.call_count, 2)
+                    for call in backend._call.call_args_list:
+                        self.assertEqual(call.args, ("cancel_navigation",))
+                        self.assertEqual(call.kwargs, {"navigation_id": "old"})
+                    backend.stop_nav.assert_not_called()
+                    backend.pause_nav.assert_not_called()
+                    self.assertIsNone(plugin._nav_action_id)
+                    self.assertEqual(notify.call_count, 1)
+                    expected = {"arrived": "completed", "stopped": "error",
+                                "superseded": "cancelled"}[terminal]
+                    self.assertEqual(notify.call_args.args[:2], ("old", expected))
+
+    def test_unknown_cancellation_does_not_terminate_replacement(self):
+        from unittest.mock import Mock
+
+        backend = Mock()
+        plugin = self.prepare(backend)
+        _, _, generation = plugin._reserve_nav("old")
+        backend.wait_nav_done.return_value = {"status": "unknown"}
+        backend.navigate_to.return_value = {"status": "navigating"}
+        waiter = plugin._acp_wait_nav
+        replacement = {}
+
+        def cancel(method, navigation_id):
+            self.assertEqual((method, navigation_id), ("cancel_navigation", "old"))
+            # Submission is allowed while ID-targeted cancellation is in flight.
+            with patch.object(plugin, "_acp_wait_nav"):
+                replacement.update(plugin.dispatch("navigate_to_pose", {"x": 2}))
+            return {"status": "superseded"}
+
+        backend._call.side_effect = cancel
+        with patch.object(CS, "_acp_notify") as notify:
+            waiter("old", "target", generation=generation)
+            self.assertEqual(plugin._nav_action_id, replacement["action_id"])
+            self.assertEqual([c.args[:2] for c in notify.call_args_list],
+                             [("old", "cancelled")])
+            backend.stop_nav.assert_not_called()
+            backend.pause_nav.assert_not_called()
+
+    def test_stall_pause_blocks_replacement_submission(self):
+        from unittest.mock import Mock
+
+        plugin = self.prepare(None)
+        plugin._client = Mock()
+        _, _, generation = plugin._reserve_nav("old")
+        plugin._nav_command_lock = ObservedLock()
+        paused = threading.Event()
+        release = threading.Event()
+        plugin._nav_arrived = Mock()
+        plugin._nav_arrived.wait.return_value = False
+        plugin._client.NavigateTo.return_value = (0, {})
+
+        def pause():
+            paused.set()
+            self.assertTrue(release.wait(timeout=3))
+            return 0, {}
+
+        plugin._client.PauseNav.side_effect = pause
+        waiter = threading.Thread(target=plugin._acp_wait_nav,
+                                  args=("old", "target", -1, None, generation))
+        replacement = threading.Thread(target=plugin.dispatch,
+                                       args=("navigate_to_pose", {"x": 2}))
+        with patch.object(CS, "_acp_notify") as notify:
+            try:
+                waiter.start()
+                self.assertTrue(paused.wait(timeout=2))
+                with patch.object(plugin, "_acp_wait_nav"):
+                    replacement.start()
+                    self.assertTrue(plugin._nav_command_lock.contended.wait(timeout=2))
+                    plugin._client.NavigateTo.assert_not_called()
+                    release.set()
+                    replacement.join(timeout=3)
+            finally:
+                release.set()
+                waiter.join(timeout=3)
+            self.assertFalse(waiter.is_alive())
+            self.assertFalse(replacement.is_alive())
+            plugin._client.PauseNav.assert_called_once()
+            plugin._client.NavigateTo.assert_called_once()
+            self.assertEqual(notify.call_args.args[:2], ("old", "error"))
+
+    def test_smart_motion_submission_status_contract(self):
+        from unittest.mock import Mock
+
+        for action in ("navigate_to_tag", "navigate_to_pose"):
+            for status in ("unknown", "expired", "error"):
+                with self.subTest(action=action, status=status):
+                    backend = Mock()
+                    plugin = self.prepare(backend)
+                    plugin._reserve_nav("old")
+                    old_generation = plugin._nav_generation
+                    started = threading.Event()
+                    release = threading.Event()
+                    threads = []
+                    real_thread = threading.Thread
+
+                    def navigate(*args, navigation_id=None, **kwargs):
+                        return {"status": status, "navigation_id": navigation_id,
+                                "error": "submission timeout"}
+
+                    def wait(**kwargs):
+                        started.set()
+                        if not release.wait(timeout=5):
+                            raise AssertionError("waiter barrier was not released")
+                        return {"status": "arrived", "pose": {"x": 1, "y": 0}}
+
+                    def waiter_thread(*args, **kwargs):
+                        thread = real_thread(*args, **kwargs)
+                        threads.append(thread)
+                        return thread
+
+                    backend.navigate_to.side_effect = navigate
+                    backend.wait_nav_done.side_effect = wait
+                    with patch.object(CS, "_acp_notify") as notify, \
+                            patch.object(CS.threading, "Thread", side_effect=waiter_thread):
+                        try:
+                            result = plugin.dispatch(action, {"tag_name": "target", "x": 1})
+                            self.assertEqual(result["status"], status)
+                            if status == "unknown":
+                                self.assertTrue(started.wait(timeout=2))
+                                self.assertEqual(result["action_id"], result["navigation_id"])
+                                self.assertEqual(plugin._nav_action_id, result["action_id"])
+                                self.assertEqual(plugin._nav_generation, old_generation + 1)
+                                backend.wait_nav_done.assert_called_once_with(
+                                    stall_timeout=90, navigation_id=result["action_id"])
+                                self.assertEqual(result["error"], "submission timeout")
+                                self.assertEqual(notify.call_args.args[:2], ("old", "cancelled"))
+                            else:
+                                self.assertNotIn("action_id", result)
+                                backend.wait_nav_done.assert_not_called()
+                                self.assertEqual(threads, [])
+                                if status == "expired":
+                                    self.assertEqual(plugin._nav_action_id, "old")
+                                    self.assertEqual(plugin._nav_generation, old_generation)
+                                    notify.assert_not_called()
+                                    backend.stop_nav.assert_not_called()
+                                    backend.pause_nav.assert_not_called()
+                                else:
+                                    self.assertIsNone(plugin._nav_action_id)
+                                    self.assertEqual(notify.call_args.args[:2], ("old", "cancelled"))
+                        finally:
+                            release.set()
+                            for thread in threads:
+                                thread.join(timeout=2)
+                                self.assertFalse(thread.is_alive())
+                        if status == "unknown":
+                            self.assertEqual([call.args[:2] for call in notify.call_args_list],
+                                             [("old", "cancelled"), (result["action_id"], "completed")])
+                            self.assertIsNone(plugin._nav_action_id)
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_safety_harness_proxy.py
+++ b/unitree/g1/tests/test_safety_harness_proxy.py
@@ -1,0 +1,149 @@
+"""SmartMotion 响应路由与日志启动约束回归测试。"""
+
+import ast
+import importlib.util
+import queue
+import sys
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SPEC = importlib.util.spec_from_file_location(
+    "safety_harness_proxy_under_test",
+    Path(__file__).resolve().parents[1] / "safety_harness.py",
+)
+HARNESS = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = HARNESS
+SPEC.loader.exec_module(HARNESS)
+
+
+class DispatchFinished(BaseException):
+    pass
+
+
+class SafetyHarnessProxyTests(unittest.TestCase):
+    def setUp(self):
+        self.proxy = HARNESS.SmartMotionProxy.__new__(HARNESS.SmartMotionProxy)
+        self.proxy._cmd_queue = queue.Queue()
+        self.proxy._result_queue = queue.Queue()
+        self.proxy._pending = {}
+        self.proxy._dispatch_lock = threading.Lock()
+        self.proxy._req_lock = threading.Lock()
+        self.proxy._req_counter = 0
+
+    def dispatch(self, *responses):
+        with patch.object(self.proxy._result_queue, "get",
+                          side_effect=[*responses, DispatchFinished()]):
+            with self.assertRaises(DispatchFinished):
+                self.proxy._dispatch_results()
+
+    def test_timed_out_navigation_result_does_not_reach_next_request(self):
+        result = self.proxy._call("wait_nav_done", timeout=0.001)
+        self.assertIn("error", result)
+        first = self.proxy._cmd_queue.get_nowait()
+        self.assertNotIn(first["_req_id"], self.proxy._pending)
+
+        results = []
+        caller = threading.Thread(target=lambda: results.append(self.proxy.get_state()))
+        caller.start()
+        try:
+            second = self.proxy._cmd_queue.get(timeout=1)
+            self.dispatch(
+                {"_req_id": first["_req_id"], "status": "superseded"},
+                {"_req_id": second["_req_id"], "state": "nav_paused"},
+            )
+        finally:
+            caller.join(timeout=16)
+        self.assertFalse(caller.is_alive())
+        self.assertEqual(results, [{"state": "nav_paused"}])
+        self.assertEqual(self.proxy._pending, {})
+
+    def test_invalid_and_unknown_responses_are_discarded(self):
+        result_q = queue.Queue(maxsize=1)
+        self.proxy._pending["current"] = result_q
+        self.dispatch(None, "invalid", {}, {"_req_id": []},
+                      {"_req_id": "unknown", "status": "arrived"})
+        self.assertTrue(result_q.empty())
+        self.dispatch({"_req_id": "current", "status": "ok"})
+        self.assertEqual(result_q.get_nowait(), {"status": "ok"})
+
+    def test_duplicate_response_cannot_block_dispatch(self):
+        first = queue.Queue(maxsize=1)
+        second = queue.Queue(maxsize=1)
+        self.proxy._pending.update(first=first, second=second)
+        with patch.object(first, "put", wraps=first.put) as put:
+            self.dispatch(
+                {"_req_id": "first", "status": "original"},
+                {"_req_id": "first", "status": "duplicate"},
+                {"_req_id": "second", "status": "ok"},
+            )
+        self.assertTrue(all(call.kwargs.get("block") is False
+                            for call in put.call_args_list))
+        self.assertEqual(first.get_nowait(), {"status": "original"})
+        self.assertEqual(second.get_nowait(), {"status": "ok"})
+
+    def test_paused_waiter_outlives_proxy_deadline(self):
+        tree = ast.parse(Path(HARNESS.__file__).read_text())
+        entry = next(node for node in tree.body
+                     if isinstance(node, ast.FunctionDef)
+                     and node.name == "_run_smart_motion_process")
+        handler = next(node for node in entry.body
+                       if isinstance(node, ast.FunctionDef)
+                       and node.name == "handle_wait_nav_done")
+        # 提取真实等待函数，将闭包变量映射到测试命名空间，避免依赖机器人 SDK。
+        handler.body = [ast.copy_location(ast.Global(names=node.names), node)
+                        if isinstance(node, ast.Nonlocal) else node
+                        for node in handler.body]
+        namespace = dict(vars(HARNESS))
+        lock = threading.Condition()
+        namespace.update(
+            state=HARNESS.MotionState.NAV_PAUSED,
+            nav_cmd={"navigation_id": "nav", "generation": 1,
+                     "target_pose": {"x": 10, "y": 0}},
+            nav_current_pose={"x": 0, "y": 0},
+            nav_arrived_flag=False, nav_arrived_error=None,
+            slam_info_lock=lock, shutdown_event=threading.Event(),
+            poll_interval=0.1,
+        )
+        exec(compile(ast.Module(body=[handler], type_ignores=[]),
+                     HARNESS.__file__, "exec"), namespace)
+        waited = []
+
+        def replace_navigation(timeout):
+            waited.append(timeout)
+            namespace["nav_cmd"] = None
+
+        with patch.object(lock, "wait", side_effect=replace_navigation), \
+                patch.object(HARNESS.time, "time", side_effect=[0, 0, 91, 92]):
+            result = namespace["handle_wait_nav_done"](60, "nav")
+        self.assertEqual(waited, [0.5])
+        self.assertEqual(result, {"status": "superseded"})
+
+    def test_missing_logsafe_aborts_startup_before_other_imports(self):
+        import builtins
+        real_import = builtins.__import__
+        imports = []
+
+        def import_module(name, *args, **kwargs):
+            imports.append(name)
+            if name == "common":
+                raise ImportError("missing logsafe")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=import_module):
+            with self.assertRaisesRegex(ImportError, "missing logsafe"):
+                HARNESS._run_smart_motion_process("g1", {}, "eth0", None, None)
+        self.assertEqual(imports, ["common"])
+
+    def test_logsafe_install_is_required_before_initialization(self):
+        from common import logsafe
+        with patch.object(logsafe, "install", side_effect=RuntimeError("install failed")) as install:
+            with self.assertRaisesRegex(RuntimeError, "install failed"):
+                HARNESS._run_smart_motion_process("g1", {}, "eth0", None, None)
+        install.assert_called_once_with(check_fd=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitree/g1/tests/test_safety_harness_proxy.py
+++ b/unitree/g1/tests/test_safety_harness_proxy.py
@@ -7,7 +7,7 @@ import sys
 import threading
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, call, patch
 
 
 SPEC = importlib.util.spec_from_file_location(
@@ -42,6 +42,7 @@ class SafetyHarnessProxyTests(unittest.TestCase):
     def test_timed_out_navigation_result_does_not_reach_next_request(self):
         result = self.proxy._call("wait_nav_done", timeout=0.001)
         self.assertIn("error", result)
+        self.assertEqual(result["status"], "unknown")
         first = self.proxy._cmd_queue.get_nowait()
         self.assertNotIn(first["_req_id"], self.proxy._pending)
 
@@ -59,6 +60,43 @@ class SafetyHarnessProxyTests(unittest.TestCase):
         self.assertFalse(caller.is_alive())
         self.assertEqual(results, [{"state": "nav_paused"}])
         self.assertEqual(self.proxy._pending, {})
+
+    def test_navigation_timeout_with_confirmed_targeted_cancellation(self):
+        for status in ("stopped", "superseded"):
+            with self.subTest(status=status), \
+                    patch.object(HARNESS.time, "monotonic", return_value=100), \
+                    patch.object(self.proxy, "_call", side_effect=[
+                        {"status": "unknown", "error": "submission timeout"},
+                        {"status": status},
+                    ]) as rpc:
+                result = self.proxy.navigate_to(1, 2, 0, navigation_id="nav")
+                self.assertEqual(result, {
+                    "status": "cancelled",
+                    "error": "Navigation submission timed out; cancellation confirmed",
+                })
+                self.assertEqual(rpc.call_args_list, [
+                    call("navigate_to", x=1, y=2, yaw=0, target_name="",
+                         speed=0.5, mode=1, navigation_id="nav", deadline=115),
+                    call("cancel_navigation", navigation_id="nav"),
+                ])
+
+    def test_navigation_timeout_with_unconfirmed_targeted_cancellation(self):
+        with patch.object(HARNESS.time, "monotonic", return_value=100), \
+                patch.object(self.proxy, "_call", side_effect=[
+                    {"status": "unknown", "error": "submission timeout"},
+                    {"status": "unknown", "error": "cancel timeout"},
+                ]) as rpc:
+            result = self.proxy.navigate_to(1, 2, 0)
+        navigation_id = rpc.call_args_list[0].kwargs["navigation_id"]
+        self.assertIsInstance(navigation_id, str)
+        self.assertTrue(navigation_id)
+        self.assertEqual(rpc.call_args_list, [
+            call("navigate_to", x=1, y=2, yaw=0, target_name="",
+                 speed=0.5, mode=1, navigation_id=navigation_id, deadline=115),
+            call("cancel_navigation", navigation_id=navigation_id),
+        ])
+        self.assertEqual(result, {"status": "unknown", "error": "submission timeout",
+                                  "navigation_id": navigation_id})
 
     def test_invalid_and_unknown_responses_are_discarded(self):
         result_q = queue.Queue(maxsize=1)
@@ -143,6 +181,123 @@ class SafetyHarnessProxyTests(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "install failed"):
                 HARNESS._run_smart_motion_process("g1", {}, "eth0", None, None)
         install.assert_called_once_with(check_fd=False)
+
+
+class SafetyHarnessNavigationDeadlineTests(unittest.TestCase):
+    def setUp(self):
+        self.reset_handler_namespace()
+
+    def reset_handler_namespace(self):
+        tree = ast.parse(Path(HARNESS.__file__).read_text())
+        entry = next(node for node in tree.body
+                     if isinstance(node, ast.FunctionDef)
+                     and node.name == "_run_smart_motion_process")
+        handlers = [node for node in entry.body
+                    if isinstance(node, ast.FunctionDef)
+                    and node.name in ("handle_navigate_to", "cancel_navigation")]
+        self.assertEqual(len(handlers), 2)
+        # Run the real closures against isolated state without the robot SDK.
+        for handler in handlers:
+            handler.body = [ast.copy_location(ast.Global(names=node.names), node)
+                            if isinstance(node, ast.Nonlocal) else node
+                            for node in handler.body]
+        self.slam = Mock()
+        self.slam.NavigateTo.return_value = (0, "accepted")
+        self.slam.PauseNav.return_value = (0, "paused")
+        self.namespace = dict(vars(HARNESS))
+        self.namespace.update(
+            state=HARNESS.MotionState.IDLE, nav_cmd=None,
+            speed_zone=HARNESS.SpeedZone.NORMAL, nav_generation=0,
+            nav_arrived_flag=False, nav_arrived_error=None,
+            slam_info_lock=threading.Condition(), slam_client=self.slam,
+            do_stop=Mock(), do_stop_nav=Mock(), publish_event=Mock(),
+        )
+        exec(compile(ast.Module(body=handlers, type_ignores=[]),
+                     HARNESS.__file__, "exec"), self.namespace)
+        self.cancel = Mock(wraps=self.namespace["cancel_navigation"])
+        self.namespace["cancel_navigation"] = self.cancel
+
+    def navigate(self):
+        return self.namespace["handle_navigate_to"](
+            1, 2, 0, "target", navigation_id="nav", deadline=10)
+
+    def test_expired_queued_navigation_does_not_issue_physical_commands(self):
+        for state in (HARNESS.MotionState.IDLE, HARNESS.MotionState.MOVING,
+                      HARNESS.MotionState.NAVIGATING, HARNESS.MotionState.NAV_PAUSED):
+            with self.subTest(state=state), \
+                    patch.object(HARNESS.time, "monotonic", return_value=10):
+                previous = {"navigation_id": "previous"}
+                self.namespace.update(state=state, nav_cmd=previous)
+                result = self.navigate()
+                self.assertEqual(result["status"], "expired")
+                self.assertEqual(self.slam.mock_calls, [])
+                self.namespace["do_stop"].assert_not_called()
+                self.namespace["do_stop_nav"].assert_not_called()
+                self.namespace["publish_event"].assert_not_called()
+                self.cancel.assert_not_called()
+                self.assertIs(self.namespace["nav_cmd"], previous)
+                self.assertEqual(self.namespace["state"], state)
+                self.assertEqual(self.namespace["nav_generation"], 0)
+
+    def test_deadline_expiring_during_rpc_cancels_exact_navigation(self):
+        with patch.object(HARNESS.time, "monotonic", side_effect=[9, 10]):
+            result = self.navigate()
+        self.assertEqual(result["status"], "cancelled")
+        self.assertEqual(result["navigation_id"], "nav")
+        self.assertEqual(self.slam.mock_calls, [
+            call.ResumeNav(), call.NavigateTo(1, 2, 0, 0, 0, 0, 1, speed=0.5, mode=1),
+            call.PauseNav(),
+        ])
+        self.cancel.assert_called_once_with("nav")
+        self.assertIsNone(self.namespace["nav_cmd"])
+        self.assertEqual(self.namespace["state"], HARNESS.MotionState.IDLE)
+        self.namespace["publish_event"].assert_not_called()
+
+    def test_failed_pause_keeps_navigation_tracked_and_returns_unknown(self):
+        for failure in (7, RuntimeError("pause failed")):
+            with self.subTest(failure=failure):
+                self.reset_handler_namespace()
+                retained = []
+
+                def fail_pause():
+                    retained.append(self.namespace["nav_cmd"])
+                    if isinstance(failure, Exception):
+                        raise failure
+                    return failure, "failed"
+
+                self.slam.PauseNav.side_effect = fail_pause
+                with patch.object(HARNESS.time, "monotonic", side_effect=[9, 10]):
+                    result = self.navigate()
+                self.assertEqual(result["status"], "unknown")
+                self.assertEqual(result["navigation_id"], "nav")
+                self.cancel.assert_called_once_with("nav")
+                self.slam.PauseNav.assert_called_once_with()
+                self.assertIs(self.namespace["nav_cmd"], retained[0])
+                self.assertEqual(retained[0]["navigation_id"], "nav")
+                self.assertEqual(self.namespace["state"], HARNESS.MotionState.NAVIGATING)
+                self.namespace["publish_event"].assert_not_called()
+
+    def test_cancelling_old_id_does_not_pause_new_navigation(self):
+        current = {"navigation_id": "new", "generation": 2}
+        self.namespace.update(nav_cmd=current, state=HARNESS.MotionState.NAVIGATING)
+        result = self.cancel("old")
+        self.assertEqual(result, {"status": "superseded"})
+        self.assertEqual(self.slam.mock_calls, [])
+        self.assertIs(self.namespace["nav_cmd"], current)
+        self.assertEqual(self.namespace["state"], HARNESS.MotionState.NAVIGATING)
+
+    def test_navigate_rpc_exception_is_cancelled_without_escaping_handler(self):
+        self.slam.NavigateTo.side_effect = RuntimeError("RPC disconnected")
+        with patch.object(HARNESS.time, "monotonic", return_value=9):
+            result = self.navigate()
+        self.assertEqual(result["status"], "cancelled")
+        self.assertEqual(result["response"], "RPC disconnected")
+        self.assertEqual(result["navigation_id"], "nav")
+        self.cancel.assert_called_once_with("nav")
+        self.slam.PauseNav.assert_called_once_with()
+        self.assertIsNone(self.namespace["nav_cmd"])
+        self.assertEqual(self.namespace["state"], HARNESS.MotionState.IDLE)
+        self.namespace["publish_event"].assert_not_called()
 
 
 if __name__ == "__main__":

--- a/unitree/g1/tests/test_safety_harness_rclpy_integration.py
+++ b/unitree/g1/tests/test_safety_harness_rclpy_integration.py
@@ -1,0 +1,96 @@
+"""Regression tests for SmartMotion's single-owner rclpy executor."""
+
+import ast
+import threading
+import time
+import unittest
+from pathlib import Path
+
+
+HARNESS = Path(__file__).resolve().parents[1] / "safety_harness.py"
+
+try:
+    import rclpy
+    from rclpy.executors import SingleThreadedExecutor
+    from rclpy.node import Node
+    from std_msgs.msg import String
+except ImportError:
+    rclpy = None
+
+
+@unittest.skipUnless(rclpy is not None, "requires ROS2 rclpy and std_msgs")
+class SafetyHarnessRclpyIntegrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        if rclpy.ok():
+            rclpy.shutdown()
+
+    def test_executor_is_spun_only_by_main_loop(self):
+        tree = ast.parse(HARNESS.read_text())
+        spin_calls = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "spin_once"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "executor"
+        ]
+        self.assertEqual(len(spin_calls), 1)
+
+    def test_waiter_can_observe_ros_callback_without_spinning(self):
+        executor = SingleThreadedExecutor()
+        publisher_node = Node("safety_harness_test_publisher")
+        subscriber_node = Node("safety_harness_test_subscriber")
+        received = threading.Event()
+        callback_threads = []
+
+        def on_message(_message):
+            callback_threads.append(threading.get_ident())
+            received.set()
+
+        subscriber_node.create_subscription(String, "safety_harness_test", on_message, 10)
+        publisher = publisher_node.create_publisher(String, "safety_harness_test", 10)
+        executor.add_node(publisher_node)
+        executor.add_node(subscriber_node)
+
+        spin_finished = threading.Event()
+        main_loop_thread_id = []
+
+        def main_loop():
+            main_loop_thread_id.append(threading.get_ident())
+            deadline = time.monotonic() + 2
+            while not received.is_set() and time.monotonic() < deadline:
+                executor.spin_once(timeout_sec=0.05)
+            spin_finished.set()
+
+        def waiter():
+            while not received.is_set() and not spin_finished.is_set():
+                time.sleep(0.01)
+
+        try:
+            loop_thread = threading.Thread(target=main_loop)
+            waiter_thread = threading.Thread(target=waiter)
+            loop_thread.start()
+            waiter_thread.start()
+            time.sleep(0.1)
+            message = String()
+            message.data = "arrived"
+            publisher.publish(message)
+            loop_thread.join(timeout=3)
+            waiter_thread.join(timeout=3)
+
+            self.assertTrue(received.is_set())
+            self.assertFalse(waiter_thread.is_alive())
+            self.assertEqual(callback_threads, main_loop_thread_id)
+        finally:
+            executor.shutdown()
+            publisher_node.destroy_node()
+            subscriber_node.destroy_node()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概述

修复 G1 `controlled_spatial` 导航被后续命令替换时的竞态：前一次导航的 ACP 完成回调可能误发 `completed` / `error` / `timeout`，即便当前物理运动已经是新目标。

## 问题

`_acp_wait_nav` 在等待线程里判断「自己还是不是当前 nav」是非原子的，而且新导航是「先发物理命令、后 supersede 旧 action」。存在两个窗口：

1. 旧 waiter 已经通过守卫、还没调 `_acp_notify` 时，新命令进来 —— 旧 action 依然会被报 completed。
2. 新 `navigate_to` RPC 正在飞行、还没返回时，旧 SmartMotion 报了一次 stale arrival —— 此时 `_nav_action_id` 还是旧 id，旧 waiter 顺利声称终态，把已经替换掉的运动误报为 completed。

fallback 路径还有一个独立问题：只依赖 `ctrl_info.is_arrived`，但 SLAM 服务实际不发布该字段，导致导航永远走到 90s stall_timeout。

## 修复

### 主进程侧（`controlled_spatial.py`）

- 引入 `_nav_generation` 计数和四个辅助方法：`_reserve_nav` / `_rollback_nav` / `_supersede_nav` / `_try_claim_terminal`。
- 所有 `dispatch()` 里的导航分支统一改为：生成 action_id → **先** `_reserve_nav` 抢占 → 下发物理命令 → 命令失败则 `_rollback_nav`；命令成功后**再**给旧 action 发 `cancelled` → 启动等待线程。这样新 id 在物理命令下发前就已经就位，旧 waiter 的 `_try_claim_terminal` 一定失败。
- `_acp_wait_nav` 所有 `_acp_notify` 触发点（arrived / error / stall_timeout / 180s timeout）都改用 `_try_claim_terminal` 守卫；网络 I/O 保持在锁外。
- fallback 分支补齐基于位姿的到达判定（距目标 < 0.3m），与 SmartMotion 到达阈值一致。

### SmartMotion 子进程侧（`safety_harness.py`）

- `navigate_to` / `wait_nav_done` RPC 新增 `navigation_id` 字段，子进程内部维护 `nav_generation`。
- `handle_wait_nav_done` 在 `slam_info_lock` 下每步重新校验 generation 和 navigation_id，不匹配立即返回 `{"status": "superseded"}`；到达 / 超时时的状态切换（`state = IDLE`、`nav_cmd = None`）也移进锁内，防止刚安装的新 nav_cmd 被旧 waiter 抹掉。
- `wait_nav_done` 改为异步执行（起 `complete_wait_nav` 线程，结果带 `_req_id` 回传），避免长阻塞占住主 RPC 循环。
- stall_timeout 分支不再调 `do_stop_nav()`，改为锁内 generation 校验 + 直接 `slam_client.PauseNav()`。

### 其他

- `config.yaml`：`controlled_spatial.isolated_process` 默认改为 `false`。in-process 模式能直接复用 SmartMotion 的 pose-based 到达检测，可靠性更高、无额外进程/GIL 争用。
- `main.py`：`isolated_process=true` 时打 WARNING 提示会退化到 pose-based fallback。
- `main.py`：`tools/call` 拆分错误消息 —— 工具未注册报 `Unknown tool: <name>`，工具存在但插件返回 None 报 `Unknown action for tool <name>: <action>`，避免把 action 错误误导到「工具未注册」方向。
- 子进程入口 `_controlled_spatial_process`：`logsafe` 改为硬依赖（缺失直接启动失败），并在无 smart_motion 时打印一行说明。

## 验证

新增 `unitree/g1/tests/test_controlled_spatial_supersede.py`，三个测试：

| 测试 | 场景 |
|---|---|
| `test_smart_motion_arrival_completes_only_latest_navigation` | 两次 dispatch 后触发到达，断言通知序列正好是 `[(old, cancelled), (new, completed)]` |
| `test_fallback_arrival_completes_only_latest_navigation` | pose 阈值 fallback 版本的同上 |
| `test_old_arrival_during_inflight_replacement_does_not_complete_old_action` | 关键回归——第二次 `navigate_to` RPC 阻塞在飞行中时注入旧导航的 stale arrival，断言旧 action 只会收到 `cancelled` |

## 风险

- 默认关掉 `isolated_process` 意味着 `controlled_spatial` 与主进程共享 GIL / DDS。如果观察到音频卡顿或 tool 阻塞回潮，可以在配置里显式打开 `isolated_process: true`，此时 fallback 逻辑已修好可用。
- 未在真机跑过 `isolated_process=true` 下的 pose-based fallback 路径，建议至少做一次真机回归。