### PR TITLE
feat(agibot/AimDK_X2): add PCM speaker card

### DIFF
--- a/agibot/AimDK_X2/Dockerfile
+++ b/agibot/AimDK_X2/Dockerfile
@@ -7,10 +7,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3-pip pyt
 COPY requirements.txt /tmp/agibot-x2-requirements.txt
 RUN pip3 install --no-cache-dir -i ${PYPI_MIRROR} -r /tmp/agibot-x2-requirements.txt
 COPY aimdk_msgs-${AIMDK_MSGS_REV}.zip /tmp/aimdk_msgs.zip
+COPY vendor/audio_msgs /aimdk_x2_ws/src/audio_msgs
 RUN echo "${AIMDK_MSGS_SHA256}  /tmp/aimdk_msgs.zip" | sha256sum -c - && \
     mkdir -p /aimdk_x2_ws/src/aimdk_msgs && \
     python3 -m zipfile -e /tmp/aimdk_msgs.zip /aimdk_x2_ws/src/aimdk_msgs && \
-    . /opt/ros/humble/setup.sh && cd /aimdk_x2_ws && colcon build --packages-select aimdk_msgs && \
+    . /opt/ros/humble/setup.sh && cd /aimdk_x2_ws && colcon build --packages-select aimdk_msgs audio_msgs && \
     rm -rf /tmp/aimdk_msgs.zip
 WORKDIR /work
 COPY common/ /work/common/

--- a/agibot/AimDK_X2/config.yaml
+++ b/agibot/AimDK_X2/config.yaml
@@ -55,3 +55,5 @@ plugins:
     enabled: true
   slam:
     enabled: false
+  speaker:
+    enabled: true

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -1186,12 +1186,18 @@ class SpeakerPlugin:
         self._state = "ready"
         return {"state": self._state, "topic_in": [{"topic": topic, "format": self.AUDIO_FORMAT}]}
 
+    def _drop_chunk(self, reason):
+        self._dropped_chunks += 1
+        # A malformed stream arrives at audio-frame cadence.  Keep counters for diagnosis,
+        # but write only the first rejection and every 100th to avoid exhausting Docker logs.
+        if self._dropped_chunks == 1 or self._dropped_chunks % 100 == 0:
+            self.nodes.core.get_logger().warning(
+                f"[speaker] dropped {self._dropped_chunks} invalid chunk(s); latest: {reason}",
+            )
+
     def _on_chunk(self, msg):
         if msg.format != self.AUDIO_FORMAT:
-            self._dropped_chunks += 1
-            self.nodes.core.get_logger().warning(
-                f"[speaker] dropped unsupported format: {msg.format!r}",
-            )
+            self._drop_chunk(f"unsupported format {msg.format!r}")
             return
         pcm = bytes(msg.data)
         if pcm == self.AUDIO_EOF_MAGIC:
@@ -1201,10 +1207,7 @@ class SpeakerPlugin:
             self._state = "ready"
             return
         if not pcm or len(pcm) % 2:
-            self._dropped_chunks += 1
-            self.nodes.core.get_logger().warning(
-                f"[speaker] dropped invalid PCM-16 frame ({len(pcm)} bytes)",
-            )
+            self._drop_chunk(f"invalid PCM-16 frame ({len(pcm)} bytes)")
             return
 
         playback = self.nodes._AudioPlayback()
@@ -1294,9 +1297,10 @@ def build_plugins(config, namespace, ros2):
         McModePlugin(nodes), LocomotionPlugin(nodes), PresetMotionPlugin(nodes),
         JointCommandPlugin(nodes), HandCommandPlugin(nodes), LinkcraftPlugin(nodes),
         PmuLedPlugin(nodes), TtsPlugin(nodes), EmojiPlugin(nodes), MicSourcePlugin(nodes),
-        SpeakerPlugin(nodes, namespace),
         MapGetPlugin(nodes),
     ]
+    if enabled("speaker"):
+        plugins.insert(-1, SpeakerPlugin(nodes, namespace))
     if enabled("slam", default=False):
         plugins.append(SlamControlPlugin(nodes))
     return plugins

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -925,6 +925,7 @@ class TtsPlugin:
     def get_tool(self):
         return tool("tts", "actuator", "文字转语音播报（PlayTts）", {
             "type": "object",
+            "x-resource": "mouth",
             "properties": {
                 "text": {"type": "string"},
                 "priority": {"type": "string", "enum": list(TTS_PRIORITY_LEVELS), "default": "interaction"},
@@ -1144,31 +1145,34 @@ class SpeakerPlugin:
         )
 
     def get_tool(self):
+        schema = action_schema(
+            {
+                "start": (["input_topic"], "订阅画布连接的 audio/pcm-16k 输入并转发到机器人扬声器"),
+                "stop": ([], "停止接收后续音频数据"),
+                "info": ([], "查看订阅与转发状态"),
+            },
+            {
+                "input_topic": {
+                    "type": "string",
+                    "description": "画布连接提供的 audio/pcm-16k ROS 2 Topic",
+                },
+            },
+        )
+        # Physical-resource exclusion is interpreted from inputSchema by Agent Core.
+        schema["x-resource"] = "mouth"
         return {
             "name": "speaker",
             "type": "actuator",
             "multiInstance": False,
             "description": "X2 speaker — forwards canvas audio/pcm-16k to AimDK raw audio playback",
-            "inputSchema": action_schema(
-                {
-                    "start": (["input_topic"], "订阅画布连接的 audio/pcm-16k 输入并转发到机器人扬声器"),
-                    "stop": ([], "停止接收后续音频数据"),
-                    "info": ([], "查看订阅与转发状态"),
-                },
-                {
-                    "input_topic": {
-                        "type": "string",
-                        "description": "画布连接提供的 audio/pcm-16k ROS 2 Topic",
-                    },
-                },
-            ),
+            "inputSchema": schema,
             "topic_in": [{"format": self.AUDIO_FORMAT}],
-            # README_dev.md defines mouth as the physical resource for speaker/tts output.
-            "x-resource": "mouth",
         }
 
     def start(self):
-        pass
+        # DriverBundle invokes this at startup. It deliberately has no input topic, so reset
+        # only local lifecycle state; no subscription, worker, or vendor audio is started.
+        self.stop()
 
     def _unsubscribe(self):
         if self._subscription is not None:

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import threading
 import time
+import uuid
 from pathlib import Path
 
 from common.vendor_runtime import action_schema, jsonable, tool
@@ -104,7 +105,7 @@ class AimdkNodes:
         from std_msgs.msg import String
         from geometry_msgs.msg import Pose
         from nav_msgs.msg import Odometry
-        from aimdk_msgs.msg import CommonRequest
+        from aimdk_msgs.msg import AudioPlayback, CommonRequest
         from aimdk_msgs.srv import (
             ExecuteActionResource, GetAllJointState, GetCurrentInputSource, GetHandType,
             GetMcAction, GetMicSourceRequest, GetRobotResources, GetStoredMapByName,
@@ -122,6 +123,7 @@ class AimdkNodes:
         self._JointCommand = JointCommand
         self._JointCommandArray = JointCommandArray
         self._McLocomotionVelocity = McLocomotionVelocity
+        self._AudioPlayback = AudioPlayback
 
         self.config = config
         self.end_effector = str(config.get("end_effector", "hand")).lower()
@@ -180,6 +182,13 @@ class AimdkNodes:
         }
         self.hand_command_pub = self.robot.create_publisher(HandCommandArray, "/aima/hal/joint/hand/command", 10)
         self.locomotion_pub = self.robot.create_publisher(McLocomotionVelocity, "/aima/mc/locomotion/velocity", 10)
+        # The vendor's live /aima/hal/audio/playback subscriber is RELIABLE/VOLATILE.
+        # rclpy's integer-depth shorthand has those same defaults.  This publisher has no
+        # side effect by itself: SpeakerPlugin publishes only after an explicit start and an
+        # actual PCM frame arriving from the canvas-connected input topic.
+        self.audio_playback_pub = self.robot.create_publisher(
+            AudioPlayback, "/aima/hal/audio/playback", 10,
+        )
 
         def client(srv_type, name):
             return self.robot.create_client(srv_type, name)
@@ -1089,6 +1098,152 @@ class SlamControlPlugin:
         return {"state": "published", "topic": "/integrated_command", "command": string_msg.data}
 
 
+class SpeakerPlugin:
+    """Bridge a canvas ``audio/pcm-16k`` stream to AimDK's raw audio playback topic.
+
+    This intentionally does not reuse X2's text-based ``tts`` service.  The card receives
+    the common AudioChunk stream from Perception TTS on the Agent Core DDS domain, validates
+    it, then publishes the vendor-defined AudioPlayback message on the robot DDS domain.
+    """
+
+    AUDIO_FORMAT = "audio/pcm-16k"
+    SAMPLE_RATE_HZ = 16000
+    CHANNELS = 1
+    SAMPLE_FORMAT = "S16_LE"
+    CODING_FORMAT = "pcm"
+    AUDIO_EOF_MAGIC = b"\x01\x00\xff\xff\x01\x00\xff\xff"
+
+    def __init__(self, nodes, namespace):
+        from rclpy.qos import QoSProfile, QoSReliabilityPolicy
+
+        self.nodes = nodes
+        self._namespace = namespace
+        self._subscription = None
+        self._topic = None
+        self._token_id = ""
+        self._state = "idle"
+        self._forwarded_chunks = 0
+        self._dropped_chunks = 0
+        self._utterances_finished = 0
+        # Perception TTS uses BEST_EFFORT to keep latency low.  A RELIABLE reader would be
+        # QoS-incompatible and receive no frames, so match its reliability explicitly.
+        self._input_qos = QoSProfile(
+            depth=200, reliability=QoSReliabilityPolicy.BEST_EFFORT,
+        )
+
+    def get_tool(self):
+        return {
+            "name": "speaker",
+            "type": "actuator",
+            "multiInstance": False,
+            "description": "X2 speaker — forwards canvas audio/pcm-16k to AimDK raw audio playback",
+            "inputSchema": action_schema(
+                {
+                    "start": (["input_topic"], "订阅画布连接的 audio/pcm-16k 输入并转发到机器人扬声器"),
+                    "stop": ([], "停止接收后续音频数据"),
+                    "info": ([], "查看订阅与转发状态"),
+                },
+                {
+                    "input_topic": {
+                        "type": "string",
+                        "description": "画布连接提供的 audio/pcm-16k ROS 2 Topic",
+                    },
+                },
+            ),
+            "topic_in": [{"format": self.AUDIO_FORMAT}],
+            # README_dev.md defines mouth as the physical resource for speaker/tts output.
+            "x-resource": "mouth",
+        }
+
+    def start(self):
+        pass
+
+    def _unsubscribe(self):
+        if self._subscription is not None:
+            self.nodes.core.destroy_subscription(self._subscription)
+            self._subscription = None
+        self._topic = None
+
+    def stop(self):
+        # Do not publish a synthetic empty AudioPlayback packet here.  The SDK documents that
+        # changing token_id clears its playback cache, but it does not document an empty packet
+        # as a valid cache-clear request.  Until that is verified on hardware, stop means no
+        # further input is forwarded rather than making up a raw-audio stop protocol.
+        self._unsubscribe()
+        self._state = "idle"
+
+    def _start(self, topic):
+        from audio_msgs.msg import AudioChunk
+
+        if not isinstance(topic, str) or not topic:
+            raise ValueError("speaker: start requires a non-empty input_topic")
+        self._unsubscribe()
+        self._token_id = uuid.uuid4().hex
+        self._subscription = self.nodes.core.create_subscription(
+            AudioChunk, topic, self._on_chunk, self._input_qos,
+        )
+        self._topic = topic
+        self._state = "ready"
+        return {"state": self._state, "topic_in": [{"topic": topic, "format": self.AUDIO_FORMAT}]}
+
+    def _on_chunk(self, msg):
+        if msg.format != self.AUDIO_FORMAT:
+            self._dropped_chunks += 1
+            self.nodes.core.get_logger().warning(
+                f"[speaker] dropped unsupported format: {msg.format!r}",
+            )
+            return
+        pcm = bytes(msg.data)
+        if pcm == self.AUDIO_EOF_MAGIC:
+            # The marker belongs to the PhanthyMotus audio-stream contract; it is not PCM to
+            # send to the vendor speaker.  There is no verified AimDK end-of-stream packet.
+            self._utterances_finished += 1
+            self._state = "ready"
+            return
+        if not pcm or len(pcm) % 2:
+            self._dropped_chunks += 1
+            self.nodes.core.get_logger().warning(
+                f"[speaker] dropped invalid PCM-16 frame ({len(pcm)} bytes)",
+            )
+            return
+
+        playback = self.nodes._AudioPlayback()
+        playback.stamps = self.nodes.robot.get_clock().now().to_msg()
+        playback.info.channels = self.CHANNELS
+        playback.info.sample_rate = self.SAMPLE_RATE_HZ
+        playback.info.size = len(pcm)
+        playback.info.sample_format = self.SAMPLE_FORMAT
+        playback.info.coding_format = self.CODING_FORMAT
+        playback.data.data = list(pcm)
+        # AudioPlayback requires a source identifier.  This comes from the configured X2
+        # ROS namespace, not from a Q5/vendor-specific package name.
+        playback.pkg_name = f"{self._namespace}_speaker"
+        playback.token_id = self._token_id
+        self.nodes.audio_playback_pub.publish(playback)
+        self._forwarded_chunks += 1
+        self._state = "playing"
+
+    def dispatch(self, action, args):
+        if action == "start":
+            if not args.get("input_topic"):
+                return {"state": "ready", "topic_in": [{"format": self.AUDIO_FORMAT}]}
+            return self._start(args.get("input_topic"))
+        if action == "stop":
+            self.stop()
+            return {"state": self._state}
+        if action == "info":
+            return {
+                "state": self._state,
+                "topic_in": ([{"topic": self._topic, "format": self.AUDIO_FORMAT}]
+                             if self._topic else [{"format": self.AUDIO_FORMAT}]),
+                "forwarded_chunks": self._forwarded_chunks,
+                "dropped_chunks": self._dropped_chunks,
+                "utterances_finished": self._utterances_finished,
+                "stop_behavior": "stops forwarding; raw-playback queue flush is not yet hardware-verified",
+            }
+        raise ValueError(f"speaker: unknown action {action!r}")
+
+
 class MapGetPlugin:
     def __init__(self, nodes):
         self.nodes = nodes
@@ -1139,6 +1294,7 @@ def build_plugins(config, namespace, ros2):
         McModePlugin(nodes), LocomotionPlugin(nodes), PresetMotionPlugin(nodes),
         JointCommandPlugin(nodes), HandCommandPlugin(nodes), LinkcraftPlugin(nodes),
         PmuLedPlugin(nodes), TtsPlugin(nodes), EmojiPlugin(nodes), MicSourcePlugin(nodes),
+        SpeakerPlugin(nodes, namespace),
         MapGetPlugin(nodes),
     ]
     if enabled("slam", default=False):

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -15,6 +15,7 @@ tooling names these services on the wire, not a typo introduced here.
 from __future__ import annotations
 
 import json
+import queue
 import threading
 import time
 import uuid
@@ -1112,6 +1113,8 @@ class SpeakerPlugin:
     SAMPLE_FORMAT = "S16_LE"
     CODING_FORMAT = "pcm"
     AUDIO_EOF_MAGIC = b"\x01\x00\xff\xff\x01\x00\xff\xff"
+    QUEUE_SIZE = 64
+    LOG_VALUE_LIMIT = 120
 
     def __init__(self, nodes, namespace):
         from rclpy.qos import QoSProfile, QoSReliabilityPolicy
@@ -1124,7 +1127,16 @@ class SpeakerPlugin:
         self._state = "idle"
         self._forwarded_chunks = 0
         self._dropped_chunks = 0
+        self._overflow_dropped_chunks = 0
         self._utterances_finished = 0
+        # Preserve PCM order, but cap pending audio so a blocked vendor subscriber cannot
+        # create unbounded memory use or ever-growing playback latency. On overflow, retain
+        # already queued audio and drop the newest frame; info exposes that count.
+        self._pcm_queue = queue.Queue(maxsize=self.QUEUE_SIZE)
+        self._worker = None
+        self._worker_stop = threading.Event()
+        self._lifecycle_lock = threading.RLock()
+        self._worker_sentinel = object()
         # Perception TTS uses BEST_EFFORT to keep latency low.  A RELIABLE reader would be
         # QoS-incompatible and receive no frames, so match its reliability explicitly.
         self._input_qos = QoSProfile(
@@ -1164,12 +1176,64 @@ class SpeakerPlugin:
             self._subscription = None
         self._topic = None
 
+    def _stop_worker(self):
+        with self._lifecycle_lock:
+            worker = self._worker
+            self._worker_stop.set()
+            # These frames have not reached AimDK yet, so dropping them is local queue cleanup,
+            # not an unverified vendor stop/flush request.
+            while True:
+                try:
+                    self._pcm_queue.get_nowait()
+                except queue.Empty:
+                    break
+            if worker is not None:
+                self._pcm_queue.put_nowait(self._worker_sentinel)
+        if worker is not None and worker is not threading.current_thread():
+            worker.join()
+        with self._lifecycle_lock:
+            if self._worker is worker:
+                self._worker = None
+
+    def _start_worker(self):
+        self._worker_stop.clear()
+        self._worker = threading.Thread(
+            target=self._drain_pcm, daemon=True, name="aimdk_x2_speaker",
+        )
+        self._worker.start()
+
+    def _drain_pcm(self):
+        while True:
+            pcm = self._pcm_queue.get()
+            if pcm is self._worker_sentinel:
+                return
+            with self._lifecycle_lock:
+                if self._worker_stop.is_set():
+                    return
+                self._publish_pcm(pcm)
+
+    def _publish_pcm(self, pcm):
+        playback = self.nodes._AudioPlayback()
+        playback.stamps = self.nodes.robot.get_clock().now().to_msg()
+        playback.info.channels = self.CHANNELS
+        playback.info.sample_rate = self.SAMPLE_RATE_HZ
+        playback.info.size = len(pcm)
+        playback.info.sample_format = self.SAMPLE_FORMAT
+        playback.info.coding_format = self.CODING_FORMAT
+        playback.data.data = list(pcm)
+        playback.pkg_name = f"{self._namespace}_speaker"
+        playback.token_id = self._token_id
+        self.nodes.audio_playback_pub.publish(playback)
+        self._forwarded_chunks += 1
+        self._state = "playing"
+
     def stop(self):
         # Do not publish a synthetic empty AudioPlayback packet here.  The SDK documents that
         # changing token_id clears its playback cache, but it does not document an empty packet
         # as a valid cache-clear request.  Until that is verified on hardware, stop means no
         # further input is forwarded rather than making up a raw-audio stop protocol.
         self._unsubscribe()
+        self._stop_worker()
         self._state = "idle"
 
     def _start(self, topic):
@@ -1177,27 +1241,38 @@ class SpeakerPlugin:
 
         if not isinstance(topic, str) or not topic:
             raise ValueError("speaker: start requires a non-empty input_topic")
-        self._unsubscribe()
-        self._token_id = uuid.uuid4().hex
-        self._subscription = self.nodes.core.create_subscription(
-            AudioChunk, topic, self._on_chunk, self._input_qos,
-        )
-        self._topic = topic
-        self._state = "ready"
+        self.stop()
+        with self._lifecycle_lock:
+            self._token_id = uuid.uuid4().hex
+            self._subscription = self.nodes.core.create_subscription(
+                AudioChunk, topic, self._on_chunk, self._input_qos,
+            )
+            self._topic = topic
+            self._state = "ready"
+            self._start_worker()
         return {"state": self._state, "topic_in": [{"topic": topic, "format": self.AUDIO_FORMAT}]}
 
-    def _drop_chunk(self, reason):
+    @classmethod
+    def _safe_log_value(cls, value):
+        if not isinstance(value, str):
+            return "<non-string>"
+        escaped = value.encode("unicode_escape").decode("ascii")
+        if len(escaped) > cls.LOG_VALUE_LIMIT:
+            return escaped[:cls.LOG_VALUE_LIMIT - 3] + "..."
+        return escaped
+
+    def _drop_chunk(self, reason_code, detail=""):
         self._dropped_chunks += 1
         # A malformed stream arrives at audio-frame cadence.  Keep counters for diagnosis,
         # but write only the first rejection and every 100th to avoid exhausting Docker logs.
         if self._dropped_chunks == 1 or self._dropped_chunks % 100 == 0:
             self.nodes.core.get_logger().warning(
-                f"[speaker] dropped {self._dropped_chunks} invalid chunk(s); latest: {reason}",
+                f"[speaker] dropped count={self._dropped_chunks} code={reason_code} {detail}".rstrip(),
             )
 
     def _on_chunk(self, msg):
         if msg.format != self.AUDIO_FORMAT:
-            self._drop_chunk(f"unsupported format {msg.format!r}")
+            self._drop_chunk("unsupported_format", f"format={self._safe_log_value(msg.format)}")
             return
         pcm = bytes(msg.data)
         if pcm == self.AUDIO_EOF_MAGIC:
@@ -1207,24 +1282,16 @@ class SpeakerPlugin:
             self._state = "ready"
             return
         if not pcm or len(pcm) % 2:
-            self._drop_chunk(f"invalid PCM-16 frame ({len(pcm)} bytes)")
+            self._drop_chunk("invalid_pcm16_frame")
             return
-
-        playback = self.nodes._AudioPlayback()
-        playback.stamps = self.nodes.robot.get_clock().now().to_msg()
-        playback.info.channels = self.CHANNELS
-        playback.info.sample_rate = self.SAMPLE_RATE_HZ
-        playback.info.size = len(pcm)
-        playback.info.sample_format = self.SAMPLE_FORMAT
-        playback.info.coding_format = self.CODING_FORMAT
-        playback.data.data = list(pcm)
-        # AudioPlayback requires a source identifier.  This comes from the configured X2
-        # ROS namespace, not from a Q5/vendor-specific package name.
-        playback.pkg_name = f"{self._namespace}_speaker"
-        playback.token_id = self._token_id
-        self.nodes.audio_playback_pub.publish(playback)
-        self._forwarded_chunks += 1
-        self._state = "playing"
+        with self._lifecycle_lock:
+            if self._worker_stop.is_set():
+                return
+            try:
+                self._pcm_queue.put_nowait(pcm)
+            except queue.Full:
+                self._overflow_dropped_chunks += 1
+                self._drop_chunk("queue_full")
 
     def dispatch(self, action, args):
         if action == "start":
@@ -1241,10 +1308,13 @@ class SpeakerPlugin:
                              if self._topic else [{"format": self.AUDIO_FORMAT}]),
                 "forwarded_chunks": self._forwarded_chunks,
                 "dropped_chunks": self._dropped_chunks,
+                "overflow_dropped_chunks": self._overflow_dropped_chunks,
+                "queue_capacity": self.QUEUE_SIZE,
+                "queued_chunks": self._pcm_queue.qsize(),
                 "utterances_finished": self._utterances_finished,
                 "stop_behavior": "stops forwarding; raw-playback queue flush is not yet hardware-verified",
             }
-        raise ValueError(f"speaker: unknown action {action!r}")
+        return None
 
 
 class MapGetPlugin:

--- a/agibot/AimDK_X2/driver.yaml
+++ b/agibot/AimDK_X2/driver.yaml
@@ -31,6 +31,7 @@ cards:
   - { name: linkcraft,          type: actuator }
   - { name: pmu_led,            type: actuator }
   - { name: tts,                type: actuator }
+  - { name: speaker,            type: actuator }
   - { name: emoji,              type: actuator }
   - { name: mic_source,         type: actuator }
   - { name: slam_control,       type: actuator }

--- a/agibot/AimDK_X2/driver.yaml
+++ b/agibot/AimDK_X2/driver.yaml
@@ -6,7 +6,7 @@ hardware_model: "x2"
 image_name: agibot-x2
 port: 15717
 mcp_url: "http://localhost:15717/mcp"
-description: "AgiBot X2 humanoid — AimDK SDK (plain rclpy) MC mode/locomotion/preset motion, per-area joint control, dexterous hand, Linkcraft dynamic motion library, camera/lidar/IMU/SLAM, TTS/emoji/LED"
+description: "AgiBot X2 humanoid — AimDK SDK (plain rclpy) MC mode/locomotion/preset motion, per-area joint control, dexterous hand, Linkcraft dynamic motion library, camera/lidar/IMU/SLAM, TTS/PCM speaker/emoji/LED"
 build_context_extras:
   - ../../common
 # Cards this bundle exposes, for resource-center's driver marketplace listing.

--- a/agibot/AimDK_X2/reference/topics_and_services.md
+++ b/agibot/AimDK_X2/reference/topics_and_services.md
@@ -32,6 +32,7 @@ mangled-name encoding of `_` used by their own tooling — not a typo.
 | `/aimdk_5Fmsgs/srv/ExecuteActionResource` | `linkcraft` | |
 | `/aimdk_5Fmsgs/srv/SetPmuLed` | `pmu_led` | |
 | `/aimdk_5Fmsgs/srv/PlayTts` | `tts` | |
+| `/aima/hal/audio/playback` | `speaker` | accepts canvas `audio/pcm-16k`, converts it to vendor `AudioPlayback` |
 | `/aimdk_5Fmsgs/srv/PlayEmoji` | `emoji` | |
 | `/aimdk_5Fmsgs/srv/SetMicSourceRequest`, `GetMicSourceRequest` | `mic_source` | |
 | `/aimdk_5Fmsgs/srv/GetStoredMapByName` | `map_get` | |
@@ -43,9 +44,8 @@ new plugin in `device.py` if a use case comes up:
 
 - `/agent/process_audio_output`, `/face_ui_proxy/status` — top-level status topics, purpose not
   fully documented in the SDK's public catalog.
-- `/aima/hal/audio/capture`, `/aima/hal/audio/playback`, `/aima/hal/audio/focus_response`,
-  `/aima/hal/audio/play_state` — raw audio I/O topics; this driver relies on `tts`/`PlayTts`
-  instead of raw audio playback.
+- `/aima/hal/audio/capture`, `/aima/hal/audio/focus_response`, `/aima/hal/audio/play_state` —
+  raw audio topics not exposed as a card.  `speaker` is the only raw playback bridge.
 - `/aima/hal/sensor/rgb_head_rear/*`, `/aima/hal/sensor/stereo_head_front_{left,right}/*` —
   additional cameras beyond the front RGBD pair this driver exposes.
 - `/aima/hal/sensor/touch_head` — head touch sensor, no dedicated tool yet.

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -44,6 +44,17 @@ class FakeSrv:
     Response = FakeMsg
 
 
+class FakeLogger:
+    def __init__(self):
+        self.warnings = []
+
+    def warning(self, message):
+        self.warnings.append(message)
+
+    def info(self, message):
+        pass
+
+
 class FakePublisher:
     def __init__(self, msg_type, topic, qos):
         self.msg_type = msg_type
@@ -100,6 +111,7 @@ class FakeNode:
         self.publishers = {}
         self.subscriptions = []
         self.clients = {}
+        self.logger = FakeLogger()
 
     def create_publisher(self, msg_type, topic, qos):
         pub = FakePublisher(msg_type, topic, qos)
@@ -107,8 +119,15 @@ class FakeNode:
         return pub
 
     def create_subscription(self, msg_type, topic, callback, qos):
-        self.subscriptions.append((topic, callback))
-        return object()
+        subscription = (topic, callback)
+        self.subscriptions.append(subscription)
+        return subscription
+
+    def destroy_subscription(self, subscription):
+        self.subscriptions.remove(subscription)
+
+    def get_logger(self):
+        return self.logger
 
     def create_client(self, srv_type, name):
         client = FakeClient(srv_type, name)
@@ -184,6 +203,7 @@ def _install_ros_stubs():
     module("aimdk_msgs")
     module(
         "aimdk_msgs.msg",
+        AudioPlayback=FakeMsg,
         CommonRequest=FakeMsg,
         HandCommand=FakeMsg,
         HandCommandArray=FakeMsg,
@@ -199,6 +219,8 @@ def _install_ros_stubs():
         "SetMcPresetMotion", "SetMicSourceRequest", "SetPmuLed",
     ]
     module("aimdk_msgs.srv", **{name: FakeSrv for name in srv_names})
+    module("audio_msgs")
+    module("audio_msgs.msg", AudioChunk=FakeMsg)
 
 
 _install_ros_stubs()
@@ -263,7 +285,7 @@ class ToolInventoryTests(unittest.TestCase):
         definitions = tool_definitions(plugins)
         expected_actuators = {
             "mc_mode", "locomotion", "preset_motion", "joint_command", "hand_command",
-            "linkcraft", "pmu_led", "tts", "emoji", "mic_source",
+            "linkcraft", "pmu_led", "tts", "speaker", "emoji", "mic_source",
         }
         by_name = {d["name"]: d["type"] for d in definitions}
         for name in expected_actuators:

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -377,8 +377,32 @@ class SpeakerPluginTests(unittest.TestCase):
     def test_card_declares_pcm_input_and_mouth_resource(self):
         definition = self.speaker.get_tool()
         self.assertEqual(definition["topic_in"], [{"format": "audio/pcm-16k"}])
-        self.assertEqual(definition["x-resource"], "mouth")
+        self.assertEqual(definition["inputSchema"]["x-resource"], "mouth")
+        self.assertNotIn("x-resource", definition)
         self.assertEqual(definition["inputSchema"]["x-action-params"]["start"]["params"], ["input_topic"])
+
+    def test_tts_declares_the_same_mouth_resource(self):
+        tts = find_plugin(self.plugins, "tts")
+        self.assertEqual(tts.get_tool()["inputSchema"]["x-resource"], "mouth")
+
+    def test_framework_start_is_inert_then_canvas_start_and_stop_work(self):
+        self.speaker.start()
+        self.assertEqual(self.nodes.core.subscriptions, [])
+        self.assertEqual(self.nodes.audio_playback_pub.published, [])
+        self.assertIsNone(self.speaker._worker)
+        self.assertEqual(self.speaker.dispatch("info", {})["state"], "idle")
+
+        started = self.speaker.dispatch("start", {"input_topic": "/canvas/tts"})
+        worker = self.speaker._worker
+        self.assertEqual(started["state"], "ready")
+        self.assertEqual(self.nodes.core.subscriptions[-1][0], "/canvas/tts")
+        self.assertTrue(worker.is_alive())
+
+        stopped = self.speaker.dispatch("stop", {})
+        self.assertEqual(stopped["state"], "idle")
+        self.assertEqual(self.nodes.core.subscriptions, [])
+        self.assertFalse(worker.is_alive())
+        self.assertIsNone(self.speaker._worker)
 
     def test_valid_pcm_chunk_is_mapped_to_vendor_playback(self):
         result = self.speaker.dispatch("start", {"input_topic": "/canvas/tts"})

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -357,6 +357,75 @@ class DispatchSmokeTests(unittest.TestCase):
         self.assertEqual(locomotion.nodes.locomotion_pub.published[0].forward_velocity, 0.5)
 
 
+class SpeakerPluginTests(unittest.TestCase):
+    def setUp(self):
+        self.plugins = build_bundle_plugins({"end_effector": "hand", "plugins": {"speaker": {"enabled": True}}})
+        self.speaker = find_plugin(self.plugins, "speaker")
+        self.nodes = self.speaker.nodes
+
+    def test_card_declares_pcm_input_and_mouth_resource(self):
+        definition = self.speaker.get_tool()
+        self.assertEqual(definition["topic_in"], [{"format": "audio/pcm-16k"}])
+        self.assertEqual(definition["x-resource"], "mouth")
+        self.assertEqual(definition["inputSchema"]["x-action-params"]["start"]["params"], ["input_topic"])
+
+    def test_valid_pcm_chunk_is_mapped_to_vendor_playback(self):
+        result = self.speaker.dispatch("start", {"input_topic": "/canvas/tts"})
+        self.assertEqual(result["state"], "ready")
+        self.assertEqual(self.nodes.core.subscriptions[-1][0], "/canvas/tts")
+        self.assertEqual(self.nodes.audio_playback_pub.published, [])
+
+        chunk = FakeMsg()
+        chunk.format = "audio/pcm-16k"
+        chunk.data = [1, 0, 255, 255]
+        self.speaker._on_chunk(chunk)
+
+        sent = self.nodes.audio_playback_pub.published[-1]
+        self.assertEqual(sent.stamps, "stamp")
+        self.assertEqual(sent.info.channels, 1)
+        self.assertEqual(sent.info.sample_rate, 16000)
+        self.assertEqual(sent.info.size, 4)
+        self.assertEqual(sent.info.sample_format, "S16_LE")
+        self.assertEqual(sent.info.coding_format, "pcm")
+        self.assertEqual(sent.data.data, [1, 0, 255, 255])
+        self.assertEqual(sent.pkg_name, "test_ns_speaker")
+        self.assertTrue(sent.token_id)
+
+    def test_eof_invalid_frame_and_stop_do_not_publish_extra_audio(self):
+        self.speaker.dispatch("start", {"input_topic": "/canvas/tts"})
+        eof = FakeMsg()
+        eof.format = "audio/pcm-16k"
+        eof.data = list(device.SpeakerPlugin.AUDIO_EOF_MAGIC)
+        self.speaker._on_chunk(eof)
+
+        invalid = FakeMsg()
+        invalid.format = "audio/pcm-16k"
+        invalid.data = [1]
+        self.speaker._on_chunk(invalid)
+        self.assertEqual(self.nodes.audio_playback_pub.published, [])
+        self.assertEqual(self.speaker.dispatch("info", {})["utterances_finished"], 1)
+        self.assertEqual(self.speaker.dispatch("info", {})["dropped_chunks"], 1)
+
+        self.speaker.dispatch("stop", {})
+        self.assertEqual(self.nodes.core.subscriptions, [])
+        self.assertEqual(self.speaker.dispatch("info", {})["state"], "idle")
+
+    def test_invalid_audio_warning_is_throttled(self):
+        self.speaker.dispatch("start", {"input_topic": "/canvas/tts"})
+        invalid = FakeMsg()
+        invalid.format = "not-pcm"
+        invalid.data = [1, 0]
+        for _ in range(101):
+            self.speaker._on_chunk(invalid)
+        self.assertEqual(self.speaker.dispatch("info", {})["dropped_chunks"], 101)
+        self.assertEqual(len(self.nodes.core.logger.warnings), 2)
+
+    def test_speaker_respects_enabled_switch(self):
+        plugins = build_bundle_plugins({"end_effector": "hand", "plugins": {"speaker": {"enabled": False}}})
+        names = {definition["name"] for definition in tool_definitions(plugins)}
+        self.assertNotIn("speaker", names)
+
+
 class StartStopLifecycleTests(unittest.TestCase):
     """README_dev.md's 'start/stop in dispatch (Required)' rule: the canvas UI calls every
     tool with {"action": "start"} the moment its card is placed, and {"action": "stop"} when

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -9,6 +9,7 @@ verification" note in CLAUDE.md.
 from __future__ import annotations
 
 import sys
+import threading
 import types
 import unittest
 from pathlib import Path
@@ -61,9 +62,16 @@ class FakePublisher:
         self.topic = topic
         self.qos = qos
         self.published = []
+        self._published_condition = threading.Condition()
 
     def publish(self, msg):
-        self.published.append(msg)
+        with self._published_condition:
+            self.published.append(msg)
+            self._published_condition.notify_all()
+
+    def wait_for_count(self, count, timeout=1.0):
+        with self._published_condition:
+            return self._published_condition.wait_for(lambda: len(self.published) >= count, timeout)
 
 
 class FakeFuture:
@@ -363,6 +371,9 @@ class SpeakerPluginTests(unittest.TestCase):
         self.speaker = find_plugin(self.plugins, "speaker")
         self.nodes = self.speaker.nodes
 
+    def tearDown(self):
+        self.speaker.stop()
+
     def test_card_declares_pcm_input_and_mouth_resource(self):
         definition = self.speaker.get_tool()
         self.assertEqual(definition["topic_in"], [{"format": "audio/pcm-16k"}])
@@ -379,6 +390,7 @@ class SpeakerPluginTests(unittest.TestCase):
         chunk.format = "audio/pcm-16k"
         chunk.data = [1, 0, 255, 255]
         self.speaker._on_chunk(chunk)
+        self.assertTrue(self.nodes.audio_playback_pub.wait_for_count(1))
 
         sent = self.nodes.audio_playback_pub.published[-1]
         self.assertEqual(sent.stamps, "stamp")
@@ -390,6 +402,19 @@ class SpeakerPluginTests(unittest.TestCase):
         self.assertEqual(sent.data.data, [1, 0, 255, 255])
         self.assertEqual(sent.pkg_name, "test_ns_speaker")
         self.assertTrue(sent.token_id)
+
+    def test_valid_frames_are_published_in_input_order_by_worker(self):
+        self.speaker.dispatch("start", {"input_topic": "/canvas/tts"})
+        for payload in ([1, 0], [2, 0], [3, 0]):
+            chunk = FakeMsg()
+            chunk.format = "audio/pcm-16k"
+            chunk.data = payload
+            self.speaker._on_chunk(chunk)
+        self.assertTrue(self.nodes.audio_playback_pub.wait_for_count(3))
+        self.assertEqual(
+            [sent.data.data for sent in self.nodes.audio_playback_pub.published],
+            [[1, 0], [2, 0], [3, 0]],
+        )
 
     def test_eof_invalid_frame_and_stop_do_not_publish_extra_audio(self):
         self.speaker.dispatch("start", {"input_topic": "/canvas/tts"})
@@ -419,6 +444,48 @@ class SpeakerPluginTests(unittest.TestCase):
             self.speaker._on_chunk(invalid)
         self.assertEqual(self.speaker.dispatch("info", {})["dropped_chunks"], 101)
         self.assertEqual(len(self.nodes.core.logger.warnings), 2)
+
+    def test_unsafe_format_is_escaped_and_capped_in_warning(self):
+        self.speaker.dispatch("start", {"input_topic": "/canvas/tts"})
+        invalid = FakeMsg()
+        invalid.format = "bad\n\x1b[31m" + "x" * 1000
+        invalid.data = [1, 0]
+        self.speaker._on_chunk(invalid)
+        warning = self.nodes.core.logger.warnings[-1]
+        self.assertIn("code=unsupported_format", warning)
+        self.assertIn(r"bad\n\x1b[31m", warning)
+        self.assertNotIn("\n", warning)
+        self.assertNotIn("\x1b", warning)
+        self.assertLessEqual(len(warning), 200)
+
+    def test_queue_overflow_drops_newest_frame_and_reports_it(self):
+        # No worker is started here, so filling the bounded handoff queue deterministically
+        # exercises the explicit overflow policy without a scheduling race.
+        for value in range(self.speaker.QUEUE_SIZE + 1):
+            chunk = FakeMsg()
+            chunk.format = "audio/pcm-16k"
+            chunk.data = [value % 256, 0]
+            self.speaker._on_chunk(chunk)
+        info = self.speaker.dispatch("info", {})
+        self.assertEqual(info["queued_chunks"], self.speaker.QUEUE_SIZE)
+        self.assertEqual(info["overflow_dropped_chunks"], 1)
+        self.assertEqual(info["dropped_chunks"], 1)
+
+    def test_stop_joins_worker_and_repeated_start_creates_one_worker(self):
+        self.speaker.dispatch("start", {"input_topic": "/canvas/first"})
+        first = self.speaker._worker
+        self.assertTrue(first.is_alive())
+        self.speaker.dispatch("stop", {})
+        self.assertFalse(first.is_alive())
+        self.assertIsNone(self.speaker._worker)
+
+        self.speaker.dispatch("start", {"input_topic": "/canvas/second"})
+        second = self.speaker._worker
+        self.assertIsNot(first, second)
+        self.assertTrue(second.is_alive())
+
+    def test_unknown_action_returns_none(self):
+        self.assertIsNone(self.speaker.dispatch("unknown_action", {}))
 
     def test_speaker_respects_enabled_switch(self):
         plugins = build_bundle_plugins({"end_effector": "hand", "plugins": {"speaker": {"enabled": False}}})

--- a/agibot/AimDK_X2/vendor/audio_msgs/CMakeLists.txt
+++ b/agibot/AimDK_X2/vendor/audio_msgs/CMakeLists.txt
@@ -11,3 +11,4 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 )
 
 ament_export_dependencies(rosidl_default_runtime)
+ament_package()

--- a/agibot/AimDK_X2/vendor/audio_msgs/CMakeLists.txt
+++ b/agibot/AimDK_X2/vendor/audio_msgs/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.8)
+project(audio_msgs)
+
+find_package(ament_cmake REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/AudioChunk.msg"
+  DEPENDENCIES std_msgs
+)
+
+ament_export_dependencies(rosidl_default_runtime)

--- a/agibot/AimDK_X2/vendor/audio_msgs/msg/AudioChunk.msg
+++ b/agibot/AimDK_X2/vendor/audio_msgs/msg/AudioChunk.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+string format
+uint8[] data

--- a/agibot/AimDK_X2/vendor/audio_msgs/package.xml
+++ b/agibot/AimDK_X2/vendor/audio_msgs/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>audio_msgs</name>
+  <version>1.0.0</version>
+  <description>Audio stream message shared with the perception bundle.</description>
+  <maintainer email="dev@example.com">Embodied</maintainer>
+  <license>Apache-2.0</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>std_msgs</depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+</package>


### PR DESCRIPTION
## What

Add an AimDK X2 `speaker` actuator.

It receives PhanthyMotus `audio/pcm-16k` PCM input and forwards valid frames to the verified AimDK audio-playback ROS message.

## Validation

- ARM64 image build passed.
- 17 local driver unit tests passed.
- No physical robot deployment or speaker playback test has been performed.

## Infrastructure rationale

`Dockerfile` builds the component-local `audio_msgs` ROS interface required for DDS type compatibility. It adds no apt/pip dependency or large external artifact; only the small generated ROS interface artifacts are included.

`driver.yaml` advertises the enabled `speaker` card in marketplace metadata and does not affect image size.