### PR TITLE
feat(agibot-x2): add multi-instance RGB camera sources

### DIFF
--- a/agibot/AimDK_X2/Dockerfile
+++ b/agibot/AimDK_X2/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /work
 COPY common/ /work/common/
 COPY main.py device.py config.yaml driver.yaml /work/agibot/AimDK_X2/
 COPY resource/ /work/agibot/AimDK_X2/resource/
+COPY deploy/ /deploy/
 ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp ROS_LOCALHOST_ONLY=0 PYTHONUNBUFFERED=1 PYTHONPATH=/work
 EXPOSE 15717
 CMD ["/bin/bash", "-c", "source /opt/ros/humble/setup.bash && source /aimdk_x2_ws/install/setup.bash && python3 /work/agibot/AimDK_X2/main.py"]

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -402,7 +402,10 @@ class CameraPlugin:
         self._instances = {}
 
     def _instance_id(self, args):
-        return str(args.get("instance_id") or "default")
+        instance_id = args.get("instance_id")
+        if instance_id is None or not str(instance_id).strip():
+            raise ValueError("instance_id is required for multiInstance tool camera_rgb")
+        return str(instance_id)
 
     def _safe_instance_id(self, instance_id):
         # ROS 2 topic names accept ASCII letters/digits/underscore here.  Python's
@@ -532,8 +535,8 @@ class CameraPlugin:
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["info", "start", "stop"],
-                        "description": "info=查询；start=开始转发；stop=停止并释放该实例",
+                        "enum": ["info", "start", "stop", "config"],
+                        "description": "info=查询；start=开始转发；stop=停止并释放；config=切换该实例摄像头",
                     },
                 },
                 "required": ["action"],

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -422,6 +422,24 @@ class CameraPlugin:
     def _source_for(self, instance_id):
         return self._configs.get(instance_id, DEFAULT_CAMERA_RGB_SOURCE)
 
+    def _source_from_args(self, instance_id, args):
+        # Canvas instance settings are forwarded under ``config``.  Keep the
+        # top-level form as a compatibility fallback for direct callers/tests,
+        # with the canvas form taking explicit precedence.
+        config = args.get("config") or {}
+        return (
+            config.get("camera_source")
+            or args.get("camera_source")
+            or self._source_for(instance_id)
+        )
+
+    def _validate_source(self, source):
+        if source not in CAMERA_RGB_SOURCES:
+            raise ValueError(
+                f"camera_rgb: unknown camera_source {source!r}; "
+                f"valid: {list(CAMERA_RGB_SOURCES)}"
+            )
+
     def _rgb_info_locked(self, instance_id):
         source = self._source_for(instance_id)
         instance = self._instances.get(instance_id)
@@ -542,12 +560,8 @@ class CameraPlugin:
         instance_id = self._instance_id(args)
         with self._lock:
             if action == "config":
-                source = args.get("camera_source", self._source_for(instance_id))
-                if source not in CAMERA_RGB_SOURCES:
-                    raise ValueError(
-                        f"camera_rgb: unknown camera_source {source!r}; "
-                        f"valid: {list(CAMERA_RGB_SOURCES)}"
-                    )
+                source = self._source_from_args(instance_id, args)
+                self._validate_source(source)
                 was_running = instance_id in self._instances
                 changed = source != self._source_for(instance_id)
                 self._configs[instance_id] = source
@@ -556,8 +570,11 @@ class CameraPlugin:
                 return self._rgb_info_locked(instance_id)
 
             if action == "start":
-                source = self._source_for(instance_id)
-                if instance_id not in self._instances:
+                source = self._source_from_args(instance_id, args)
+                self._validate_source(source)
+                instance = self._instances.get(instance_id)
+                self._configs[instance_id] = source
+                if instance is None or instance["source"] != source:
                     self._start_rgb_locked(instance_id, source)
                 return self._rgb_info_locked(instance_id)
 

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -75,6 +75,25 @@ EMOJI_IDS = {
 
 MIC_SOURCES = {"internal": 0, "external": 1}
 
+# X2 advertises publishers for all five compressed RGB streams concurrently.  PhanthyMotus
+# exposes them through one multi-instance card: each canvas instance chooses one source and
+# receives a distinct core-domain output topic.
+CAMERA_RGB_SOURCES = {
+    "interaction": "/aima/hal/sensor/rgb_head_front_center/rgb_image/compressed",
+    "rgbd_front": "/aima/hal/sensor/rgbd_head_front/rgb_image/compressed",
+    "stereo_left": "/aima/hal/sensor/stereo_head_front_left/rgb_image/compressed",
+    "stereo_right": "/aima/hal/sensor/stereo_head_front_right/rgb_image/compressed",
+    "rear": "/aima/hal/sensor/rgb_head_rear/rgb_image/compressed",
+}
+CAMERA_RGB_SOURCE_TITLES = {
+    "interaction": "交互 RGB（头部正面）",
+    "rgbd_front": "RGBD 彩色（头部前方）",
+    "stereo_left": "前方左目",
+    "stereo_right": "前方右目",
+    "rear": "后置 RGB",
+}
+DEFAULT_CAMERA_RGB_SOURCE = "interaction"
+
 RESOURCE_DIR = Path(__file__).with_name("resource")
 
 
@@ -137,6 +156,11 @@ class AimdkNodes:
         sensor_qos = QoSProfile(depth=5, reliability=QoSReliabilityPolicy.BEST_EFFORT)
         command_qos = QoSProfile(depth=10, durability=QoSDurabilityPolicy.TRANSIENT_LOCAL)
 
+        # CameraPlugin creates RGB publishers/subscriptions per canvas instance.  Keep the
+        # type and QoS on this shared node holder so the plugin does not need another ROS node.
+        self.compressed_image_type = CompressedImage
+        self.sensor_qos = sensor_qos
+
         self.streams = {}
 
         def mirror(key, msg_type, robot_topic, fmt, depth=10, qos=None):
@@ -159,12 +183,10 @@ class AimdkNodes:
         self.streams["imu"] = {"robot_topic": "/aima/hal/imu/{chest,torso}/state", "topic": imu_topic, "format": "data/json"}
 
         mirror("hand_state", HandStateArray, "/aima/hal/joint/hand/state", "data/json", qos=sensor_qos)
-        # SDK's topics_and_services catalog documents rgbd_head_front/* as the front camera, but
-        # on real hardware that topic has zero publishers -- this unit's camera service actually
-        # publishes RGB under rgb_head_front_center/* instead (confirmed live via `ros2 topic
-        # info`, 30Hz). No depth topic is published anywhere on this hardware at all, so
-        # camera_depth stays wired to the documented (currently inactive) topic.
-        mirror("camera_rgb", CompressedImage, "/aima/hal/sensor/rgb_head_front_center/rgb_image/compressed", "image/jpeg", qos=sensor_qos)
+        # RGB subscriptions are intentionally not created here: camera_rgb is multi-instance,
+        # so CameraPlugin creates and destroys one subscription for each active canvas card.
+        # A 2026-09-04 live topic inspection confirmed publishers for all five RGB sources in
+        # CAMERA_RGB_SOURCES and for the RGBD depth stream below.
         mirror("camera_depth", Image, "/aima/hal/sensor/rgbd_head_front/depth_image", "image/depth-z16", qos=sensor_qos)
         mirror("lidar", PointCloud2, "/aima/hal/sensor/lidar_chest_front/lidar_pointcloud", "sensor/pointcloud", qos=sensor_qos)
         mirror("slam_odom", Odometry, "/slam/lidar_odom", "data/json", qos=sensor_qos)
@@ -374,10 +396,119 @@ class ImuPlugin:
 class CameraPlugin:
     def __init__(self, nodes):
         self.nodes = nodes
+        self._lock = threading.RLock()
+        self._configs = {}
+        self._instances = {}
+
+    def _instance_id(self, args):
+        return str(args.get("instance_id") or "default")
+
+    def _safe_instance_id(self, instance_id):
+        safe = "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in instance_id)
+        if not safe:
+            safe = "default"
+        if safe[0].isdigit():
+            safe = f"instance_{safe}"
+        return safe
+
+    def _output_topic(self, instance_id):
+        return f"/{self.nodes.namespace}/agibot_x2/camera_rgb/{self._safe_instance_id(instance_id)}"
+
+    def _source_for(self, instance_id):
+        return self._configs.get(instance_id, DEFAULT_CAMERA_RGB_SOURCE)
+
+    def _rgb_info_locked(self, instance_id):
+        source = self._source_for(instance_id)
+        instance = self._instances.get(instance_id)
+        output_topic = self._output_topic(instance_id)
+        return {
+            "state": "running" if instance is not None else "idle",
+            "instance_id": instance_id,
+            "camera_source": source,
+            "sources_available": list(CAMERA_RGB_SOURCES),
+            "robot_topic": CAMERA_RGB_SOURCES[source],
+            "topic": output_topic,
+            "format": "image/jpeg",
+            "frames_published": instance["frames"] if instance is not None else 0,
+            "topic_out": [{"topic": output_topic, "format": "image/jpeg"}],
+        }
+
+    def _stop_rgb_locked(self, instance_id):
+        instance = self._instances.pop(instance_id, None)
+        if instance is None:
+            return
+        # Remove the subscription before its publisher so no new callback can be queued for
+        # an output that has already been destroyed.
+        self.nodes.robot.destroy_subscription(instance["subscription"])
+        self.nodes.core.destroy_publisher(instance["publisher"])
+
+    def _start_rgb_locked(self, instance_id, source):
+        self._stop_rgb_locked(instance_id)
+        output_topic = self._output_topic(instance_id)
+        publisher = self.nodes.core.create_publisher(
+            self.nodes.compressed_image_type, output_topic, 5,
+        )
+        state = {"publisher": publisher, "subscription": None, "frames": 0, "source": source}
+
+        def forward(msg):
+            # HTTP dispatch and ROS callbacks run on different threads.  Holding the same lock
+            # as stop/config prevents publishing through a publisher while it is being retired.
+            with self._lock:
+                if self._instances.get(instance_id) is not state:
+                    return
+                publisher.publish(msg)
+                state["frames"] += 1
+
+        try:
+            state["subscription"] = self.nodes.robot.create_subscription(
+                self.nodes.compressed_image_type,
+                CAMERA_RGB_SOURCES[source],
+                forward,
+                self.nodes.sensor_qos,
+            )
+        except Exception:
+            self.nodes.core.destroy_publisher(publisher)
+            raise
+        self._instances[instance_id] = state
 
     def get_tools(self):
+        rgb_tool = {
+            "name": "camera_rgb",
+            "type": "sensor",
+            "multiInstance": True,
+            "description": "X2 多机位 RGB 实时画面；每个卡片实例独立选择一路摄像头",
+            "configSchema": {
+                "type": "object",
+                "properties": {
+                    "camera_source": {
+                        "type": "string",
+                        "description": "该卡片实例订阅的 X2 RGB 摄像头",
+                        "scope": "instance",
+                        "default": DEFAULT_CAMERA_RGB_SOURCE,
+                        "oneOf": [
+                            {"const": source, "title": CAMERA_RGB_SOURCE_TITLES[source]}
+                            for source in CAMERA_RGB_SOURCES
+                        ],
+                    },
+                },
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["info", "start", "stop"],
+                        "description": "info=查询；start=开始转发；stop=停止并释放该实例",
+                    },
+                },
+                "required": ["action"],
+            },
+            # An empty path tells the canvas that this sensor has an image output while
+            # info(instance_id) supplies the real, instance-specific path.
+            "topic_out": [{"topic": "", "format": "image/jpeg"}],
+        }
         return [
-            _stream_tool("camera_rgb", self.nodes.streams["camera_rgb"], "前置 RGBD 相机彩色画面（压缩 JPEG）"),
+            rgb_tool,
             _stream_tool("camera_depth", self.nodes.streams["camera_depth"], "前置 RGBD 相机深度画面"),
         ]
 
@@ -385,13 +516,47 @@ class CameraPlugin:
         pass
 
     def stop(self):
-        pass
+        with self._lock:
+            for instance_id in list(self._instances):
+                self._stop_rgb_locked(instance_id)
 
     def dispatch(self, action, args):
         name = args.get("_tool_name")
-        if action == "stop":
-            return {"state": "idle"}
-        return {"state": "running", **self.nodes.streams[name]}
+        if name == "camera_depth":
+            if action == "stop":
+                return {"state": "idle"}
+            return {"state": "running", **self.nodes.streams["camera_depth"]}
+
+        instance_id = self._instance_id(args)
+        with self._lock:
+            if action == "config":
+                source = args.get("camera_source", self._source_for(instance_id))
+                if source not in CAMERA_RGB_SOURCES:
+                    raise ValueError(
+                        f"camera_rgb: unknown camera_source {source!r}; "
+                        f"valid: {list(CAMERA_RGB_SOURCES)}"
+                    )
+                was_running = instance_id in self._instances
+                changed = source != self._source_for(instance_id)
+                self._configs[instance_id] = source
+                if was_running and changed:
+                    self._start_rgb_locked(instance_id, source)
+                return self._rgb_info_locked(instance_id)
+
+            if action == "start":
+                source = self._source_for(instance_id)
+                if instance_id not in self._instances:
+                    self._start_rgb_locked(instance_id, source)
+                return self._rgb_info_locked(instance_id)
+
+            if action == "stop":
+                self._stop_rgb_locked(instance_id)
+                return self._rgb_info_locked(instance_id)
+
+            if action in ("info", "read", "get", "camera_rgb"):
+                return self._rgb_info_locked(instance_id)
+
+        raise ValueError(f"camera_rgb: unknown action {action!r}")
 
 
 class LidarPlugin:

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -405,7 +405,12 @@ class CameraPlugin:
         return str(args.get("instance_id") or "default")
 
     def _safe_instance_id(self, instance_id):
-        safe = "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in instance_id)
+        # ROS 2 topic names accept ASCII letters/digits/underscore here.  Python's
+        # str.isalnum() also accepts Unicode letters, so guard it with isascii().
+        safe = "".join(
+            ch if ch.isascii() and (ch.isalnum() or ch == "_") else "_"
+            for ch in instance_id
+        )
         if not safe:
             safe = "default"
         if safe[0].isdigit():
@@ -555,7 +560,9 @@ class CameraPlugin:
         if name == "camera_depth":
             if action == "stop":
                 return {"state": "idle"}
-            return {"state": "running", **self.nodes.streams["camera_depth"]}
+            if action in ("start", "info", "read", "get", "camera_depth"):
+                return {"state": "running", **self.nodes.streams["camera_depth"]}
+            raise ValueError(f"camera_depth: unknown action {action!r}")
 
         instance_id = self._instance_id(args)
         with self._lock:

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -538,8 +538,19 @@ class CameraPlugin:
                         "enum": ["info", "start", "stop", "config"],
                         "description": "info=查询；start=开始转发；stop=停止并释放；config=切换该实例摄像头",
                     },
+                    "camera_source": {
+                        "type": "string",
+                        "description": "config 动作要切换到的 X2 RGB 摄像头",
+                        "enum": list(CAMERA_RGB_SOURCES),
+                    },
                 },
                 "required": ["action"],
+                "x-action-params": {
+                    "info": {"params": [], "description": "查询该相机实例状态"},
+                    "start": {"params": [], "description": "按实例配置开始转发画面"},
+                    "stop": {"params": [], "description": "停止并释放该相机实例"},
+                    "config": {"params": ["camera_source"], "description": "切换该实例的 RGB 摄像头来源"},
+                },
             },
             # An empty path tells the canvas that this sensor has an image output while
             # info(instance_id) supplies the real, instance-specific path.

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -14,6 +14,7 @@ tooling names these services on the wire, not a typo introduced here.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import threading
 import time
@@ -409,7 +410,11 @@ class CameraPlugin:
             safe = "default"
         if safe[0].isdigit():
             safe = f"instance_{safe}"
-        return safe
+        # Sanitizing is lossy (for example, "card-a" and "card_a" both become
+        # "card_a").  Preserve a readable prefix and append a stable identity suffix so
+        # two canvas instances cannot share a topic merely because of normalization.
+        digest = hashlib.sha256(instance_id.encode("utf-8")).hexdigest()[:8]
+        return f"{safe}_{digest}"
 
     def _output_topic(self, instance_id):
         return f"/{self.nodes.namespace}/agibot_x2/camera_rgb/{self._safe_instance_id(instance_id)}"
@@ -439,8 +444,10 @@ class CameraPlugin:
             return
         # Remove the subscription before its publisher so no new callback can be queued for
         # an output that has already been destroyed.
-        self.nodes.robot.destroy_subscription(instance["subscription"])
-        self.nodes.core.destroy_publisher(instance["publisher"])
+        try:
+            self.nodes.robot.destroy_subscription(instance["subscription"])
+        finally:
+            self.nodes.core.destroy_publisher(instance["publisher"])
 
     def _start_rgb_locked(self, instance_id, source):
         self._stop_rgb_locked(instance_id)
@@ -449,6 +456,10 @@ class CameraPlugin:
             self.nodes.compressed_image_type, output_topic, 5,
         )
         state = {"publisher": publisher, "subscription": None, "frames": 0, "source": source}
+        # Register before create_subscription(): an executor may deliver the first frame as
+        # soon as the subscription is created, and the callback must already recognize its
+        # owning instance.  The exception path removes this provisional state again.
+        self._instances[instance_id] = state
 
         def forward(msg):
             # HTTP dispatch and ROS callbacks run on different threads.  Holding the same lock
@@ -467,9 +478,10 @@ class CameraPlugin:
                 self.nodes.sensor_qos,
             )
         except Exception:
+            if self._instances.get(instance_id) is state:
+                self._instances.pop(instance_id, None)
             self.nodes.core.destroy_publisher(publisher)
             raise
-        self._instances[instance_id] = state
 
     def get_tools(self):
         rgb_tool = {

--- a/agibot/AimDK_X2/reference/topics_and_services.md
+++ b/agibot/AimDK_X2/reference/topics_and_services.md
@@ -20,7 +20,7 @@ mangled-name encoding of `_` used by their own tooling — not a typo.
 | `/aima/hal/sensor/stereo_head_front_left/rgb_image/compressed` | `camera_rgb` (`stereo_left`) | `CompressedImage`; publisher confirmed on X2 hardware on 2026-09-04 |
 | `/aima/hal/sensor/stereo_head_front_right/rgb_image/compressed` | `camera_rgb` (`stereo_right`) | `CompressedImage`; publisher confirmed on X2 hardware on 2026-09-04 |
 | `/aima/hal/sensor/rgb_head_rear/rgb_image/compressed` | `camera_rgb` (`rear`) | `CompressedImage`; publisher confirmed on X2 hardware on 2026-09-04 |
-| `/aima/hal/sensor/rgbd_head_front/depth_image` | `camera_depth` | `Image`; publisher confirmed on X2 hardware on 2026-09-04 |
+| `/aima/hal/sensor/rgbd_head_front/depth_image` | `camera_depth` | existing raw-depth relay; unchanged and outside this RGB-card change |
 | `/aima/mc/locomotion/velocity` | `locomotion` | |
 | `/integrated_command` | `slam_control` | plain `std_msgs/String`, not a service |
 | `/relocalization_pose` | `slam_control` | |
@@ -63,10 +63,9 @@ the selected robot-domain subscription and core-domain publisher; `stop(instance
 only that instance's resources.  Changing `camera_source` while an instance is running replaces
 its subscription but keeps its output topic stable.
 
-`camera_depth` remains a separate, single-instance card because its ROS message and output format
-(`sensor_msgs/msg/Image`, `image/depth-z16`) differ from the compressed RGB streams.  The presence
-of left/right image publishers alone is not evidence that those streams are synchronized,
-rectified, or ready for stereo ranging.
+`camera_depth` remains an existing, separate, single-instance card and is not changed by this RGB
+work.  The presence of left/right image publishers alone is not evidence that those streams are
+synchronized, rectified, or ready for stereo ranging.
 
 ## Available in the SDK but not yet wired
 

--- a/agibot/AimDK_X2/reference/topics_and_services.md
+++ b/agibot/AimDK_X2/reference/topics_and_services.md
@@ -15,8 +15,12 @@ mangled-name encoding of `_` used by their own tooling — not a typo.
 | `/aima/hal/joint/*/command` | `joint_command` | wildcard resolved to `leg`/`waist`/`arm`/`head` |
 | `/aima/hal/pmu/state` | — | not currently exposed as a tool (no card in the approved plan) |
 | `/aima/hal/sensor/lidar_chest_front/lidar_pointcloud` | `lidar` | `sensor/pointcloud` |
-| `/aima/hal/sensor/rgb_head_front_center/rgb_image/compressed` | `camera_rgb` | catalog documents `rgbd_head_front/rgb_image/compressed` instead, but on real hardware that topic has zero publishers — confirmed via `ros2 topic info` that `rgb_head_front_center` is what's actually live (30Hz); see below |
-| `/aima/hal/sensor/rgbd_head_front/depth_image` | `camera_depth` | zero publishers on real hardware, and no depth topic exists anywhere in the live `ros2 topic list` on this unit — depth appears to not be active/available on this X2 at all, kept wired to the documented name pending vendor confirmation |
+| `/aima/hal/sensor/rgb_head_front_center/rgb_image/compressed` | `camera_rgb` (`interaction`) | `CompressedImage`; publisher confirmed on X2 hardware on 2026-09-04 |
+| `/aima/hal/sensor/rgbd_head_front/rgb_image/compressed` | `camera_rgb` (`rgbd_front`) | `CompressedImage`; publisher confirmed on X2 hardware on 2026-09-04 |
+| `/aima/hal/sensor/stereo_head_front_left/rgb_image/compressed` | `camera_rgb` (`stereo_left`) | `CompressedImage`; publisher confirmed on X2 hardware on 2026-09-04 |
+| `/aima/hal/sensor/stereo_head_front_right/rgb_image/compressed` | `camera_rgb` (`stereo_right`) | `CompressedImage`; publisher confirmed on X2 hardware on 2026-09-04 |
+| `/aima/hal/sensor/rgb_head_rear/rgb_image/compressed` | `camera_rgb` (`rear`) | `CompressedImage`; publisher confirmed on X2 hardware on 2026-09-04 |
+| `/aima/hal/sensor/rgbd_head_front/depth_image` | `camera_depth` | `Image`; publisher confirmed on X2 hardware on 2026-09-04 |
 | `/aima/mc/locomotion/velocity` | `locomotion` | |
 | `/integrated_command` | `slam_control` | plain `std_msgs/String`, not a service |
 | `/relocalization_pose` | `slam_control` | |
@@ -36,6 +40,30 @@ mangled-name encoding of `_` used by their own tooling — not a typo.
 | `/aimdk_5Fmsgs/srv/SetMicSourceRequest`, `GetMicSourceRequest` | `mic_source` | |
 | `/aimdk_5Fmsgs/srv/GetStoredMapByName` | `map_get` | |
 
+## `camera_rgb` multi-instance routing
+
+`camera_rgb` is one sensor-card type with five selectable sources.  Its
+`camera_source` setting has `scope: instance`, so two copies of the card can select different
+cameras and run concurrently.  `interaction` is the default to preserve the previous card's
+source selection.
+
+Each card instance gets an independent core-domain output topic.  A canvas card whose ID is
+`card-example-1` reports:
+
+```text
+/{namespace}/agibot_x2/camera_rgb/card_example_1  (image/jpeg)
+```
+
+`info(instance_id)` returns this path before streaming starts.  `start(instance_id)` creates
+the selected robot-domain subscription and core-domain publisher; `stop(instance_id)` destroys
+only that instance's resources.  Changing `camera_source` while an instance is running replaces
+its subscription but keeps its output topic stable.
+
+`camera_depth` remains a separate, single-instance card because its ROS message and output format
+(`sensor_msgs/msg/Image`, `image/depth-z16`) differ from the compressed RGB streams.  The presence
+of left/right image publishers alone is not evidence that those streams are synchronized,
+rectified, or ready for stereo ranging.
+
 ## Available in the SDK but not yet wired
 
 Left out of this driver's initial tool set to stay within the approved plan's scope — add a
@@ -46,8 +74,6 @@ new plugin in `device.py` if a use case comes up:
 - `/aima/hal/audio/capture`, `/aima/hal/audio/playback`, `/aima/hal/audio/focus_response`,
   `/aima/hal/audio/play_state` — raw audio I/O topics; this driver relies on `tts`/`PlayTts`
   instead of raw audio playback.
-- `/aima/hal/sensor/rgb_head_rear/*`, `/aima/hal/sensor/stereo_head_front_{left,right}/*` —
-  additional cameras beyond the front RGBD pair this driver exposes.
 - `/aima/hal/sensor/touch_head` — head touch sensor, no dedicated tool yet.
 - `/aimdk_5Fmsgs/srv/AbandonAudioFocus`, `RequestAudioFocus`, `GetMute`, `SetMute`, `GetVolume`,
   `SetVolume` — audio focus/volume management.

--- a/agibot/AimDK_X2/reference/topics_and_services.md
+++ b/agibot/AimDK_X2/reference/topics_and_services.md
@@ -51,8 +51,12 @@ Each card instance gets an independent core-domain output topic.  A canvas card 
 `card-example-1` reports:
 
 ```text
-/{namespace}/agibot_x2/camera_rgb/card_example_1  (image/jpeg)
+/{namespace}/agibot_x2/camera_rgb/card_example_1_6b56f645  (image/jpeg)
 ```
+
+The final eight hexadecimal characters are a stable digest of the unsanitized card ID.  They
+prevent IDs such as `card-a` and `card_a` from collapsing onto the same ROS topic after invalid
+topic-name characters are replaced.
 
 `info(instance_id)` returns this path before streaming starts.  `start(instance_id)` creates
 the selected robot-domain subscription and core-domain publisher; `stop(instance_id)` destroys

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -219,6 +219,7 @@ _install_ros_stubs()
 import yaml  # noqa: E402
 
 import device  # noqa: E402
+from common.vendor_runtime import DriverBundle  # noqa: E402
 
 
 def load_driver_yaml_cards():
@@ -405,6 +406,22 @@ class CameraMultiInstanceTests(unittest.TestCase):
             if sub.topic in device.CAMERA_RGB_SOURCES.values()
         ]
         self.assertEqual(len(rgb_subs), 2)
+
+    def test_bundle_start_consumes_nested_canvas_instance_config(self):
+        bundle = DriverBundle(self.plugins)
+        result = bundle.dispatch("camera_rgb", {
+            "action": "start",
+            "instance_id": "rear-from-canvas",
+            "config": {"camera_source": "rear"},
+        })
+
+        self.assertEqual(result["state"], "running")
+        self.assertEqual(result["camera_source"], "rear")
+        self.assertEqual(result["robot_topic"], device.CAMERA_RGB_SOURCES["rear"])
+        self.assertIn(
+            device.CAMERA_RGB_SOURCES["rear"],
+            {subscription.topic for subscription in self.nodes.robot.subscriptions},
+        )
 
     def test_frame_is_forwarded_unchanged_and_counted(self):
         result = self.camera.dispatch("start", {"_tool_name": "camera_rgb", "instance_id": "card-frame"})

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -384,6 +384,14 @@ class CameraMultiInstanceTests(unittest.TestCase):
         )["topic"]
         self.assertNotEqual(dashed, underscored)
 
+    def test_unicode_instance_id_starts_with_ascii_only_topic(self):
+        result = self.camera.dispatch(
+            "start", {"_tool_name": "camera_rgb", "instance_id": "camera-摄"},
+        )
+        self.assertEqual(result["state"], "running")
+        self.assertTrue(result["topic"].isascii())
+        self.assertNotIn("摄", result["topic"])
+
     def test_two_instances_can_stream_different_sources_concurrently(self):
         self.camera.dispatch("config", {
             "_tool_name": "camera_rgb", "instance_id": "front-card", "camera_source": "interaction",
@@ -495,6 +503,18 @@ class CameraMultiInstanceTests(unittest.TestCase):
         )
         self.assertEqual(info["state"], "idle")
         self.assertNotIn(info["topic"], self.nodes.core.publishers)
+
+    def test_depth_card_has_explicit_lifecycle_actions(self):
+        for action, expected_state in (
+            ("start", "running"),
+            ("info", "running"),
+            ("stop", "idle"),
+        ):
+            result = self.camera.dispatch(action, {"_tool_name": "camera_depth"})
+            self.assertEqual(result["state"], expected_state)
+
+        with self.assertRaises(ValueError):
+            self.camera.dispatch("unknown", {"_tool_name": "camera_depth"})
 
 
 class StartStopLifecycleTests(unittest.TestCase):

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -358,7 +358,16 @@ class CameraMultiInstanceTests(unittest.TestCase):
     def test_rgb_tool_is_multi_instance_with_instance_source_config(self):
         tool = next(d for d in self.camera.get_tools() if d["name"] == "camera_rgb")
         self.assertTrue(tool["multiInstance"])
-        self.assertIn("config", tool["inputSchema"]["properties"]["action"]["enum"])
+        input_schema = tool["inputSchema"]
+        self.assertIn("config", input_schema["properties"]["action"]["enum"])
+        self.assertEqual(
+            input_schema["x-action-params"]["config"]["params"],
+            ["camera_source"],
+        )
+        self.assertEqual(
+            set(input_schema["properties"]["camera_source"]["enum"]),
+            set(device.CAMERA_RGB_SOURCES),
+        )
         source = tool["configSchema"]["properties"]["camera_source"]
         self.assertEqual(source["scope"], "instance")
         self.assertEqual(source["default"], device.DEFAULT_CAMERA_RGB_SOURCE)

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -107,8 +107,21 @@ class FakeNode:
         return pub
 
     def create_subscription(self, msg_type, topic, callback, qos):
-        self.subscriptions.append((topic, callback))
-        return object()
+        subscription = types.SimpleNamespace(msg_type=msg_type, topic=topic, callback=callback, qos=qos)
+        self.subscriptions.append(subscription)
+        return subscription
+
+    def destroy_subscription(self, subscription):
+        if subscription in self.subscriptions:
+            self.subscriptions.remove(subscription)
+            return True
+        return False
+
+    def destroy_publisher(self, publisher):
+        if self.publishers.get(publisher.topic) is publisher:
+            del self.publishers[publisher.topic]
+            return True
+        return False
 
     def create_client(self, srv_type, name):
         client = FakeClient(srv_type, name)
@@ -333,6 +346,108 @@ class DispatchSmokeTests(unittest.TestCase):
         self.assertTrue(locomotion._registered)
         self.assertEqual(len(locomotion.nodes.locomotion_pub.published), 1)
         self.assertEqual(locomotion.nodes.locomotion_pub.published[0].forward_velocity, 0.5)
+
+
+class CameraMultiInstanceTests(unittest.TestCase):
+    def setUp(self):
+        self.plugins = build_bundle_plugins()
+        self.camera = find_plugin(self.plugins, "camera_rgb")
+        self.nodes = self.camera.nodes
+
+    def test_rgb_tool_is_multi_instance_with_instance_source_config(self):
+        tool = next(d for d in self.camera.get_tools() if d["name"] == "camera_rgb")
+        self.assertTrue(tool["multiInstance"])
+        source = tool["configSchema"]["properties"]["camera_source"]
+        self.assertEqual(source["scope"], "instance")
+        self.assertEqual(source["default"], device.DEFAULT_CAMERA_RGB_SOURCE)
+        self.assertEqual(
+            {choice["const"] for choice in source["oneOf"]},
+            set(device.CAMERA_RGB_SOURCES),
+        )
+
+    def test_info_returns_deterministic_instance_topic_before_start(self):
+        result = self.camera.dispatch("info", {"_tool_name": "camera_rgb", "instance_id": "card-a-1"})
+        self.assertEqual(result["state"], "idle")
+        self.assertEqual(result["camera_source"], "interaction")
+        self.assertEqual(
+            result["topic_out"],
+            [{"topic": "/test_ns/agibot_x2/camera_rgb/card_a_1", "format": "image/jpeg"}],
+        )
+
+    def test_two_instances_can_stream_different_sources_concurrently(self):
+        self.camera.dispatch("config", {
+            "_tool_name": "camera_rgb", "instance_id": "front-card", "camera_source": "interaction",
+        })
+        self.camera.dispatch("config", {
+            "_tool_name": "camera_rgb", "instance_id": "rear-card", "camera_source": "rear",
+        })
+        front = self.camera.dispatch("start", {"_tool_name": "camera_rgb", "instance_id": "front-card"})
+        rear = self.camera.dispatch("start", {"_tool_name": "camera_rgb", "instance_id": "rear-card"})
+
+        self.assertEqual(front["state"], "running")
+        self.assertEqual(rear["state"], "running")
+        self.assertNotEqual(front["topic"], rear["topic"])
+        active_topics = {sub.topic for sub in self.nodes.robot.subscriptions}
+        self.assertIn(device.CAMERA_RGB_SOURCES["interaction"], active_topics)
+        self.assertIn(device.CAMERA_RGB_SOURCES["rear"], active_topics)
+
+        rgb_subs = [
+            sub for sub in self.nodes.robot.subscriptions
+            if sub.topic in device.CAMERA_RGB_SOURCES.values()
+        ]
+        self.assertEqual(len(rgb_subs), 2)
+
+    def test_frame_is_forwarded_unchanged_and_counted(self):
+        result = self.camera.dispatch("start", {"_tool_name": "camera_rgb", "instance_id": "card-frame"})
+        source_topic = device.CAMERA_RGB_SOURCES["interaction"]
+        subscription = next(sub for sub in self.nodes.robot.subscriptions if sub.topic == source_topic)
+        frame = FakeMsg()
+        subscription.callback(frame)
+
+        publisher = self.nodes.core.publishers[result["topic"]]
+        self.assertEqual(publisher.published, [frame])
+        info = self.camera.dispatch("info", {"_tool_name": "camera_rgb", "instance_id": "card-frame"})
+        self.assertEqual(info["frames_published"], 1)
+
+    def test_running_instance_hot_switches_without_affecting_other_instance(self):
+        self.camera.dispatch("start", {"_tool_name": "camera_rgb", "instance_id": "switch-me"})
+        self.camera.dispatch("start", {"_tool_name": "camera_rgb", "instance_id": "keep-me"})
+        keep_topic = self.camera.dispatch(
+            "info", {"_tool_name": "camera_rgb", "instance_id": "keep-me"},
+        )["topic"]
+
+        switched = self.camera.dispatch("config", {
+            "_tool_name": "camera_rgb", "instance_id": "switch-me", "camera_source": "stereo_left",
+        })
+        self.assertEqual(switched["state"], "running")
+        self.assertEqual(switched["robot_topic"], device.CAMERA_RGB_SOURCES["stereo_left"])
+        self.assertIn(keep_topic, self.nodes.core.publishers)
+        rgb_subs = [
+            sub.topic for sub in self.nodes.robot.subscriptions
+            if sub.topic in device.CAMERA_RGB_SOURCES.values()
+        ]
+        self.assertEqual(rgb_subs.count(device.CAMERA_RGB_SOURCES["interaction"]), 1)
+        self.assertEqual(rgb_subs.count(device.CAMERA_RGB_SOURCES["stereo_left"]), 1)
+
+    def test_stop_releases_only_target_instance_and_is_idempotent(self):
+        self.camera.dispatch("start", {"_tool_name": "camera_rgb", "instance_id": "a"})
+        self.camera.dispatch("config", {
+            "_tool_name": "camera_rgb", "instance_id": "b", "camera_source": "rear",
+        })
+        self.camera.dispatch("start", {"_tool_name": "camera_rgb", "instance_id": "b"})
+
+        stopped = self.camera.dispatch("stop", {"_tool_name": "camera_rgb", "instance_id": "a"})
+        stopped_again = self.camera.dispatch("stop", {"_tool_name": "camera_rgb", "instance_id": "a"})
+        running = self.camera.dispatch("info", {"_tool_name": "camera_rgb", "instance_id": "b"})
+        self.assertEqual(stopped["state"], "idle")
+        self.assertEqual(stopped_again["state"], "idle")
+        self.assertEqual(running["state"], "running")
+
+    def test_invalid_source_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self.camera.dispatch("config", {
+                "_tool_name": "camera_rgb", "instance_id": "bad", "camera_source": "made_up",
+            })
 
 
 class StartStopLifecycleTests(unittest.TestCase):

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -371,8 +371,17 @@ class CameraMultiInstanceTests(unittest.TestCase):
         self.assertEqual(result["camera_source"], "interaction")
         self.assertEqual(
             result["topic_out"],
-            [{"topic": "/test_ns/agibot_x2/camera_rgb/card_a_1", "format": "image/jpeg"}],
+            [{"topic": "/test_ns/agibot_x2/camera_rgb/card_a_1_94b5805e", "format": "image/jpeg"}],
         )
+
+    def test_lossy_ros_name_sanitizing_does_not_merge_instance_topics(self):
+        dashed = self.camera.dispatch(
+            "info", {"_tool_name": "camera_rgb", "instance_id": "card-a"},
+        )["topic"]
+        underscored = self.camera.dispatch(
+            "info", {"_tool_name": "camera_rgb", "instance_id": "card_a"},
+        )["topic"]
+        self.assertNotEqual(dashed, underscored)
 
     def test_two_instances_can_stream_different_sources_concurrently(self):
         self.camera.dispatch("config", {
@@ -448,6 +457,27 @@ class CameraMultiInstanceTests(unittest.TestCase):
             self.camera.dispatch("config", {
                 "_tool_name": "camera_rgb", "instance_id": "bad", "camera_source": "made_up",
             })
+
+    def test_subscription_creation_failure_releases_provisional_instance(self):
+        original = self.nodes.robot.create_subscription
+
+        def fail_create_subscription(*args, **kwargs):
+            raise RuntimeError("subscription failed")
+
+        self.nodes.robot.create_subscription = fail_create_subscription
+        try:
+            with self.assertRaises(RuntimeError):
+                self.camera.dispatch(
+                    "start", {"_tool_name": "camera_rgb", "instance_id": "broken"},
+                )
+        finally:
+            self.nodes.robot.create_subscription = original
+
+        info = self.camera.dispatch(
+            "info", {"_tool_name": "camera_rgb", "instance_id": "broken"},
+        )
+        self.assertEqual(info["state"], "idle")
+        self.assertNotIn(info["topic"], self.nodes.core.publishers)
 
 
 class StartStopLifecycleTests(unittest.TestCase):

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -316,6 +316,16 @@ class ModelPluginTests(unittest.TestCase):
             model_plugin.dispatch("model", {"variant": "nonexistent"})
 
 
+class PackagingTests(unittest.TestCase):
+    def test_docker_image_includes_deployment_service_fragment(self):
+        dockerfile = (DEVICE_DIR / "Dockerfile").read_text(encoding="utf-8")
+        self.assertRegex(
+            dockerfile,
+            r"(?m)^COPY\s+deploy/\s+/deploy/\s*$",
+            "run-pr-image.sh requires /deploy/service.yml inside every driver image",
+        )
+
+
 class DispatchSmokeTests(unittest.TestCase):
     """Exercise a couple of simple service-backed dispatch() calls end-to-end against the
     fake ROS client, to catch request/response field mismatches (as opposed to only

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -358,6 +358,7 @@ class CameraMultiInstanceTests(unittest.TestCase):
     def test_rgb_tool_is_multi_instance_with_instance_source_config(self):
         tool = next(d for d in self.camera.get_tools() if d["name"] == "camera_rgb")
         self.assertTrue(tool["multiInstance"])
+        self.assertIn("config", tool["inputSchema"]["properties"]["action"]["enum"])
         source = tool["configSchema"]["properties"]["camera_source"]
         self.assertEqual(source["scope"], "instance")
         self.assertEqual(source["default"], device.DEFAULT_CAMERA_RGB_SOURCE)
@@ -374,6 +375,11 @@ class CameraMultiInstanceTests(unittest.TestCase):
             result["topic_out"],
             [{"topic": "/test_ns/agibot_x2/camera_rgb/card_a_1_94b5805e", "format": "image/jpeg"}],
         )
+
+    def test_missing_instance_id_is_rejected_for_every_rgb_action(self):
+        for action in ("info", "start", "stop", "config"):
+            with self.subTest(action=action), self.assertRaises(ValueError):
+                self.camera.dispatch(action, {"_tool_name": "camera_rgb"})
 
     def test_lossy_ros_name_sanitizing_does_not_merge_instance_topics(self):
         dashed = self.camera.dispatch(
@@ -526,15 +532,17 @@ class StartStopLifecycleTests(unittest.TestCase):
     LED) just from a card being dragged onto the canvas. This regression-tests that every
     plugin handles both without touching a service client or publisher."""
 
-    def _assert_inert(self, plugin, tool_name, nodes):
+    def _assert_inert(self, plugin, definition, nodes):
+        tool_name = definition["name"]
         publishers_before = {
             topic: len(pub.published) for topic, pub in nodes.robot.publishers.items()
         }
         for client in nodes.robot.clients.values():
             client.last_request = None
 
+        instance_args = {"instance_id": "lifecycle-test"} if definition.get("multiInstance") else {}
         for action in ("start", "stop"):
-            result = plugin.dispatch(action, {"_tool_name": tool_name})
+            result = plugin.dispatch(action, {"_tool_name": tool_name, **instance_args})
             self.assertIsInstance(result, dict, f"{tool_name}.dispatch({action!r}) must return a dict")
             self.assertIn("state", result, f"{tool_name}.dispatch({action!r}) must report a state")
 
@@ -553,7 +561,7 @@ class StartStopLifecycleTests(unittest.TestCase):
             for definition in (plugin.get_tools() if hasattr(plugin, "get_tools") else [plugin.get_tool()]):
                 if definition["type"] == "resource":
                     continue  # resource tools always dispatch with action == tool name, never start/stop
-                self._assert_inert(plugin, definition["name"], nodes)
+                self._assert_inert(plugin, definition, nodes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make AimDK X2 `camera_rgb` a multi-instance sensor card
- let each instance select one verified X2 RGB source: interaction, RGBD color, stereo left, stereo right, or rear
- give every instance an independent ROS 2 output topic for concurrent monitoring and downstream processing
- create/destroy subscriptions and publishers per instance, including hot source switching
- keep the existing `camera_depth` relay separate and unchanged

## Validation

- Python syntax compilation passed
- all 25 X2 pure-Python unit tests passed locally
- coverage includes schema, deterministic/non-colliding instance topics, two concurrent sources, raw JPEG forwarding, hot switching, idempotent stop, invalid-source rejection, subscription-failure cleanup, Unicode-safe ROS topics, explicit depth-card action validation, required multi-instance IDs, schema-advertised hot switching, and canvas-style nested configuration through `DriverBundle.dispatch()`
- `git diff --check` passed

The host Python did not have the pinned `PyYAML==6.0.2`, so the local test process used a minimal in-memory parser only for the unchanged `driver.yaml` card list; the driver image installs PyYAML from `requirements.txt`.

## Review follow-up

The canvas passes per-instance settings as `args["config"]`; the driver now gives nested `config.camera_source` precedence, while retaining the top-level form for compatibility. The raw `camera_depth` relay predates this PR and its runtime implementation is not modified here; this PR is limited to compressed RGB sources.

## Safety / scope

No robot deployment or physical actuator test was performed. The change only handles camera subscriptions and ROS 2 image forwarding. The presence of left/right publishers is not presented as evidence of stereo synchronization, rectification, or ranging capability.