### PR TITLE
DDS 隔离：把内部总线锁在本机，并修掉天轶的本体链路回归

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,23 @@ environment:
   - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
 ```
 
-Every driver's `deploy/service.yml` carries this except two dual-domain drivers that configure DDS in
-code (`engineai/t800`, `x-humanoid/tianyi2.0` — see the table in README_dev). Deploying through the
-dashboard needs no extra step. It matters when you write a new driver or hand-assemble a compose
-file, because a container that misses it **cannot reach Agent Core at all** — the device registers
+Every driver's `deploy/service.yml` carries this, with two exceptions that are not the same kind of
+exception. `x-humanoid/tianyi2.0` mounts the profile but selects it per DDS context in code, because a
+process-wide default would put its body link on loopback and cut it — it is isolated.
+`engineai/t800` runs on CycloneDDS, which a FastDDS profile cannot reach at all, so **its domain-42
+context is still on the LAN** — a known gap, not a covered case. Deploying through the dashboard
+needs no extra step. This matters when you write a new driver or hand-assemble a compose file,
+because a container that misses the profile **cannot reach Agent Core at all** — the device registers
 over HTTP and appears in the dashboard while none of its topics ever carry data.
 
 `ROS_DOMAIN_ID` is 42 on every robot; there are no per-robot numbers to allocate. Links to the robot
 body are unaffected — those go over CycloneDDS with an explicitly bound interface, which this
-profile does not touch. Full rationale, the failure modes and how to verify:
-[README_dev.md § DDS isolation](README_dev.md#dds-isolation--every-driver-must-load-the-profile).
+profile does not touch.
+
+`./scripts/check_service_yml.py` verifies all of the above across every driver; run it on any PR that
+adds or edits a `service.yml`. Full rationale, the failure modes and how to verify:
+[README_dev.md § DDS isolation](README_dev.md#dds-isolation--load-the-profile-unless-the-driver-manages-dds-itself)
+and [§ service.yml checklist](README_dev.md#serviceyml-checklist-for-a-new-driver).
 
 ### Run Locally (without Docker)
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,13 @@ environment:
   - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
 ```
 
-Every driver's `deploy/service.yml` carries this, with two exceptions that are not the same kind of
-exception. `x-humanoid/tianyi2.0` mounts the profile but selects it per DDS context in code, because a
-process-wide default would put its body link on loopback and cut it — it is isolated.
+Every driver's `deploy/service.yml` carries this, with two exceptions, neither of them fully
+isolated. `x-humanoid/tianyi2.0` cannot use this profile at all: it holds a body context and an
+Agent Core context in one process, and a loopback-only profile cuts the body link. It runs the
+**vendor** profile process-wide instead, whose whitelist happens to exclude the office LAN — so no
+cross-robot command leakage, but not loopback either. (Per-participant profile selection is *not*
+possible here; FastDDS caches profiles process-wide. An earlier version of this file claimed
+otherwise and the claim cost a regression — see README_dev.)
 `engineai/t800` runs on CycloneDDS, which a FastDDS profile cannot reach at all, so **its domain-42
 context is still on the LAN** — a known gap, not a covered case. Deploying through the dashboard
 needs no extra step. This matters when you write a new driver or hand-assemble a compose file,

--- a/README.md
+++ b/README.md
@@ -57,6 +57,30 @@ When run without arguments, `build.sh` shows an interactive multi-select menu to
 
 Once the driver container starts, it registers itself with Agent Core at `http://<agent-core>:15678/api/mcp`. You can then see the device and its tools in the Web Dashboard.
 
+### DDS is confined to the local machine
+
+Every container on the ROS2 bus — Agent Core, perception, actucore and **every driver** — loads the
+same loopback-only FastDDS profile, so a robot's internal bus cannot be seen from the network:
+
+```yaml
+volumes:
+  - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
+environment:
+  - ROS_DOMAIN_ID=42
+  - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
+```
+
+Every driver's `deploy/service.yml` carries this except two dual-domain drivers that configure DDS in
+code (`engineai/t800`, `x-humanoid/tianyi2.0` — see the table in README_dev). Deploying through the
+dashboard needs no extra step. It matters when you write a new driver or hand-assemble a compose
+file, because a container that misses it **cannot reach Agent Core at all** — the device registers
+over HTTP and appears in the dashboard while none of its topics ever carry data.
+
+`ROS_DOMAIN_ID` is 42 on every robot; there are no per-robot numbers to allocate. Links to the robot
+body are unaffected — those go over CycloneDDS with an explicitly bound interface, which this
+profile does not touch. Full rationale, the failure modes and how to verify:
+[README_dev.md § DDS isolation](README_dev.md#dds-isolation--every-driver-must-load-the-profile).
+
 ### Run Locally (without Docker)
 
 ```bash

--- a/README_dev.md
+++ b/README_dev.md
@@ -769,12 +769,14 @@ Two things that bite when deploying by hand:
   which is expected — the whitelist decides which interface it joins on). Agent Core also exposes
   `GET /api/peer/dds_isolation`.
 
-**Two drivers do not set these lines in `environment`, because a process-wide default would reach
-the wrong context.** If you write a driver in either shape, the profile has to be applied in code:
+**Two drivers do not set these lines in `environment`, for two different reasons — and only one of
+them is a solved case.** If you write a driver in either shape, read the row that matches:
 
-| Driver | Why the compose variable does not work |
-|---|---|
-| `engineai/t800` | Its `CMD` forces `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`, so **both** its domains run on CycloneDDS. `FASTRTPS_DEFAULT_PROFILES_FILE` has no effect at all; CycloneDDS is configured through `CYCLONEDDS_URI`, which this driver already pins to the robot interface (`eth1`). |
+| Driver | Why the compose variable does not work | Status |
+|---|---|---|
+| `engineai/t800` | Its `CMD` forces `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`, so **both** its domains run on CycloneDDS. `FASTRTPS_DEFAULT_PROFILES_FILE` has no effect at all; CycloneDDS is configured through `CYCLONEDDS_URI`, which this driver pins to the robot interface (`eth1`) — for both contexts. | **Open gap — not isolated.** Its domain-42 traffic is still on the LAN. Closing it needs a separate CycloneDDS config confining the Agent Core context to loopback, selected per context the way tianyi does for FastDDS. Untried: no T800 hardware available. `check_service_yml.py` reports it as `GAP`. |
+| `x-humanoid/tianyi2.0` | It holds **two FastDDS contexts in one process** (`DualDomainROS2` in `main.py`, `BridgeROS2` in `joints_bridge.py`) and selects a profile per context by setting the variable around each `rclpy.init()`: the vendor profile for the body (domain 0), the loopback profile for Agent Core (domain 42). A process-wide default would put the body link on loopback and cut it — which is why the mount is there but the environment variable is not. | **Isolated**, verified on the robot (below). |
+
 | `x-humanoid/tianyi2.0` | It holds **two FastDDS contexts in one process** (`DualDomainROS2` in `main.py`, `BridgeROS2` in `joints_bridge.py`) and selects a profile per context by setting the variable around each `rclpy.init()`: the vendor profile for the body (domain 0), the loopback profile for Agent Core (domain 42). A process-wide default would put the body link on loopback and cut it — which is why the mount is there but the environment variable is not. |
 
 Tianyi's Agent Core context **is** isolated now (it used to pop the variable and run on every
@@ -785,6 +787,42 @@ interface). Measured on the robot with the body powered: its domain-42 sockets m
 Core's topic count and joint/IMU/battery states were unchanged. The code falls back to popping the
 variable if the profile file is missing, so a container predating the mount still reaches Agent Core
 rather than failing silently — it logs that it is not isolated.
+
+### service.yml checklist for a new driver
+
+Run `./scripts/check_service_yml.py` to verify all of this — it is what a reviewer should run on any
+PR that adds or edits a `deploy/service.yml`. It exits non-zero on a violation, so it also works as
+a CI step.
+
+- [ ] mounts `/opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro`
+- [ ] sets `FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml`
+- [ ] does not set `FASTDDS_BUILTIN_TRANSPORTS` — it conflicts with the profile's
+      `useBuiltinTransports=false`, and an image that bakes it into `ENV` cannot be corrected from
+      compose anyway (the XML wins, so the variable only misleads whoever reads the file next)
+- [ ] `ROS_DOMAIN_ID=42` — the same on every robot; there is nothing to allocate. A driver holding
+      a second context may spell it `<PREFIX>_ROS_DOMAIN_ID` for the body and
+      `AGENT_CORE_ROS_DOMAIN_ID` for this one; only the Agent Core side must be 42
+- [ ] `network_mode: host` — isolation works by confining DDS to loopback, and containers share a
+      loopback only under host networking
+
+The first two are the ones that break a robot rather than merely leaving it unisolated: with
+`useBuiltinTransports=false` everywhere else, a container that misses them ends up on a different
+transport from the rest of the machine and **cannot reach Agent Core at all** — the device registers
+over HTTP and appears in the dashboard while none of its topics ever carry data, which sends you
+looking at the driver instead of at compose.
+
+The checker keeps two tables instead of one, so that neither exception quietly becomes a loophole:
+
+- `IN_CODE_PROFILE` — drivers that must **not** set the environment variable because they select a
+  profile per context in code (`x-humanoid/tianyi2.0`). The mount is still required. Setting the
+  variable here is a failure, not a pass.
+- `KNOWN_GAPS` — drivers a FastDDS profile cannot isolate at all, currently `engineai/t800`, whose
+  RMW is CycloneDDS. It is reported as `GAP` and does not fail the run. Adding a third such driver
+  means editing this table, which is the point: the gap stays visible rather than passing a check
+  named "isolation".
+
+`ipc` and `pid` are deliberately **not** checked — they vary legitimately across drivers (a drone
+does not need `pid: host`), and the profile disables shared memory anyway.
 
 ---
 

--- a/README_dev.md
+++ b/README_dev.md
@@ -702,10 +702,13 @@ unitree-g1:                      # Service name (must be unique)
   privileged: true               # Required: access to /dev and hardware
   volumes:
     - /dev:/dev                  # Required: device access for cameras, sensors, etc.
+    # Required: the loopback-only DDS profile. See "DDS isolation" below —
+    # a driver that skips this cannot talk to Agent Core at all.
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
   environment:
-    - ROS_DOMAIN_ID=42
+    - ROS_DOMAIN_ID=42           # Same on every robot; do not allocate per-robot
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-    - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
   logging:
     driver: local
@@ -722,6 +725,63 @@ unitree-g1:                      # Service name (must be unique)
 - `network_mode`, `ipc`, `pid` are injected by Agent Core during deployment — do not specify them in service.yml
 - The `__IMAGE__` placeholder is automatically replaced with the actual image reference
 - Service name should follow the pattern `{provider}-{model}` (e.g. `unitree-g1`, `phanthy-remote-control`)
+- Do **not** set `FASTDDS_BUILTIN_TRANSPORTS`. It conflicts with the profile's
+  `useBuiltinTransports=false`, and the value cannot be unset from compose once an image bakes it
+  into its `ENV` — the XML wins anyway, so the variable is only a source of confusion.
+
+---
+
+### DDS isolation — load the profile unless the driver manages DDS itself
+
+**Both lines above are mandatory for any driver that reaches Agent Core over FastDDS**, which is all
+of them except the two dual-domain cases listed at the end of this section. A driver container without them is not merely
+unisolated: with `useBuiltinTransports=false` everywhere else, it ends up on a different transport
+from the rest of the machine and **cannot reach Agent Core at all**. The symptom is a device that
+registers over HTTP and shows up in the dashboard, while none of its topics ever carry data.
+
+Why the profile exists: `/remote_control/message` — a *command* topic — was reaching every robot on
+the office LAN. An instruction typed on one robot was executed by a second one too, with the
+identical timestamp in both logs. DDS has no addressing and no authentication; every subscriber on
+the domain receives everything. The fix pins FastDDS to `127.0.0.1`
+(`interfaceWhiteList`), and because containers run with `network_mode: host` they share one
+loopback — the local bus works normally, nothing crosses the machine.
+
+`ROS_DOMAIN_ID` stays **42 everywhere**. Per-robot domain numbers were tried and rejected: the
+usable range is narrow, and cloned images have no way to coordinate a unique number.
+
+**Your robot-body link is unaffected.** Drivers that speak to the hardware over the vendor SDK use
+**CycloneDDS** with an explicitly bound interface (`ChannelFactoryInitialize(0, "eth0")`), and
+`FASTRTPS_DEFAULT_PROFILES_FILE` only affects FastDDS. The two stacks coexist in one process.
+Verified on a real R1: with and without the profile, a read-only `rt/lowstate` probe reported the
+identical packet count and IMU yaw. Raw UDP multicast (R1's microphone uses `239.168.123.161:5555`
+via `IP_ADD_MEMBERSHIP`) is likewise untouched — it is not DDS.
+
+Two things that bite when deploying by hand:
+
+- **A missing file fails silently, and worse.** If the host has no
+  `/opt/phanthy-motus/dds-local.xml`, Docker's bind mount creates a *directory* with that name;
+  FastDDS ignores it and falls back to every interface. Agent Core writes the file from its own
+  image when it is absent — but a container that already mounted the phantom directory must be
+  **recreated**, not restarted (`docker start` cannot change a mount type fixed at creation; it
+  fails with `not a directory: Are you trying to mount a directory onto a file`).
+- **Judge by socket bindings, not by config.** Check that the driver's UDP sockets bind loopback:
+  `sudo ss -lunp | grep 179` should show `127.0.0.1:179xx` (plus a `239.255.0.1` multicast join,
+  which is expected — the whitelist decides which interface it joins on). Agent Core also exposes
+  `GET /api/peer/dds_isolation`.
+
+**Two drivers deliberately do not carry these lines, because the variable would not reach the
+context that matters.** If you write a driver in either shape, the profile has to be applied in code,
+not in compose:
+
+| Driver | Why the compose variable does not work |
+|---|---|
+| `engineai/t800` | Its `CMD` forces `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`, so **both** its domains run on CycloneDDS. `FASTRTPS_DEFAULT_PROFILES_FILE` has no effect at all; CycloneDDS is configured through `CYCLONEDDS_URI`, which this driver already pins to the robot interface (`eth1`). |
+| `x-humanoid/tianyi2.0` | `joints_bridge.py` sets the *vendor* profile for the body context (domain 0), then **pops** `FASTRTPS_DEFAULT_PROFILES_FILE` before creating the Agent Core context (domain 42). Anything set in compose is removed before the context that would use it exists — so that context currently runs on the default transport, i.e. every interface. |
+
+The Tianyi case is a **known isolation gap**, not a design decision: its Agent Core domain is still
+reachable from the network. Fixing it means setting the loopback profile (instead of popping the
+variable) just before `ctx_core` is created, which needs a check on the real robot because the same
+lines carry its body link.
 
 ---
 

--- a/README_dev.md
+++ b/README_dev.md
@@ -769,24 +769,56 @@ Two things that bite when deploying by hand:
   which is expected — the whitelist decides which interface it joins on). Agent Core also exposes
   `GET /api/peer/dds_isolation`.
 
-**Two drivers do not set these lines in `environment`, for two different reasons — and only one of
-them is a solved case.** If you write a driver in either shape, read the row that matches:
+**Two drivers do not set these lines in `environment`, for two different reasons — and neither is
+"isolated" in the sense the fleet profile means.** If you write a driver in either shape, read the
+row that matches:
 
 | Driver | Why the compose variable does not work | Status |
 |---|---|---|
-| `engineai/t800` | Its `CMD` forces `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`, so **both** its domains run on CycloneDDS. `FASTRTPS_DEFAULT_PROFILES_FILE` has no effect at all; CycloneDDS is configured through `CYCLONEDDS_URI`, which this driver pins to the robot interface (`eth1`) — for both contexts. | **Open gap — not isolated.** Its domain-42 traffic is still on the LAN. Closing it needs a separate CycloneDDS config confining the Agent Core context to loopback, selected per context the way tianyi does for FastDDS. Untried: no T800 hardware available. `check_service_yml.py` reports it as `GAP`. |
-| `x-humanoid/tianyi2.0` | It holds **two FastDDS contexts in one process** (`DualDomainROS2` in `main.py`, `BridgeROS2` in `joints_bridge.py`) and selects a profile per context by setting the variable around each `rclpy.init()`: the vendor profile for the body (domain 0), the loopback profile for Agent Core (domain 42). A process-wide default would put the body link on loopback and cut it — which is why the mount is there but the environment variable is not. | **Isolated**, verified on the robot (below). |
+| `engineai/t800` | Its `CMD` forces `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`, so **both** its domains run on CycloneDDS. `FASTRTPS_DEFAULT_PROFILES_FILE` has no effect at all; CycloneDDS is configured through `CYCLONEDDS_URI`, which this driver pins to the robot interface (`eth1`) — for both contexts. | **Open gap.** Its domain-42 traffic is still on the LAN. Untried: no T800 hardware available. `check_service_yml.py` reports it as `GAP`. |
+| `x-humanoid/tianyi2.0` | It holds **two FastDDS contexts in one process** (`DualDomainROS2` in `main.py`, `BridgeROS2` in `joints_bridge.py`), and the fleet profile would put the body link on loopback and cut it. It therefore selects the **vendor** profile (`/work/dds_profile.xml`) for the whole process, before any participant exists. | **Partly isolated, by whitelist rather than by loopback** — see below. |
 
-| `x-humanoid/tianyi2.0` | It holds **two FastDDS contexts in one process** (`DualDomainROS2` in `main.py`, `BridgeROS2` in `joints_bridge.py`) and selects a profile per context by setting the variable around each `rclpy.init()`: the vendor profile for the body (domain 0), the loopback profile for Agent Core (domain 42). A process-wide default would put the body link on loopback and cut it — which is why the mount is there but the environment variable is not. |
+### One profile per process — per-participant selection does not work
 
-Tianyi's Agent Core context **is** isolated now (it used to pop the variable and run on every
-interface). Measured on the robot with the body powered: its domain-42 sockets moved from
-`0.0.0.0:17900/17912-17915` to `127.0.0.1`, the two profile lines appear in its log
-(`domain0: using DDS profile /work/dds_profile.xml`, `domain42: using DDS profile
-/opt/phanthy-motus/dds-local.xml`), the body's `/arm/*` topics stayed visible on domain 0, and Agent
-Core's topic count and joint/IMU/battery states were unchanged. The code falls back to popping the
-variable if the profile file is missing, so a container predating the mount still reaches Agent Core
-rather than failing silently — it logs that it is not isolated.
+An earlier version of this section said tianyi "selects a profile per DDS context by setting the
+variable around each `rclpy.init()`", and cited it as proof that per-participant profiles are
+possible. **That was wrong, and shipping it silently cut part of the body link.** Two separate
+reasons, either one fatal:
+
+1. **FastDDS reads `FASTRTPS_DEFAULT_PROFILES_FILE` at participant creation, not at
+   `rclpy.init()`** — and rmw_fastrtps creates the participant lazily, with the first `Node` on the
+   context. Setting the variable around each `rclpy.init()` sets it around the wrong call: by the
+   time the first real Node appears, the variable holds whatever was written last.
+2. **The parsed profiles are cached process-wide**, so switching the variable between contexts
+   cannot give them different profiles at all — it only decides which single profile both use.
+   Measured on the robot: a process that set the vendor profile, created a domain-0 node, then set
+   the loopback profile and created a domain-42 node, ended with *both* domains bound to
+   `127.0.0.1` **and** `192.168.41.2` — the vendor whitelist, for both.
+
+What the wrong profile cost, for calibration on how quiet this failure is: with the loopback-only
+profile in force, the domain-0 participant bound `127.0.0.1` but not `192.168.41.2`, where the
+vendor stack lives. Visible domain-0 topics fell from 77 to 33, all 26 of the driver's own
+`tianyi2_*` nodes vanished from domain 0, and lyre's `/audio_play/play_text` became undiscoverable
+(2.76 s to discover under the vendor profile; nothing after 15 s under the loopback one). Nothing
+was logged. `/arm/status` and `/head/status` survived, so the robot looked healthy — while TTS
+reported success and produced no sound, with lyre's journal confirming it had received nothing.
+
+The earlier "verified" claim was a real measurement, but a one-sided one: it checked that domain 42
+had moved to `127.0.0.1` and did not check what had happened to domain 0. When you verify an
+isolation change, measure **both** sides of the link it runs through.
+
+So tianyi runs the vendor profile process-wide. Its whitelist is
+`{192.168.41.2, 127.0.0.1}`: the body link works, and — the point of the fleet-wide profile — the
+**office LAN is excluded**, so domain 42 cannot carry `/remote_control/message` to another robot.
+Be precise about what that is not: domain 42 is still reachable from the body board on
+`192.168.41.x`. That board runs no Agent Core and is internal to this robot, so nothing there can
+act on a command. Narrowing it to true loopback needs the agent-core-facing publishers moved into
+their own process, one profile each.
+
+Because of this, tianyi does **not** use the `dds-local.xml` mount, and `check_service_yml.py` does
+not require it for that driver. Verified after the fix: both domains bind `127.0.0.1` and
+`192.168.41.2`, **no `10.100.x`**; 26 `tianyi2_*` nodes visible on domain 0; TTS returns `ready`
+and plays with a real sid, `PlayProgress` and a `COMPLETED` `PlayEvent`.
 
 ### service.yml checklist for a new driver
 
@@ -813,9 +845,10 @@ looking at the driver instead of at compose.
 
 The checker keeps two tables instead of one, so that neither exception quietly becomes a loophole:
 
-- `IN_CODE_PROFILE` — drivers that must **not** set the environment variable because they select a
-  profile per context in code (`x-humanoid/tianyi2.0`). The mount is still required. Setting the
-  variable here is a failure, not a pass.
+- `OWN_PROFILE` — drivers that must **not** set the fleet profile because they ship their own for
+  the whole process (`x-humanoid/tianyi2.0`; see § "One profile per process" above for why per-context
+  selection is not an option). The mount is not required either — requiring it would imply the file
+  is in use. Setting the fleet profile here is a failure, not a pass: it cuts the body link.
 - `KNOWN_GAPS` — drivers a FastDDS profile cannot isolate at all, currently `engineai/t800`, whose
   RMW is CycloneDDS. It is reported as `GAP` and does not fail the run. Adding a third such driver
   means editing this table, which is the point: the gap stays visible rather than passing a check

--- a/README_dev.md
+++ b/README_dev.md
@@ -769,19 +769,22 @@ Two things that bite when deploying by hand:
   which is expected — the whitelist decides which interface it joins on). Agent Core also exposes
   `GET /api/peer/dds_isolation`.
 
-**Two drivers deliberately do not carry these lines, because the variable would not reach the
-context that matters.** If you write a driver in either shape, the profile has to be applied in code,
-not in compose:
+**Two drivers do not set these lines in `environment`, because a process-wide default would reach
+the wrong context.** If you write a driver in either shape, the profile has to be applied in code:
 
 | Driver | Why the compose variable does not work |
 |---|---|
 | `engineai/t800` | Its `CMD` forces `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`, so **both** its domains run on CycloneDDS. `FASTRTPS_DEFAULT_PROFILES_FILE` has no effect at all; CycloneDDS is configured through `CYCLONEDDS_URI`, which this driver already pins to the robot interface (`eth1`). |
-| `x-humanoid/tianyi2.0` | `joints_bridge.py` sets the *vendor* profile for the body context (domain 0), then **pops** `FASTRTPS_DEFAULT_PROFILES_FILE` before creating the Agent Core context (domain 42). Anything set in compose is removed before the context that would use it exists — so that context currently runs on the default transport, i.e. every interface. |
+| `x-humanoid/tianyi2.0` | It holds **two FastDDS contexts in one process** (`DualDomainROS2` in `main.py`, `BridgeROS2` in `joints_bridge.py`) and selects a profile per context by setting the variable around each `rclpy.init()`: the vendor profile for the body (domain 0), the loopback profile for Agent Core (domain 42). A process-wide default would put the body link on loopback and cut it — which is why the mount is there but the environment variable is not. |
 
-The Tianyi case is a **known isolation gap**, not a design decision: its Agent Core domain is still
-reachable from the network. Fixing it means setting the loopback profile (instead of popping the
-variable) just before `ctx_core` is created, which needs a check on the real robot because the same
-lines carry its body link.
+Tianyi's Agent Core context **is** isolated now (it used to pop the variable and run on every
+interface). Measured on the robot with the body powered: its domain-42 sockets moved from
+`0.0.0.0:17900/17912-17915` to `127.0.0.1`, the two profile lines appear in its log
+(`domain0: using DDS profile /work/dds_profile.xml`, `domain42: using DDS profile
+/opt/phanthy-motus/dds-local.xml`), the body's `/arm/*` topics stayed visible on domain 0, and Agent
+Core's topic count and joint/IMU/battery states were unchanged. The code falls back to popping the
+variable if the profile file is missing, so a container predating the mount still reaches Agent Core
+rather than failing silently — it logs that it is not isolated.
 
 ---
 

--- a/booster/k1/deploy/service.yml
+++ b/booster/k1/deploy/service.yml
@@ -6,12 +6,13 @@ booster-k1:
   pid: host
   privileged: true
   volumes:
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
     - /dev:/dev
     - /opt/phanthy-motus/data:/opt/phanthy-motus/data
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-    - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
   logging:
     driver: local

--- a/brainco/revo2/deploy/service.yml
+++ b/brainco/revo2/deploy/service.yml
@@ -5,13 +5,14 @@ brainco-revo2:
   ipc: host
   privileged: true
   volumes:
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
     - /dev:/dev
     - /opt/phanthy-motus/data:/opt/phanthy-motus/data
     - /run/udev:/run/udev:ro
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-    - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
   logging:
     driver: local

--- a/dji/M300/deploy/service.yml
+++ b/dji/M300/deploy/service.yml
@@ -7,6 +7,7 @@ dji-m300:
   ipc: host
   privileged: true
   volumes:
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
     - /dev:/dev
     - /opt/phanthy-motus/data:/opt/phanthy-motus/data
     - /run/udev:/run/udev:ro
@@ -20,6 +21,7 @@ dji-m300:
     - AGENT_CORE_URL=https://127.0.0.1:15678
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
   logging:
     driver: local

--- a/dji/mavic3e/deploy/service.yml
+++ b/dji/mavic3e/deploy/service.yml
@@ -5,6 +5,7 @@ dji-mavic3e:
   ipc: host
   privileged: true
   volumes:
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
     - /dev:/dev
     - /opt/phanthy-motus/data:/opt/phanthy-motus/data
     - /run/udev:/run/udev:ro
@@ -14,6 +15,7 @@ dji-mavic3e:
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
   logging:
     driver: local

--- a/dji/mavic4e/deploy/service.yml
+++ b/dji/mavic4e/deploy/service.yml
@@ -5,6 +5,7 @@ dji-mavic4e:
   ipc: host
   privileged: true
   volumes:
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
     - /dev:/dev
     - /opt/phanthy-motus/data:/opt/phanthy-motus/data
     - /run/udev:/run/udev:ro
@@ -14,6 +15,7 @@ dji-mavic4e:
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
   logging:
     driver: local

--- a/noetix/bumi/deploy/service.yml
+++ b/noetix/bumi/deploy/service.yml
@@ -6,12 +6,13 @@ noetix-bumi:
   pid: host
   privileged: true
   volumes:
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
     - /dev:/dev
     - /opt/phanthy-motus/data:/opt/phanthy-motus/data
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-    - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
   logging:
     driver: local

--- a/pndbotics/adam/deploy/service.yml
+++ b/pndbotics/adam/deploy/service.yml
@@ -7,6 +7,7 @@ pndbotics-adam:
   pid: host
   privileged: true
   volumes:
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
     - /dev:/dev
     - /opt/phanthy-motus/data:/opt/phanthy-motus/data
     # ZED SDK binaries and the Jetson/aarch64 pyzed extension are provided by
@@ -16,7 +17,7 @@ pndbotics-adam:
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-    - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
     - GRPC_HOST=localhost
     - GRPC_PORT=6666

--- a/robotera/q5_bundle/deploy/service.yml
+++ b/robotera/q5_bundle/deploy/service.yml
@@ -6,6 +6,7 @@ robotera-q5:
   env_file:
     - /opt/phanthy-motus/.env
   volumes:
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
     - /opt/phanthy-motus/data:/opt/phanthy-motus/data
     - /home/nvidia/teleop_client/install:/opt/teleop_client/install:ro
     - /home/nvidia/cyclonedds-orin.xml:/etc/cyclonedds/q5.xml:ro
@@ -13,6 +14,10 @@ robotera-q5:
     - Q5_ROS_DOMAIN_ID=211
     - AGENT_CORE_ROS_DOMAIN_ID=42
     - Q5_CYCLONEDDS_URI=file:///etc/cyclonedds/q5.xml
+    # 只作用于 FastDDS，即 domain 42 上与 agent-core 的那一侧（q5_media_bridge.py）。
+    # 本体走 CycloneDDS + domain 211（Q5_CYCLONEDDS_URI / rmw_cyclonedds_cpp），
+    # 不受本文件影响。
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - ROS_LOCALHOST_ONLY=0
     - PYTHONUNBUFFERED=1
   logging:

--- a/scripts/check_service_yml.py
+++ b/scripts/check_service_yml.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Check every driver's deploy/service.yml for the DDS isolation contract.
+
+Run this on any PR that adds or edits a service.yml. Exits non-zero on a violation,
+so it also works as a CI step.
+
+    ./scripts/check_service_yml.py            # all drivers
+    ./scripts/check_service_yml.py unitree/g1 # just one
+
+What it enforces, and why each item is worth a check rather than a README line:
+
+  * the loopback profile is mounted, and (unless the driver picks profiles in code)
+    selected via FASTRTPS_DEFAULT_PROFILES_FILE. Miss these and the container ends up
+    on a different transport from everything else on the machine, so it cannot reach
+    Agent Core at all. The failure does not look like "not isolated" — the device
+    registers over HTTP and shows up in the dashboard while none of its topics ever
+    carry data, which sends you looking at the driver instead of at compose.
+
+  * FASTDDS_BUILTIN_TRANSPORTS is absent. It contradicts the profile's
+    useBuiltinTransports=false, and the XML wins, so the variable does nothing except
+    tell the next reader something untrue.
+
+  * domain 42, spelled either ROS_DOMAIN_ID or <PREFIX>_ROS_DOMAIN_ID for a driver
+    that holds two contexts. There is nothing to allocate here; a different number is
+    a mistake, not a choice.
+
+  * network_mode: host. Isolation works by confining DDS to loopback, and containers
+    share a loopback only under host networking.
+
+KNOWN_GAPS below is the honest part: a driver whose RMW is CycloneDDS is not covered by
+a FastDDS profile at all, and saying so out loud beats letting it pass a check named
+"isolation". Those are reported and counted, but do not fail the run.
+"""
+
+import os
+import sys
+import glob
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML required: pip3 install pyyaml")
+
+PROFILE = '/opt/phanthy-motus/dds-local.xml'
+MOUNT = f'{PROFILE}:{PROFILE}:ro'
+DOMAIN = '42'
+
+# Drivers that must NOT set FASTRTPS_DEFAULT_PROFILES_FILE, with the reason. A
+# process-wide default applies to every participant in the process, so a driver holding
+# a body context and an Agent Core context in one process has to select per context —
+# it sets the variable around each rclpy.init() instead. The mount is still required.
+IN_CODE_PROFILE = {
+    'x-humanoid/tianyi2.0': 'DualDomainROS2 in main.py sets the variable per rclpy.init() '
+                            '(body on domain 0 via the vendor profile, core on 42)',
+}
+
+# Drivers a FastDDS profile cannot isolate, with what they would need instead. Reported,
+# not fatal — the point is that the gap stays visible rather than passing as compliant.
+KNOWN_GAPS = {
+    'engineai/t800': 'RMW is rmw_cyclonedds_cpp (Dockerfile T800_PREFERRED_RMW), so '
+                     'FASTRTPS_DEFAULT_PROFILES_FILE is inert; its CYCLONEDDS_URI binds '
+                     'NETWORK_INTERFACE for both contexts, leaving the domain-42 one on '
+                     'the LAN. Needs a CycloneDDS-level restriction for the core context.',
+}
+
+
+def env_map(env):
+    """Accept both list-of-KEY=VALUE and mapping forms; compose allows either."""
+    if isinstance(env, dict):
+        return {str(k): '' if v is None else str(v) for k, v in env.items()}
+    out = {}
+    for item in env or []:
+        k, _, v = str(item).partition('=')
+        out[k.strip()] = v.strip()
+    return out
+
+
+def check(path, driver):
+    """Return (violations, notes) for one service.yml."""
+    bad, notes = [], []
+    with open(path) as fh:
+        doc = yaml.safe_load(fh) or {}
+    if len(doc) != 1:
+        return [f'expected exactly one service, found {len(doc)}'], notes
+    svc = next(iter(doc.values())) or {}
+
+    volumes = [str(v) for v in (svc.get('volumes') or [])]
+    env = env_map(svc.get('environment'))
+
+    gap = KNOWN_GAPS.get(driver)
+
+    if MOUNT not in volumes:
+        # A read-write mount also works, but ro is the intent and a typo'd path is the
+        # failure mode we are actually guarding against: Docker silently creates a
+        # *directory* of that name, FastDDS falls back to every interface, nothing logs.
+        loose = [v for v in volumes if PROFILE in v]
+        if loose:
+            bad.append(f'profile mounted as {loose[0]!r}, expected {MOUNT!r}')
+        elif not gap:
+            bad.append(f'missing volume {MOUNT!r} — without it the container is not isolated, '
+                       'and a mistyped path fails silently')
+
+    reason = IN_CODE_PROFILE.get(driver)
+    have_var = env.get('FASTRTPS_DEFAULT_PROFILES_FILE')
+    if reason:
+        if have_var:
+            bad.append(f'must NOT set FASTRTPS_DEFAULT_PROFILES_FILE: {reason}')
+        else:
+            notes.append(f'profile selected in code — {reason}')
+    elif not gap:
+        if not have_var:
+            bad.append('missing FASTRTPS_DEFAULT_PROFILES_FILE — the mount alone selects nothing')
+        elif have_var != PROFILE:
+            bad.append(f'FASTRTPS_DEFAULT_PROFILES_FILE={have_var}, expected {PROFILE}')
+
+    if 'FASTDDS_BUILTIN_TRANSPORTS' in env:
+        bad.append('remove FASTDDS_BUILTIN_TRANSPORTS — it conflicts with the profile\'s '
+                   'useBuiltinTransports=false and the XML wins anyway')
+
+    # Either the plain name, or a prefixed one for a driver with a second context.
+    domains = {k: v for k, v in env.items() if k.endswith('ROS_DOMAIN_ID')}
+    core = [v for k, v in domains.items()
+            if k == 'ROS_DOMAIN_ID' or k.startswith(('AGENT_CORE', 'CORE'))]
+    if core and DOMAIN not in core:
+        bad.append(f'Agent Core domain is {core}, expected {DOMAIN} — the same on every robot')
+    elif not domains and not reason and not gap:
+        notes.append('no ROS_DOMAIN_ID in the fragment; confirm it is set in the image')
+
+    # network_mode: host is load-bearing here, not boilerplate — isolation works by
+    # confining DDS to loopback, and containers only share a loopback under host
+    # networking. All 14 drivers set it. ipc/pid are deliberately *not* checked: they
+    # vary across drivers, the profile disables shared memory anyway, and failing five
+    # existing drivers over them on day one is how a checker earns being ignored.
+    if svc.get('network_mode') != 'host':
+        bad.append(f'network_mode is {svc.get("network_mode")!r}, expected \'host\' — '
+                   'containers share a loopback only under host networking, and loopback '
+                   'is what makes local peers reachable while the LAN is not')
+
+    if gap:
+        notes.append(f'KNOWN GAP — {gap}')
+    return bad, notes
+
+
+def main(argv):
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if argv:
+        paths = [os.path.join(root, a, 'deploy', 'service.yml') for a in argv]
+        for p in paths:
+            if not os.path.exists(p):
+                sys.exit(f'no such service.yml: {p}')
+    else:
+        paths = sorted(glob.glob(os.path.join(root, '*', '*', 'deploy', 'service.yml')))
+
+    failed = gaps = 0
+    for path in paths:
+        driver = os.path.relpath(os.path.dirname(os.path.dirname(path)), root)
+        try:
+            bad, notes = check(path, driver)
+        except Exception as exc:                      # noqa: BLE001 — report, keep going
+            print(f'FAIL {driver}\n       could not parse: {exc}')
+            failed += 1
+            continue
+        if bad:
+            failed += 1
+            print(f'FAIL {driver}')
+            for b in bad:
+                print(f'       {b}')
+        elif any(n.startswith('KNOWN GAP') for n in notes):
+            gaps += 1
+            print(f'GAP  {driver}')
+        else:
+            print(f'ok   {driver}')
+        for n in notes:
+            print(f'       note: {n}')
+
+    print(f'\n{len(paths)} checked, {failed} failed, {gaps} known gap(s)')
+    if failed:
+        print('See README_dev.md § "DDS isolation" for what each item is protecting against.')
+    return 1 if failed else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_service_yml.py
+++ b/scripts/check_service_yml.py
@@ -9,8 +9,9 @@ so it also works as a CI step.
 
 What it enforces, and why each item is worth a check rather than a README line:
 
-  * the loopback profile is mounted, and (unless the driver picks profiles in code)
-    selected via FASTRTPS_DEFAULT_PROFILES_FILE. Miss these and the container ends up
+  * the loopback profile is mounted and selected via FASTRTPS_DEFAULT_PROFILES_FILE, unless the
+    driver ships its own profile (see OWN_PROFILE — per-participant selection is impossible, so a
+    dual-context driver must pick one profile for the whole process). Miss these and the container ends up
     on a different transport from everything else on the machine, so it cannot reach
     Agent Core at all. The failure does not look like "not isolated" — the device
     registers over HTTP and shows up in the dashboard while none of its topics ever
@@ -49,9 +50,16 @@ DOMAIN = '42'
 # process-wide default applies to every participant in the process, so a driver holding
 # a body context and an Agent Core context in one process has to select per context —
 # it sets the variable around each rclpy.init() instead. The mount is still required.
-IN_CODE_PROFILE = {
-    'x-humanoid/tianyi2.0': 'DualDomainROS2 in main.py sets the variable per rclpy.init() '
-                            '(body on domain 0 via the vendor profile, core on 42)',
+# Drivers that must NOT set FASTRTPS_DEFAULT_PROFILES_FILE to the fleet profile, with the
+# reason. Per-participant selection is impossible (FastDDS caches profiles process-wide), so a
+# driver holding a body context and an Agent Core context in one process has to pick ONE profile
+# for the process — and the fleet's loopback-only one cuts the body link. These drivers ship their
+# own, so they do not need the mount either: requiring it would only suggest it is in use.
+OWN_PROFILE = {
+    'x-humanoid/tianyi2.0': 'two FastDDS contexts in one process (DualDomainROS2 in main.py, '
+                            'BridgeROS2 in joints_bridge.py); runs the vendor profile '
+                            '/work/dds_profile.xml process-wide, whose whitelist excludes the '
+                            'office LAN. Setting the fleet profile here cuts the body link.',
 }
 
 # Drivers a FastDDS profile cannot isolate, with what they would need instead. Reported,
@@ -60,7 +68,9 @@ KNOWN_GAPS = {
     'engineai/t800': 'RMW is rmw_cyclonedds_cpp (Dockerfile T800_PREFERRED_RMW), so '
                      'FASTRTPS_DEFAULT_PROFILES_FILE is inert; its CYCLONEDDS_URI binds '
                      'NETWORK_INTERFACE for both contexts, leaving the domain-42 one on '
-                     'the LAN. Needs a CycloneDDS-level restriction for the core context.',
+                     'the LAN. Closing it needs a CycloneDDS-side restriction; note that a '
+                     'single process gets one config there too, so it is the same '
+                     'one-profile-per-process constraint as tianyi.',
 }
 
 
@@ -89,7 +99,7 @@ def check(path, driver):
 
     gap = KNOWN_GAPS.get(driver)
 
-    if MOUNT not in volumes:
+    if MOUNT not in volumes and driver not in OWN_PROFILE:
         # A read-write mount also works, but ro is the intent and a typo'd path is the
         # failure mode we are actually guarding against: Docker silently creates a
         # *directory* of that name, FastDDS falls back to every interface, nothing logs.
@@ -100,13 +110,13 @@ def check(path, driver):
             bad.append(f'missing volume {MOUNT!r} — without it the container is not isolated, '
                        'and a mistyped path fails silently')
 
-    reason = IN_CODE_PROFILE.get(driver)
+    reason = OWN_PROFILE.get(driver)
     have_var = env.get('FASTRTPS_DEFAULT_PROFILES_FILE')
     if reason:
         if have_var:
             bad.append(f'must NOT set FASTRTPS_DEFAULT_PROFILES_FILE: {reason}')
         else:
-            notes.append(f'profile selected in code — {reason}')
+            notes.append(f'ships its own process-wide profile — {reason}')
     elif not gap:
         if not have_var:
             bad.append('missing FASTRTPS_DEFAULT_PROFILES_FILE — the mount alone selects nothing')

--- a/unitree/g1/deploy/service.yml
+++ b/unitree/g1/deploy/service.yml
@@ -6,12 +6,13 @@ unitree-g1:
   pid: host
   privileged: true
   volumes:
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
     - /dev:/dev
     - /opt/phanthy-motus/data:/opt/phanthy-motus/data
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-    - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
   logging:
     driver: local

--- a/unitree/go1/deploy/service.yml
+++ b/unitree/go1/deploy/service.yml
@@ -6,12 +6,13 @@ unitree-go1-bundle:              # 服务名遵循 {provider}-{model}-{bundle} �
   pid: host
   privileged: true
   volumes:
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
     - /dev:/dev
     - /opt/phanthy-motus/data:/opt/phanthy-motus/data
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-    - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
     # Go1 EDU 控制目标（默认板载网段）；网口留空自动探测
     - NETWORK_INTERFACE=

--- a/unitree/go2/deploy/service.yml
+++ b/unitree/go2/deploy/service.yml
@@ -6,6 +6,7 @@ unitree-go2:
   pid: host
   privileged: true
   volumes:
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
     - /dev:/dev
     - /unitree/module:/unitree/module
     - /home/unitree/cyclonedds_ws:/home/unitree/cyclonedds_ws:ro
@@ -16,7 +17,7 @@ unitree-go2:
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-    - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
   logging:
     driver: local

--- a/unitree/r1/deploy/service.yml
+++ b/unitree/r1/deploy/service.yml
@@ -6,11 +6,12 @@ unitree-r1:
   pid: host
   privileged: true
   volumes:
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
     - /dev:/dev
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-    - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
   logging:
     driver: local

--- a/x-humanoid/tianyi2.0/deploy/service.yml
+++ b/x-humanoid/tianyi2.0/deploy/service.yml
@@ -9,13 +9,14 @@ tianyi2:
     - /dev:/dev
     - /opt/phanthy-motus/data:/opt/phanthy-motus/data
     - /home/nvidia/data/param/dds_profile.xml:/work/dds_profile.xml:ro
-    # The loopback profile, used for the *agent-core* context only. Deliberately not
-    # set as FASTRTPS_DEFAULT_PROFILES_FILE in `environment`: this driver holds two
-    # DDS contexts in one process (body on domain 0 via the vendor profile above,
-    # agent-core on domain 42) and picks a profile per context by setting the variable
-    # around each rclpy.init(). A process-wide default would put the body link on
-    # loopback and cut it. See DualDomainROS2 in main.py.
-    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
+    # No /opt/phanthy-motus/dds-local.xml mount, and no FASTRTPS_DEFAULT_PROFILES_FILE
+    # in `environment`. This driver holds two DDS contexts in one process (body on
+    # domain 0, agent-core on domain 42), FastDDS caches profiles process-wide, so one
+    # profile is all the process gets — and the fleet's loopback-only one confines the
+    # body context to 127.0.0.1, cutting the link to the vendor stack on 192.168.41.x.
+    # It therefore uses the vendor profile above for both, whose whitelist
+    # {192.168.41.2, 127.0.0.1} still excludes the office LAN, which is what the
+    # fleet-wide isolation is for. See DualDomainROS2._select_profile in main.py.
   environment:
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
     - PYTHONUNBUFFERED=1

--- a/x-humanoid/tianyi2.0/deploy/service.yml
+++ b/x-humanoid/tianyi2.0/deploy/service.yml
@@ -9,6 +9,13 @@ tianyi2:
     - /dev:/dev
     - /opt/phanthy-motus/data:/opt/phanthy-motus/data
     - /home/nvidia/data/param/dds_profile.xml:/work/dds_profile.xml:ro
+    # The loopback profile, used for the *agent-core* context only. Deliberately not
+    # set as FASTRTPS_DEFAULT_PROFILES_FILE in `environment`: this driver holds two
+    # DDS contexts in one process (body on domain 0 via the vendor profile above,
+    # agent-core on domain 42) and picks a profile per context by setting the variable
+    # around each rclpy.init(). A process-wide default would put the body link on
+    # loopback and cut it. See DualDomainROS2 in main.py.
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
   environment:
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
     - PYTHONUNBUFFERED=1

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -4523,77 +4523,192 @@ class TtsPlugin:
         # Health check: verify PlayEvent pipeline is working
         self._startup_error = self._lyre_health_check()
 
-    def _lyre_health_check(self) -> str | None:
-        """Call play_text and verify PlayEvent arrives. Returns error message or None."""
+    # lyre is a host systemd unit; the driver reaches it through PID 1's namespaces.
+    _LYRE_UNIT = "lyre"
+    _NSENTER = ["nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p", "--"]
+    # Discovery of play_text measured 2.0–2.9 s on a settled robot, but start() runs
+    # while ~35 plugins are initialising. A generous window costs nothing when things
+    # work and avoids the misdiagnosis below; the first version allowed 5 s.
+    _DISCOVERY_WAIT_S = 20.0
+    # `systemctl restart lyre` stops a ros2 launch tree and starts it again. The first
+    # version capped the subprocess at 15 s and reported the restart as *failed* while
+    # it was in fact still working.
+    _RESTART_CMD_TIMEOUT_S = 90
+    _RESTART_DISCOVERY_WAIT_S = 60.0
+
+    def _lyre_unit_state(self) -> str:
+        """systemd's view of lyre, which does not depend on DDS at all.
+
+        This is what separates "lyre is down" from "lyre is fine but our participant
+        has not discovered it": the two need opposite responses, and DDS visibility
+        alone cannot tell them apart.
+        """
         import subprocess as _sp
+        try:
+            r = _sp.run(self._NSENTER + ["systemctl", "is-active", self._LYRE_UNIT],
+                        capture_output=True, timeout=10, text=True)
+            return ((r.stdout or "") + (r.stderr or "")).strip() or "unknown"
+        except Exception as e:
+            return f"unknown ({e})"
+
+    def _restart_lyre(self) -> str | None:
+        """Restart lyre. Returns an error string, or None on success."""
+        import subprocess as _sp
+        print(f"[TtsPlugin] restarting lyre (unit state was "
+              f"{self._lyre_unit_state()!r})", flush=True)
+        try:
+            r = _sp.run(self._NSENTER + ["systemctl", "restart", self._LYRE_UNIT],
+                        capture_output=True, timeout=self._RESTART_CMD_TIMEOUT_S, text=True)
+        except Exception as e:
+            return f"重启 lyre 失败：{e}"
+        if r.returncode != 0:
+            return f"重启 lyre 失败：{((r.stderr or r.stdout) or '').strip()[:200]}"
+        state = self._lyre_unit_state()
+        print(f"[TtsPlugin] lyre restarted, unit state now {state!r}", flush=True)
+        return None
+
+    def _wait_service(self, timeout_s: float) -> bool:
+        """Poll for the play_text server. No spinning needed — graph discovery happens
+        in the DDS threads, and the executor thread may not be running yet."""
+        import time as _time
+        deadline = _time.time() + timeout_s
+        while _time.time() < deadline:
+            if self._play_client.service_is_ready():
+                return True
+            _time.sleep(0.2)
+        return False
+
+    def _lyre_health_check(self) -> str | None:
+        """Verify the whole TTS chain: service discoverable → call accepted → PlayEvent
+        arrives. Returns an error message, or None when healthy.
+
+        Each failure mode gets its own message. The first version returned
+        "播放成功但无法收到完成事件" for all five of them, including the case where the
+        service was never discovered and nothing was ever played — which pointed the
+        investigation at the audio hardware for a while. It also restarted lyre on any
+        failure, so a discovery problem in this driver was "fixed" by killing a
+        perfectly healthy service, and the retry then ran before lyre could come back.
+        """
         import time as _time
 
         for attempt in range(2):
-            if attempt > 0:
-                # Restart lyre via nsenter on second attempt
-                print("[TtsPlugin] health check failed, restarting lyre...", flush=True)
-                try:
-                    _sp.run(["nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p", "--",
-                             "systemctl", "restart", "lyre"],
-                            capture_output=True, timeout=15)
-                    _time.sleep(5)
-                except Exception as e:
-                    print(f"[TtsPlugin] lyre restart failed: {e}", flush=True)
+            if not self._wait_service(self._DISCOVERY_WAIT_S):
+                state = self._lyre_unit_state()
+                if state != "active":
+                    # lyre really is down — restarting it is the right recovery, and
+                    # this is the only path where a restart is warranted up front.
+                    print(f"[TtsPlugin] play_text not found and lyre is {state!r} "
+                          f"— restarting", flush=True)
+                    err = self._restart_lyre()
+                    if err:
+                        return (f"Lyre 服务未运行（systemd: {state}），自动重启失败。{err} "
+                                f"请在机器人上执行 sudo systemctl restart lyre。")
+                    if not self._wait_service(self._RESTART_DISCOVERY_WAIT_S):
+                        return (f"Lyre 服务原为 {state}，已自动重启并恢复运行，但 "
+                                f"{self._RESTART_DISCOVERY_WAIT_S:.0f}s 内仍未发现 "
+                                f"/audio_play/play_text 服务。请检查 lyre 日志："
+                                f"journalctl -u lyre -n 100。")
+                    print("[TtsPlugin] play_text found after lyre restart", flush=True)
+                else:
+                    # lyre is up but we cannot see it. Restarting lyre would destroy a
+                    # working service without touching the actual fault, which is on
+                    # our side of the link (DDS domain / profile / interface).
+                    print(f"[TtsPlugin] play_text not discovered in "
+                          f"{self._DISCOVERY_WAIT_S:.0f}s, but lyre is active "
+                          f"— not restarting it", flush=True)
+                    return (f"Lyre 服务正在运行（systemd: active），但 "
+                            f"{self._DISCOVERY_WAIT_S:.0f}s 内发现不到 "
+                            f"/audio_play/play_text。问题在驱动到 lyre 的 DDS 链路，"
+                            f"不在 lyre 本身：请核对 domain 0 与 FastDDS profile "
+                            f"（本驱动应使用厂商 profile /work/dds_profile.xml，"
+                            f"需能绑到 192.168.41.x）。重启 lyre 不会有帮助。")
 
-            # Wait for service to be available (poll without spinning — executor thread handles it)
-            service_ready = False
-            deadline = _time.time() + 5
-            while _time.time() < deadline:
-                if self._play_client.service_is_ready():
-                    service_ready = True
-                    break
-                _time.sleep(0.2)
-            if not service_ready:
-                print(f"[TtsPlugin] health check attempt {attempt+1}: play_text service not available", flush=True)
-                continue
-
-            # Send a silent test (single dot — minimal TTS)
+            # Service is there — send a minimal test and require a real response.
             from lyre_msgs.srv import PlayText
             req = PlayText.Request()
             req.text = "."
             req.force = True
             future = self._play_client.call_async(req)
-
-            # Wait for response (max 3s) — executor spin thread delivers it
-            deadline = _time.time() + 3
+            deadline = _time.time() + 5
             while not future.done() and _time.time() < deadline:
                 _time.sleep(0.1)
-
             if not future.done():
-                print(f"[TtsPlugin] health check attempt {attempt+1}: play_text call timeout", flush=True)
-                continue
+                print(f"[TtsPlugin] health check attempt {attempt+1}: "
+                      f"play_text 调用无响应", flush=True)
+                if attempt == 0:
+                    err = self._restart_lyre()
+                    if err:
+                        return f"play_text 服务可见但调用无响应，且{err}"
+                    continue
+                return ("Lyre 的 play_text 服务可见，但调用 5s 无响应，重启后依旧。"
+                        "lyre 进程可能已卡死：请查看 journalctl -u lyre -n 100。")
 
             resp = future.result()
             if resp is None or resp.code != 0:
-                print(f"[TtsPlugin] health check attempt {attempt+1}: play_text returned error", flush=True)
-                continue
+                msg = getattr(resp, "message", "") if resp is not None else "no response"
+                print(f"[TtsPlugin] health check attempt {attempt+1}: "
+                      f"play_text 返回错误 code={getattr(resp, 'code', '?')}", flush=True)
+                if attempt == 0:
+                    if self._restart_lyre() is None:
+                        continue
+                return (f"Lyre 拒绝了合成请求：code="
+                        f"{getattr(resp, 'code', '?')} message={msg!r}。"
+                        f"请检查 lyre 的 TTS 引擎与授权状态。")
 
             sid = resp.sid
-            # Wait for PlayEvent with this sid (3s timeout)
-            # The executor spin thread will call _on_play_event which populates _play_event_buffer
-            deadline = _time.time() + 3
+            if not sid:
+                # lyre generates a sid when the request omits one, so an empty sid
+                # means we cannot correlate PlayEvent and every playback would fall
+                # back to a fixed sleep.
+                return ("Lyre 接受了请求但未返回 sid，无法与 PlayEvent 关联，"
+                        "播放完成时间将不可知。请检查 lyre 版本是否匹配 lyre_msgs。")
+
+            deadline = _time.time() + 5
             while _time.time() < deadline:
                 if sid in self._play_event_buffer:
                     break
                 _time.sleep(0.1)
 
             if sid in self._play_event_buffer:
-                # Cleanup test sid from buffers
                 self._play_event_buffer.pop(sid, None)
                 self._pending_play.pop(sid, None)
                 self._pending_play_status.pop(sid, None)
                 self._pending_play_duration.pop(sid, None)
                 print(f"[TtsPlugin] health check passed (attempt {attempt+1})", flush=True)
-                return None  # success
-            else:
-                print(f"[TtsPlugin] health check attempt {attempt+1}: PlayEvent not received for sid={sid}", flush=True)
+                return None
 
-        return "Lyre TTS PlayEvent 链路异常：播放成功但无法收到完成事件。已尝试重启 lyre 仍未恢复，请检查 lyre 服务状态。"
+            # Call accepted, no event. This is the one case the original message
+            # described, and the one where restarting lyre is genuinely indicated.
+            print(f"[TtsPlugin] health check attempt {attempt+1}: "
+                  f"PlayEvent not received for sid={sid}", flush=True)
+            if attempt == 0:
+                err = self._restart_lyre()
+                if err:
+                    return f"播放成功但收不到 PlayEvent 完成事件，且{err}"
+                continue
+
+        return ("Lyre TTS 事件链路异常：合成请求被接受，但收不到 /audio_play/event "
+                "的完成事件，已自动重启 lyre 仍未恢复。播放时长将只能按字数估算。"
+                "请检查 lyre 服务：journalctl -u lyre -n 100。")
+
+    def _recheck_health(self) -> str | None:
+        """Cheap re-check for start/info: is the service there, and what does systemd
+        say? Plays nothing.
+
+        The startup result used to be latched forever, so once the check had failed
+        the dashboard kept reporting a fault long after the chain recovered.
+        """
+        if not self._play_client:
+            return "Lyre TTS 客户端未创建（lyre_msgs 导入失败）。"
+        if self._wait_service(3.0):
+            return None
+        state = self._lyre_unit_state()
+        if state != "active":
+            return (f"Lyre 服务未运行（systemd: {state}）。"
+                    f"请执行 sudo systemctl restart lyre，或重启本驱动容器以自动恢复。")
+        return (f"Lyre 服务正在运行，但当前发现不到 /audio_play/play_text。"
+                f"这是驱动到 lyre 的 DDS 链路问题（domain 0 / FastDDS profile），"
+                f"重启 lyre 无用。")
 
     # PlayEvent event codes
     _EVENT_NAMES = {0: "STARTED", 1: "COMPLETED", 2: "STOPPED", 3: "CANCELLED", 4: "FAILED"}
@@ -4644,8 +4759,20 @@ class TtsPlugin:
         elif action == "resume":
             return self._call_empty_service(self._resume_client, "resume")
         elif action in ("start", "info"):
-            if hasattr(self, '_startup_error') and self._startup_error:
-                return {"state": "error", "message": self._startup_error}
+            # Re-check rather than replay the startup verdict. The startup result used
+            # to be latched for the life of the process, so a chain that recovered
+            # (lyre finished restarting, discovery converged) still reported a fault
+            # on every start/info — and the operator had no way to clear it short of
+            # restarting the container.
+            if getattr(self, "_startup_error", None):
+                current = self._recheck_health()
+                if current is None:
+                    print("[TtsPlugin] startup error cleared — chain is healthy now",
+                          flush=True)
+                    self._startup_error = None
+                    return {"state": "ready"}
+                self._startup_error = current
+                return {"state": "error", "message": current}
             return {"state": "ready"}
         return {"error": f"unknown action: {action}"}
 
@@ -4740,10 +4867,20 @@ class TtsPlugin:
                 break
 
             seg_sid = None
+            no_response = False
             if future.done():
                 result = future.result()
                 if result:
                     seg_sid = getattr(result, 'sid', None)
+                else:
+                    no_response = True
+            else:
+                # The call never came back. Nothing is playing: lyre either is not
+                # there or is wedged. Distinguished from "responded without a sid"
+                # because that one may well be audible, whereas this one is silence.
+                no_response = True
+                print(f"[TtsPlugin] no response from play_text in "
+                      f"{timeout_service:.0f}s seg {i+1}/{len(segments)}", flush=True)
             if seg_sid:
                 sid = seg_sid
 
@@ -4821,6 +4958,17 @@ class TtsPlugin:
                     continue
                 elif seg_status == "error" and is_last:
                     overall_status = "error"
+            elif no_response:
+                # Do not sleep-then-claim-success. This path used to fall into the
+                # fallback below and report ACP completed, so a silent robot looked
+                # like a successful utterance — verified on the robot, lyre had
+                # received nothing at all while the driver reported completion.
+                overall_status = "error"
+                print(f"[TtsPlugin] seg {i+1}/{len(segments)}: play_text 无响应，"
+                      f"未发声，报错而非假成功", flush=True)
+                self._startup_error = self._recheck_health() or (
+                    "play_text 调用无响应。")
+                break
             elif not seg_sid:
                 # 没拿到 sid，fallback 按字数估算（但也要检查 cancel）
                 fallback_s = len(seg_text) / 2.5 + 5.0
@@ -4845,9 +4993,14 @@ class TtsPlugin:
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
+            acp_result = {"action": "speak", "sid": sid or "unknown",
+                          "segments": len(segments)}
+            # Carry the reason, not just the verdict — "error" with no detail sends the
+            # reader to the logs, and this is the field the dashboard already shows.
+            if overall_status == "error" and getattr(self, "_startup_error", None):
+                acp_result["error"] = self._startup_error
             p = _json.dumps({"action_id": action_id, "status": overall_status,
-                             "result": {"action": "speak", "sid": sid or "unknown",
-                                        "segments": len(segments)}}).encode()
+                             "result": acp_result}).encode()
             r = urllib.request.Request(f"{url}/api/acp/complete", data=p,
                                       headers={"Content-Type": "application/json"}, method="POST")
             urllib.request.urlopen(r, timeout=5, context=ctx)

--- a/x-humanoid/tianyi2.0/joints_bridge.py
+++ b/x-humanoid/tianyi2.0/joints_bridge.py
@@ -25,7 +25,14 @@ class BridgeROS2:
         self.ctx_tianyi = Context()
         rclpy.init(context=self.ctx_tianyi, domain_id=0)
         self.executor_tianyi = rclpy.executors.MultiThreadedExecutor(context=self.ctx_tianyi)
-        os.environ.pop("FASTRTPS_DEFAULT_PROFILES_FILE", None)
+        # Domain 42 reaches agent-core on this same host, so it is loopback-only.
+        # Popping the variable here left it on every interface — see the longer note
+        # in main.py's DualDomainROS2, which carries the same pair of contexts.
+        core_profile = "/opt/phanthy-motus/dds-local.xml"
+        if os.path.exists(core_profile):
+            os.environ["FASTRTPS_DEFAULT_PROFILES_FILE"] = core_profile
+        else:
+            os.environ.pop("FASTRTPS_DEFAULT_PROFILES_FILE", None)
         self.ctx_core = Context()
         rclpy.init(context=self.ctx_core, domain_id=42)
         self.executor_core = rclpy.executors.MultiThreadedExecutor(context=self.ctx_core)

--- a/x-humanoid/tianyi2.0/joints_bridge.py
+++ b/x-humanoid/tianyi2.0/joints_bridge.py
@@ -19,20 +19,23 @@ from device import StatePlugin
 
 class BridgeROS2:
     def __init__(self):
+        # One profile for the whole process: FastDDS caches XML profiles, so switching
+        # FASTRTPS_DEFAULT_PROFILES_FILE between the two contexts cannot give them
+        # different ones — it only decides which single profile both use, and getting
+        # that wrong silently cut the body link. Full account in main.py's
+        # DualDomainROS2._select_profile. The vendor whitelist
+        # {192.168.41.2, 127.0.0.1} keeps the body reachable and excludes the office
+        # LAN, which is what the domain-42 isolation is for.
         dds_profile = "/work/dds_profile.xml"
         if os.path.exists(dds_profile):
             os.environ["FASTRTPS_DEFAULT_PROFILES_FILE"] = dds_profile
+        else:
+            os.environ.pop("FASTRTPS_DEFAULT_PROFILES_FILE", None)
+            print(f"[joints-bridge] WARNING {dds_profile} missing — both domains will "
+                  f"use every interface, including the office LAN", flush=True)
         self.ctx_tianyi = Context()
         rclpy.init(context=self.ctx_tianyi, domain_id=0)
         self.executor_tianyi = rclpy.executors.MultiThreadedExecutor(context=self.ctx_tianyi)
-        # Domain 42 reaches agent-core on this same host, so it is loopback-only.
-        # Popping the variable here left it on every interface — see the longer note
-        # in main.py's DualDomainROS2, which carries the same pair of contexts.
-        core_profile = "/opt/phanthy-motus/dds-local.xml"
-        if os.path.exists(core_profile):
-            os.environ["FASTRTPS_DEFAULT_PROFILES_FILE"] = core_profile
-        else:
-            os.environ.pop("FASTRTPS_DEFAULT_PROFILES_FILE", None)
         self.ctx_core = Context()
         rclpy.init(context=self.ctx_core, domain_id=42)
         self.executor_core = rclpy.executors.MultiThreadedExecutor(context=self.ctx_core)

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -327,8 +327,25 @@ class DualDomainROS2:
         rclpy.init(context=self.ctx_tianyi, domain_id=0)
         self.executor_tianyi = rclpy.executors.MultiThreadedExecutor(context=self.ctx_tianyi)
 
-        # Domain 42: publish to agent-core (no DDS profile — use all interfaces)
-        os.environ.pop("FASTRTPS_DEFAULT_PROFILES_FILE", None)
+        # Domain 42: publish to agent-core. Loopback-only, because agent-core runs on
+        # this same host and nothing off-machine has any business on this domain —
+        # `/remote_control/message` carries *commands*, and DDS has no addressing, so
+        # every ROS_DOMAIN_ID=42 subscriber on the subnet used to receive them (one
+        # instruction typed on one robot was executed by a second one, same timestamp
+        # in both logs). Popping the variable here left this context on all
+        # interfaces, which is the one gap the fleet-wide profile could not close:
+        # this process sets the variable itself, so compose cannot do it for us.
+        #
+        # Falls back to popping only if the profile is missing, so a container that
+        # predates the mount still starts rather than failing to reach agent-core.
+        core_profile = "/opt/phanthy-motus/dds-local.xml"
+        if os.path.exists(core_profile):
+            os.environ["FASTRTPS_DEFAULT_PROFILES_FILE"] = core_profile
+            print(f"[ros2] domain42: using DDS profile {core_profile}")
+        else:
+            os.environ.pop("FASTRTPS_DEFAULT_PROFILES_FILE", None)
+            print(f"[ros2] domain42: {core_profile} missing — NOT isolated, "
+                  f"traffic will reach every interface")
         self.ctx_core = Context()
         rclpy.init(context=self.ctx_core, domain_id=42)
         self.executor_core = rclpy.executors.MultiThreadedExecutor(context=self.ctx_core)

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -314,38 +314,77 @@ def _resolve_namespace(cfg: dict) -> str:
 # ── Dual Domain ROS2 Init ────────────────────────────────────────────────────
 
 class DualDomainROS2:
-    """Manages two ROS2 contexts: domain 0 (tianyi) and domain 42 (agent-core)."""
+    """Manages two ROS2 contexts: domain 0 (tianyi) and domain 42 (agent-core).
+
+    Both contexts share **one** FastDDS profile, because that is all FastDDS offers a
+    single process — see ``_select_profile``.
+    """
+
+    @staticmethod
+    def _select_profile() -> str:
+        """Load the one FastDDS profile this process gets, before any participant.
+
+        Two things were learned the hard way here, both silent when wrong.
+
+        **FastDDS reads FASTRTPS_DEFAULT_PROFILES_FILE at participant creation, not at
+        ``rclpy.init()``** — and rmw_fastrtps creates the participant lazily, with the
+        first Node on the context. Code that set the variable around each
+        ``rclpy.init()`` was therefore setting it around the wrong call: by the time
+        the first real Node appeared, the variable held whatever had been written last,
+        and both contexts got that.
+
+        **And the profiles are cached process-wide anyway**, so switching the variable
+        between contexts cannot give them different profiles. Measured on the robot: a
+        process that set the vendor profile, created a domain-0 node, then set the
+        loopback profile and created a domain-42 node, ended up with *both* domains
+        bound to 127.0.0.1 and 192.168.41.2 — the vendor whitelist, for both. An
+        earlier version of this file claimed to select a profile per context and was
+        cited elsewhere as proof that per-participant profiles work. It never worked.
+
+        What the wrong profile costs: with the loopback-only profile in force, the
+        domain-0 participant bound 127.0.0.1 but not 192.168.41.2, where the vendor
+        stack lives. Visible domain-0 topics fell from 77 to 33 and lyre's
+        ``/audio_play/play_text`` became undiscoverable (2.76 s to discover under the
+        vendor profile; still nothing after 15 s under the loopback one). Nothing was
+        logged, ``/arm/status`` and ``/head/status`` survived, so the robot looked
+        healthy while TTS reported success and made no sound.
+
+        So: the vendor profile, for the whole process. Its whitelist is
+        {192.168.41.2, 127.0.0.1}, which keeps the body link up and — the point of the
+        fleet-wide isolation — **excludes the office LAN**, so domain 42 cannot carry
+        `/remote_control/message` to another robot. It is not loopback-only: domain 42
+        is also reachable from the body board on 192.168.41.x. That board runs no
+        Agent Core and is internal to this robot, so nothing there can act on a
+        command. Narrowing it further needs the agent-core-facing publishers moved
+        into their own process, one profile each.
+        """
+        vendor = "/work/dds_profile.xml"
+        if os.path.exists(vendor):
+            os.environ["FASTRTPS_DEFAULT_PROFILES_FILE"] = vendor
+            print(f"[ros2] process-wide DDS profile: {vendor} "
+                  f"(whitelist 192.168.41.2 + 127.0.0.1 — body link up, office LAN "
+                  f"excluded on both domain 0 and domain 42)")
+            return vendor
+        os.environ.pop("FASTRTPS_DEFAULT_PROFILES_FILE", None)
+        print(f"[ros2] WARNING {vendor} missing — no DDS profile. Both domains will "
+              f"use every interface, including the office LAN: domain 42 is NOT "
+              f"isolated and commands may reach other robots.")
+        return ""
 
     def __init__(self):
-        # Domain 0: connect to tianyi body controller
-        # Use lyre's DDS profile so we can discover topics on 192.168.41.x / 127.0.0.1
-        dds_profile = "/work/dds_profile.xml"
-        if os.path.exists(dds_profile):
-            os.environ["FASTRTPS_DEFAULT_PROFILES_FILE"] = dds_profile
-            print(f"[ros2] domain0: using DDS profile {dds_profile}")
+        # One profile, chosen before any participant exists.
+        self._dds_profile = self._select_profile()
+
+        # Domain 0: the tianyi body controller, on 192.168.41.x.
         self.ctx_tianyi = Context()
         rclpy.init(context=self.ctx_tianyi, domain_id=0)
         self.executor_tianyi = rclpy.executors.MultiThreadedExecutor(context=self.ctx_tianyi)
 
-        # Domain 42: publish to agent-core. Loopback-only, because agent-core runs on
-        # this same host and nothing off-machine has any business on this domain —
-        # `/remote_control/message` carries *commands*, and DDS has no addressing, so
-        # every ROS_DOMAIN_ID=42 subscriber on the subnet used to receive them (one
-        # instruction typed on one robot was executed by a second one, same timestamp
-        # in both logs). Popping the variable here left this context on all
-        # interfaces, which is the one gap the fleet-wide profile could not close:
-        # this process sets the variable itself, so compose cannot do it for us.
-        #
-        # Falls back to popping only if the profile is missing, so a container that
-        # predates the mount still starts rather than failing to reach agent-core.
-        core_profile = "/opt/phanthy-motus/dds-local.xml"
-        if os.path.exists(core_profile):
-            os.environ["FASTRTPS_DEFAULT_PROFILES_FILE"] = core_profile
-            print(f"[ros2] domain42: using DDS profile {core_profile}")
-        else:
-            os.environ.pop("FASTRTPS_DEFAULT_PROFILES_FILE", None)
-            print(f"[ros2] domain42: {core_profile} missing — NOT isolated, "
-                  f"traffic will reach every interface")
+        # Domain 42: Agent Core, on this same host. `/remote_control/message` carries
+        # *commands* and DDS has no addressing, so every ROS_DOMAIN_ID=42 subscriber on
+        # the subnet used to receive them — an instruction typed on one robot was
+        # executed by a second one, same timestamp in both logs. The whitelist above is
+        # what closes that: no office-LAN interface, so nothing off this robot.
         self.ctx_core = Context()
         rclpy.init(context=self.ctx_core, domain_id=42)
         self.executor_core = rclpy.executors.MultiThreadedExecutor(context=self.ctx_core)


### PR DESCRIPTION
## 为什么

`/remote_control/message` 是**指令**话题，此前在办公网上到达每一台机器人 —— 一台机器人上敲的指令被第二台一起执行，两边日志同一个时间戳。DDS 没有寻址也没有认证，同 domain 的订阅者全都收到。

## 做了什么

**所有驱动加载同一份 loopback profile**（`dds-local.xml`），把 FastDDS 限制在 `127.0.0.1`。容器都是 `network_mode: host`、共享同一个 loopback，所以本机互通、跨机物理断开。`ROS_DOMAIN_ID` 保持 42 不变 —— 零协调，没有需要人管理的唯一编号。

**驱动连机器人本体不受影响**：那条链路走 CycloneDDS 且显式绑网卡（`ChannelFactoryInitialize(0, "eth0")`），`FASTRTPS_DEFAULT_PROFILES_FILE` 只作用于 FastDDS。R1 真机验证：加载 profile 前后 `rt/lowstate` 的包数与 IMU 偏航角逐项一致。

**新增 `scripts/check_service_yml.py`**：遍历全部 14 个驱动检查这份契约，违规退出非零，可作 CI 步骤或 review 命令。七条规则逐条构造违规验证过都会触发。刻意不检查 `ipc`/`pid` —— 它们在各驱动间有正当差异，第一版把它们算必填时当场否掉 14 个里的 5 个既有驱动，那正是自检开始被无视的地方。

## 其中包含一个我自己引入的回归及其修复

`aa81d79` 想让天轶的 domain 42 单独走 loopback profile，做法是在两次 `rclpy.init()` 前后改环境变量。**两个前提都错**：FastDDS 读这个变量是在 **participant 创建时**（而 participant 跟着第一个 `Node` 懒创建），且**解析后的 profile 在进程内缓存**，切变量给不了两个 context 不同 profile。

结果 domain 0 也被锁进 loopback，而厂商栈在 `192.168.41.x`：可见话题 77→33、驱动自己 26 个节点从 domain 0 全消失、lyre 的 `/audio_play/play_text` 发现不了。但 `/arm/status`、`/head/status` 还活着，所以机器人看着正常，而 **TTS 报成功、不出声**（lyre 侧 journal 证实完全没收到请求）。全程无日志。

`6783fe5` 改为整进程一份 profile、用厂商那份，白名单 `{192.168.41.2, 127.0.0.1}`：本体通，**且不含办公网** —— 隔离真正要防的东西守住了。明确记录这不等于 loopback-only（domain 42 在本体板上仍可达，那块板不跑 Agent Core、属机器人内部）；要真收窄得把面向 agent-core 的发布拆进独立进程。

## 顺带把天轶 TTS 启动做成可诊断的

- 区分"lyre 真的没跑"（判据 `systemctl is-active`，与 DDS 无关）和"lyre 好着但我们发现不到"。前者才自动重启 lyre 并等到恢复；后者**不重启** —— 旧逻辑任何失败都重启，把驱动侧的发现问题"修"成杀掉一个健康服务，而且重启命令本身就超过它给的 15s 超时。
- 五条失败路径各自给出对应文案，不再一律报"播放成功但无法收到完成事件"（那句话在"服务都没发现、根本没播"时把排查引向了音频硬件）。
- 启动结论不再永久锁死：`start`/`info` 会做一次不发声的复查，好了自动清除。
- `speak` 拿不到 service response 时报 error，不再"睡 10 秒然后报 ACP completed"。

## 验证

天轶 2.0（10.100.129.72）：健康检查 attempt 1 通过且未重启 lyre；两个 domain 均绑 `127.0.0.1` + `192.168.41.2`、**无 10.100.x**；domain 0 上可见 26 个 `tianyi2_*` 节点（修复前 0 个）；`tts info` 返回 `ready`；通过驱动 speak 拿到 sid、`PlayProgress duration=3.1s`、`PlayEvent COMPLETED`，lyre journal 侧确认收到 started/completed；容器 `RestartCount=0`。

R1 真机确认本体链路不受影响（见上）。`check_service_yml.py` 全量：13 通过、1 已知缺口（`engineai/t800` 的 RMW 是 CycloneDDS，FastDDS profile 管不到，无硬件可验）。

## 遗留

- `engineai/t800` 的 domain 42 仍在局域网上 —— 已在文档和检查器里标为可见缺口，不是"已覆盖"。
- 天轶上目前是 `docker cp` 热修，需重建镜像固化。
- 运动指令未执行验证（安全铁律），仅验证了只读状态链路与音频。

🤖 Generated with [Claude Code](https://claude.com/claude-code)