### PR TITLE
fix(agibot-x2): report joint state query failures

### DIFF
--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -315,7 +315,17 @@ class JointStatePlugin:
         request = GetAllJointState.Request()
         request.request = self.nodes.request_header()
         result = call_service(self.nodes.get_all_joint_state, request)
+        status = int(result.reponse.status.value)
+        if status != 1:  # CommonState.SUCCESS
+            return {
+                "state": "unavailable",
+                "service": "GetAllJointState",
+                "status": status,
+                "message": result.reponse.message,
+            }
         return {
+            "state": "ok",
+            "service": "GetAllJointState",
             "leg": jsonable(result.leg_joints),
             "waist": jsonable(result.waist_joints),
             "arm": jsonable(result.arm_joints),

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -334,6 +334,43 @@ class DispatchSmokeTests(unittest.TestCase):
         self.assertEqual(len(locomotion.nodes.locomotion_pub.published), 1)
         self.assertEqual(locomotion.nodes.locomotion_pub.published[0].forward_velocity, 0.5)
 
+    def test_joint_state_returns_joint_values_after_a_successful_query(self):
+        plugins = build_bundle_plugins()
+        joint_state = find_plugin(plugins, "joint_state")
+        response = FakeMsg()
+        response.reponse.status.value = 1
+        response.reponse.message = ""
+        arm_joint = FakeMsg()
+        arm_joint.name = "left_shoulder_pitch_joint"
+        arm_joint.position = 0.25
+        response.leg_joints = []
+        response.waist_joints = []
+        response.arm_joints = [arm_joint]
+        response.head_joints = []
+        joint_state.nodes.get_all_joint_state.response = response
+
+        result = joint_state.dispatch("get", {})
+
+        self.assertEqual(result["state"], "ok")
+        self.assertEqual(result["service"], "GetAllJointState")
+        self.assertEqual(result["arm"], [{"name": "left_shoulder_pitch_joint", "position": 0.25}])
+
+    def test_joint_state_reports_failed_queries_instead_of_default_values(self):
+        plugins = build_bundle_plugins()
+        joint_state = find_plugin(plugins, "joint_state")
+        response = FakeMsg()
+        response.reponse.status.value = 0
+        response.reponse.message = "joint state unavailable"
+        joint_state.nodes.get_all_joint_state.response = response
+
+        result = joint_state.dispatch("get", {})
+
+        self.assertEqual(result, {
+            "state": "unavailable",
+            "service": "GetAllJointState",
+            "status": 0,
+            "message": "joint state unavailable",
+        })
 
 class StartStopLifecycleTests(unittest.TestCase):
     """README_dev.md's 'start/stop in dispatch (Required)' rule: the canvas UI calls every


### PR DESCRIPTION
## 问题

`GetAllJointState` 返回 `CommonResponse`，但原实现没有检查其状态。服务查询失败时，卡片可能展示默认的 0 值，容易误认为是机器人真实关节数据。

## 修改

- 保持现有 `joint_state` 卡片名称和 `GetAllJointState` 服务接口；
- 服务成功时返回 leg、waist、arm、head 四组原始关节数据；
- 服务失败时返回 `state: unavailable`、厂家状态码和消息，不再展示误导性的默认关节值；
- 未新增 topic、未新增卡片、未改动机器人控制逻辑。

## 测试

- X2 单测：14/14 通过；
- Python 语法检查：通过；
- `git diff --check`：通过。