### PR TITLE
feat(agibot): add X2 joints skeleton stream

### DIFF
--- a/agibot/AimDK_X2/config.yaml
+++ b/agibot/AimDK_X2/config.yaml
@@ -9,7 +9,7 @@ ros_namespace: "agibot_x2"
 
 # Which end-effector variant this robot is built with — selects the URDF served by the
 # `model` resource tool and the joint layout used by hand_state/hand_command.
-end_effector: "hand"   # fist | hand | ultra
+end_effector: "ultra"  # fist | hand | ultra
 
 ros:
   robot_domain_id: 0

--- a/agibot/AimDK_X2/config.yaml
+++ b/agibot/AimDK_X2/config.yaml
@@ -21,6 +21,9 @@ plugins:
     enabled: true
   joint_state:
     enabled: true
+  joints:
+    enabled: true
+    poll_interval_sec: 0.1
   hand_state:
     enabled: true
   imu:

--- a/agibot/AimDK_X2/deploy/service.yml
+++ b/agibot/AimDK_X2/deploy/service.yml
@@ -8,10 +8,11 @@ agibot-x2:
   volumes:
     - /dev:/dev
     - /opt/phanthy-motus/data:/opt/phanthy-motus/data
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-    - FASTDDS_BUILTIN_TRANSPORTS=DEFAULT
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
   logging:
     driver: local

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -158,6 +158,14 @@ class AimdkNodes:
         self.robot.create_subscription(Imu, "/aima/hal/imu/torso/state", self._imu_callback("torso", imu_pub), sensor_qos)
         self.streams["imu"] = {"robot_topic": "/aima/hal/imu/{chest,torso}/state", "topic": imu_topic, "format": "data/json"}
 
+        joints_topic = f"/{namespace}/agibot_x2/joints"
+        self.joints_pub = self.core.create_publisher(String, joints_topic, 5)
+        self.streams["joints"] = {
+            "robot_topic": "/aimdk_5Fmsgs/srv/GetAllJointState",
+            "topic": joints_topic,
+            "format": "sensor/skeleton",
+        }
+
         mirror("hand_state", HandStateArray, "/aima/hal/joint/hand/state", "data/json", qos=sensor_qos)
         # SDK's topics_and_services catalog documents rgbd_head_front/* as the front camera, but
         # on real hardware that topic has zero publishers -- this unit's camera service actually
@@ -245,6 +253,15 @@ class AimdkNodes:
         with self.lock:
             return self.values.get(key, {})
 
+    def publish_joints(self, joints):
+        payload = {"joints": joints}
+        output = self._msg["String"]()
+        output.data = json.dumps(payload, ensure_ascii=False)
+        self.joints_pub.publish(output)
+        with self.lock:
+            self.values["joints"] = payload
+        return payload
+
     def urdf_text(self, variant=None):
         variant = (variant or self.end_effector).lower()
         path = RESOURCE_DIR / f"x2_{variant}.urdf"
@@ -321,6 +338,64 @@ class JointStatePlugin:
             "arm": jsonable(result.arm_joints),
             "head": jsonable(result.head_joints),
         }
+
+
+class JointsPlugin:
+    """Normalize GetAllJointState into the skeleton renderer's joint stream format."""
+
+    def __init__(self, nodes, poll_interval_sec):
+        self.nodes = nodes
+        self.poll_interval_sec = poll_interval_sec
+        self._stop = threading.Event()
+        self._thread = None
+
+    def get_tool(self):
+        return _stream_tool("joints", self.nodes.streams["joints"], "全身关节骨骼状态流（GetAllJointState）")
+
+    @staticmethod
+    def normalize(result):
+        joints = []
+        for group in ("leg_joints", "waist_joints", "arm_joints", "head_joints"):
+            for state in getattr(result, group, ()):
+                joints.append({
+                    "idx": len(joints),
+                    "name": state.name,
+                    "q": state.position,
+                    "dq": state.velocity,
+                    "tau": state.effort,
+                    "error_code": state.error_code,
+                })
+        return joints
+
+    def _poll(self):
+        from aimdk_msgs.srv import GetAllJointState
+        while not self._stop.is_set():
+            try:
+                request = GetAllJointState.Request()
+                request.request = self.nodes.request_header()
+                result = call_service(self.nodes.get_all_joint_state, request, timeout=1.0)
+                self.nodes.publish_joints(self.normalize(result))
+            except Exception as exc:
+                print(f"[joints] GetAllJointState failed: {exc}", flush=True)
+            self._stop.wait(self.poll_interval_sec)
+
+    def start(self):
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._poll, name="agibot-x2-joints", daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=self.poll_interval_sec + 1.0)
+            self._thread = None
+
+    def dispatch(self, action, args):
+        if action == "stop":
+            return {"state": "idle"}
+        return {"state": "running", **self.nodes.streams["joints"]}
 
 
 class HandStatePlugin:
@@ -1132,6 +1207,11 @@ def build_plugins(config, namespace, ros2):
     def enabled(name, default=True):
         return plugin_config.get(name, {}).get("enabled", default)
 
+    joints_config = plugin_config.get("joints", {})
+    joints_interval_sec = float(joints_config.get("poll_interval_sec", 0.1))
+    if joints_interval_sec <= 0:
+        raise ValueError("plugins.joints.poll_interval_sec must be greater than zero")
+
     plugins = [
         McStatePlugin(nodes), JointStatePlugin(nodes), HandStatePlugin(nodes),
         ImuPlugin(nodes), CameraPlugin(nodes), LidarPlugin(nodes), SlamPosePlugin(nodes),
@@ -1141,6 +1221,8 @@ def build_plugins(config, namespace, ros2):
         PmuLedPlugin(nodes), TtsPlugin(nodes), EmojiPlugin(nodes), MicSourcePlugin(nodes),
         MapGetPlugin(nodes),
     ]
+    if enabled("joints", default=True):
+        plugins.append(JointsPlugin(nodes, joints_interval_sec))
     if enabled("slam", default=False):
         plugins.append(SlamControlPlugin(nodes))
     return plugins

--- a/agibot/AimDK_X2/driver.yaml
+++ b/agibot/AimDK_X2/driver.yaml
@@ -14,6 +14,7 @@ build_context_extras:
 cards:
   - { name: mc_state,           type: sensor }
   - { name: joint_state,        type: sensor }
+  - { name: joints,             type: sensor }
   - { name: hand_state,         type: sensor }
   - { name: imu,                type: sensor }
   - { name: camera_rgb,         type: sensor }

--- a/agibot/AimDK_X2/reference/message_schemas.md
+++ b/agibot/AimDK_X2/reference/message_schemas.md
@@ -60,6 +60,31 @@ hal/srv/SetPmuLed.srv:         req: CommonRequest request; string trace_id;
                                 resp: ResponseHeader header; uint16 status_code
 ```
 
+## `joints` skeleton stream
+
+The `joint_state` card exposes the raw, synchronous `GetAllJointState` result grouped as
+`leg`, `waist`, `arm`, and `head`. The separate `joints` card polls that same read-only service
+and publishes `sensor/skeleton` JSON to `/<ros_namespace>/agibot_x2/joints` for visualization:
+
+```json
+{
+  "joints": [
+    {
+      "idx": 0,
+      "name": "<JointState.name>",
+      "q": 0.0,
+      "dq": 0.0,
+      "tau": 0.0,
+      "error_code": 0
+    }
+  ]
+}
+```
+
+The list order is always `leg`, `waist`, `arm`, then `head`, preserving AimDK's order inside each
+group. `q`, `dq`, and `tau` map directly to `JointState.position`, `.velocity`, and `.effort`.
+AimDK's response has no motor-temperature field, so this card deliberately does not invent one.
+
 ## Motion control (`mc`)
 
 ```

--- a/agibot/AimDK_X2/tests/test_device.py
+++ b/agibot/AimDK_X2/tests/test_device.py
@@ -274,8 +274,13 @@ class ToolInventoryTests(unittest.TestCase):
         by_name = {d["name"]: d["type"] for d in tool_definitions(plugins)}
         self.assertEqual(by_name["model"], "resource")
         self.assertEqual(by_name["map_get"], "processor")
-        for name in ("mc_state", "joint_state", "hand_state", "imu", "camera_rgb", "camera_depth", "lidar", "slam_pose"):
+        for name in ("mc_state", "joint_state", "joints", "hand_state", "imu", "camera_rgb", "camera_depth", "lidar", "slam_pose"):
             self.assertEqual(by_name[name], "sensor")
+
+    def test_joints_exposes_skeleton_stream(self):
+        plugins = build_bundle_plugins()
+        definition = next(d for d in tool_definitions(plugins) if d["name"] == "joints")
+        self.assertEqual(definition["topic_out"], [{"topic": "/test_ns/agibot_x2/joints", "format": "sensor/skeleton"}])
 
     def test_mc_mode_and_preset_motion_action_enums_nonempty(self):
         plugins = build_bundle_plugins()
@@ -300,6 +305,43 @@ class ModelPluginTests(unittest.TestCase):
         model_plugin = find_plugin(plugins, "model")
         with self.assertRaises(ValueError):
             model_plugin.dispatch("model", {"variant": "nonexistent"})
+
+
+class JointsPluginTests(unittest.TestCase):
+    def test_normalize_flattens_groups_in_canonical_order(self):
+        def joint(name, position, velocity, effort, error_code):
+            state = FakeMsg()
+            state.name = name
+            state.position = position
+            state.velocity = velocity
+            state.effort = effort
+            state.error_code = error_code
+            return state
+
+        result = FakeMsg()
+        result.leg_joints = [joint("leg", 1.0, 2.0, 3.0, 4)]
+        result.waist_joints = [joint("waist", 5.0, 6.0, 7.0, 8)]
+        result.arm_joints = [joint("arm", 9.0, 10.0, 11.0, 12)]
+        result.head_joints = [joint("head", 13.0, 14.0, 15.0, 16)]
+
+        self.assertEqual(device.JointsPlugin.normalize(result), [
+            {"idx": 0, "name": "leg", "q": 1.0, "dq": 2.0, "tau": 3.0, "error_code": 4},
+            {"idx": 1, "name": "waist", "q": 5.0, "dq": 6.0, "tau": 7.0, "error_code": 8},
+            {"idx": 2, "name": "arm", "q": 9.0, "dq": 10.0, "tau": 11.0, "error_code": 12},
+            {"idx": 3, "name": "head", "q": 13.0, "dq": 14.0, "tau": 15.0, "error_code": 16},
+        ])
+
+    def test_normalize_accepts_empty_groups(self):
+        result = FakeMsg()
+        result.leg_joints = []
+        result.waist_joints = []
+        result.arm_joints = []
+        result.head_joints = []
+        self.assertEqual(device.JointsPlugin.normalize(result), [])
+
+    def test_invalid_poll_interval_rejected(self):
+        with self.assertRaisesRegex(ValueError, "poll_interval_sec"):
+            build_bundle_plugins({"end_effector": "hand", "plugins": {"joints": {"poll_interval_sec": 0}}})
 
 
 class DispatchSmokeTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add the read-only `joints` sensor card for AgiBot Lingxi X2.
- Normalize AimDK GetAllJointState telemetry into the `sensor/skeleton` contract at 10Hz.
- Configure the deployed X2 for the `ultra` end-effector and correct the DDS deployment profile.

## Verification
- [x] `python3 -m unittest discover -s agibot/AimDK_X2/tests -p 'test_*.py'`
- [x] `python3 scripts/check_service_yml.py agibot/AimDK_X2`
- [x] `git diff --check HEAD~2..HEAD`

Hardware deployment and canvas rendering verification are pending on the target X2.

🤖 Generated with [phanthy code](https://phanthy.dev/phanthy-code)