### PR TITLE
declare x-resource on acting tools; plus tianyi2.0 socket bridge fixes

### DIFF
--- a/README_dev.md
+++ b/README_dev.md
@@ -1055,6 +1055,60 @@ def _nav_poll_thread(self, action_id, target, stall_timeout=60):
 - Tools without `x-completion` → unchanged behavior (sync return)
 - Tools that don't return `action_id` → no pending registered, barrier passes through
 - Drivers that don't POST completion → barrier will timeout gracefully (uses `x-completion.timeout`)
+- Tools without `x-resource` → treated as exclusive against **everything** (old global
+  barrier behaviour). Declaring is an optimisation, never a requirement.
+
+---
+
+## Physical Resources (`x-resource`)
+
+The ACP barrier is scoped by **physical channel**, not by tool type. Declare which
+channel(s) an action occupies, next to `x-completion`:
+
+```python
+"inputSchema": {
+    "type": "object",
+    "properties": { ... },
+    "required": ["action"],
+    "x-completion": {"actions": ["speak"], "timeout": 60},
+    "x-resource": "mouth",                    # or ["base", "arm_l"] for multi-channel
+}
+```
+
+**Why this exists.** The barrier used to block *any* acting tool on *any* pending
+action. That conflates two unrelated things — "I need X's result before Y"
+(causality) and "X and Y both need the mouth" (exclusion) — and implements neither,
+landing on "everyone waits for everyone". Speaking blocked navigating. One
+background agent speaking blocked every other agent's every actuator call, on
+unrelated hardware. `robotera/q5_bundle/` already splits `base_drive`,
+`arm_gesture`, `leg_control` and `waist_control` into separate tools; the global
+barrier serialised all four for no reason.
+
+**Naming.** A resource is a thing there is physically one of. Use the same string
+across every tool that drives the same hardware, and different strings for channels
+that genuinely move independently:
+
+| Channel | Typical tools |
+|---------|---------------|
+| `mouth` | `tts`, `speaker` |
+| `base`  | `loco`, `navigate`, `base_drive` |
+| `arm_l` / `arm_r` | `arm_gesture`, arm IK, gripper |
+| `leg`   | `leg_control`, `switch_mode` |
+| `waist` | `waist_control` |
+| `head`  | gimbal / head pan-tilt |
+
+**Rules.**
+
+- **Undeclared means exclusive against everything.** Omitting `x-resource` is safe;
+  a *wrong* one is not, since it can let two conflicting actions run at once.
+- Malformed values (`{}`, `42`, `""`, `[]`) fall back to undeclared rather than to
+  "conflicts with nothing" — a typo must not silently unlock parallel actuation.
+- One tool may hold several channels: `"x-resource": ["base", "arm_l"]` for an action
+  that drives while pointing. It then conflicts with anything touching either.
+- Two *different* drivers using the same channel name is meaningful and correct —
+  two `tts` tools on one robot are still one speaker.
+- This is orthogonal to `type`. `type` decides whether a tool is barriered at all
+  (`sensor`/`resource` never are); `x-resource` decides *what it waits for*.
 
 ---
 

--- a/README_dev.md
+++ b/README_dev.md
@@ -1056,7 +1056,8 @@ def _nav_poll_thread(self, action_id, target, stall_timeout=60):
 - Tools that don't return `action_id` → no pending registered, barrier passes through
 - Drivers that don't POST completion → barrier will timeout gracefully (uses `x-completion.timeout`)
 - Tools without `x-resource` → treated as exclusive against **everything** (old global
-  barrier behaviour). Declaring is an optimisation, never a requirement.
+  barrier behaviour). Safe, but see "Declare it on *every* acting tool" below: a
+  partially-declared driver is the case that behaves worst.
 
 ---
 
@@ -1109,6 +1110,68 @@ that genuinely move independently:
   two `tts` tools on one robot are still one speaker.
 - This is orthogonal to `type`. `type` decides whether a tool is barriered at all
   (`sensor`/`resource` never are); `x-resource` decides *what it waits for*.
+
+### Declare it on *every* acting tool, not only the async ones
+
+The barrier has two sides, and only one of them needs `x-completion`:
+
+| role | what `x-resource` does | needs `x-completion`? |
+|------|------------------------|------------------------|
+| **holder** | tells others what this action blocks while it runs | yes — only an async action has a pending |
+| **requester** | tells the barrier what this call must *wait for* | **no** — every `actuator`/`processor` tool asks |
+
+Miss the requester side and the tool asks with "undeclared", which means *conflicts
+with everything*, so it waits on any pending action anywhere on the robot. Measured
+on Tianyi, where `arm_gesture`/`tts` were declared but the direct-control `arm`/`head`
+were not:
+
+| observed | cause |
+|---|---|
+| head sat idle 5 s before moving | `head` (undeclared) waited on an `arm_gesture` pending |
+| arm sat idle 8 s before moving | `arm` (undeclared) waited on a `tts` pending |
+
+So **a partially-declared driver is worse than an undeclared one**: undeclared is
+uniformly serial and honest about it, partial looks like it should overlap and
+doesn't. It also compounds — with motions serialised behind unrelated channels,
+delegated subagents ran long enough to hit their delegation timeout, got cancelled
+mid-run, and the caller redid work that had already happened.
+
+Three-way summary of getting it wrong:
+
+- **undeclared** → safe, slow. No correctness risk.
+- **partially declared** → safe, slow, and *surprising*. This is the trap.
+- **wrongly declared** → the only case that is unsafe, because it permits
+  concurrency that the hardware does not.
+
+A tool that genuinely occupies no channel cannot say so — an empty `x-resource`
+normalises to "undeclared" on purpose, so a typo fails safe. Such a tool is almost
+always mis-typed: if it only reads state, give it `type: sensor` or `resource`, which
+exempts it from the barrier entirely. (Note that changing `type` also changes who may
+call it: a `viewer`-role peer may call sensor tools. Do not retype a tool casually.)
+
+### It is a vocabulary, not a fixed list — including for non-humanoids
+
+Agent Core contains **no channel names at all**; it only intersects the strings
+drivers declare. The names above are a humanoid convention, nothing more. A drone
+would declare `rotor`, `gimbal`, `camera`; an underwater vehicle `thruster`,
+`ballast`, `rudder`, `manipulator`. Nothing needs to change in the core for either.
+
+Two limits are worth knowing before relying on it:
+
+**It expresses mutual exclusion only.** Not ordering ("announce *before* moving"),
+not simultaneity ("both arms must start together"), not reader/writer sharing, not
+hierarchy (`arm_l` and a wrist-only tool are unrelated strings unless the wrist tool
+also declares `arm_l`), and not capacity (two motors each fine alone but not
+together). If your platform needs those, this is not the mechanism.
+
+**It assumes actions are discrete and bounded** — the same assumption `x-completion`
+makes. A multirotor's rotors are held *continuously* while airborne: hovering is a
+state, not an action that completes. Declaring `rotor` on a takeoff tool that never
+reports completion would hold that channel forever and block everything behind it.
+For continuous-state platforms, either keep the state-entering tool out of ACP
+(no `x-completion`, so no pending is held) or model the *transitions* as the actions.
+`dji/mavic3e` currently declares no `x-completion` at all, so it is in the first
+camp by default.
 
 ---
 

--- a/booster/k1/device.py
+++ b/booster/k1/device.py
@@ -715,6 +715,7 @@ class AudioPlugin:
                     "actions": ["play_sound"],
                     "timeout": 60,
                 },
+                "x-resource": "mouth",
             },
         }
 

--- a/robotera/q5_bundle/arm_gesture.py
+++ b/robotera/q5_bundle/arm_gesture.py
@@ -307,6 +307,12 @@ class Plugin:
                     "actions": ["salute", "welcome", "raise", "shake_hands", "high_five", "reset"],
                     "timeout": 60,
                 },
+                # Both arms, deliberately. `side` picks left/right/both per call, but
+                # x-resource is static per schema, so claiming only one would let a
+                # `side="both"` gesture run concurrently with a single-arm one on the
+                # same joints. Over-serialising left against right is the cheap
+                # mistake here; the other direction moves real hardware twice.
+                "x-resource": ["arm_l", "arm_r"],
             },
         }
 

--- a/robotera/q5_bundle/base_drive.py
+++ b/robotera/q5_bundle/base_drive.py
@@ -340,6 +340,9 @@ class Plugin:
                     "actions": ["forward", "backward", "turn_left", "turn_right", "move"],
                     "timeout": self._max_duration + (self._stop_repetitions / self._publish_rate) + 1.0,
                 },
+                # The chassis. Independent of the arms, the waist and the speaker —
+                # the old global ACP barrier serialised all of them against this.
+                "x-resource": "base",
             },
         }
 

--- a/robotera/q5_bundle/leg_control.py
+++ b/robotera/q5_bundle/leg_control.py
@@ -122,7 +122,10 @@ class Plugin:
                                 "x-completion": {
                                     "actions": ["set", "zero"],
                                     "timeout": 30,
-                                }}}
+                                },
+                                # Hip/knee/ankle. Independent of the arms, the waist
+                                # and the speaker.
+                                "x-resource": "leg"}}
 
     @staticmethod
     def _wait_future(future, timeout):

--- a/robotera/q5_bundle/waist_control.py
+++ b/robotera/q5_bundle/waist_control.py
@@ -190,6 +190,8 @@ class Plugin:
                     "actions": [*WAIST_ACTIONS.keys(), "reset"],
                     "timeout": 15,
                 },
+                # Waist yaw. Independent of legs, arms and the speaker.
+                "x-resource": "waist",
             }}
 
     def _safety(self):

--- a/unitree/g1/controlled_spatial.py
+++ b/unitree/g1/controlled_spatial.py
@@ -407,6 +407,9 @@ class ControlledSpatialPlugin:
                     "actions": ["navigate_to_tag", "navigate_to_pose"],
                     "timeout": 180,
                 },
+                # Drives the chassis. Same channel as loco — the two must serialise
+                # against each other, but a 180s navigation should not block speech.
+                "x-resource": "base",
                 "x-action-params": {
                     "start_mapping": {"params": ["map_name"], "description": "Start SLAM mapping with given map name"},
                     "stop_mapping": {"params": [], "description": "Stop mapping and save the map"},

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -1444,6 +1444,7 @@ class LocoPlugin:
                     "actions": ["move"],
                     "timeout": 60,
                 },
+                "x-resource": "base",
                 "x-action-params": {
                     "move":             {"params": ["vx", "vy", "vyaw", "duration"], "description": "Move with specified velocities. duration>0 for timed move, 0 or negative for continuous until stop."},
                     "stop_move":        {"params": [],                                 "description": "Stop all movement immediately"},
@@ -1541,6 +1542,12 @@ class LocoPlugin:
                     "actions": ["lie2standup", "standup2lie", "standup2squat", "squat2standup"],
                     "timeout": 150,
                 },
+                # Deliberately no x-resource. A posture transition moves the whole
+                # body, and nothing else should run during one — undeclared means
+                # exclusive against everything, which is exactly right here. This is
+                # the same reasoning that keeps switch_mode out of the interrupt
+                # sweep in agent-core: aborting a controlled descent partway is how
+                # it becomes a fall.
                 "x-action-params": {
                     "lie2standup":     {"params": [], "description": "躺起 (阻尼/零力矩 → 主运控)"},
                     "standup2lie":     {"params": [], "description": "安全躺下 (主运控 → 平衡蹲姿 → 阻尼)"},

--- a/x-humanoid/tianyi2.0/Dockerfile
+++ b/x-humanoid/tianyi2.0/Dockerfile
@@ -39,7 +39,7 @@ ENV LD_LIBRARY_PATH=/tianyi_ws/install/bodyctrl_msgs/lib:/tianyi_ws/install/lyre
 
 COPY resource/ /work/resource/
 COPY common/ /work/common/
-COPY main.py device.py joints_bridge.py light.py nav_client.py ext_devices.py config.yaml driver.yaml controlled_spatial.py controlled_spatial_map.py /work/
+COPY main.py device.py joints_bridge.py light.py nav_client.py ext_devices.py config.yaml driver.yaml controlled_spatial.py controlled_spatial_map.py socket_bridge.py bridge_integration.py bridged_publisher.py /work/
 COPY deploy/     /deploy/
 RUN mkdir -p /opt/phanthy-motus/data/maps
 

--- a/x-humanoid/tianyi2.0/Dockerfile
+++ b/x-humanoid/tianyi2.0/Dockerfile
@@ -40,6 +40,7 @@ ENV LD_LIBRARY_PATH=/tianyi_ws/install/bodyctrl_msgs/lib:/tianyi_ws/install/lyre
 COPY resource/ /work/resource/
 COPY common/ /work/common/
 COPY main.py device.py joints_bridge.py light.py nav_client.py ext_devices.py config.yaml driver.yaml controlled_spatial.py controlled_spatial_map.py socket_bridge.py bridge_integration.py bridged_publisher.py /work/
+COPY dds-local.xml /opt/phanthy-motus/
 COPY deploy/     /deploy/
 RUN mkdir -p /opt/phanthy-motus/data/maps
 

--- a/x-humanoid/tianyi2.0/bridged_publisher.py
+++ b/x-humanoid/tianyi2.0/bridged_publisher.py
@@ -45,6 +45,7 @@ class BridgedPublisher:
         self._socket = None
         self._connected = False
         self._msg_count = 0
+        self._send_lock = threading.Lock()  # Protect socket send operations
 
         # All publishers connect to the same main socket
         self.socket_path = os.path.join(self.SOCKET_DIR, self.MAIN_SOCKET)
@@ -114,10 +115,16 @@ class BridgedPublisher:
             serialized = serialize_message(msg)
 
             # Send: [4-byte length][serialized message]
-            self._socket.sendall(struct.pack("<I", len(serialized)))
-            self._socket.sendall(serialized)
+            # Use lock to prevent interleaving when multiple threads publish to same topic
+            with self._send_lock:
+                self._socket.sendall(struct.pack("<I", len(serialized)))
+                self._socket.sendall(serialized)
 
             self._msg_count += 1
+
+            # Debug: log first few IMU publishes
+            if "imu" in self.topic.lower() and self._msg_count <= 5:
+                print(f"[bridged_pub] {self.topic}: published msg #{self._msg_count}, size={len(serialized)} bytes", flush=True)
 
         except (BrokenPipeError, ConnectionResetError, OSError) as e:
             # Connection lost, mark as disconnected for retry

--- a/x-humanoid/tianyi2.0/bridged_publisher.py
+++ b/x-humanoid/tianyi2.0/bridged_publisher.py
@@ -64,7 +64,6 @@ class BridgedPublisher:
 
             self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self._socket.connect(self.socket_path)
-            self._connected = True
 
             # Send topic metadata on first connect
             # Convert msg_type to ROS2 format: sensor_msgs/msg/JointState
@@ -90,8 +89,13 @@ class BridgedPublisher:
             self._socket.sendall(struct.pack("<I", len(metadata_bytes)))
             self._socket.sendall(metadata_bytes)
 
+            # Only mark connected after metadata is successfully sent
+            self._connected = True
+            print(f"[bridged_pub] {self.topic}: connected and metadata sent", flush=True)
+
             return True
         except Exception as e:
+            print(f"[bridged_pub] {self.topic}: connection failed: {e}", flush=True)
             if self._socket:
                 self._socket.close()
                 self._socket = None

--- a/x-humanoid/tianyi2.0/config.yaml
+++ b/x-humanoid/tianyi2.0/config.yaml
@@ -2,10 +2,16 @@ mcp_port: 15707
 ros_namespace: ""   # 留空则自动使用 hostname
 name: "Tianyi 2.0 Pro"
 
+# Forward all topics from domain 0 (body controller) to domain 42 (agent-core)
+# via socket bridge. This enables proper DDS isolation.
+domain_bridge:
+  enabled: true
+
+# DEPRECATED: Use domain_bridge instead. Left for backward compatibility.
 # Run the skeleton publisher in its own ROS process. The main bundle keeps
 # the other cards but does not publish a competing joints topic.
 joints_bridge:
-  enabled: true
+  enabled: false
 
 # Make power-on self-check automatic on the robot's x86 motion-control board.
 auto_self_check:

--- a/x-humanoid/tianyi2.0/controlled_spatial.py
+++ b/x-humanoid/tianyi2.0/controlled_spatial.py
@@ -338,6 +338,9 @@ class ControlledSpatialPlugin:
                     "actions": ["navigate_to_tag", "navigate_to_pose"],
                     "timeout": 180
                 },
+                # Drives the chassis — same channel as the nav / home / chassis_raw
+                # tools in device.py.
+                "x-resource": "base",
                 "x-action-params": {
                     "start_mapping": {"params": ["map_name", "password"], "description": "🔒 向操作者索取密码后传入 password 字段。Start SLAM mapping with given map name."},
                     "stop_mapping": {"params": [], "description": "Stop mapping and save the map"},

--- a/x-humanoid/tianyi2.0/dds-local.xml
+++ b/x-humanoid/tianyi2.0/dds-local.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  dds-local.xml — 把 ROS2 (FastDDS) 流量锁在本机。
+
+  为什么需要：DDS 没有「发给某台机器」的概念，同一 domain 内所有订阅者都收到。
+  两台机器人都用 ROS_DOMAIN_ID=42 时，在一台上发的指令另一台也会执行 —— 实测
+  两台收到的是同一条消息（ts 完全一致），各自跑了一轮 LLM 并各自播报。
+
+  为什么用网卡白名单而不是别的：
+    * 每台分配不同 ROS_DOMAIN_ID —— 可用范围窄（约 0-101），机器人一多必然冲突，
+      镜像克隆与多站点部署无法协调。
+    * ROS_LOCALHOST_ONLY=1 —— 实测本机也断，/perception/* 全部消失。
+    * FASTDDS_BUILTIN_TRANSPORTS=SHM —— 可行但进程级生效，且与任何需要跨机的
+      DDS 用途互斥。
+  白名单方案下所有机器人共用同一份配置、同一个 domain 42：内部流量物理上出不了
+  本机，各机器人互相看不见，因此不需要任何唯一编号，零协调。
+
+  容器均为 network_mode: host，共享同一个 loopback，所以本机各容器照常互通 ——
+  实测两个 loopback-only 参与者可正常收发。
+
+  作用范围：只影响 FastDDS。驱动连机器人本体走 CycloneDDS + 独立网卡
+  （如 R1 的 eth10 / 192.168.123.x），不受此文件影响 —— 已在 R1 实测：
+  加载本文件前后，本体 rt/lowstate 读取的包数与 IMU 数值完全一致。
+
+  ⚠️ 必须所有在 DDS 总线上的容器一起加载。只有部分容器加载时，未加载的那些
+  会与本机其余部分失联（实测：只改一个参与者时它就只剩 2 个话题）。
+
+  ⚠️ 本文件缺失或路径错时，FastDDS 会静默回退到默认传输 —— 隔离失效但一切
+  看起来正常。agent-core 启动时会自检并在日志中说明，见 src/dds_isolation.py。
+-->
+<dds xmlns="http://www.eprosima.com">
+  <profiles>
+    <transport_descriptors>
+      <transport_descriptor>
+        <transport_id>lo_only</transport_id>
+        <type>UDPv4</type>
+        <interfaceWhiteList>
+          <address>127.0.0.1</address>
+        </interfaceWhiteList>
+      </transport_descriptor>
+    </transport_descriptors>
+
+    <participant profile_name="local_only" is_default_profile="true">
+      <rtps>
+        <userTransports>
+          <transport_id>lo_only</transport_id>
+        </userTransports>
+        <!-- 关掉内建传输，否则默认的 UDPv4/SHM 仍会绑到所有网卡上，白名单等于没设 -->
+        <useBuiltinTransports>false</useBuiltinTransports>
+      </rtps>
+    </participant>
+  </profiles>
+</dds>

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -2590,6 +2590,7 @@ class HeadGesturePlugin:
                     "actions": ["scan", "shake"],
                     "timeout": 30,
                 },
+                "x-resource": "head",
                 "x-action-params": {
                     "tilt": {"params": ["side", "tilt_amplitude", "speed", "hold"], "description": "向指定方向歪头、保持后回正"},
                     "reset": {"params": ["speed"], "description": "取消序列并将头部回正"},
@@ -3584,6 +3585,10 @@ class ArmGesturePlugin:
                     "actions": ["salute", "welcome", "shake_hands"],
                     "timeout": 30,
                 },
+                # Both arms: the gestures are static per schema and some are
+                # two-handed, so claiming one side could let them overlap on shared
+                # joints. See README_dev.md § Physical Resources.
+                "x-resource": ["arm_l", "arm_r"],
                 "x-action-params": {
                     "salute": {"params": ["salute_side", "speed"], "description": "抬起小臂、将手靠近额侧、停留后回正"},
                     "welcome": {"params": ["side", "cycles", "speed"], "description": "在身体侧上方抬起手掌并左右摆动后回正"},
@@ -4494,6 +4499,10 @@ class TtsPlugin:
                 },
                 "required": ["action"],
                 "x-completion": {"actions": ["speak"], "timeout": 180},
+                # Same speaker as voice_play below — one physical channel, two tools,
+                # so they must serialise against each other while leaving the chassis
+                # and arms free.
+                "x-resource": "mouth",
                 "x-action-params": {
                     "speak": {"params": ["text", "force"], "description": "合成并播放文本"},
                     "interrupt": {"params": [], "description": "立即停止播放并丢弃剩余内容，无需再调 pause"},
@@ -5104,6 +5113,8 @@ class VoicePlayActuatorPlugin:
                     "actions": ["play_text", "play_file", "play_url"],
                     "timeout": 60
                 },
+                # lyre audio output — the same speaker the tts tool uses.
+                "x-resource": "mouth",
                 "x-action-params": {
                     "play_file": {"params": ["path", "force"], "description": "播放本地音频文件"},
                     "play_url":  {"params": ["url", "force"],  "description": "播放远程URL音频"},
@@ -5313,6 +5324,8 @@ class NavPlugin:
                     "actions": ["move_to", "rotate", "rotate_to"],
                     "timeout": 180,
                 },
+                # Slamtec chassis. Same channel as home and chassis_raw.
+                "x-resource": "base",
                 "x-action-params": {
                     "move_to": {"params": ["x", "y", "speed"],
                                 "description": "自主导航到目标点(带避障)，系统自动等待到达"},
@@ -5547,6 +5560,7 @@ class HomePlugin:
                     "actions": ["go_home"],
                     "timeout": 180,
                 },
+                "x-resource": "base",
                 "x-action-params": {
                     "list_docks": {"params": [], "description": "列出当前地图已注册的全部充电桩，返回名称、dock_id 与位姿；可据此选择或删除充电桩"},
                     "register_dock": {"params": ["display_name"], "description": "将机器人当前定位位姿保存为一个新充电桩，并自动设为当前回桩目标。执行前应让机器人停在实际充电桩的对接位置并确认定位正常；成功后可直接执行 go_home"},
@@ -7217,6 +7231,7 @@ class ChassisRawPlugin:
                     "actions": ["move", "rotate"],
                     "timeout": 60
                 },
+                "x-resource": "base",
                 "x-action-params": {
                     "move":   {"params": ["direction", "duration"],
                                "description": "前进/后退, 固定速率 0.3 m/s, duration=-1 持续运动"},

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -2437,6 +2437,8 @@ class HeadPlugin:
                                "description": "预设方向"},
                 },
                 "required": ["action"],
+                # 头部 3DOF —— 与 head_gesture 同一通道
+                "x-resource": "head",
                 "x-action-params": {
                     "move_pos": {"params": ["yaw", "pitch", "roll"],
                                  "description": "移动头部到指定角度(度)"},
@@ -3055,6 +3057,8 @@ class ArmPlugin:
                            )},
                 },
                 "required": ["action"],
+                # 双臂关节 —— 与 arm_gesture 同一通道。side 按调用变化而 schema 是静态的，只声明一侧会让双臂动作与单臂动作并发抢同一批关节
+                "x-resource": ["arm_l", "arm_r"],
                 "x-action-params": {
                     "move_pos": {"params": ["left_positions", "right_positions", "speed"],
                                  "description": (
@@ -4078,6 +4082,8 @@ class WaistPlugin:
                     "speed": {"type": "number", "description": "运动速度(rad/s), 默认0.5"},
                 },
                 "required": ["action"],
+                # 腰部偏航 + 腿部升降 —— 没有别的工具碰这两个自由度
+                "x-resource": "waist",
                 "x-action-params": {
                     "move_waist": {"params": ["yaw", "speed"],
                                  "description": "腰部偏航: 控制yaw角度(-120°~120°)"},
@@ -4284,6 +4290,8 @@ class HandPlugin:
                                        "description": "thumb rotation"},
                 },
                 "required": ["action"],
+                # 灵巧手指关节 —— 与手臂是独立自由度，可以同时动
+                "x-resource": ["hand_l", "hand_r"],
                 "x-action-params": {
                     **{g: {"params": ["side"],
                            "description": f"预设手势: {self._GESTURE_LABELS[g]}"}

--- a/x-humanoid/tianyi2.0/main.py
+++ b/x-humanoid/tianyi2.0/main.py
@@ -675,6 +675,10 @@ def _start_domain_bridge(cfg: dict) -> None:
     bridge_path = Path(__file__).parent / "socket_bridge.py"
     bridge_env = os.environ.copy()
 
+    # Socket bridge must use the same DDS config as agent-core (loopback only)
+    # to ensure they can communicate on domain 42
+    bridge_env["FASTRTPS_DEFAULT_PROFILES_FILE"] = "/opt/phanthy-motus/dds-local.xml"
+
     try:
         _domain_bridge_proc = subprocess.Popen(
             [sys.executable, str(bridge_path)],

--- a/x-humanoid/tianyi2.0/socket_bridge.py
+++ b/x-humanoid/tianyi2.0/socket_bridge.py
@@ -127,9 +127,17 @@ class SocketBridgeServer:
             length_bytes = conn.recv(4)
             if len(length_bytes) < 4:
                 return
-            
+
             metadata_len = struct.unpack("<I", length_bytes)[0]
-            metadata_bytes = conn.recv(metadata_len)
+
+            # Read metadata in chunks (like message data)
+            metadata_bytes = b""
+            while len(metadata_bytes) < metadata_len:
+                chunk = conn.recv(min(metadata_len - len(metadata_bytes), 65536))
+                if not chunk:
+                    return
+                metadata_bytes += chunk
+
             metadata = json.loads(metadata_bytes.decode("utf-8"))
 
             topic = metadata["topic"]

--- a/x-humanoid/tianyi2.0/socket_bridge.py
+++ b/x-humanoid/tianyi2.0/socket_bridge.py
@@ -84,8 +84,8 @@ class TopicHandler:
             self.pub.publish(msg)
             self.msg_count += 1
 
-            # Debug first few messages for camera
-            if "camera" in self.topic and self.msg_count <= 5:
+            # Debug first few messages for camera and imu
+            if ("camera" in self.topic or "imu" in self.topic) and self.msg_count <= 5:
                 print(f"[socket-bridge] {self.topic}: msg #{self.msg_count}, serialized={len(serialized_msg)} bytes, type={type(msg)}", flush=True)
 
             if self.msg_count % 100 == 0:
@@ -95,6 +95,8 @@ class TopicHandler:
                 )
         except Exception as e:
             print(f"[socket-bridge] ERROR publishing to {self.topic}: {e}", flush=True)
+            print(f"[socket-bridge]   serialized length: {len(serialized_msg)} bytes", flush=True)
+            print(f"[socket-bridge]   first 100 bytes: {serialized_msg[:100]}", flush=True)
             import traceback
             traceback.print_exc()
 

--- a/x-humanoid/tianyi2.0/socket_bridge.py
+++ b/x-humanoid/tianyi2.0/socket_bridge.py
@@ -68,11 +68,9 @@ class TopicHandler:
             context=ctx,
         )
 
-        # Choose QoS based on topic
-        if any(x in topic for x in ["/state/joints", "/state/imu", "/camera/"]):
-            qos = BEST_EFFORT_QOS
-        else:
-            qos = RELIABLE_QOS
+        # Use BEST_EFFORT for all topics to match Agent Core's expectations
+        # Agent Core's phanthy_bus_bridge subscribes with BEST_EFFORT
+        qos = BEST_EFFORT_QOS
 
         self.pub = self.node.create_publisher(self.msg_class, topic, qos)
         executor.add_node(self.node)
@@ -86,6 +84,10 @@ class TopicHandler:
             self.pub.publish(msg)
             self.msg_count += 1
 
+            # Debug first few messages for camera
+            if "camera" in self.topic and self.msg_count <= 5:
+                print(f"[socket-bridge] {self.topic}: msg #{self.msg_count}, serialized={len(serialized_msg)} bytes, type={type(msg)}", flush=True)
+
             if self.msg_count % 100 == 0:
                 print(
                     f"[socket-bridge] {self.topic}: published {self.msg_count} messages",
@@ -93,6 +95,8 @@ class TopicHandler:
                 )
         except Exception as e:
             print(f"[socket-bridge] ERROR publishing to {self.topic}: {e}", flush=True)
+            import traceback
+            traceback.print_exc()
 
 
 class SocketBridgeServer:

--- a/x-humanoid/tianyi2.0/socket_bridge.py
+++ b/x-humanoid/tianyi2.0/socket_bridge.py
@@ -2,15 +2,15 @@
 """
 Socket Bridge Server - Receives messages via Unix socket and publishes to domain 42.
 
-This process runs independently with dds-local.xml, allowing it to communicate
-with agent-core while the main process uses dds_profile.xml for body controller.
+This process runs independently, allowing it to communicate with agent-core
+while the main process uses domain 0 for body controller.
 
 Architecture:
     Main process (domain 0, dds_profile.xml)
         → Plugins use BridgedPublisher
         → Send via Unix socket
         → This bridge process
-        → Publish to domain 42 (dds-local.xml)
+        → Publish to domain 42 (inherits DDS config from environment)
         → Agent Core receives
 
 Usage:
@@ -101,15 +101,16 @@ class SocketBridgeServer:
     SOCKET_DIR = "/tmp/tianyi_bridge"
 
     def __init__(self):
-        # Setup domain 42 with dds-local.xml
-        # This isolates DDS traffic to loopback, preventing cross-robot interference
-        os.environ["FASTRTPS_DEFAULT_PROFILES_FILE"] = "/opt/phanthy-motus/dds-local.xml"
+        # Setup domain 42 with default DDS config (same as agent-core)
+        # Agent-core and socket bridge must use the same DDS configuration
+        # to communicate. They inherit from main process environment.
         self.ctx = Context()
         rclpy.init(context=self.ctx, domain_id=42)
         self.executor = rclpy.executors.MultiThreadedExecutor(context=self.ctx)
 
+        dds_config = os.environ.get("FASTRTPS_DEFAULT_PROFILES_FILE", "default")
         print(
-            "[socket-bridge] domain 42 initialized with /opt/phanthy-motus/dds-local.xml",
+            f"[socket-bridge] domain 42 initialized (DDS config: {dds_config})",
             flush=True,
         )
 

--- a/x-humanoid/tianyi2.0/socket_bridge.py
+++ b/x-humanoid/tianyi2.0/socket_bridge.py
@@ -61,6 +61,7 @@ class TopicHandler:
         self.msg_type_name = msg_type_name
         self.msg_class = get_message(msg_type_name)
         self.msg_count = 0
+        self.context_invalid = False
 
         # Create publisher on domain 42
         self.node = Node(
@@ -94,7 +95,15 @@ class TopicHandler:
                     flush=True,
                 )
         except Exception as e:
+            error_msg = str(e)
             print(f"[socket-bridge] ERROR publishing to {self.topic}: {e}", flush=True)
+
+            # If context is invalid, mark this handler as broken so it can be recreated
+            if "context is invalid" in error_msg or "publisher's context is invalid" in error_msg:
+                print(f"[socket-bridge] Context invalid for {self.topic}, handler needs recreation", flush=True)
+                self.context_invalid = True
+                raise  # Re-raise to let caller know this handler is broken
+
             print(f"[socket-bridge]   serialized length: {len(serialized_msg)} bytes", flush=True)
             print(f"[socket-bridge]   first 100 bytes: {serialized_msg[:100]}", flush=True)
             import traceback
@@ -151,8 +160,18 @@ class SocketBridgeServer:
 
             print(f"[socket-bridge] new client: {topic} ({msg_type})", flush=True)
 
-            # Create handler if not exists
-            if topic not in self.handlers:
+            # Create handler if not exists or if previous handler has invalid context
+            if topic not in self.handlers or getattr(self.handlers.get(topic), 'context_invalid', False):
+                if topic in self.handlers:
+                    print(f"[socket-bridge] recreating handler for {topic} (previous context was invalid)", flush=True)
+                    # Clean up old handler
+                    old_handler = self.handlers[topic]
+                    try:
+                        self.executor.remove_node(old_handler.node)
+                        old_handler.node.destroy_node()
+                    except Exception as e:
+                        print(f"[socket-bridge] cleanup error for {topic}: {e}", flush=True)
+
                 self.handlers[topic] = TopicHandler(topic, msg_type, self.ctx, self.executor)
 
             handler = self.handlers[topic]


### PR DESCRIPTION
Companion to 4paradigm/phanthymotus#171, which scopes agent-core's ACP barrier by physical channel and adds an ordering rule on top of it.

> **This branch carries two unrelated bodies of work.** Commits `48e59a1`, `0ba1d20`, `3b7e25f` are the `x-resource` declarations described below. The other eleven are tianyi2.0 socket-bridge / DDS fixes pushed by someone else onto the same branch — they are listed at the bottom and I have neither written nor tested them. Reviewers should treat the two halves separately.

## Part 1 — `x-resource` declarations (`48e59a1`, `0ba1d20`, `3b7e25f`)

### Why

The ACP barrier used to block any acting tool on any pending action, which conflates causality with exclusion and implements neither. `robotera/q5_bundle/` already splits `base_drive`, `arm_gesture`, `leg_control` and `waist_control` into separate tools, and all four serialised against each other for no reason.

The barrier is now scoped by channel, so declare the channel. **Undeclared still means exclusive against everything**, so anything left alone keeps behaving exactly as before — this is opt-in per tool.

### Declared

| channel | tools |
|---|---|
| `mouth` | perception `tts`, tianyi `tts` + `voice_play`, k1 `audio` |
| `base` | g1 `loco` + navigate, tianyi `nav`/`home`/`chassis_raw` + navigate, q5 `base_drive` |
| `head` | tianyi `head_gesture`, tianyi `head` |
| `leg` | q5 `leg_control` |
| `waist` | q5 `waist_control`, tianyi `waist` |
| `arm_l`+`arm_r` | q5 `arm_gesture`, tianyi `arm_gesture`, tianyi `arm` |
| `hand_l`+`hand_r` | tianyi `hand` |

### The second commit exists because the first was half a contract

I declared only on tools that also declare `x-completion`, reasoning about "async actions that hold a channel". The barrier has two sides:

| role | what `x-resource` does | needs `x-completion`? |
|---|---|---|
| **holder** | tells others what this action blocks | yes — only an async action has a pending |
| **requester** | tells the barrier what to *wait for* | **no** — every acting tool asks |

Missing the requester side means a tool asks with "undeclared", i.e. conflicts with everything, and waits on any pending action anywhere. Measured on Tianyi, where `arm_gesture`/`tts` were declared but direct-control `arm`/`head` were not:

| observed | cause |
|---|---|
| head idle 5 s before moving | `head` waited on an `arm_gesture` pending |
| arm idle 8 s before moving | `arm` waited on a `tts` pending |

It compounded: with motions serialised behind unrelated channels, delegated subagents ran long enough to hit their delegation timeout, were cancelled mid-run, and the caller redid work that had already happened.

So **a partially-declared driver is worse than an undeclared one** — undeclared is uniformly serial and honest, partial looks like it should overlap and does not. Documented as: undeclared = safe/slow, partial = safe/slow/surprising, wrong = the only unsafe one.

### Judgement calls worth review

- **Arm/hand gestures claim both sides** even where `side` selects one per call: `x-resource` is static per schema, so claiming one side would let a two-handed motion overlap a one-handed one on shared joints. Over-serialising left against right costs latency; the other direction moves hardware twice.
- **g1 `switch_mode` is deliberately undeclared.** A posture transition moves the whole body and nothing should overlap it, which is exactly what undeclared means. Same reasoning that keeps it out of agent-core's interrupt sweep: aborting a controlled descent partway is how it becomes a fall.
- **Tianyi declares `mouth` on two tools** (`tts`, `voice_play`) — two names over one speaker, which is why granularity is a channel and not a tool name.
- **Left alone:** `health_check` is declared `actuator` but only aggregates status, so it barriers as an exclusive requester. The right fix is `type: sensor`, but that also widens peer access (a `viewer` peer may call sensor tools) — not a change to make in passing. `chat`/`voice_chat` are mode switches. `light`/`spatial_map` are built elsewhere and were not inspected.
- **`dji/mavic3e` untouched deliberately.** It declares no `x-completion` at all, and a multirotor's hover is a *state*, not an action that completes — declaring a channel on a takeoff tool that never reports completion would hold it forever.

### Docs (`3b7e25f`)

`README_dev.md` § *Physical Resources* now states both sides of the barrier, the three-way wrong-ness summary, that the core holds no channel names (so `rotor`/`gimbal` or `thruster`/`ballast` need nothing new), and the two limits: it expresses **mutual exclusion only** (no ordering, simultaneity, reader/writer, hierarchy or capacity), and it assumes actions are **discrete and bounded**.

### Tests

Per-directory, since a pre-existing `test_device.py` basename collision prevents one run: g1 67, r1 54, t800 250, agibot 12, brainco 22, tianyi 5, root 22 — all pass. `pytest .` shows 14 collection errors from vendored SDKs (missing `rclpy`); identical on a stashed tree, so pre-existing.

Verified live: perception advertises `x-resource: mouth`, and agent-core logs `registered pending: … (resource=mouth)` and `want=mouth, sequential, 1/1 pending to wait for`.

## Part 2 — tianyi2.0 socket bridge / DDS (not mine)

`455363a` `40c504b` `768f3af` `d204c98` `918a9b5` `8d26330` `562f89f` `6e72147` `d300013` `fa96a93` `44203f8`

IMU publish rate, duplicate metadata on reconnect, TopicHandler recreation on invalid ROS context, BridgedPublisher thread safety, deserialization logging, BEST_EFFORT QoS, `dds-local.xml`, DDS config inheritance, `domain_bridge` default, and Docker image contents. **I did not write or test these and cannot vouch for them.** They landed on this branch while the `x-resource` work was in review; merging this PR merges them too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)