### PR TITLE
feat(agibot-x2):hand_command

### DIFF
--- a/agibot/AimDK_X2/Dockerfile
+++ b/agibot/AimDK_X2/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /work
 COPY common/ /work/common/
 COPY main.py device.py config.yaml driver.yaml /work/agibot/AimDK_X2/
 COPY resource/ /work/agibot/AimDK_X2/resource/
+COPY deploy/service.yml /deploy/service.yml
 ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp ROS_LOCALHOST_ONLY=0 PYTHONUNBUFFERED=1 PYTHONPATH=/work
 EXPOSE 15717
 CMD ["/bin/bash", "-c", "source /opt/ros/humble/setup.bash && source /aimdk_x2_ws/install/setup.bash && python3 /work/agibot/AimDK_X2/main.py"]

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -782,6 +782,26 @@ class HandCommandPlugin:
     def stop(self):
         pass
 
+    def _get_hand_types(self):
+        """Return the actual left/right hand types reported by the robot.
+
+        HandCommandArray carries a HandType for each side.  Leaving those fields at
+        their generated-message default (NONE) makes a command ambiguous to the
+        EtherCAT hand controller, even when the robot has dexterous hands fitted.
+        Query the source of truth immediately before publishing rather than assuming
+        the configured URDF variant matches the installed hardware.
+        """
+        from aimdk_msgs.srv import GetHandType
+
+        request = GetHandType.Request()
+        request.request = self.nodes.request_header()
+        result = call_service(self.nodes.get_hand_type, request)
+        return int(result.left_hands_type.value), int(result.right_hands_type.value)
+
+    @staticmethod
+    def _is_controllable_hand(hand_type):
+        return hand_type in (1, 2, 3)
+
     def dispatch(self, action, args):
         from aimdk_msgs.msg import HandCommand
 
@@ -804,8 +824,20 @@ class HandCommandPlugin:
         else:
             raise ValueError(f"hand_command: unknown action {action!r}")
 
+        left_type, right_type = self._get_hand_types()
+        if left and not self._is_controllable_hand(left_type):
+            raise ValueError(
+                f"hand_command: left hand is not controllable (type={HAND_TYPES.get(left_type, 'unknown')})"
+            )
+        if right and not self._is_controllable_hand(right_type):
+            raise ValueError(
+                f"hand_command: right hand is not controllable (type={HAND_TYPES.get(right_type, 'unknown')})"
+            )
+
         msg = self.nodes._HandCommandArray()
         msg.header.stamp = self.nodes.robot.get_clock().now().to_msg()
+        msg.left_hand_type.value = left_type
+        msg.right_hand_type.value = right_type
         for finger, position in zip(self.FINGERS, left):
             cmd = HandCommand()
             cmd.name = finger

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -753,10 +753,10 @@ class JointCommandPlugin:
 
 class HandCommandPlugin:
     ACTIONS = {
-        "open": ([], "张开手掌（左右手可分别指定）"),
-        "close": ([], "握拳（左右手可分别指定）"),
+        "open": (["side"], "张开指定一侧或双侧手掌"),
+        "close": (["side"], "握拳指定一侧或双侧手掌"),
         "set_positions": (["left", "right"], "自定义左右手各手指的位置数组"),
-        "get_state": ([], "查询手部关节最新状态快照"),
+        "get_state": ([], "查询手部关节状态快照和当前左右手型"),
     }
     # Modeled after BrainCo Revo2's finger-joint naming as a generic reference (X2's own
     # HandType enum has no BrainCo entry — this is a naming-convention analogy only).
@@ -771,6 +771,7 @@ class HandCommandPlugin:
         return tool("hand_command", "actuator", "手部指令：张开/握拳/自定义手指位置（HandCommandArray）", action_schema(
             self.ACTIONS,
             {
+                "side": {"type": "string", "enum": ["left", "right", "both"], "description": "要控制的手：left=左手，right=右手，both=双手"},
                 "left": {"type": "array", "items": {"type": "number"}, "description": "左手各手指位置 [thumb, index, middle, ring, little]"},
                 "right": {"type": "array", "items": {"type": "number"}, "description": "右手各手指位置 [thumb, index, middle, ring, little]"},
             },
@@ -812,12 +813,22 @@ class HandCommandPlugin:
         if action == "info":
             return {"state": "ready"}
         if action == "get_state":
-            return self.nodes.snapshot("hand_state")
+            left_type, right_type = self._get_hand_types()
+            return {
+                **self.nodes.snapshot("hand_state"),
+                "left_hand_type": HAND_TYPES.get(left_type, "unknown"),
+                "left_hand_type_value": left_type,
+                "right_hand_type": HAND_TYPES.get(right_type, "unknown"),
+                "right_hand_type_value": right_type,
+            }
 
         if action in ("open", "close"):
+            side = args.get("side")
+            if side not in ("left", "right", "both"):
+                raise ValueError("hand_command: side must be left, right, or both")
             value = self.OPEN_POSITION if action == "open" else self.CLOSE_POSITION
-            left = [value] * len(self.FINGERS)
-            right = [value] * len(self.FINGERS)
+            left = [value] * len(self.FINGERS) if side in ("left", "both") else []
+            right = [value] * len(self.FINGERS) if side in ("right", "both") else []
         elif action == "set_positions":
             left = args.get("left", [])
             right = args.get("right", [])

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -797,6 +797,12 @@ class HandCommandPlugin:
         request = GetHandType.Request()
         request.request = self.nodes.request_header()
         result = call_service(self.nodes.get_hand_type, request)
+        status = int(result.reponse.status.value)
+        if status != 1:  # CommonState.SUCCESS
+            raise RuntimeError(
+                "hand_command: GetHandType failed "
+                f"(status={status}, message={result.reponse.message!r})"
+            )
         return int(result.left_hands_type.value), int(result.right_hands_type.value)
 
     @staticmethod

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -315,7 +315,17 @@ class JointStatePlugin:
         request = GetAllJointState.Request()
         request.request = self.nodes.request_header()
         result = call_service(self.nodes.get_all_joint_state, request)
+        status = int(result.reponse.status.value)
+        if status != 1:  # CommonState.SUCCESS
+            return {
+                "state": "unavailable",
+                "service": "GetAllJointState",
+                "status": status,
+                "message": result.reponse.message,
+            }
         return {
+            "state": "ok",
+            "service": "GetAllJointState",
             "leg": jsonable(result.leg_joints),
             "waist": jsonable(result.waist_joints),
             "arm": jsonable(result.arm_joints),

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -315,17 +315,7 @@ class JointStatePlugin:
         request = GetAllJointState.Request()
         request.request = self.nodes.request_header()
         result = call_service(self.nodes.get_all_joint_state, request)
-        status = int(result.reponse.status.value)
-        if status != 1:  # CommonState.SUCCESS
-            return {
-                "state": "unavailable",
-                "service": "GetAllJointState",
-                "status": status,
-                "message": result.reponse.message,
-            }
         return {
-            "state": "ok",
-            "service": "GetAllJointState",
             "leg": jsonable(result.leg_joints),
             "waist": jsonable(result.waist_joints),
             "arm": jsonable(result.arm_joints),

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -30,10 +30,15 @@ class FakeMsg:
     # Names jsonable() probes via hasattr() to detect numpy-likes/dataclasses; must NOT
     # auto-vivify these or hasattr() reports a false positive and jsonable() calls it.
     _AUTOVIV_BLOCKLIST = {"tolist"}
+    _LIST_FIELDS = {"joints", "left_hands", "right_hands"}
 
     def __getattr__(self, name):
         if name.startswith("__") or name in FakeMsg._AUTOVIV_BLOCKLIST:
             raise AttributeError(name)
+        if name in FakeMsg._LIST_FIELDS:
+            value = []
+            object.__setattr__(self, name, value)
+            return value
         value = FakeMsg()
         object.__setattr__(self, name, value)
         return value
@@ -333,6 +338,33 @@ class DispatchSmokeTests(unittest.TestCase):
         self.assertTrue(locomotion._registered)
         self.assertEqual(len(locomotion.nodes.locomotion_pub.published), 1)
         self.assertEqual(locomotion.nodes.locomotion_pub.published[0].forward_velocity, 0.5)
+
+    def test_hand_command_uses_the_hand_types_reported_by_the_robot(self):
+        plugins = build_bundle_plugins()
+        hand_command = find_plugin(plugins, "hand_command")
+        hand_command.nodes.get_hand_type.response = FakeMsg()
+        hand_command.nodes.get_hand_type.response.left_hands_type.value = 1
+        hand_command.nodes.get_hand_type.response.right_hands_type.value = 3
+
+        result = hand_command.dispatch("open", {})
+
+        self.assertEqual(result["state"], "published")
+        sent = hand_command.nodes.hand_command_pub.published[-1]
+        self.assertEqual(sent.left_hand_type.value, 1)
+        self.assertEqual(sent.right_hand_type.value, 3)
+        self.assertEqual(len(sent.left_hands), 5)
+        self.assertEqual(len(sent.right_hands), 5)
+
+    def test_hand_command_rejects_an_unconfigured_hand_without_publishing(self):
+        plugins = build_bundle_plugins()
+        hand_command = find_plugin(plugins, "hand_command")
+        hand_command.nodes.get_hand_type.response = FakeMsg()
+        hand_command.nodes.get_hand_type.response.left_hands_type.value = 0
+        hand_command.nodes.get_hand_type.response.right_hands_type.value = 0
+
+        with self.assertRaisesRegex(ValueError, "not controllable"):
+            hand_command.dispatch("close", {})
+        self.assertEqual(hand_command.nodes.hand_command_pub.published, [])
 
 
 class StartStopLifecycleTests(unittest.TestCase):

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -346,7 +346,7 @@ class DispatchSmokeTests(unittest.TestCase):
         hand_command.nodes.get_hand_type.response.left_hands_type.value = 1
         hand_command.nodes.get_hand_type.response.right_hands_type.value = 3
 
-        result = hand_command.dispatch("open", {})
+        result = hand_command.dispatch("open", {"side": "both"})
 
         self.assertEqual(result["state"], "published")
         self.assertEqual(
@@ -367,7 +367,7 @@ class DispatchSmokeTests(unittest.TestCase):
         hand_command.nodes.get_hand_type.response.right_hands_type.value = 0
 
         with self.assertRaisesRegex(ValueError, "not controllable"):
-            hand_command.dispatch("close", {})
+            hand_command.dispatch("close", {"side": "both"})
         self.assertEqual(hand_command.nodes.hand_command_pub.published, [])
 
     def test_hand_command_rejects_error_and_unknown_hand_types_without_publishing(self):
@@ -380,8 +380,38 @@ class DispatchSmokeTests(unittest.TestCase):
                 hand_command.nodes.get_hand_type.response.right_hands_type.value = hand_type
 
                 with self.assertRaisesRegex(ValueError, "not controllable"):
-                    hand_command.dispatch("close", {})
+                    hand_command.dispatch("close", {"side": "both"})
                 self.assertEqual(hand_command.nodes.hand_command_pub.published, [])
+
+    def test_hand_command_can_target_a_controllable_right_hand(self):
+        plugins = build_bundle_plugins()
+        hand_command = find_plugin(plugins, "hand_command")
+        hand_command.nodes.get_hand_type.response = FakeMsg()
+        hand_command.nodes.get_hand_type.response.left_hands_type.value = 0
+        hand_command.nodes.get_hand_type.response.right_hands_type.value = 3
+
+        result = hand_command.dispatch("open", {"side": "right"})
+
+        self.assertEqual(result["state"], "published")
+        self.assertEqual(result["left_count"], 0)
+        self.assertEqual(result["right_count"], 5)
+        sent = hand_command.nodes.hand_command_pub.published[-1]
+        self.assertEqual(sent.left_hands, [])
+        self.assertEqual(len(sent.right_hands), 5)
+
+    def test_hand_command_get_state_reports_current_hand_types(self):
+        plugins = build_bundle_plugins()
+        hand_command = find_plugin(plugins, "hand_command")
+        hand_command.nodes.get_hand_type.response = FakeMsg()
+        hand_command.nodes.get_hand_type.response.left_hands_type.value = 0
+        hand_command.nodes.get_hand_type.response.right_hands_type.value = 3
+
+        result = hand_command.dispatch("get_state", {})
+
+        self.assertEqual(result["left_hand_type"], "none")
+        self.assertEqual(result["left_hand_type_value"], 0)
+        self.assertEqual(result["right_hand_type"], "leisai_nimble_hands")
+        self.assertEqual(result["right_hand_type_value"], 3)
 
 
 class StartStopLifecycleTests(unittest.TestCase):

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -348,44 +348,6 @@ class DispatchSmokeTests(unittest.TestCase):
         self.assertEqual(len(locomotion.nodes.locomotion_pub.published), 1)
         self.assertEqual(locomotion.nodes.locomotion_pub.published[0].forward_velocity, 0.5)
 
-    def test_joint_state_returns_joint_values_after_a_successful_query(self):
-        plugins = build_bundle_plugins()
-        joint_state = find_plugin(plugins, "joint_state")
-        response = FakeMsg()
-        response.reponse.status.value = 1
-        response.reponse.message = ""
-        arm_joint = FakeMsg()
-        arm_joint.name = "left_shoulder_pitch_joint"
-        arm_joint.position = 0.25
-        response.leg_joints = []
-        response.waist_joints = []
-        response.arm_joints = [arm_joint]
-        response.head_joints = []
-        joint_state.nodes.get_all_joint_state.response = response
-
-        result = joint_state.dispatch("get", {})
-
-        self.assertEqual(result["state"], "ok")
-        self.assertEqual(result["service"], "GetAllJointState")
-        self.assertEqual(result["arm"], [{"name": "left_shoulder_pitch_joint", "position": 0.25}])
-
-    def test_joint_state_reports_failed_queries_instead_of_default_values(self):
-        plugins = build_bundle_plugins()
-        joint_state = find_plugin(plugins, "joint_state")
-        response = FakeMsg()
-        response.reponse.status.value = 0
-        response.reponse.message = "joint state unavailable"
-        joint_state.nodes.get_all_joint_state.response = response
-
-        result = joint_state.dispatch("get", {})
-
-        self.assertEqual(result, {
-            "state": "unavailable",
-            "service": "GetAllJointState",
-            "status": 0,
-            "message": "joint state unavailable",
-        })
-
     def test_hand_command_uses_the_hand_types_reported_by_the_robot(self):
         plugins = build_bundle_plugins()
         hand_command = find_plugin(plugins, "hand_command")

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -349,6 +349,10 @@ class DispatchSmokeTests(unittest.TestCase):
         result = hand_command.dispatch("open", {})
 
         self.assertEqual(result["state"], "published")
+        self.assertEqual(
+            hand_command.nodes.get_hand_type.last_request.request.header.stamp,
+            "stamp",
+        )
         sent = hand_command.nodes.hand_command_pub.published[-1]
         self.assertEqual(sent.left_hand_type.value, 1)
         self.assertEqual(sent.right_hand_type.value, 3)
@@ -365,6 +369,19 @@ class DispatchSmokeTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "not controllable"):
             hand_command.dispatch("close", {})
         self.assertEqual(hand_command.nodes.hand_command_pub.published, [])
+
+    def test_hand_command_rejects_error_and_unknown_hand_types_without_publishing(self):
+        for hand_type in (255, 99):
+            with self.subTest(hand_type=hand_type):
+                plugins = build_bundle_plugins()
+                hand_command = find_plugin(plugins, "hand_command")
+                hand_command.nodes.get_hand_type.response = FakeMsg()
+                hand_command.nodes.get_hand_type.response.left_hands_type.value = hand_type
+                hand_command.nodes.get_hand_type.response.right_hands_type.value = hand_type
+
+                with self.assertRaisesRegex(ValueError, "not controllable"):
+                    hand_command.dispatch("close", {})
+                self.assertEqual(hand_command.nodes.hand_command_pub.published, [])
 
 
 class StartStopLifecycleTests(unittest.TestCase):

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -348,6 +348,44 @@ class DispatchSmokeTests(unittest.TestCase):
         self.assertEqual(len(locomotion.nodes.locomotion_pub.published), 1)
         self.assertEqual(locomotion.nodes.locomotion_pub.published[0].forward_velocity, 0.5)
 
+    def test_joint_state_returns_joint_values_after_a_successful_query(self):
+        plugins = build_bundle_plugins()
+        joint_state = find_plugin(plugins, "joint_state")
+        response = FakeMsg()
+        response.reponse.status.value = 1
+        response.reponse.message = ""
+        arm_joint = FakeMsg()
+        arm_joint.name = "left_shoulder_pitch_joint"
+        arm_joint.position = 0.25
+        response.leg_joints = []
+        response.waist_joints = []
+        response.arm_joints = [arm_joint]
+        response.head_joints = []
+        joint_state.nodes.get_all_joint_state.response = response
+
+        result = joint_state.dispatch("get", {})
+
+        self.assertEqual(result["state"], "ok")
+        self.assertEqual(result["service"], "GetAllJointState")
+        self.assertEqual(result["arm"], [{"name": "left_shoulder_pitch_joint", "position": 0.25}])
+
+    def test_joint_state_reports_failed_queries_instead_of_default_values(self):
+        plugins = build_bundle_plugins()
+        joint_state = find_plugin(plugins, "joint_state")
+        response = FakeMsg()
+        response.reponse.status.value = 0
+        response.reponse.message = "joint state unavailable"
+        joint_state.nodes.get_all_joint_state.response = response
+
+        result = joint_state.dispatch("get", {})
+
+        self.assertEqual(result, {
+            "state": "unavailable",
+            "service": "GetAllJointState",
+            "status": 0,
+            "message": "joint state unavailable",
+        })
+
     def test_hand_command_uses_the_hand_types_reported_by_the_robot(self):
         plugins = build_bundle_plugins()
         hand_command = find_plugin(plugins, "hand_command")

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -308,6 +308,15 @@ class ModelPluginTests(unittest.TestCase):
 
 
 class DispatchSmokeTests(unittest.TestCase):
+    @staticmethod
+    def _hand_type_response(left, right, *, status=1, message=""):
+        response = FakeMsg()
+        response.reponse.status.value = status
+        response.reponse.message = message
+        response.left_hands_type.value = left
+        response.right_hands_type.value = right
+        return response
+
     """Exercise a couple of simple service-backed dispatch() calls end-to-end against the
     fake ROS client, to catch request/response field mismatches (as opposed to only
     checking tool metadata)."""
@@ -342,9 +351,7 @@ class DispatchSmokeTests(unittest.TestCase):
     def test_hand_command_uses_the_hand_types_reported_by_the_robot(self):
         plugins = build_bundle_plugins()
         hand_command = find_plugin(plugins, "hand_command")
-        hand_command.nodes.get_hand_type.response = FakeMsg()
-        hand_command.nodes.get_hand_type.response.left_hands_type.value = 1
-        hand_command.nodes.get_hand_type.response.right_hands_type.value = 3
+        hand_command.nodes.get_hand_type.response = self._hand_type_response(1, 3)
 
         result = hand_command.dispatch("open", {"side": "both"})
 
@@ -362,9 +369,7 @@ class DispatchSmokeTests(unittest.TestCase):
     def test_hand_command_rejects_an_unconfigured_hand_without_publishing(self):
         plugins = build_bundle_plugins()
         hand_command = find_plugin(plugins, "hand_command")
-        hand_command.nodes.get_hand_type.response = FakeMsg()
-        hand_command.nodes.get_hand_type.response.left_hands_type.value = 0
-        hand_command.nodes.get_hand_type.response.right_hands_type.value = 0
+        hand_command.nodes.get_hand_type.response = self._hand_type_response(0, 0)
 
         with self.assertRaisesRegex(ValueError, "not controllable"):
             hand_command.dispatch("close", {"side": "both"})
@@ -375,9 +380,7 @@ class DispatchSmokeTests(unittest.TestCase):
             with self.subTest(hand_type=hand_type):
                 plugins = build_bundle_plugins()
                 hand_command = find_plugin(plugins, "hand_command")
-                hand_command.nodes.get_hand_type.response = FakeMsg()
-                hand_command.nodes.get_hand_type.response.left_hands_type.value = hand_type
-                hand_command.nodes.get_hand_type.response.right_hands_type.value = hand_type
+                hand_command.nodes.get_hand_type.response = self._hand_type_response(hand_type, hand_type)
 
                 with self.assertRaisesRegex(ValueError, "not controllable"):
                     hand_command.dispatch("close", {"side": "both"})
@@ -386,9 +389,7 @@ class DispatchSmokeTests(unittest.TestCase):
     def test_hand_command_can_target_a_controllable_right_hand(self):
         plugins = build_bundle_plugins()
         hand_command = find_plugin(plugins, "hand_command")
-        hand_command.nodes.get_hand_type.response = FakeMsg()
-        hand_command.nodes.get_hand_type.response.left_hands_type.value = 0
-        hand_command.nodes.get_hand_type.response.right_hands_type.value = 3
+        hand_command.nodes.get_hand_type.response = self._hand_type_response(0, 3)
 
         result = hand_command.dispatch("open", {"side": "right"})
 
@@ -402,9 +403,7 @@ class DispatchSmokeTests(unittest.TestCase):
     def test_hand_command_get_state_reports_current_hand_types(self):
         plugins = build_bundle_plugins()
         hand_command = find_plugin(plugins, "hand_command")
-        hand_command.nodes.get_hand_type.response = FakeMsg()
-        hand_command.nodes.get_hand_type.response.left_hands_type.value = 0
-        hand_command.nodes.get_hand_type.response.right_hands_type.value = 3
+        hand_command.nodes.get_hand_type.response = self._hand_type_response(0, 3)
 
         result = hand_command.dispatch("get_state", {})
 
@@ -412,6 +411,17 @@ class DispatchSmokeTests(unittest.TestCase):
         self.assertEqual(result["left_hand_type_value"], 0)
         self.assertEqual(result["right_hand_type"], "leisai_nimble_hands")
         self.assertEqual(result["right_hand_type_value"], 3)
+
+    def test_hand_command_reports_a_failed_hand_type_query_without_publishing(self):
+        plugins = build_bundle_plugins()
+        hand_command = find_plugin(plugins, "hand_command")
+        hand_command.nodes.get_hand_type.response = self._hand_type_response(
+            0, 0, status=2, message="hand controller unavailable"
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "GetHandType failed .*hand controller unavailable"):
+            hand_command.dispatch("open", {"side": "right"})
+        self.assertEqual(hand_command.nodes.hand_command_pub.published, [])
 
 
 class StartStopLifecycleTests(unittest.TestCase):


### PR DESCRIPTION
## 功能说明

修复 AgiBot X2 `hand_command` 卡片。卡片在发布手部命令前查询机器人实际左右手 `HandType`，并将其写入 `HandCommandArray`；若某侧未配置手或报告错误手型，则拒绝发布，避免界面显示成功但机器人忽略命令。

## 修改文件

- `agibot/AimDK_X2/device.py`
  - 查询 `GetHandType`；
  - 填写左右手 `HandType`；
  - 拒绝向无可控手或错误手型发布命令。
- `agibot/AimDK_X2/tests/test_device.py`
  - 增加手型写入和无可控手拒绝发布测试。

## 测试方法与结果

- Python 语法检查：通过。
- X2 专项单元测试：14/14 通过。
- `git diff --check`：通过。

## 部署方式

沿用既有 AgiBot X2 驱动部署流程。

## Docker 或其他运行环境变化

- Dockerfile 将 `deploy/service.yml` 复制到镜像内的 `/deploy/service.yml`。

`deploy/run-pr-image.sh` 及 Dashboard 部署流程会从镜像提取该文件，并据此启动 X2 服务。此前镜像未包含它，会导致该部署路径无法启动；因此这是部署该驱动所必需的修复。

该改动仅加入一个小型服务配置 YAML，不增加系统依赖、不改变容器权限，也不改变运行时命令。

## 已知限制

真机已确认手部状态与命令 Topic 存在，且底层 EtherCAT 节点订阅手部命令 Topic；但厂家诊断工具无法下载依赖，因此本次未完成真机开闭手验证。仍需在稳定站立和安全看护条件下验证实际手型、手指名称与位置范围。