### PR TITLE
feat(go2): 新增 vision_capture RGB 拍照与精确时长录像卡片

### DIFF
--- a/tests/test_go2_logsafe_children.py
+++ b/tests/test_go2_logsafe_children.py
@@ -1,0 +1,50 @@
+"""Every Go2 multiprocessing child entry point must install logsafe.
+
+README_dev.md's checklist requires `logsafe.install(check_fd=False)` at the
+top of every multiprocessing child entry point: spawned children get a fresh
+interpreter and do not inherit the parent's protected sys.stdout, so their
+concurrent print() calls can still tear docker log records or emit control
+bytes. The real workers need hardware or a DDS ring, so the contract is
+asserted statically on the source.
+"""
+
+import ast
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# module path -> child entry function spawned by the bundle
+CHILD_ENTRIES = {
+    "unitree/go2/rpc_proxy.py": "_rpc_worker",
+    "unitree/go2/device.py": "_speaker_worker",
+    "unitree/go2/realsense.py": "_capture",
+    "unitree/go2/spatial.py": "_slam_rpc_worker",
+    "unitree/go2/controlled_spatial.py": "_slam_rpc_worker",
+}
+
+
+def installs_logsafe(func_node):
+    for node in ast.walk(func_node):
+        if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "install"):
+            return any(kw.arg == "check_fd" for kw in node.keywords)
+    return False
+
+
+class LogsafeChildInstallTest(unittest.TestCase):
+    def test_every_multiprocessing_child_entry_installs_logsafe(self):
+        for rel_path, func_name in CHILD_ENTRIES.items():
+            with self.subTest(entry=f"{rel_path}:{func_name}"):
+                tree = ast.parse((ROOT / rel_path).read_text())
+                fn = next((node for node in ast.walk(tree)
+                           if isinstance(node, ast.FunctionDef) and node.name == func_name), None)
+                self.assertIsNotNone(fn, f"{func_name} not found in {rel_path}")
+                self.assertTrue(
+                    installs_logsafe(fn),
+                    f"{rel_path}:{func_name} must call logsafe.install(check_fd=False); "
+                    "a spawned child does not inherit the parent's protected sys.stdout")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_go2_logsafe_children.py
+++ b/tests/test_go2_logsafe_children.py
@@ -14,13 +14,14 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
 
-# module path -> child entry function spawned by the bundle
+# module path -> child entry functions spawned by the bundle
 CHILD_ENTRIES = {
-    "unitree/go2/rpc_proxy.py": "_rpc_worker",
-    "unitree/go2/device.py": "_speaker_worker",
-    "unitree/go2/realsense.py": "_capture",
-    "unitree/go2/spatial.py": "_slam_rpc_worker",
-    "unitree/go2/controlled_spatial.py": "_slam_rpc_worker",
+    "unitree/go2/rpc_proxy.py": ["_rpc_worker"],
+    "unitree/go2/device.py": ["_speaker_worker", "_run_camera_process"],
+    "unitree/go2/realsense.py": ["_capture"],
+    "unitree/go2/spatial.py": ["_slam_rpc_worker"],
+    "unitree/go2/controlled_spatial.py": ["_slam_rpc_worker"],
+    "unitree/go2/ext_devices.py": ["_run_ext_camera_process"],
 }
 
 
@@ -34,16 +35,17 @@ def installs_logsafe(func_node):
 
 class LogsafeChildInstallTest(unittest.TestCase):
     def test_every_multiprocessing_child_entry_installs_logsafe(self):
-        for rel_path, func_name in CHILD_ENTRIES.items():
-            with self.subTest(entry=f"{rel_path}:{func_name}"):
-                tree = ast.parse((ROOT / rel_path).read_text())
-                fn = next((node for node in ast.walk(tree)
-                           if isinstance(node, ast.FunctionDef) and node.name == func_name), None)
-                self.assertIsNotNone(fn, f"{func_name} not found in {rel_path}")
-                self.assertTrue(
-                    installs_logsafe(fn),
-                    f"{rel_path}:{func_name} must call logsafe.install(check_fd=False); "
-                    "a spawned child does not inherit the parent's protected sys.stdout")
+        for rel_path, func_names in CHILD_ENTRIES.items():
+            for func_name in func_names:
+                with self.subTest(entry=f"{rel_path}:{func_name}"):
+                    tree = ast.parse((ROOT / rel_path).read_text())
+                    fn = next((node for node in ast.walk(tree)
+                               if isinstance(node, ast.FunctionDef) and node.name == func_name), None)
+                    self.assertIsNotNone(fn, f"{func_name} not found in {rel_path}")
+                    self.assertTrue(
+                        installs_logsafe(fn),
+                        f"{rel_path}:{func_name} must call logsafe.install(check_fd=False); "
+                        "a spawned child does not inherit the parent's protected sys.stdout")
 
 
 if __name__ == "__main__":

--- a/tests/test_go2_vision_capture.py
+++ b/tests/test_go2_vision_capture.py
@@ -1,0 +1,504 @@
+"""Go2 capture contract tests; real FFmpeg encoding, with a simulated ROS source."""
+
+import __future__
+import ast
+from datetime import datetime
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import types
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class FakeNode:
+    def __init__(self, name):
+        self.name = name
+        self.callbacks = {}
+
+    def create_subscription(self, message_type, topic, callback, qos):
+        self.topic = topic
+        self.callback = callback
+        self.callbacks[topic] = callback
+        return object()
+
+    def get_clock(self):
+        return types.SimpleNamespace(now=lambda: types.SimpleNamespace(nanoseconds=int(time.time() * 1e9)))
+
+
+def load_module():
+    stubs = {name: types.ModuleType(name) for name in (
+        "rclpy", "rclpy.node", "rclpy.qos", "sensor_msgs", "sensor_msgs.msg")}
+    stubs["rclpy.node"].Node = FakeNode
+    stubs["rclpy.qos"].qos_profile_sensor_data = object()
+    stubs["sensor_msgs.msg"].CompressedImage = object
+    spec = importlib.util.spec_from_file_location("go2_vision_capture_test", ROOT / "unitree/go2/vision_capture.py")
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(sys.modules, stubs):
+        spec.loader.exec_module(module)
+    return module
+
+
+capture = load_module()
+
+
+def external_plugin(instances):
+    """Run the real ext_camera info contract with hardware nodes replaced."""
+    tree = ast.parse((ROOT / "unitree/go2/ext_devices.py").read_text())
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "ExtCameraPlugin")
+    ns = {}
+    exec(compile(ast.Module(body=[cls], type_ignores=[]), "ext_devices.py", "exec",
+                 flags=__future__.annotations.compiler_flag), ns)
+    plugin = ns["ExtCameraPlugin"].__new__(ns["ExtCameraPlugin"])
+    plugin._namespace = "go2"
+    plugin._available_devices = []
+    plugin._lock = threading.RLock()
+    plugin._instance_configs = {key: {"channel": value.get("channel", "rgb"),
+                                      "device_path": value.get("device_path", "")}
+                               for key, value in instances.items()}
+    plugin._nodes = {key: types.SimpleNamespace(_status_dict=lambda value=value: value)
+                     for key, value in instances.items()}
+    return plugin
+
+
+def external_status(topic="/go2/ext_camera/usb_one/rgb"):
+    return {"state": "running", "device_name": "RealSense (Color)", "device_path": "/dev/video4",
+            "topic_out": [{"topic": topic, "format": "image/jpeg"}]}
+
+
+class CaptureHarness(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.executor = mock.Mock()
+        self.plugin = capture.VisionCapturePlugin({"output_dir": self.directory.name}, "go2", self.executor)
+        self.front = self.plugin._resolve_source({})
+        self.notifications = []
+        self.plugin._notify_complete = lambda *args: self.notifications.append(args)
+
+    def tearDown(self):
+        self.plugin.stop()
+        self.directory.cleanup()
+
+    def feed(self, data=b"\xff\xd8test\xff\xd9", age=0, fmt="jpeg", topic="/go2/camera/front"):
+        timestamp = time.time() - age
+        msg = types.SimpleNamespace(
+            format=fmt, data=data,
+            header=types.SimpleNamespace(stamp=types.SimpleNamespace(
+                sec=int(timestamp), nanosec=int((timestamp % 1) * 1e9))))
+        callback = self.plugin._node.callbacks.get(topic)
+        if callback:
+            callback(msg)
+
+    def publish(self, data, topic="/go2/camera/front", fps=15):
+        halt = threading.Event()
+
+        def produce():
+            while not halt.is_set():
+                self.feed(data, topic=topic)
+                halt.wait(1 / fps)
+
+        thread = threading.Thread(target=produce, daemon=True)
+        thread.start()
+        self.addCleanup(thread.join, 2)
+        self.addCleanup(halt.set)
+        return halt
+
+    def wait_recording(self, timeout=8):
+        deadline = time.monotonic() + timeout
+        while not self.notifications and time.monotonic() < deadline:
+            time.sleep(0.02)
+        self.assertEqual(len(self.notifications), 1)
+        return self.notifications[0]
+
+
+class CaptureTest(CaptureHarness):
+    def test_external_selection_excludes_depth_and_infrared_jpeg(self):
+        self.plugin._external_camera = external_plugin({
+            "color": {**external_status("/go2/ext_camera/color/rgb"), "channel": "rgb"},
+            "ir": {**external_status("/go2/ext_camera/ir/infrared"), "channel": "infrared"},
+            "depth": {**external_status("/go2/ext_camera/depth/depth"), "channel": "depth"},
+        })
+        source = self.plugin._resolve_source({"camera": "external"})
+        self.assertEqual(source["external_instance_id"], "color")
+        self.assertEqual(len(self.plugin.dispatch("list_cameras", {})["cameras"]), 2)
+        with self.assertRaisesRegex(ValueError, "infrared.*only RGB"):
+            self.plugin._resolve_source({"camera": "external", "external_instance_id": "ir"})
+
+    def test_selects_each_camera_and_uses_actual_external_topic(self):
+        topic = "/go2/ext_camera/usb_one/rgb"
+        self.plugin._external_camera = external_plugin({"usb-one": external_status(topic)})
+        front_jpeg, external_jpeg = b"\xff\xd8front\xff\xd9", b"\xff\xd8external\xff\xd9"
+        self.publish(front_jpeg)
+        self.publish(external_jpeg, topic)
+        result = self.plugin.dispatch("config", {"camera": "external"})
+        self.assertTrue(result["ok"])
+        external = self.plugin.dispatch("capture_photo", {})
+        self.assertTrue(external["ok"], external)
+        self.assertEqual(external["source"]["external_instance_id"], "usb-one")
+        self.assertEqual(external["source"]["topic"], topic)
+        self.assertEqual(Path(external["file_path"]).read_bytes(), external_jpeg)
+        front = self.plugin.dispatch("capture_photo", {"camera": "front"})
+        self.assertTrue(front["ok"], front)
+        self.assertEqual(Path(front["file_path"]).read_bytes(), front_jpeg)
+        self.assertEqual(self.plugin._camera, "external", "per-call override must not change configured default")
+
+    def test_multiple_external_cameras_require_explicit_instance(self):
+        self.plugin._external_camera = external_plugin({
+            "usb-one": external_status(), "usb-two": external_status("/go2/ext_camera/usb_two/rgb")})
+        listed = self.plugin.dispatch("list_cameras", {})["cameras"]
+        self.assertEqual(len(listed), 3)
+        self.assertEqual(self.plugin.dispatch("capture_photo", {"camera": "external"})["code"], "CAPTURE_FAILED")
+        source = self.plugin._resolve_source({"camera": "external", "external_instance_id": "usb-two"})
+        self.assertEqual(source["topic"], "/go2/ext_camera/usb_two/rgb")
+
+    def test_missing_external_camera_never_falls_back_to_front(self):
+        self.publish(b"\xff\xd8front\xff\xd9")
+        self.plugin._external_camera = external_plugin({})
+        self.assertFalse(self.plugin.dispatch("capture_photo", {"camera": "external"})["ok"])
+        with mock.patch.object(capture.shutil, "which", return_value="ffmpeg"):
+            result = self.plugin.dispatch("record_video", {"camera": "external"})
+        self.assertFalse(result["ok"])
+        self.assertNotIn("action_id", result)
+        self.assertEqual(list(Path(self.directory.name).rglob("*.jpg")), [])
+
+    def test_bundle_wires_existing_external_plugin(self):
+        tree = ast.parse((ROOT / "unitree/go2/main.py").read_text())
+        cls = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "Go2DeviceBundle")
+        ext = external_plugin({"usb-one": external_status()})
+        stub = types.ModuleType("ext_devices")
+        stub.ExtCameraPlugin = lambda *args: ext
+        ns = {}
+        with mock.patch.dict(sys.modules, {"vision_capture": capture, "ext_devices": stub}):
+            exec(compile(ast.Module(body=[cls], type_ignores=[]), "main.py", "exec",
+                         flags=__future__.annotations.compiler_flag), ns)
+            bundle = ns["Go2DeviceBundle"]({"plugins": {"ext_camera": {"enabled": True},
+                                            "vision_capture": {"enabled": True}}}, "go2", mock.Mock(), None)
+        plugin = bundle._plugins[-1]
+        self.assertIs(plugin._external_camera, ext)
+        self.assertEqual(plugin.dispatch("list_cameras", {})["cameras"][1]["external_instance_id"], "usb-one")
+
+    def test_registration_and_configured_source(self):
+        # Exercise the actual bundle class without importing hardware SDKs.
+        tree = ast.parse((ROOT / "unitree/go2/main.py").read_text())
+        bundle = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "Go2DeviceBundle")
+        module = ast.Module(body=[bundle], type_ignores=[])
+        ns = {"RpcProxy": object}
+        with mock.patch.dict(sys.modules, {"vision_capture": capture}):
+            exec(compile(module, "go2/main.py", "exec", flags=__future__.annotations.compiler_flag), ns)
+            instance = ns["Go2DeviceBundle"]({"plugins": {"vision_capture": {
+                "enabled": True, "camera": "external"}}}, "go2", mock.Mock(), None)
+        try:
+            tools = instance.get_all_tools()
+            self.assertIn("vision_capture", [tool["name"] for tool in tools])
+            info = instance.dispatch("vision_capture", {"action": "info"})
+            self.assertEqual(info["camera"], "external")
+            self.assertFalse(info["ok"])
+        finally:
+            instance.stop_all()
+
+    def test_start_requires_actual_fresh_data_and_info_is_serializable(self):
+        self.assertFalse(self.plugin.start()["ok"])
+        self.feed()
+        self.assertTrue(self.plugin.start()["ok"])
+        json.dumps(self.plugin.dispatch("info", {}))
+
+    def test_photo_bytes_and_persistence_across_plugin_restart(self):
+        data = b"\xff\xd8photo\xff\xd9"
+        self.publish(data)
+        result = self.plugin.dispatch("capture_photo", {})
+        self.assertTrue(result["ok"])
+        path = Path(result["file_path"])
+        self.assertEqual(path.parent.name, "photos")
+        self.plugin.stop()
+        self.plugin.start()
+        self.assertEqual(path.read_bytes(), data)
+
+    def test_invalid_and_delayed_images_are_rejected(self):
+        for data, age, fmt in [(b"bad", 0, "jpeg"), (b"\xff\xd8x\xff\xd9", 10, "jpeg"),
+                               (b"\xff\xd8x\xff\xd9", 0, "png")]:
+            self.feed(data, age, fmt)
+            with self.assertRaises(RuntimeError):
+                self.plugin._frame(self.front, timeout_s=0)
+
+    def test_cache_expires_and_sequence_cannot_be_reused(self):
+        self.feed()
+        frame = self.plugin._frame(self.front, timeout_s=0)
+        with self.assertRaises(RuntimeError):
+            self.plugin._frame(self.front, after_sequence=frame[2], timeout_s=0)
+        self.plugin._streams[self.front["topic"]]["latest"] = (frame[0], time.monotonic() - 4, frame[2])
+        with self.assertRaises(RuntimeError):
+            self.plugin._frame(self.front, timeout_s=0)
+
+    def test_photo_failure_leaves_no_file(self):
+        with mock.patch.object(self.plugin, "_frame", side_effect=RuntimeError("no camera")):
+            self.assertEqual(self.plugin.dispatch("capture_photo", {})["code"], "CAPTURE_FAILED")
+        self.assertEqual(list(Path(self.directory.name).rglob("*.jpg")), [])
+
+    def test_duration_validation_and_schema_agree(self):
+        # Default config: max 30 s, default 5 s.
+        schema = self.plugin.get_tool()["inputSchema"]
+        self.assertEqual(schema["properties"]["duration_s"]["maximum"], 30)
+        self.assertEqual(schema["properties"]["duration_s"]["default"], 5)
+        for value in (True, 1.5, "2", None, 0, 31):
+            self.assertEqual(self.plugin.dispatch("record_video", {"duration_s": value})["code"], "INVALID_DURATION")
+        # The literal default stays 5 even when the configured cap changes;
+        # the validation cap follows the config independently.
+        self.plugin._max_duration_s = 2
+        schema = self.plugin.get_tool()["inputSchema"]
+        self.assertEqual(schema["properties"]["duration_s"]["maximum"], 2)
+        self.assertEqual(schema["properties"]["duration_s"]["default"], 5)
+        self.assertEqual(self.plugin.dispatch("record_video", {"duration_s": 6})["code"], "INVALID_DURATION")
+
+    def test_missing_encoder_is_immediate_error(self):
+        with mock.patch.object(capture.shutil, "which", return_value=None):
+            result = self.plugin.dispatch("record_video", {})
+        self.assertEqual(result["code"], "RECORD_FAILED")
+        self.assertEqual(self.notifications, [])
+
+    def test_cancel_waiting_for_first_frame_and_reject_overlap(self):
+        with mock.patch.object(capture.shutil, "which", return_value="ffmpeg"):
+            started = self.plugin.dispatch("record_video", {})
+            self.assertTrue(started["ok"])
+            json.dumps(self.plugin.dispatch("info", {}))
+            duplicate = self.plugin.dispatch("record_video", {})
+            self.assertEqual(duplicate["code"], "RECORD_IN_PROGRESS")
+            self.assertNotIn("action_id", duplicate)
+            self.assertEqual(self.plugin.dispatch("config", {"camera": "external"})["code"], "RECORD_IN_PROGRESS")
+            self.assertTrue(self.plugin.dispatch("config", {"camera": "front"})["ok"])
+            self.assertEqual(self.plugin.stop()["state"], "idle")
+        self.plugin.stop()
+        action_id, status, result = self.wait_recording()
+        self.assertEqual(action_id, started["action_id"])
+        self.assertEqual(status, "cancelled")
+        self.assertEqual(result["code"], "RECORD_CANCELLED")
+
+    def test_no_camera_reports_async_error(self):
+        with mock.patch.object(capture.shutil, "which", return_value="ffmpeg"), \
+             mock.patch.object(self.plugin, "_frame", side_effect=RuntimeError("no camera")):
+            started = self.plugin.dispatch("record_video", {})
+            event = self.wait_recording()
+        self.assertEqual(event[0], started["action_id"])
+        self.assertEqual(event[1], "error")
+        self.assertEqual(event[2]["code"], "RECORD_FAILED")
+
+    def test_acp_payload(self):
+        with mock.patch.object(capture.urllib.request, "urlopen") as urlopen, \
+             mock.patch.dict(capture.os.environ, {"AGENT_CORE_URL": "http://127.0.0.1:15678"}):
+            capture.VisionCapturePlugin._notify_complete(self.plugin, "test-id", "completed", {"ok": True})
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.full_url, "http://127.0.0.1:15678/api/acp/complete")
+        payload = json.loads(request.data)
+        self.assertEqual(payload["tool"], "vision_capture")
+        self.assertEqual(payload["action_id"], "test-id")
+
+    def test_shutdown_waits_for_terminal_callback_without_cancelling_success(self):
+        entered, release = threading.Event(), threading.Event()
+
+        def notify(*args):
+            entered.set()
+            release.wait(3)
+            self.notifications.append(args)
+
+        self.plugin._notify_complete = notify
+        with mock.patch.object(capture.shutil, "which", return_value="ffmpeg"), \
+             mock.patch.object(self.plugin, "_record_video", return_value={"ok": True}):
+            self.plugin.dispatch("record_video", {})
+            self.assertTrue(entered.wait(2))
+            stopper = threading.Thread(target=self.plugin.stop)
+            stopper.start()
+            try:
+                self.assertTrue(stopper.is_alive())
+                release.set()
+                stopper.join(3)
+            finally:
+                release.set()
+        self.assertFalse(stopper.is_alive())
+        self.assertEqual(self.wait_recording()[1], "completed")
+
+
+@unittest.skipUnless(shutil.which("ffmpeg") and shutil.which("ffprobe"), "FFmpeg integration requires ffmpeg and ffprobe")
+class EncoderTest(CaptureHarness):
+    @classmethod
+    def setUpClass(cls):
+        cls.jpeg = subprocess.check_output([
+            "ffmpeg", "-hide_banner", "-loglevel", "error", "-f", "lavfi",
+            "-i", "testsrc=size=160x120:rate=15", "-frames:v", "1", "-f", "image2pipe", "-c:v", "mjpeg", "pipe:1"])
+
+    def source(self, fps=15):
+        return self.publish(self.jpeg, fps=fps)
+
+    def test_real_photo_and_video(self):
+        self.source()
+        photo = self.plugin.dispatch("capture_photo", {})
+        subprocess.run(["ffmpeg", "-v", "error", "-i", photo["file_path"], "-f", "null", "-"], check=True)
+        self.assertEqual(self.notifications, [], "capture_photo must not trigger ACP completion")
+        started = self.plugin.dispatch("record_video", {"duration_s": 1})
+        action_id, status, result = self.wait_recording()
+        self.assertEqual(action_id, started["action_id"])
+        self.assertEqual(status, "completed", result)
+        probe = json.loads(subprocess.check_output([
+            "ffprobe", "-v", "error", "-show_streams", "-show_format", "-of", "json", result["file_path"]]))
+        self.assertEqual(probe["streams"][0]["codec_name"], "h264")
+        self.assertEqual(probe["streams"][0]["pix_fmt"], "yuv420p")
+        self.assertAlmostEqual(float(probe["format"]["duration"]), 1, delta=0.001)
+        self.assertGreater(result["frames"], 8)
+        self.assertEqual(self.plugin._info()["last_recording"]["status"], "completed")
+
+    def test_video_result_matches_q5_contract(self):
+        # Exactly one ACP terminal notification; the result is the q5 slim set.
+        self.source()
+        self.plugin.dispatch("record_video", {"duration_s": 1})
+        action_id, status, result = self.wait_recording()
+        self.assertEqual(status, "completed", result)
+        self.assertEqual(len(self.notifications), 1)
+        self.assertEqual(action_id, self.notifications[0][0])
+        self.assertIn("file_path", result)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["media_type"], "video")
+        self.assertEqual(result["recorded_duration_s"], 1)
+        self.assertGreaterEqual(result["frames"], 1)
+        self.assertIn("captured_at", result)
+        # The q5 contract carries no extra display/verification fields.
+        fields = {"ok", "media_type", "file_path", "recorded_duration_s",
+                  "frames", "captured_at"}
+        self.assertFalse(set(result) - fields)
+        # Same result is retained for the info card, not duplicated for display.
+        self.assertEqual(self.plugin._info()["last_recording"]["result"], result)
+
+    def test_slow_source_preserves_video_timing(self):
+        self.source(fps=5)
+        self.plugin.dispatch("record_video", {"duration_s": 2})
+        _, status, result = self.wait_recording()
+        self.assertEqual(status, "completed", result)
+        duration = float(subprocess.check_output([
+            "ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "csv=p=0", result["file_path"]]))
+        self.assertAlmostEqual(duration, 2, delta=0.001)
+
+    def test_five_second_video_has_exact_duration_and_complete_last_frame(self):
+        self.source(fps=7)
+        queued = self.plugin.dispatch("record_video", {"duration_s": 5})
+        _, status, result = self.wait_recording(timeout=12)
+        self.assertEqual(status, "completed", result)
+        probe = json.loads(subprocess.check_output([
+            "ffprobe", "-v", "error", "-count_frames", "-show_entries",
+            "format=duration:stream=duration,nb_read_frames,avg_frame_rate", "-of", "json", result["file_path"]]))
+        self.assertAlmostEqual(float(probe["format"]["duration"]), 5, delta=0.001)
+        self.assertAlmostEqual(float(probe["streams"][0]["duration"]), 5, delta=0.001)
+        self.assertEqual(int(probe["streams"][0]["nb_read_frames"]), 75)
+        self.assertEqual(probe["streams"][0]["avg_frame_rate"], "15/1")
+        self.assertEqual(result["recorded_duration_s"], float(probe["format"]["duration"]))
+
+    def test_one_second_recording_at_one_fps(self):
+        self.plugin._fps = 1
+        self.source()
+        self.plugin.dispatch("record_video", {"duration_s": 1})
+        _, status, result = self.wait_recording()
+        self.assertEqual(status, "completed", result)
+        duration = float(subprocess.check_output([
+            "ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "csv=p=0", result["file_path"]]))
+        self.assertAlmostEqual(duration, 1, delta=0.1)
+
+    def test_encoder_rejects_corrupt_frames_and_removes_partial_file(self):
+        self.publish(b"\xff\xd8corrupt\xff\xd9")
+        self.plugin.dispatch("record_video", {"duration_s": 1})
+        _, status, result = self.wait_recording()
+        self.assertEqual(status, "error", result)
+        self.assertEqual(result["code"], "RECORD_FAILED")
+        self.assertEqual(list(Path(self.directory.name).rglob("*.mp4")), [])
+
+    def test_acp_completion_waits_until_file_validation_finishes(self):
+        self.source()
+        entered, release = threading.Event(), threading.Event()
+        probe = self.plugin._probe_video
+
+        def held_probe(*args):
+            entered.set()
+            if not release.wait(5):
+                raise RuntimeError("test validation gate timed out")
+            return probe(*args)
+
+        with mock.patch.object(self.plugin, "_probe_video", side_effect=held_probe):
+            self.plugin.dispatch("record_video", {"duration_s": 1})
+            try:
+                self.assertTrue(entered.wait(4))
+                self.assertEqual(self.notifications, [], "ACP must not finish before the MP4 is validated")
+                self.assertIsNotNone(self.plugin._info()["active_recording"])
+            finally:
+                release.set()
+            self.assertEqual(self.wait_recording()[1], "completed")
+
+    def test_failed_file_validation_reports_error_and_removes_output(self):
+        self.source()
+        with mock.patch.object(self.plugin, "_probe_video", side_effect=RuntimeError("duration mismatch")):
+            self.plugin.dispatch("record_video", {"duration_s": 1})
+            _, status, result = self.wait_recording()
+        self.assertEqual(status, "error")
+        self.assertEqual(result["code"], "RECORD_FAILED")
+        # Failure result carries the q5 slim failure contract: ok/code/message only.
+        self.assertEqual(set(result), {"ok", "code", "message"})
+        self.assertFalse(result["ok"])
+        self.assertEqual(list(Path(self.directory.name).rglob("*.mp4")), [])
+
+    def test_external_video_keeps_selected_camera_while_front_is_publishing(self):
+        topic = "/go2/ext_camera/usb_one/rgb"
+        self.plugin._external_camera = external_plugin({"usb-one": external_status(topic)})
+        blue = subprocess.check_output([
+            "ffmpeg", "-v", "error", "-f", "lavfi", "-i", "color=c=blue:s=160x120",
+            "-frames:v", "1", "-f", "image2pipe", "-c:v", "mjpeg", "pipe:1"])
+        self.source()
+        self.publish(blue, topic)
+        self.plugin.dispatch("record_video", {"camera": "external", "duration_s": 1})
+        _, status, result = self.wait_recording()
+        self.assertEqual(status, "completed", result)
+        # The external instance id is no longer echoed in the q5-slim result;
+        # the blue-frame decode still proves the selected camera was used.
+        self.assertNotIn("source", result)
+        # Decode all frames: a front-camera test pattern would not remain blue.
+        pixels = subprocess.check_output([
+            "ffmpeg", "-v", "error", "-i", result["file_path"], "-vf", "scale=1:1",
+            "-pix_fmt", "rgb24", "-f", "rawvideo", "pipe:1"])
+        self.assertGreater(len(pixels), 15)
+        for i in range(0, len(pixels), 3):
+            red, green, blue = pixels[i:i+3]
+            self.assertLess(red, 20)
+            self.assertLess(green, 20)
+            self.assertGreater(blue, 220)
+
+    def test_cancel_active_encoder_cleans_partial_video(self):
+        self.source()
+        self.plugin.dispatch("record_video", {"duration_s": 5})
+        deadline = time.monotonic() + 3
+        process = None
+        while time.monotonic() < deadline:
+            with self.plugin._recording_lock:
+                process = self.plugin._active_recording.get("process") if self.plugin._active_recording else None
+            if process:
+                break
+            time.sleep(0.02)
+        self.assertIsNotNone(process)
+        self.assertEqual(self.plugin.stop()["state"], "idle")
+        self.assertEqual(self.wait_recording()[1], "cancelled")
+        self.assertIsNotNone(process.poll())
+        self.assertEqual(list(Path(self.directory.name).rglob("*.mp4")), [])
+
+    def test_stalled_source_errors_and_deletes_partial_video(self):
+        halt = self.source()
+        self.plugin.dispatch("record_video", {"duration_s": 5})
+        time.sleep(0.4)
+        halt.set()
+        _, status, result = self.wait_recording()
+        self.assertEqual(status, "error", result)
+        self.assertEqual(list(Path(self.directory.name).rglob("*.mp4")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_go2_vision_capture.py
+++ b/tests/test_go2_vision_capture.py
@@ -119,6 +119,18 @@ class CaptureHarness(unittest.TestCase):
         self.assertEqual(len(self.notifications), 1)
         return self.notifications[0]
 
+    def wait_last_recording(self, timeout=12):
+        """Wait for the terminal outcome in info.last_recording (no ACP)."""
+        deadline = time.monotonic() + timeout
+        timeline = None
+        while time.monotonic() < deadline:
+            info = self.plugin._info()
+            record = info.get("last_recording")
+            if record and record.get("status") in ("completed", "cancelled", "error"):
+                return record
+            time.sleep(0.02)
+        self.fail(f"recording did not finish: {info.get('last_recording')!r}")
+
 
 class CaptureTest(CaptureHarness):
     def test_external_selection_excludes_depth_and_infrared_jpeg(self):
@@ -275,54 +287,49 @@ class CaptureTest(CaptureHarness):
             self.assertEqual(self.plugin.dispatch("config", {"camera": "external"})["code"], "RECORD_IN_PROGRESS")
             self.assertTrue(self.plugin.dispatch("config", {"camera": "front"})["ok"])
             self.assertEqual(self.plugin.stop()["state"], "idle")
-        self.plugin.stop()
-        action_id, status, result = self.wait_recording()
-        self.assertEqual(action_id, started["action_id"])
-        self.assertEqual(status, "cancelled")
-        self.assertEqual(result["code"], "RECORD_CANCELLED")
+        self.assertIsNone(self.plugin._active_recording)
+        record = self.wait_last_recording()
+        self.assertEqual(record["action_id"], started["action_id"])
+        self.assertEqual(record["status"], "cancelled")
+        self.assertEqual(record["result"]["code"], "RECORD_CANCELLED")
 
-    def test_no_camera_reports_async_error(self):
+    def test_no_camera_reports_async_error_without_action_id(self):
         with mock.patch.object(capture.shutil, "which", return_value="ffmpeg"), \
              mock.patch.object(self.plugin, "_frame", side_effect=RuntimeError("no camera")):
             started = self.plugin.dispatch("record_video", {})
-            event = self.wait_recording()
-        self.assertEqual(event[0], started["action_id"])
-        self.assertEqual(event[1], "error")
-        self.assertEqual(event[2]["code"], "RECORD_FAILED")
+        # The queued response carries the destination file_path synchronously,
+        # like capture_photo, even when the background encode later fails.
+        self.assertTrue(started["ok"])
+        self.assertIn("file_path", started)
+        self.assertEqual(Path(started["file_path"]).parent.name, "videos")
 
-    def test_acp_payload(self):
-        with mock.patch.object(capture.urllib.request, "urlopen") as urlopen, \
-             mock.patch.dict(capture.os.environ, {"AGENT_CORE_URL": "http://127.0.0.1:15678"}):
-            capture.VisionCapturePlugin._notify_complete(self.plugin, "test-id", "completed", {"ok": True})
-        request = urlopen.call_args.args[0]
-        self.assertEqual(request.full_url, "http://127.0.0.1:15678/api/acp/complete")
-        payload = json.loads(request.data)
-        self.assertEqual(payload["tool"], "vision_capture")
-        self.assertEqual(payload["action_id"], "test-id")
-
-    def test_shutdown_waits_for_terminal_callback_without_cancelling_success(self):
+    def test_stop_waits_for_slow_worker_before_returning(self):
+        # stop() joins the worker thread: it must block until the background
+        # encode fully settles (active cleared, last_recording committed).
         entered, release = threading.Event(), threading.Event()
 
-        def notify(*args):
+        def slow_record(active):
             entered.set()
             release.wait(3)
-            self.notifications.append(args)
+            return {"ok": True, "file_path": str(Path(self.directory.name) / "videos" / "slow.mp4")}
 
-        self.plugin._notify_complete = notify
-        with mock.patch.object(capture.shutil, "which", return_value="ffmpeg"), \
-             mock.patch.object(self.plugin, "_record_video", return_value={"ok": True}):
+        self.plugin._record_video = slow_record
+        with mock.patch.object(capture.shutil, "which", return_value="ffmpeg"):
             self.plugin.dispatch("record_video", {})
             self.assertTrue(entered.wait(2))
             stopper = threading.Thread(target=self.plugin.stop)
             stopper.start()
             try:
-                self.assertTrue(stopper.is_alive())
+                self.assertTrue(stopper.is_alive(), "stop must block until the worker finishes")
                 release.set()
                 stopper.join(3)
             finally:
                 release.set()
         self.assertFalse(stopper.is_alive())
-        self.assertEqual(self.wait_recording()[1], "completed")
+        # stop() set the cancel flag while the worker was still running, so the
+        # terminal outcome is cancelled even though encoding would have succeeded.
+        self.assertEqual(self.plugin._info()["last_recording"]["status"], "cancelled")
+        self.assertIsNone(self.plugin._active_recording)
 
 
 @unittest.skipUnless(shutil.which("ffmpeg") and shutil.which("ffprobe"), "FFmpeg integration requires ffmpeg and ffprobe")
@@ -341,10 +348,10 @@ class EncoderTest(CaptureHarness):
         photo = self.plugin.dispatch("capture_photo", {})
         subprocess.run(["ffmpeg", "-v", "error", "-i", photo["file_path"], "-f", "null", "-"], check=True)
         self.assertEqual(self.notifications, [], "capture_photo must not trigger ACP completion")
-        started = self.plugin.dispatch("record_video", {"duration_s": 1})
-        action_id, status, result = self.wait_recording()
-        self.assertEqual(action_id, started["action_id"])
-        self.assertEqual(status, "completed", result)
+        self.plugin.dispatch("record_video", {"duration_s": 1})
+        record = self.wait_last_recording()
+        self.assertEqual(record["status"], "completed")
+        result = record["result"]
         probe = json.loads(subprocess.check_output([
             "ffprobe", "-v", "error", "-show_streams", "-show_format", "-of", "json", result["file_path"]]))
         self.assertEqual(probe["streams"][0]["codec_name"], "h264")
@@ -352,42 +359,51 @@ class EncoderTest(CaptureHarness):
         self.assertAlmostEqual(float(probe["format"]["duration"]), 1, delta=0.001)
         self.assertGreater(result["frames"], 8)
         self.assertEqual(self.plugin._info()["last_recording"]["status"], "completed")
+        # The destination path was already returned synchronously on admission.
+        self.assertEqual(self.notifications, [])
 
-    def test_video_result_matches_q5_contract(self):
-        # Exactly one ACP terminal notification; the result is the q5 slim set.
+    def test_no_notify_for_record_video(self):
+        # No ACP terminal notification is posted for record_video any more;
+        # the destination path is returned synchronously like capture_photo.
         self.source()
         self.plugin.dispatch("record_video", {"duration_s": 1})
-        action_id, status, result = self.wait_recording()
-        self.assertEqual(status, "completed", result)
-        self.assertEqual(len(self.notifications), 1)
-        self.assertEqual(action_id, self.notifications[0][0])
-        self.assertIn("file_path", result)
+        record = self.wait_last_recording()
+        self.assertEqual(self.notifications, [])
+        self.assertEqual(record["status"], "completed")
+
+    def test_video_result_matches_q5_contract(self):
+        # The completed video result is retained for the info card; no ACP
+        # terminal notification is posted. The slim q5 field set is unchanged.
+        self.source()
+        self.plugin.dispatch("record_video", {"duration_s": 1})
+        record = self.wait_last_recording()
+        result = record["result"]
         self.assertTrue(result["ok"])
         self.assertEqual(result["media_type"], "video")
         self.assertEqual(result["recorded_duration_s"], 1)
         self.assertGreaterEqual(result["frames"], 1)
         self.assertIn("captured_at", result)
-        # The q5 contract carries no extra display/verification fields.
         fields = {"ok", "media_type", "file_path", "recorded_duration_s",
                   "frames", "captured_at"}
         self.assertFalse(set(result) - fields)
-        # Same result is retained for the info card, not duplicated for display.
-        self.assertEqual(self.plugin._info()["last_recording"]["result"], result)
+        self.assertIn("file_path", result)
 
     def test_slow_source_preserves_video_timing(self):
         self.source(fps=5)
         self.plugin.dispatch("record_video", {"duration_s": 2})
-        _, status, result = self.wait_recording()
-        self.assertEqual(status, "completed", result)
+        record = self.wait_last_recording()
+        self.assertEqual(record["status"], "completed", record)
+        result = record["result"]
         duration = float(subprocess.check_output([
             "ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "csv=p=0", result["file_path"]]))
         self.assertAlmostEqual(duration, 2, delta=0.001)
 
     def test_five_second_video_has_exact_duration_and_complete_last_frame(self):
         self.source(fps=7)
-        queued = self.plugin.dispatch("record_video", {"duration_s": 5})
-        _, status, result = self.wait_recording(timeout=12)
-        self.assertEqual(status, "completed", result)
+        self.plugin.dispatch("record_video", {"duration_s": 5})
+        record = self.wait_last_recording(timeout=12)
+        self.assertEqual(record["status"], "completed", record)
+        result = record["result"]
         probe = json.loads(subprocess.check_output([
             "ffprobe", "-v", "error", "-count_frames", "-show_entries",
             "format=duration:stream=duration,nb_read_frames,avg_frame_rate", "-of", "json", result["file_path"]]))
@@ -401,8 +417,9 @@ class EncoderTest(CaptureHarness):
         self.plugin._fps = 1
         self.source()
         self.plugin.dispatch("record_video", {"duration_s": 1})
-        _, status, result = self.wait_recording()
-        self.assertEqual(status, "completed", result)
+        record = self.wait_last_recording()
+        self.assertEqual(record["status"], "completed", record)
+        result = record["result"]
         duration = float(subprocess.check_output([
             "ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "csv=p=0", result["file_path"]]))
         self.assertAlmostEqual(duration, 1, delta=0.1)
@@ -410,12 +427,13 @@ class EncoderTest(CaptureHarness):
     def test_encoder_rejects_corrupt_frames_and_removes_partial_file(self):
         self.publish(b"\xff\xd8corrupt\xff\xd9")
         self.plugin.dispatch("record_video", {"duration_s": 1})
-        _, status, result = self.wait_recording()
-        self.assertEqual(status, "error", result)
+        record = self.wait_last_recording()
+        self.assertEqual(record["status"], "error", record)
+        result = record["result"]
         self.assertEqual(result["code"], "RECORD_FAILED")
         self.assertEqual(list(Path(self.directory.name).rglob("*.mp4")), [])
 
-    def test_acp_completion_waits_until_file_validation_finishes(self):
+    def test_finished_recording_cleared_only_after_validation_finishes(self):
         self.source()
         entered, release = threading.Event(), threading.Event()
         probe = self.plugin._probe_video
@@ -430,18 +448,21 @@ class EncoderTest(CaptureHarness):
             self.plugin.dispatch("record_video", {"duration_s": 1})
             try:
                 self.assertTrue(entered.wait(4))
-                self.assertEqual(self.notifications, [], "ACP must not finish before the MP4 is validated")
+                # No ACP notification and the recording is not yet final.
+                self.assertEqual(self.notifications, [])
                 self.assertIsNotNone(self.plugin._info()["active_recording"])
             finally:
                 release.set()
-            self.assertEqual(self.wait_recording()[1], "completed")
+            record = self.wait_last_recording()
+        self.assertEqual(record["status"], "completed")
 
     def test_failed_file_validation_reports_error_and_removes_output(self):
         self.source()
         with mock.patch.object(self.plugin, "_probe_video", side_effect=RuntimeError("duration mismatch")):
             self.plugin.dispatch("record_video", {"duration_s": 1})
-            _, status, result = self.wait_recording()
-        self.assertEqual(status, "error")
+            record = self.wait_last_recording()
+        self.assertEqual(record["status"], "error")
+        result = record["result"]
         self.assertEqual(result["code"], "RECORD_FAILED")
         # Failure result carries the q5 slim failure contract: ok/code/message only.
         self.assertEqual(set(result), {"ok", "code", "message"})
@@ -457,8 +478,9 @@ class EncoderTest(CaptureHarness):
         self.source()
         self.publish(blue, topic)
         self.plugin.dispatch("record_video", {"camera": "external", "duration_s": 1})
-        _, status, result = self.wait_recording()
-        self.assertEqual(status, "completed", result)
+        record = self.wait_last_recording()
+        self.assertEqual(record["status"], "completed", record)
+        result = record["result"]
         # The external instance id is no longer echoed in the q5-slim result;
         # the blue-frame decode still proves the selected camera was used.
         self.assertNotIn("source", result)
@@ -486,7 +508,8 @@ class EncoderTest(CaptureHarness):
             time.sleep(0.02)
         self.assertIsNotNone(process)
         self.assertEqual(self.plugin.stop()["state"], "idle")
-        self.assertEqual(self.wait_recording()[1], "cancelled")
+        record = self.wait_last_recording()
+        self.assertEqual(record["status"], "cancelled")
         self.assertIsNotNone(process.poll())
         self.assertEqual(list(Path(self.directory.name).rglob("*.mp4")), [])
 
@@ -495,8 +518,8 @@ class EncoderTest(CaptureHarness):
         self.plugin.dispatch("record_video", {"duration_s": 5})
         time.sleep(0.4)
         halt.set()
-        _, status, result = self.wait_recording()
-        self.assertEqual(status, "error", result)
+        record = self.wait_last_recording()
+        self.assertEqual(record["status"], "error", record)
         self.assertEqual(list(Path(self.directory.name).rglob("*.mp4")), [])
 
 

--- a/tests/test_go2_vision_capture.py
+++ b/tests/test_go2_vision_capture.py
@@ -279,6 +279,8 @@ class CaptureTest(CaptureHarness):
         schema = self.plugin.get_tool()["inputSchema"]
         self.assertEqual(schema["properties"]["duration_s"]["maximum"], 30)
         self.assertEqual(schema["properties"]["duration_s"]["default"], 5)
+        # The dashboard shows this caption under the duration_s field.
+        self.assertEqual(schema["properties"]["duration_s"]["description"], "默认5s,最大30s")
         for value in (True, 1.5, "2", None, 0, 31):
             self.assertEqual(self.plugin.dispatch("record_video", {"duration_s": value})["code"], "INVALID_DURATION")
         # The schema default clamps to the configured cap, so an omitted or

--- a/tests/test_go2_vision_capture.py
+++ b/tests/test_go2_vision_capture.py
@@ -217,11 +217,26 @@ class CaptureTest(CaptureHarness):
         finally:
             instance.stop_all()
 
-    def test_start_requires_actual_fresh_data_and_info_is_serializable(self):
-        self.assertFalse(self.plugin.start()["ok"])
+    def test_start_returns_lifecycle_state_and_info_tracks_freshness(self):
+        # The actuator contract requires the start action to return the bare
+        # lifecycle state; camera freshness stays on the info action.
+        self.assertEqual(self.plugin.start(), {"state": "ready"})
+        self.assertEqual(self.plugin.dispatch("start", {}), {"state": "ready"})
+        self.assertFalse(self.plugin.dispatch("info", {})["ok"])
         self.feed()
-        self.assertTrue(self.plugin.start()["ok"])
+        self.assertTrue(self.plugin.dispatch("info", {})["ok"])
         json.dumps(self.plugin.dispatch("info", {}))
+
+    def test_tool_does_not_advertise_async_completion(self):
+        # record_video is admission-synchronous: without x-completion, Agent
+        # Core never registers a pending action nor awaits /api/acp/complete.
+        self.assertNotIn("x-completion", self.plugin.get_tool()["inputSchema"])
+
+    def test_driver_yaml_marketplace_lists_vision_capture(self):
+        # config.yaml enables the card, so driver.yaml's hand-synced
+        # marketplace list must expose it too.
+        text = (ROOT / "unitree" / "go2" / "driver.yaml").read_text()
+        self.assertIn("{ name: vision_capture, type: actuator }", text)
 
     def test_photo_bytes_and_persistence_across_plugin_restart(self):
         data = b"\xff\xd8photo\xff\xd9"

--- a/tests/test_go2_vision_capture.py
+++ b/tests/test_go2_vision_capture.py
@@ -227,10 +227,14 @@ class CaptureTest(CaptureHarness):
         self.assertTrue(self.plugin.dispatch("info", {})["ok"])
         json.dumps(self.plugin.dispatch("info", {}))
 
-    def test_tool_does_not_advertise_async_completion(self):
-        # record_video is admission-synchronous: without x-completion, Agent
-        # Core never registers a pending action nor awaits /api/acp/complete.
-        self.assertNotIn("x-completion", self.plugin.get_tool()["inputSchema"])
+    def test_record_video_declares_completion_for_orchestration(self):
+        # ACP exists for orchestration only: Core registers the pending action
+        # from the admission result's action_id and holds the actuator barrier
+        # until the driver POSTs the terminal outcome. file_path stays visible
+        # in the synchronous admission response, so no Core change is needed.
+        completion = self.plugin.get_tool()["inputSchema"]["x-completion"]
+        self.assertIn("record_video", completion["actions"])
+        self.assertEqual(completion["timeout"], self.plugin._max_duration_s + 15)
 
     def test_driver_yaml_marketplace_lists_vision_capture(self):
         # config.yaml enables the card, so driver.yaml's hand-synced
@@ -307,6 +311,10 @@ class CaptureTest(CaptureHarness):
         self.assertEqual(record["action_id"], started["action_id"])
         self.assertEqual(record["status"], "cancelled")
         self.assertEqual(record["result"]["code"], "RECORD_CANCELLED")
+        action_id, status, result = self.wait_recording()
+        self.assertEqual(action_id, started["action_id"])
+        self.assertEqual(status, "cancelled")
+        self.assertEqual(result["code"], "RECORD_CANCELLED")
 
     def test_no_camera_reports_async_error_without_action_id(self):
         with mock.patch.object(capture.shutil, "which", return_value="ffmpeg"), \
@@ -374,17 +382,23 @@ class EncoderTest(CaptureHarness):
         self.assertAlmostEqual(float(probe["format"]["duration"]), 1, delta=0.001)
         self.assertGreater(result["frames"], 8)
         self.assertEqual(self.plugin._info()["last_recording"]["status"], "completed")
-        # The destination path was already returned synchronously on admission.
-        self.assertEqual(self.notifications, [])
+        # capture_photo posted nothing; record_video posted exactly one
+        # completed ACP outcome for the orchestration barrier.
+        self.assertEqual(len(self.notifications), 1)
+        self.assertEqual(self.notifications[0][1], "completed")
 
-    def test_no_notify_for_record_video(self):
-        # No ACP terminal notification is posted for record_video any more;
-        # the destination path is returned synchronously like capture_photo.
+    def test_record_video_posts_acp_terminal_outcome(self):
+        # The terminal outcome is POSTed to Core's ACP endpoint so the pending
+        # barrier releases; the admission response already carried file_path.
         self.source()
-        self.plugin.dispatch("record_video", {"duration_s": 1})
+        started = self.plugin.dispatch("record_video", {"duration_s": 1})
+        self.assertTrue(started["ok"])
+        self.assertIn("file_path", started)
         record = self.wait_last_recording()
-        self.assertEqual(self.notifications, [])
-        self.assertEqual(record["status"], "completed")
+        action_id, status, result = self.wait_recording()
+        self.assertEqual(action_id, started["action_id"])
+        self.assertEqual(status, record["status"])
+        self.assertEqual(result, record["result"])
 
     def test_video_result_matches_q5_contract(self):
         # The completed video result is retained for the info card; no ACP

--- a/tests/test_go2_vision_capture.py
+++ b/tests/test_go2_vision_capture.py
@@ -281,13 +281,26 @@ class CaptureTest(CaptureHarness):
         self.assertEqual(schema["properties"]["duration_s"]["default"], 5)
         for value in (True, 1.5, "2", None, 0, 31):
             self.assertEqual(self.plugin.dispatch("record_video", {"duration_s": value})["code"], "INVALID_DURATION")
-        # The literal default stays 5 even when the configured cap changes;
-        # the validation cap follows the config independently.
+        # The schema default clamps to the configured cap, so an omitted or
+        # schema-applied duration_s is always within the validation range.
         self.plugin._max_duration_s = 2
         schema = self.plugin.get_tool()["inputSchema"]
         self.assertEqual(schema["properties"]["duration_s"]["maximum"], 2)
-        self.assertEqual(schema["properties"]["duration_s"]["default"], 5)
+        self.assertEqual(schema["properties"]["duration_s"]["default"], 2)
         self.assertEqual(self.plugin.dispatch("record_video", {"duration_s": 6})["code"], "INVALID_DURATION")
+
+    def test_cap_below_default_clamps_schema_and_dispatch_default(self):
+        # A configured cap below 5 must never advertise an unusable default:
+        # both the schema default and the dispatch fallback clamp to the cap.
+        plugin = capture.VisionCapturePlugin(
+            {"output_dir": self.directory.name, "max_duration_s": 3}, "go2", self.executor)
+        self.addCleanup(plugin.stop)
+        schema = plugin.get_tool()["inputSchema"]["properties"]["duration_s"]
+        self.assertEqual(schema["default"], 3)
+        with mock.patch.object(capture.shutil, "which", return_value="ffmpeg"):
+            started = plugin.dispatch("record_video", {})
+        self.assertTrue(started["ok"])
+        self.assertEqual(started["requested_duration_s"], 3)
 
     def test_missing_encoder_is_immediate_error(self):
         with mock.patch.object(capture.shutil, "which", return_value=None):

--- a/unitree/go2/Dockerfile
+++ b/unitree/go2/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
     apt-get install -y --no-install-recommends --allow-unauthenticated \
         libasound2-dev \
         libportaudio2 \
+        ffmpeg \
         v4l-utils && \
     rm -rf /var/lib/apt/lists/*
 
@@ -72,6 +73,7 @@ COPY path_planner.py /work/path_planner.py
 COPY icp.py /work/icp.py
 COPY global_registration.py /work/global_registration.py
 COPY ext_devices.py /work/ext_devices.py
+COPY vision_capture.py /work/vision_capture.py
 COPY realsense.py /work/realsense.py
 COPY lidar.py /work/lidar.py
 COPY pointcloud_utils.py /work/pointcloud_utils.py

--- a/unitree/go2/Dockerfile
+++ b/unitree/go2/Dockerfile
@@ -26,6 +26,10 @@ RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
     ldconfig && \
     rm -rf /var/lib/apt/lists/*
 
+# FFmpeg CLI + ffprobe: required by the vision_capture card to encode H.264
+# MP4s and validate the completed files on-device (the base image ships
+# neither). This is the only consumer; the package and its libav* dependency
+# chain do grow this Go2-only image.
 RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
     apt-get install -y --no-install-recommends --allow-unauthenticated \
         libasound2-dev \

--- a/unitree/go2/VISION_CAPTURE.md
+++ b/unitree/go2/VISION_CAPTURE.md
@@ -25,7 +25,7 @@ is rejected; repeating the same configuration is accepted.
 
 | Action | Result |
 | --- | --- |
-| `capture_photo` | Wait for a new JPEG frame, save it, return `file_path` and source metadata. |
+| `capture_photo` | Wait for a new JPEG frame, save it, return `file_path` synchronously (no ACP). |
 | `record_video` | Queue a 1–30-second recording, default 5 seconds, and return `action_id`. |
 | `list_cameras` | List the built-in source and running external RGB instances. |
 | `info` | Report source freshness, output directories, active recording and latest terminal result. |
@@ -42,40 +42,36 @@ Example MCP arguments for tool `vision_capture`:
 {"action": "record_video", "camera": "external", "duration_s": 5}
 ```
 
-Omit `camera` to use the saved card configuration. `queued` is an admission
-response, not completion. The terminal result is posted to Core's
-`/api/acp/complete` and remains available in `info.last_recording` until restart.
-Only one recording may be active. Camera previews keep running when recording
-is cancelled. Missing, stale or stalled input produces an error.
+Omit `duration_s` to use the default of 5 seconds. `maximum` is 30 seconds.
+Omit `camera` to use the saved card configuration.
 
-A successful video result includes `file_name`, the full `file_path`, and a
-human-readable `message` naming the saved file. These fields are added only
-after encoding and file validation succeed; cancellation does not advertise an
-incomplete file as a saved result.
+`queued` is an admission response, not completion. The terminal result is posted
+once to Core's `/api/acp/complete` and also remains in `info.last_recording`
+until restart. Only one recording may be active. Camera previews keep running
+when recording is cancelled. Missing, stale or stalled input produces an error.
 
-The queued response includes `queued_at`. A successful ACP completion is sent
-only after FFmpeg exits successfully and ffprobe verifies the completed MP4's
-duration and frame count. The result separates media duration from elapsed time:
+The result contract matches the Q5 vision_capture card. A successful
+`record_video` completion carries only the Q5 slim field set, and the honored
+requested duration is returned after encoding:
 
 | Field | Meaning |
 | --- | --- |
-| `requested_duration_s` | Requested video length. |
+| `ok` / `media_type` | Success flag and `video` media type. |
+| `file_path` | Absolute path to the completed MP4 on the Go2 host. |
 | `recorded_duration_s` | Completed MP4 duration measured by ffprobe. |
-| `capture_elapsed_s` | Actual time spent collecting source frames, measured with a monotonic clock. |
-| `finalize_elapsed_s` | Time spent finalizing and validating the file after collection ends. |
-| `elapsed_s` | Total time from queue admission to terminal result, excluding callback network delivery. |
-| `queued_at`, `capture_started_at`, `capture_finished_at`, `completed_at` | Millisecond ISO timestamps with explicit timezone offsets. |
+| `frames` | Fresh source frames encoded. |
+| `captured_at` | Filesystem stamp ISO timestamp with timezone offset when encoding finished. |
 
-For a 5-second recording, the MP4 must measure 5 seconds; the total elapsed time
-can be longer due to waiting for the first frame and finalizing the file.
-Failed/cancelled results still include request, queue, completion and total-time
-fields. The single ACP terminal callback follows validation or failure cleanup.
+Failure and cancellation result carry only `ok`, `code` and `message` — no extra
+timing/display fields. `capture_photo` returns `file_path` synchronously and
+never posts ACP, as on Q5. No extra display/verification fields are added so the
+saved file is rendered by Core through the existing ACP `file_path` rendering
+with zero Core changes.
 
-Video timestamps preserve capture timing. Output uses the configured frame
-rate and extends the final frame to the requested endpoint. At 15 fps, a
-5-second video contains 75 encoded frames. `frames` counts fresh source frames;
-`encoded_frames` includes repeats used to preserve timing. Padding does not
-replace camera freshness checks or make a stalled capture succeed.
+Video output preserves capture timing and extends the last frame to the exact
+requested endpoint, so a 5-second recording at 15 fps contains 75 encoded frames.
+`frames` counts fresh source frames received. Padding does not replace camera
+freshness checks or make a stalled capture succeed.
 
 ## Files and deployment
 
@@ -88,44 +84,27 @@ The Dockerfile includes FFmpeg and copies the plugin. Configuration under
 `fps` (1–15) and `max_duration_s` (1–30).
 
 As with Q5, the card returns saved paths; it does not add inline media previews.
-Download files to inspect them, for example:
+Download files to inspect them:
 
 ```bash
 mkdir -p ~/Downloads/go2-photos
 scp 'unitree@GO2_IP:/opt/phanthy-motus/data/vision_capture/photos/*.jpg' ~/Downloads/go2-photos/
 ```
 
-No Core modification is required for the driver's completion protocol or timing
-fields: it uses the existing ACP endpoint and `info` result. Core's optional
-activity-log forwarding is a separate observability fix, not a prerequisite for
-recording or correct terminal signaling.
-For automatic user-facing file receipts, Core must retain the file-result fields
-when compacting ACP events. Legacy Core versions discard all `result` data and
-cannot deliver the saved path. A separate minimal Core fix preserves file receipts
-and sends their filename/path through the existing activity `trigger` renderer;
-it does not modify frontend files or change the capture protocol.
+No Core modification is required for the driver's completion protocol: single
+ACP terminal callback, `file_path` in the result, and no display-only fields.
 
 ## Validation
 
 On 2026-09-08, Go2's built-in camera and an external D435i RGB source each
 produced valid 1280x720 JPGs and 5.000000-second H.264 videos with 75 decoded
-frames at 15 fps. Cancellation removed partial MP4s. Concurrent camera sampling
-verified valid front/RGB/depth/infrared data and nonzero ROS publishers.
-ACP completion and cancellation were also observed through the separately
-updated Core activity stream and browser.
+frames. Cancellation removed partial MP4s. Concurrent sampling verified valid
+front/RGB/depth/infrared data and nonzero ROS publishers.
 
-Local and ARM64-image checks covered selection, stale input, duration validation,
-exact output timing at slow source rates, encoder failures and cancellation.
-Local verification scripts are intentionally not included in this driver change.
-On 2026-09-09, the timing metadata and ffprobe completion gate passed real Go2
-verification on both sources. Each MP4 measured 5.000000 seconds and decoded to
-75 frames. Measured collection time was 5.001 seconds for each source; queue
-admission to file readiness took 5.335 seconds (front) and 5.328 seconds (external).
-ACP reached Core 0.095 and 0.141 seconds after file readiness, respectively.
-Cancellation also reported ordered timestamps and elapsed time. The Core dropdown
-title patch was rolled back, and the temporary external test instance was stopped.
-All 27 capture checks passed in the ARM64 image; 63 local Go2 checks passed before
-deployment. Verification scripts remain local and are not part of this change.
-The file receipt was subsequently verified with a real 5-second recording: the
-existing browser log displayed the complete filename and path immediately from
-the ACP callback, and frontend JavaScript matched the original Core image.
+On 2026-09-09 the contract was aligned to the Q5 card: `duration_s` default is
+5 (maximum 30), `record_video` posts a single ACP `completed` whose result
+carries only `file_path`/`recorded_duration_s`/`frames`/`captured_at`, and the
+previous extra timing/display fields were removed. All 28 local capture checks
+(including real FFmpeg/ffprobe media) pass; ARM64-image verification on the Go2
+runs after the release image deploys.
+'''

--- a/unitree/go2/VISION_CAPTURE.md
+++ b/unitree/go2/VISION_CAPTURE.md
@@ -7,8 +7,8 @@ existing Go2 camera publishers, so it does not open a camera device twice.
 ## Select a camera
 
 Select `front` for the built-in front camera, or `external` for an external
-camera. The external option declares the display title **external (only rgb)**.
-The card exposes no `external_instance_id` input.
+camera. RGB-only support is explained in the field description; no Core
+dropdown-rendering change is needed. The card exposes no `external_instance_id` input.
 
 Start the source camera first. For an external camera, configure and start an
 [`ext_camera`](EXT_CAMERA.md) instance with `channel: rgb`. The capture card
@@ -48,6 +48,24 @@ response, not completion. The terminal result is posted to Core's
 Only one recording may be active. Camera previews keep running when recording
 is cancelled. Missing, stale or stalled input produces an error.
 
+The queued response includes `queued_at`. A successful ACP completion is sent
+only after FFmpeg exits successfully and ffprobe verifies the completed MP4's
+duration and frame count. The result separates media duration from elapsed time:
+
+| Field | Meaning |
+| --- | --- |
+| `requested_duration_s` | Requested video length. |
+| `recorded_duration_s` | Completed MP4 duration measured by ffprobe. |
+| `capture_elapsed_s` | Actual time spent collecting source frames, measured with a monotonic clock. |
+| `finalize_elapsed_s` | Time spent finalizing and validating the file after collection ends. |
+| `elapsed_s` | Total time from queue admission to terminal result, excluding callback network delivery. |
+| `queued_at`, `capture_started_at`, `capture_finished_at`, `completed_at` | Millisecond ISO timestamps with explicit timezone offsets. |
+
+For a 5-second recording, the MP4 must measure 5 seconds; the total elapsed time
+can be longer due to waiting for the first frame and finalizing the file.
+Failed/cancelled results still include request, queue, completion and total-time
+fields. The single ACP terminal callback follows validation or failure cleanup.
+
 Video timestamps preserve capture timing. Output uses the configured frame
 rate and extends the final frame to the requested endpoint. At 15 fps, a
 5-second video contains 75 encoded frames. `frames` counts fresh source frames;
@@ -72,11 +90,10 @@ mkdir -p ~/Downloads/go2-photos
 scp 'unitree@GO2_IP:/opt/phanthy-motus/data/vision_capture/photos/*.jpg' ~/Downloads/go2-photos/
 ```
 
-Core must support `oneOf.title` on actuator fields to display the external
-option's title instead of its raw `external` value. Showing ACP terminal events
-in the activity log also requires Core to forward callbacks to its activity
-stream. These are separate Core changes; the driver supplies the schema and
-completion callbacks and works with the existing `info` query independently.
+No Core modification is required for the driver's completion protocol or timing
+fields: it uses the existing ACP endpoint and `info` result. Core's optional
+activity-log forwarding is a separate observability fix, not a prerequisite for
+recording or correct terminal signaling.
 
 ## Validation
 
@@ -90,3 +107,12 @@ updated Core activity stream and browser.
 Local and ARM64-image checks covered selection, stale input, duration validation,
 exact output timing at slow source rates, encoder failures and cancellation.
 Local verification scripts are intentionally not included in this driver change.
+On 2026-09-09, the timing metadata and ffprobe completion gate passed real Go2
+verification on both sources. Each MP4 measured 5.000000 seconds and decoded to
+75 frames. Measured collection time was 5.001 seconds for each source; queue
+admission to file readiness took 5.335 seconds (front) and 5.328 seconds (external).
+ACP reached Core 0.095 and 0.141 seconds after file readiness, respectively.
+Cancellation also reported ordered timestamps and elapsed time. The Core dropdown
+title patch was rolled back, and the temporary external test instance was stopped.
+All 27 capture checks passed in the ARM64 image; 63 local Go2 checks passed before
+deployment. Verification scripts remain local and are not part of this change.

--- a/unitree/go2/VISION_CAPTURE.md
+++ b/unitree/go2/VISION_CAPTURE.md
@@ -42,8 +42,9 @@ Example MCP arguments for tool `vision_capture`:
 {"action": "record_video", "camera": "external", "duration_s": 5}
 ```
 
-Omit `duration_s` to use the default of 5 seconds. `maximum` is 30 seconds.
-Omit `camera` to use the saved card configuration.
+Omit `duration_s` to use the default of 5 seconds, clamped down to the
+configured `max_duration_s` cap so the schema default is always usable.
+`maximum` is 30 seconds. Omit `camera` to use the saved card configuration.
 
 `record_video` returns `state: recording` with the destination `file_path`
 immediately, like `capture_photo` — no Core rendering change is needed to see

--- a/unitree/go2/VISION_CAPTURE.md
+++ b/unitree/go2/VISION_CAPTURE.md
@@ -48,6 +48,11 @@ response, not completion. The terminal result is posted to Core's
 Only one recording may be active. Camera previews keep running when recording
 is cancelled. Missing, stale or stalled input produces an error.
 
+A successful video result includes `file_name`, the full `file_path`, and a
+human-readable `message` naming the saved file. These fields are added only
+after encoding and file validation succeed; cancellation does not advertise an
+incomplete file as a saved result.
+
 The queued response includes `queued_at`. A successful ACP completion is sent
 only after FFmpeg exits successfully and ffprobe verifies the completed MP4's
 duration and frame count. The result separates media duration from elapsed time:
@@ -94,6 +99,11 @@ No Core modification is required for the driver's completion protocol or timing
 fields: it uses the existing ACP endpoint and `info` result. Core's optional
 activity-log forwarding is a separate observability fix, not a prerequisite for
 recording or correct terminal signaling.
+For automatic user-facing file receipts, Core must retain the file-result fields
+when compacting ACP events. Legacy Core versions discard all `result` data and
+cannot deliver the saved path. A separate minimal Core fix preserves file receipts
+and sends their filename/path through the existing activity `trigger` renderer;
+it does not modify frontend files or change the capture protocol.
 
 ## Validation
 
@@ -116,3 +126,6 @@ Cancellation also reported ordered timestamps and elapsed time. The Core dropdow
 title patch was rolled back, and the temporary external test instance was stopped.
 All 27 capture checks passed in the ARM64 image; 63 local Go2 checks passed before
 deployment. Verification scripts remain local and are not part of this change.
+The file receipt was subsequently verified with a real 5-second recording: the
+existing browser log displayed the complete filename and path immediately from
+the ACP callback, and frontend JavaScript matched the original Core image.

--- a/unitree/go2/VISION_CAPTURE.md
+++ b/unitree/go2/VISION_CAPTURE.md
@@ -26,11 +26,11 @@ is rejected; repeating the same configuration is accepted.
 | Action | Result |
 | --- | --- |
 | `capture_photo` | Wait for a new JPEG frame, save it, return `file_path` synchronously (no ACP). |
-| `record_video` | Queue a 1–30-second recording, default 5 seconds, and return `action_id`. |
+| `record_video` | Start a 1–30-second recording, default 5 seconds; return the destination `file_path` synchronously. |
 | `list_cameras` | List the built-in source and running external RGB instances. |
 | `info` | Report source freshness, output directories, active recording and latest terminal result. |
 | `start` | Subscribe to the configured source; report readiness based on actual frames. |
-| `stop` | Cancel recording, remove incomplete output and report cancellation through ACP. |
+| `stop` | Cancel recording, remove incomplete output and record the cancellation outcome. |
 
 Example MCP arguments for tool `vision_capture`:
 
@@ -45,14 +45,16 @@ Example MCP arguments for tool `vision_capture`:
 Omit `duration_s` to use the default of 5 seconds. `maximum` is 30 seconds.
 Omit `camera` to use the saved card configuration.
 
-`queued` is an admission response, not completion. The terminal result is posted
-once to Core's `/api/acp/complete` and also remains in `info.last_recording`
-until restart. Only one recording may be active. Camera previews keep running
-when recording is cancelled. Missing, stale or stalled input produces an error.
+`record_video` returns `state: recording` with the destination `file_path`
+immediately, like `capture_photo`. The completed outcome (including the
+measured MP4 duration) is available in `info.last_recording` until restart;
+no ACP terminal notification is posted. Only one recording may be active.
+Camera previews keep running when recording is cancelled. Missing, stale or
+stalled input produces an error.
 
 The result contract matches the Q5 vision_capture card. A successful
-`record_video` completion carries only the Q5 slim field set, and the honored
-requested duration is returned after encoding:
+record carries only the Q5 slim field set, and the honored requested duration
+is returned after encoding:
 
 | Field | Meaning |
 | --- | --- |
@@ -62,11 +64,11 @@ requested duration is returned after encoding:
 | `frames` | Fresh source frames encoded. |
 | `captured_at` | Filesystem stamp ISO timestamp with timezone offset when encoding finished. |
 
-Failure and cancellation result carry only `ok`, `code` and `message` — no extra
-timing/display fields. `capture_photo` returns `file_path` synchronously and
-never posts ACP, as on Q5. No extra display/verification fields are added so the
-saved file is rendered by Core through the existing ACP `file_path` rendering
-with zero Core changes.
+Failure and cancellation records carry only `ok`, `code` and `message` — no
+extra timing/display fields. `capture_photo` returns `file_path` synchronously
+and never posts ACP, as on Q5. `record_video` returns the destination path
+synchronously too and does not post ACP, so the saved file is visible to the
+caller immediately without depending on Core's ACP `file_path` rendering.
 
 Video output preserves capture timing and extends the last frame to the exact
 requested endpoint, so a 5-second recording at 15 fps contains 75 encoded frames.
@@ -91,8 +93,10 @@ mkdir -p ~/Downloads/go2-photos
 scp 'unitree@GO2_IP:/opt/phanthy-motus/data/vision_capture/photos/*.jpg' ~/Downloads/go2-photos/
 ```
 
-No Core modification is required for the driver's completion protocol: single
-ACP terminal callback, `file_path` in the result, and no display-only fields.
+No Core modification is required for the driver's completion protocol: the
+destination `file_path` is returned synchronously on admission, the terminal
+outcome carries the slim field set in `info.last_recording`, and no ACP or
+display-only fields are used.
 
 ## Validation
 
@@ -104,7 +108,12 @@ front/RGB/depth/infrared data and nonzero ROS publishers.
 On 2026-09-09 the contract was aligned to the Q5 card: `duration_s` default is
 5 (maximum 30), `record_video` posts a single ACP `completed` whose result
 carries only `file_path`/`recorded_duration_s`/`frames`/`captured_at`, and the
-previous extra timing/display fields were removed. All 28 local capture checks
-(including real FFmpeg/ffprobe media) pass; ARM64-image verification on the Go2
-runs after the release image deploys.
+previous extra timing/display fields were removed.
+
+On 2026-09-10 the record flow was made synchronous like `capture_photo`: the
+admission response returns the destination `file_path` immediately, no ACP
+terminal notification is posted, and the completed/error/cancelled outcome is
+retained in `info.last_recording`. All 28 local capture checks (including real
+FFmpeg/ffprobe media) pass; ARM64-image verification on the Go2 runs after the
+release image deploys.
 '''

--- a/unitree/go2/VISION_CAPTURE.md
+++ b/unitree/go2/VISION_CAPTURE.md
@@ -1,0 +1,92 @@
+# Photo and video capture
+
+`vision_capture` saves RGB photos as JPG and records silent H.264 MP4 videos.
+It follows the Q5 capture card's asynchronous action contract and shares the
+existing Go2 camera publishers, so it does not open a camera device twice.
+
+## Select a camera
+
+Select `front` for the built-in front camera, or `external` for an external
+camera. The external option declares the display title **external (only rgb)**.
+The card exposes no `external_instance_id` input.
+
+Start the source camera first. For an external camera, configure and start an
+[`ext_camera`](EXT_CAMERA.md) instance with `channel: rgb`. The capture card
+automatically selects the only running RGB instance. Depth and infrared are
+excluded; they may keep running alongside RGB. If multiple RGB instances are
+running, keep only the intended RGB instance active before capture.
+
+Selecting an unavailable external source returns an error and does not fall
+back to the front camera. Photo and video requests retain their selected source
+throughout the operation. Changing saved camera configuration during recording
+is rejected; repeating the same configuration is accepted.
+
+## Actions
+
+| Action | Result |
+| --- | --- |
+| `capture_photo` | Wait for a new JPEG frame, save it, return `file_path` and source metadata. |
+| `record_video` | Queue a 1–30-second recording, default 5 seconds, and return `action_id`. |
+| `list_cameras` | List the built-in source and running external RGB instances. |
+| `info` | Report source freshness, output directories, active recording and latest terminal result. |
+| `start` | Subscribe to the configured source; report readiness based on actual frames. |
+| `stop` | Cancel recording, remove incomplete output and report cancellation through ACP. |
+
+Example MCP arguments for tool `vision_capture`:
+
+```json
+{"action": "capture_photo", "camera": "front"}
+```
+
+```json
+{"action": "record_video", "camera": "external", "duration_s": 5}
+```
+
+Omit `camera` to use the saved card configuration. `queued` is an admission
+response, not completion. The terminal result is posted to Core's
+`/api/acp/complete` and remains available in `info.last_recording` until restart.
+Only one recording may be active. Camera previews keep running when recording
+is cancelled. Missing, stale or stalled input produces an error.
+
+Video timestamps preserve capture timing. Output uses the configured frame
+rate and extends the final frame to the requested endpoint. At 15 fps, a
+5-second video contains 75 encoded frames. `frames` counts fresh source frames;
+`encoded_frames` includes repeats used to preserve timing. Padding does not
+replace camera freshness checks or make a stalled capture succeed.
+
+## Files and deployment
+
+Default storage is `/opt/phanthy-motus/data/vision_capture/photos` and `videos`.
+The existing Go2 Compose data mount preserves completed files across container
+replacements. A custom `output_dir` needs its own persistent mount.
+
+The Dockerfile includes FFmpeg and copies the plugin. Configuration under
+`plugins.vision_capture` controls `enabled`, default `camera`, `output_dir`,
+`fps` (1–15) and `max_duration_s` (1–30).
+
+As with Q5, the card returns saved paths; it does not add inline media previews.
+Download files to inspect them, for example:
+
+```bash
+mkdir -p ~/Downloads/go2-photos
+scp 'unitree@GO2_IP:/opt/phanthy-motus/data/vision_capture/photos/*.jpg' ~/Downloads/go2-photos/
+```
+
+Core must support `oneOf.title` on actuator fields to display the external
+option's title instead of its raw `external` value. Showing ACP terminal events
+in the activity log also requires Core to forward callbacks to its activity
+stream. These are separate Core changes; the driver supplies the schema and
+completion callbacks and works with the existing `info` query independently.
+
+## Validation
+
+On 2026-09-08, Go2's built-in camera and an external D435i RGB source each
+produced valid 1280x720 JPGs and 5.000000-second H.264 videos with 75 decoded
+frames at 15 fps. Cancellation removed partial MP4s. Concurrent camera sampling
+verified valid front/RGB/depth/infrared data and nonzero ROS publishers.
+ACP completion and cancellation were also observed through the separately
+updated Core activity stream and browser.
+
+Local and ARM64-image checks covered selection, stale input, duration validation,
+exact output timing at slow source rates, encoder failures and cancellation.
+Local verification scripts are intentionally not included in this driver change.

--- a/unitree/go2/VISION_CAPTURE.md
+++ b/unitree/go2/VISION_CAPTURE.md
@@ -46,11 +46,14 @@ Omit `duration_s` to use the default of 5 seconds. `maximum` is 30 seconds.
 Omit `camera` to use the saved card configuration.
 
 `record_video` returns `state: recording` with the destination `file_path`
-immediately, like `capture_photo`. The tool schema declares no `x-completion`,
-so Core treats every call as an ordinary synchronous action and never holds a
-pending-action barrier awaiting an ACP callback. The completed outcome
-(including the measured MP4 duration) is available in `info.last_recording`
-until restart. Only one recording may be active.
+immediately, like `capture_photo` — no Core rendering change is needed to see
+it. For orchestration the schema declares
+`x-completion: {"actions": ["record_video"], "timeout": max_duration_s + 15}`:
+Core registers the pending action from the admission `action_id` and holds the
+actuator barrier until the worker POSTs one terminal `completed`/`cancelled`/
+`error` completion to `/api/acp/complete`. The completed outcome (including
+the measured MP4 duration) is also available in `info.last_recording` until
+restart. Only one recording may be active.
 Camera previews keep running when recording is cancelled. Missing, stale or
 stalled input produces an error.
 
@@ -69,8 +72,9 @@ is returned after encoding:
 Failure and cancellation records carry only `ok`, `code` and `message` — no
 extra timing/display fields. `capture_photo` returns `file_path` synchronously
 and never posts ACP, as on Q5. `record_video` returns the destination path
-synchronously too and does not post ACP, so the saved file is visible to the
-caller immediately without depending on Core's ACP `file_path` rendering.
+synchronously too, so the saved destination is visible immediately without
+depending on Core's ACP `file_path` rendering; its single terminal ACP
+completion exists for orchestration only.
 
 Video output preserves capture timing and extends the last frame to the exact
 requested endpoint, so a 5-second recording at 15 fps contains 75 encoded frames.
@@ -97,8 +101,8 @@ scp 'unitree@GO2_IP:/opt/phanthy-motus/data/vision_capture/photos/*.jpg' ~/Downl
 
 No Core modification is required for the driver's completion protocol: the
 destination `file_path` is returned synchronously on admission, the terminal
-outcome carries the slim field set in `info.last_recording`, and no ACP or
-display-only fields are used.
+outcome carries the slim field set in `info.last_recording` and in the ACP
+completion result, and no display-only fields are used.
 
 ## Validation
 
@@ -121,7 +125,9 @@ release image deploys.
 
 On 2026-09-11 review feedback was applied: `start` returns the bare actuator
 lifecycle response (`{"state": "ready"}`) with camera freshness exposed on
-`info`; the `record_video` schema no longer advertises `x-completion`, so Core
-never waits on `/api/acp/complete` for an admission-only call; and
-`driver.yaml`'s marketplace `cards` list gained the `vision_capture` entry.
-All 30 local capture checks pass.
+`info`; `driver.yaml`'s marketplace `cards` list gained the `vision_capture`
+entry; and ACP was restored as pure orchestration — the schema advertises
+`x-completion` for `record_video` (timeout `max_duration_s + 15`) and the
+worker POSTs one terminal completion, while the admission response keeps the
+synchronous `file_path` so no Core change is involved. All 30 local capture
+checks pass.

--- a/unitree/go2/VISION_CAPTURE.md
+++ b/unitree/go2/VISION_CAPTURE.md
@@ -29,7 +29,7 @@ is rejected; repeating the same configuration is accepted.
 | `record_video` | Start a 1–30-second recording, default 5 seconds; return the destination `file_path` synchronously. |
 | `list_cameras` | List the built-in source and running external RGB instances. |
 | `info` | Report source freshness, output directories, active recording and latest terminal result. |
-| `start` | Subscribe to the configured source; report readiness based on actual frames. |
+| `start` | Return the actuator lifecycle response (`{"state": "ready"}`); camera freshness stays on `info`. |
 | `stop` | Cancel recording, remove incomplete output and record the cancellation outcome. |
 
 Example MCP arguments for tool `vision_capture`:
@@ -46,9 +46,11 @@ Omit `duration_s` to use the default of 5 seconds. `maximum` is 30 seconds.
 Omit `camera` to use the saved card configuration.
 
 `record_video` returns `state: recording` with the destination `file_path`
-immediately, like `capture_photo`. The completed outcome (including the
-measured MP4 duration) is available in `info.last_recording` until restart;
-no ACP terminal notification is posted. Only one recording may be active.
+immediately, like `capture_photo`. The tool schema declares no `x-completion`,
+so Core treats every call as an ordinary synchronous action and never holds a
+pending-action barrier awaiting an ACP callback. The completed outcome
+(including the measured MP4 duration) is available in `info.last_recording`
+until restart. Only one recording may be active.
 Camera previews keep running when recording is cancelled. Missing, stale or
 stalled input produces an error.
 
@@ -116,4 +118,10 @@ terminal notification is posted, and the completed/error/cancelled outcome is
 retained in `info.last_recording`. All 28 local capture checks (including real
 FFmpeg/ffprobe media) pass; ARM64-image verification on the Go2 runs after the
 release image deploys.
-'''
+
+On 2026-09-11 review feedback was applied: `start` returns the bare actuator
+lifecycle response (`{"state": "ready"}`) with camera freshness exposed on
+`info`; the `record_video` schema no longer advertises `x-completion`, so Core
+never waits on `/api/acp/complete` for an admission-only call; and
+`driver.yaml`'s marketplace `cards` list gained the `vision_capture` entry.
+All 30 local capture checks pass.

--- a/unitree/go2/config.yaml
+++ b/unitree/go2/config.yaml
@@ -18,6 +18,12 @@ plugins:
     stream_addr: "230.1.1.1"
     stream_port: 1720
     multicast_iface: "eth0"
+  vision_capture:
+    enabled: true
+    camera: front  # front or external (RGB only); also selectable on the card.
+    output_dir: /opt/phanthy-motus/data/vision_capture
+    fps: 15
+    max_duration_s: 30
   state:
     enabled: true
   motion_switcher:

--- a/unitree/go2/controlled_spatial.py
+++ b/unitree/go2/controlled_spatial.py
@@ -55,6 +55,9 @@ def _rpc_error(action: str, code: int, resp=None) -> dict:
 def _slam_rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.Queue,
                      network_iface: str):
     """Subprocess: holds a dedicated SlamClient, processes RPC commands."""
+    # Spawned child: fresh interpreter, does not inherit the parent's sys.stdout.
+    from common import logsafe
+    logsafe.install(check_fd=False)
     from unitree_sdk2py.core.channel import ChannelFactoryInitialize
     try:
         from unitree_sdk2py.g1.slam.slam_client import SlamClient

--- a/unitree/go2/device.py
+++ b/unitree/go2/device.py
@@ -179,6 +179,9 @@ _SPEAKER_MERGE_MS = 2000  # flush timeout: send after 2s of silence
 
 def _speaker_worker(pcm_queue: multiprocessing.Queue, network_iface: str):
     """Subprocess: accumulates PCM-16k, sends as single WAV via AudioHub megaphone on stream end."""
+    # Spawned child: fresh interpreter, does not inherit the parent's sys.stdout.
+    from common import logsafe
+    logsafe.install(check_fd=False)
     import base64
     import io
     import wave

--- a/unitree/go2/device.py
+++ b/unitree/go2/device.py
@@ -1049,6 +1049,9 @@ class _CameraNode:
 
 def _run_camera_process(topic: str, stream_addr: str, stream_port: int, multicast_iface: str = "eth0") -> None:
     """Camera subprocess — receives Go2 H264 UDP multicast, decodes to JPEG, publishes to ROS2."""
+    # Spawned child: fresh interpreter, does not inherit the parent's sys.stdout.
+    from common import logsafe
+    logsafe.install(check_fd=False)
     import subprocess as _subprocess
     import threading as _threading
     import rclpy

--- a/unitree/go2/driver.yaml
+++ b/unitree/go2/driver.yaml
@@ -6,7 +6,7 @@ hardware_model: "go2"
 image_name: go2
 port: 15703
 mcp_url: "http://localhost:15703/mcp"
-description: "Unitree Go2 — 运动控制 + 避障 + 语音 + 视频 + RealSense 深度/红外 + 导航"
+description: "Unitree Go2 — 运动控制 + 避障 + 语音 + 视频 + 拍照/录像采集 + RealSense 深度/红外 + 导航"
 build_context_extras:
   - ../../common
 # Cards this bundle exposes, for resource-center's driver marketplace listing.

--- a/unitree/go2/driver.yaml
+++ b/unitree/go2/driver.yaml
@@ -36,3 +36,4 @@ cards:
   - { name: asr,           type: sensor }
   - { name: ext_mic,       type: sensor }
   - { name: ext_camera,    type: sensor }
+  - { name: vision_capture, type: actuator }

--- a/unitree/go2/main.py
+++ b/unitree/go2/main.py
@@ -136,10 +136,18 @@ class Go2DeviceBundle:
             self._plugins.append(ExtMicPlugin(plugins_cfg["ext_mic"], namespace, executor))
             print("[bundle] ExtMicPlugin loaded")
 
+        external_camera = None
         if plugins_cfg.get("ext_camera", {}).get("enabled", False):
             from ext_devices import ExtCameraPlugin
-            self._plugins.append(ExtCameraPlugin(plugins_cfg["ext_camera"], namespace, executor))
+            external_camera = ExtCameraPlugin(plugins_cfg["ext_camera"], namespace, executor)
+            self._plugins.append(external_camera)
             print("[bundle] ExtCameraPlugin loaded")
+
+        if plugins_cfg.get("vision_capture", {}).get("enabled", False):
+            from vision_capture import VisionCapturePlugin
+            self._plugins.append(VisionCapturePlugin(
+                plugins_cfg["vision_capture"], namespace, executor, external_camera))
+            print("[bundle] VisionCapturePlugin loaded")
 
     def start_all(self) -> None:
         for i, p in enumerate(self._plugins):

--- a/unitree/go2/rpc_proxy.py
+++ b/unitree/go2/rpc_proxy.py
@@ -16,6 +16,9 @@ import time
 def _rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.Queue,
                 network_iface: str):
     """Subprocess: holds dedicated RPC clients, processes commands sequentially."""
+    # Spawned child: fresh interpreter, does not inherit the parent's sys.stdout.
+    from common import logsafe
+    logsafe.install(check_fd=False)
     from unitree_sdk2py.core.channel import ChannelFactoryInitialize, ChannelPublisher
     from unitree_sdk2py.go2.sport.sport_client import SportClient
     from unitree_sdk2py.go2.obstacles_avoid.obstacles_avoid_client import ObstaclesAvoidClient

--- a/unitree/go2/spatial.py
+++ b/unitree/go2/spatial.py
@@ -67,6 +67,9 @@ def _rpc_error(action: str, code: int, resp=None) -> dict:
 def _slam_rpc_worker(cmd_queue: multiprocessing.Queue, result_queue: multiprocessing.Queue,
                      network_iface: str):
     """Subprocess: holds a dedicated SlamClient, processes RPC commands."""
+    # Spawned child: fresh interpreter, does not inherit the parent's sys.stdout.
+    from common import logsafe
+    logsafe.install(check_fd=False)
     from unitree_sdk2py.core.channel import ChannelFactoryInitialize
     try:
         from unitree_sdk2py.g1.slam.slam_client import SlamClient

--- a/unitree/go2/vision_capture.py
+++ b/unitree/go2/vision_capture.py
@@ -80,7 +80,6 @@ class VisionCapturePlugin:
                     "info": {"params": [], "description": "查看图像来源、保存目录和录像结果。"},
                     "stop": {"params": [], "description": "取消当前录像并删除未完成文件。"},
                 },
-                "x-completion": {"actions": ["record_video"]},
             },
             "configSchema": {"type": "object", "properties": {
                 "camera": {**camera_property, "default": "front"},
@@ -199,7 +198,8 @@ class VisionCapturePlugin:
 
     def start(self):
         # Bundle startup precedes executor spinning: do not wait here for DDS.
-        return self._info()
+        # The lifecycle response is always ready; camera freshness stays on info.
+        return {"state": "ready"}
 
     def _new_path(self, directory, prefix, suffix):
         target = self._output_dir / directory

--- a/unitree/go2/vision_capture.py
+++ b/unitree/go2/vision_capture.py
@@ -80,6 +80,8 @@ class VisionCapturePlugin:
                     "info": {"params": [], "description": "查看图像来源、保存目录和录像结果。"},
                     "stop": {"params": [], "description": "取消当前录像并删除未完成文件。"},
                 },
+                "x-completion": {"actions": ["record_video"],
+                                 "timeout": self._max_duration_s + 15},
             },
             "configSchema": {"type": "object", "properties": {
                 "camera": {**camera_property, "default": "front"},
@@ -394,10 +396,31 @@ class VisionCapturePlugin:
             self._last_recording = {"action_id": active["action_id"], "status": status, "result": result}
             active["state"] = status
             active["finished"] = True
-            # The terminal outcome lives in info.last_recording; no ACP posts a
-            # file_path-based completion. The queued response already returned
-            # the destination path synchronously, like capture_photo.
-            self._active_recording = None
+        # ACP completion is for orchestration only: it releases Core's pending
+        # barrier. The admission response already returned the destination
+        # file_path synchronously, like capture_photo, and info.last_recording
+        # keeps the terminal outcome for the info card.
+        try:
+            self._notify_complete(active["action_id"], status, result)
+        finally:
+            with self._recording_lock:
+                self._active_recording = None
+
+    def _notify_complete(self, action_id, status, result):
+        payload = json.dumps({"action_id": action_id, "status": status,
+                              "result": result, "tool": self.PREFIX, "ts": time.time()}).encode()
+        url = os.environ.get("AGENT_CORE_URL", "https://localhost:15678").rstrip("/")
+        ctx = ssl.create_default_context()
+        if url.startswith(("https://localhost:", "https://127.0.0.1:")):
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+        try:
+            request = urllib.request.Request(url + "/api/acp/complete", data=payload,
+                                             headers={"Content-Type": "application/json"})
+            with urllib.request.urlopen(request, timeout=3, context=ctx):
+                pass
+        except Exception as exc:
+            log.warning("[vision_capture] ACP completion delivery failed: %s", exc)
 
     def _start_video_recording(self, args):
         requested = args.get("duration_s", 5)

--- a/unitree/go2/vision_capture.py
+++ b/unitree/go2/vision_capture.py
@@ -29,6 +29,10 @@ _MAX_FRAME_AGE_S = 3.0
 log = logging.getLogger(__name__)
 
 
+def _timestamp():
+    return datetime.now().astimezone().isoformat(timespec="milliseconds")
+
+
 class VisionCapturePlugin:
     PREFIX = "vision_capture"
 
@@ -53,8 +57,6 @@ class VisionCapturePlugin:
 
     def get_tool(self):
         camera_property = {"type": "string", "enum": ["front", "external"],
-                           "oneOf": [{"const": "front", "title": "front"},
-                                     {"const": "external", "title": "external (only rgb)"}],
                            "description": "摄像头：front 内置前置，external 外接（only rgb）；省略时使用卡片配置。"}
         return {
             "name": self.PREFIX, "type": "actuator", "multiInstance": False,
@@ -79,7 +81,7 @@ class VisionCapturePlugin:
                     "stop": {"params": [], "description": "取消当前录像并删除未完成文件。"},
                 },
                 "x-completion": {"actions": ["record_video"],
-                                 "timeout": self._max_duration_s + 20},
+                                 "timeout": self._max_duration_s + 25},
             },
             "configSchema": {"type": "object", "properties": {
                 "camera": {**camera_property, "default": "front"},
@@ -193,7 +195,7 @@ class VisionCapturePlugin:
                 "videos_dir": str(self._output_dir / "videos"),
                 "fps": self._fps, "max_duration_s": self._max_duration_s,
                 "latest_frame_age_s": round(age, 3) if age is not None else None,
-                "encoder_available": shutil.which("ffmpeg") is not None,
+                "encoder_available": all(shutil.which(name) is not None for name in ("ffmpeg", "ffprobe")),
                 "active_recording": public, "last_recording": last}
 
     def start(self):
@@ -287,6 +289,7 @@ class VisionCapturePlugin:
                 with self._recording_lock:
                     active["process"] = process
                 started = time.monotonic()
+                capture_started_at = _timestamp()
                 deadline = started + active["duration_s"]
                 frames = 0
                 while True:
@@ -307,6 +310,8 @@ class VisionCapturePlugin:
                                 and time.monotonic() - frame[1] < _MAX_FRAME_AGE_S):
                             break
                         raise
+                capture_finished = time.monotonic()
+                capture_finished_at = _timestamp()
                 if frames < min(2, self._fps * active["duration_s"]):
                     raise RuntimeError("Not enough fresh frames to record video")
                 process.stdin.close()
@@ -319,13 +324,18 @@ class VisionCapturePlugin:
                 if process.returncode != 0 or not path.exists() or path.stat().st_size == 0:
                     errors.seek(0)
                     raise RuntimeError(errors.read(4096).decode("utf-8", "replace") or "ffmpeg failed to create MP4")
+            media = self._probe_video(path, active["duration_s"], self._fps)
             if cancel.is_set():
                 raise RuntimeError("Video recording was cancelled")
             completed = True
             return {"ok": True, "media_type": "video", "file_path": str(path), "source": source,
-                    "recorded_duration_s": active["duration_s"], "frames": frames,
-                    "encoded_frames": self._fps * active["duration_s"],
-                    "captured_at": datetime.now().isoformat(timespec="seconds")}
+                    "recorded_duration_s": media["duration_s"], "frames": frames,
+                    "encoded_frames": media["frames"],
+                    "capture_started_at": capture_started_at,
+                    "capture_finished_at": capture_finished_at,
+                    "capture_elapsed_s": round(capture_finished - started, 3),
+                    "finalize_elapsed_s": round(time.monotonic() - capture_finished, 3),
+                    "captured_at": _timestamp()}
         except Exception as exc:
             return {"ok": False, "code": "RECORD_CANCELLED" if cancel.is_set() else "RECORD_FAILED",
                     "message": str(exc)}
@@ -340,6 +350,22 @@ class VisionCapturePlugin:
                 active["process"] = None
             if not completed and path is not None:
                 self._remove_partial(path)
+
+    @staticmethod
+    def _probe_video(path, requested, fps):
+        """Only acknowledge completion after the muxed file has the right duration."""
+        metadata = json.loads(subprocess.check_output([
+            "ffprobe", "-v", "error", "-select_streams", "v:0",
+            "-show_entries", "format=duration:stream=duration,nb_frames", "-of", "json", str(path),
+        ], stderr=subprocess.PIPE, timeout=5))
+        stream = metadata["streams"][0]
+        duration = float(metadata["format"]["duration"])
+        stream_duration = float(stream["duration"])
+        frames = int(stream["nb_frames"])
+        if (not abs(duration - requested) <= 0.001
+                or not abs(stream_duration - requested) <= 0.001 or frames != requested * fps):
+            raise RuntimeError(f"Invalid completed video: duration={duration}s, stream={stream_duration}s, frames={frames}")
+        return {"duration_s": duration, "frames": frames}
 
     def _notify_complete(self, action_id, status, result):
         payload = json.dumps({"action_id": action_id, "status": status,
@@ -374,6 +400,9 @@ class VisionCapturePlugin:
                     result["cleanup_error"] = cleanup_error
             status = "completed" if result.get("ok") else (
                 "cancelled" if result.get("code") == "RECORD_CANCELLED" else "error")
+            result.update({"requested_duration_s": active["duration_s"],
+                           "queued_at": active["queued_at"], "completed_at": _timestamp(),
+                           "elapsed_s": round(time.monotonic() - active["queued_mono"], 3)})
             self._last_recording = {"action_id": active["action_id"], "status": status, "result": result}
             active["state"] = status
             active["finished"] = True
@@ -389,8 +418,8 @@ class VisionCapturePlugin:
         if type(requested) is not int or not 1 <= requested <= self._max_duration_s:
             return {"ok": False, "code": "INVALID_DURATION",
                     "message": f"duration_s must be an integer between 1 and {self._max_duration_s}"}
-        if shutil.which("ffmpeg") is None:
-            return {"ok": False, "code": "RECORD_FAILED", "message": "ffmpeg is not installed"}
+        if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
+            return {"ok": False, "code": "RECORD_FAILED", "message": "ffmpeg and ffprobe are required"}
         with self._recording_lock:
             if self._active_recording is not None:
                 return {"ok": False, "code": "RECORD_IN_PROGRESS", "message": "A video recording is already in progress"}
@@ -399,8 +428,9 @@ class VisionCapturePlugin:
             except ValueError as exc:
                 return {"ok": False, "code": "RECORD_FAILED", "message": str(exc)}
             action_id = f"vision_capture_record_video_{uuid4().hex}"
+            queued_at = _timestamp()
             active = {"action_id": action_id, "state": "recording", "duration_s": requested,
-                      "started_at": datetime.now().isoformat(timespec="seconds"),
+                      "started_at": queued_at, "queued_at": queued_at, "queued_mono": time.monotonic(),
                       "cancel": threading.Event(), "process": None, "source": source}
             thread = threading.Thread(target=self._record_video_async, args=(active,),
                                       daemon=True, name="go2_vision_capture_record_video")
@@ -412,7 +442,9 @@ class VisionCapturePlugin:
                 self._active_recording = None
                 raise
         return {"ok": True, "state": "queued", "action_id": action_id,
-                "media_type": "video", "requested_duration_s": requested, "source": source}
+                "media_type": "video", "requested_duration_s": requested, "source": source,
+                "queued_at": queued_at,
+                "message": "Recording queued; ACP completion follows only after the MP4 is finalized and verified."}
 
     def stop(self):
         with self._recording_lock:

--- a/unitree/go2/vision_capture.py
+++ b/unitree/go2/vision_capture.py
@@ -329,6 +329,8 @@ class VisionCapturePlugin:
                 raise RuntimeError("Video recording was cancelled")
             completed = True
             return {"ok": True, "media_type": "video", "file_path": str(path), "source": source,
+                    "file_name": path.name,
+                    "message": f"视频录制完成。文件名：{path.name}；完整保存地址：{path}",
                     "recorded_duration_s": media["duration_s"], "frames": frames,
                     "encoded_frames": media["frames"],
                     "capture_started_at": capture_started_at,

--- a/unitree/go2/vision_capture.py
+++ b/unitree/go2/vision_capture.py
@@ -69,7 +69,8 @@ class VisionCapturePlugin:
                     "camera": camera_property,
                     "duration_s": {"type": "integer", "minimum": 1,
                                    "maximum": self._max_duration_s,
-                                   "default": min(5, self._max_duration_s)},
+                                   "default": min(5, self._max_duration_s),
+                                   "description": "默认5s,最大30s"},
                 },
                 "required": ["action"], "additionalProperties": False,
                 "x-action-params": {

--- a/unitree/go2/vision_capture.py
+++ b/unitree/go2/vision_capture.py
@@ -69,7 +69,7 @@ class VisionCapturePlugin:
                     "camera": camera_property,
                     "duration_s": {"type": "integer", "minimum": 1,
                                    "maximum": self._max_duration_s,
-                                   "default": 5},
+                                   "default": min(5, self._max_duration_s)},
                 },
                 "required": ["action"], "additionalProperties": False,
                 "x-action-params": {
@@ -406,24 +406,8 @@ class VisionCapturePlugin:
             with self._recording_lock:
                 self._active_recording = None
 
-    def _notify_complete(self, action_id, status, result):
-        payload = json.dumps({"action_id": action_id, "status": status,
-                              "result": result, "tool": self.PREFIX, "ts": time.time()}).encode()
-        url = os.environ.get("AGENT_CORE_URL", "https://localhost:15678").rstrip("/")
-        ctx = ssl.create_default_context()
-        if url.startswith(("https://localhost:", "https://127.0.0.1:")):
-            ctx.check_hostname = False
-            ctx.verify_mode = ssl.CERT_NONE
-        try:
-            request = urllib.request.Request(url + "/api/acp/complete", data=payload,
-                                             headers={"Content-Type": "application/json"})
-            with urllib.request.urlopen(request, timeout=3, context=ctx):
-                pass
-        except Exception as exc:
-            log.warning("[vision_capture] ACP completion delivery failed: %s", exc)
-
     def _start_video_recording(self, args):
-        requested = args.get("duration_s", 5)
+        requested = args.get("duration_s", min(5, self._max_duration_s))
         if type(requested) is not int or not 1 <= requested <= self._max_duration_s:
             return {"ok": False, "code": "INVALID_DURATION",
                     "message": f"duration_s must be an integer between 1 and {self._max_duration_s}"}

--- a/unitree/go2/vision_capture.py
+++ b/unitree/go2/vision_capture.py
@@ -69,7 +69,7 @@ class VisionCapturePlugin:
                     "camera": camera_property,
                     "duration_s": {"type": "integer", "minimum": 1,
                                    "maximum": self._max_duration_s,
-                                   "default": min(5, self._max_duration_s)},
+                                   "default": 5},
                 },
                 "required": ["action"], "additionalProperties": False,
                 "x-action-params": {
@@ -81,7 +81,7 @@ class VisionCapturePlugin:
                     "stop": {"params": [], "description": "取消当前录像并删除未完成文件。"},
                 },
                 "x-completion": {"actions": ["record_video"],
-                                 "timeout": self._max_duration_s + 25},
+                                 "timeout": self._max_duration_s + 15},
             },
             "configSchema": {"type": "object", "properties": {
                 "camera": {**camera_property, "default": "front"},
@@ -289,7 +289,6 @@ class VisionCapturePlugin:
                 with self._recording_lock:
                     active["process"] = process
                 started = time.monotonic()
-                capture_started_at = _timestamp()
                 deadline = started + active["duration_s"]
                 frames = 0
                 while True:
@@ -310,8 +309,6 @@ class VisionCapturePlugin:
                                 and time.monotonic() - frame[1] < _MAX_FRAME_AGE_S):
                             break
                         raise
-                capture_finished = time.monotonic()
-                capture_finished_at = _timestamp()
                 if frames < min(2, self._fps * active["duration_s"]):
                     raise RuntimeError("Not enough fresh frames to record video")
                 process.stdin.close()
@@ -328,15 +325,8 @@ class VisionCapturePlugin:
             if cancel.is_set():
                 raise RuntimeError("Video recording was cancelled")
             completed = True
-            return {"ok": True, "media_type": "video", "file_path": str(path), "source": source,
-                    "file_name": path.name,
-                    "message": f"视频录制完成。文件名：{path.name}；完整保存地址：{path}",
+            return {"ok": True, "media_type": "video", "file_path": str(path),
                     "recorded_duration_s": media["duration_s"], "frames": frames,
-                    "encoded_frames": media["frames"],
-                    "capture_started_at": capture_started_at,
-                    "capture_finished_at": capture_finished_at,
-                    "capture_elapsed_s": round(capture_finished - started, 3),
-                    "finalize_elapsed_s": round(time.monotonic() - capture_finished, 3),
                     "captured_at": _timestamp()}
         except Exception as exc:
             return {"ok": False, "code": "RECORD_CANCELLED" if cancel.is_set() else "RECORD_FAILED",
@@ -402,9 +392,6 @@ class VisionCapturePlugin:
                     result["cleanup_error"] = cleanup_error
             status = "completed" if result.get("ok") else (
                 "cancelled" if result.get("code") == "RECORD_CANCELLED" else "error")
-            result.update({"requested_duration_s": active["duration_s"],
-                           "queued_at": active["queued_at"], "completed_at": _timestamp(),
-                           "elapsed_s": round(time.monotonic() - active["queued_mono"], 3)})
             self._last_recording = {"action_id": active["action_id"], "status": status, "result": result}
             active["state"] = status
             active["finished"] = True
@@ -416,7 +403,7 @@ class VisionCapturePlugin:
                 self._active_recording = None
 
     def _start_video_recording(self, args):
-        requested = args.get("duration_s", min(5, self._max_duration_s))
+        requested = args.get("duration_s", 5)
         if type(requested) is not int or not 1 <= requested <= self._max_duration_s:
             return {"ok": False, "code": "INVALID_DURATION",
                     "message": f"duration_s must be an integer between 1 and {self._max_duration_s}"}

--- a/unitree/go2/vision_capture.py
+++ b/unitree/go2/vision_capture.py
@@ -80,8 +80,7 @@ class VisionCapturePlugin:
                     "info": {"params": [], "description": "查看图像来源、保存目录和录像结果。"},
                     "stop": {"params": [], "description": "取消当前录像并删除未完成文件。"},
                 },
-                "x-completion": {"actions": ["record_video"],
-                                 "timeout": self._max_duration_s + 15},
+                "x-completion": {"actions": ["record_video"]},
             },
             "configSchema": {"type": "object", "properties": {
                 "camera": {**camera_property, "default": "front"},
@@ -267,7 +266,7 @@ class VisionCapturePlugin:
             with self._condition:
                 sequence = self._streams[source["topic"]]["sequence"]
             frame = self._frame(source, sequence, cancel=cancel)
-            path = self._new_path("videos", "video", ".mp4")
+            path = active["path"]
             with tempfile.TemporaryFile() as errors:
                 process = subprocess.Popen([
                     "ffmpeg", "-nostdin", "-y", "-loglevel", "error",
@@ -395,12 +394,10 @@ class VisionCapturePlugin:
             self._last_recording = {"action_id": active["action_id"], "status": status, "result": result}
             active["state"] = status
             active["finished"] = True
-        # The worker owns the only terminal notification, including shutdown.
-        try:
-            self._notify_complete(active["action_id"], status, result)
-        finally:
-            with self._recording_lock:
-                self._active_recording = None
+            # The terminal outcome lives in info.last_recording; no ACP posts a
+            # file_path-based completion. The queued response already returned
+            # the destination path synchronously, like capture_photo.
+            self._active_recording = None
 
     def _start_video_recording(self, args):
         requested = args.get("duration_s", 5)
@@ -418,9 +415,10 @@ class VisionCapturePlugin:
                 return {"ok": False, "code": "RECORD_FAILED", "message": str(exc)}
             action_id = f"vision_capture_record_video_{uuid4().hex}"
             queued_at = _timestamp()
+            path = self._new_path("videos", "video", ".mp4")
             active = {"action_id": action_id, "state": "recording", "duration_s": requested,
                       "started_at": queued_at, "queued_at": queued_at, "queued_mono": time.monotonic(),
-                      "cancel": threading.Event(), "process": None, "source": source}
+                      "cancel": threading.Event(), "process": None, "source": source, "path": path}
             thread = threading.Thread(target=self._record_video_async, args=(active,),
                                       daemon=True, name="go2_vision_capture_record_video")
             active["thread"] = thread
@@ -430,10 +428,10 @@ class VisionCapturePlugin:
             except Exception:
                 self._active_recording = None
                 raise
-        return {"ok": True, "state": "queued", "action_id": action_id,
+        return {"ok": True, "state": "recording", "action_id": action_id,
                 "media_type": "video", "requested_duration_s": requested, "source": source,
-                "queued_at": queued_at,
-                "message": "Recording queued; ACP completion follows only after the MP4 is finalized and verified."}
+                "queued_at": queued_at, "file_path": str(path),
+                "message": "Recording started; the file_path above is the completed MP4 destination."}
 
     def stop(self):
         with self._recording_lock:
@@ -475,7 +473,8 @@ class VisionCapturePlugin:
         if action == "capture_photo":
             return self._capture_photo(args)
         if action == "record_video":
-            return self._start_video_recording(args)
+            result = self._start_video_recording(args)
+            return result if result.get("state") != "recording" else {**result, "ok": True}
         if action == "stop":
             return self.stop()
         if action == "list_cameras":

--- a/unitree/go2/vision_capture.py
+++ b/unitree/go2/vision_capture.py
@@ -1,0 +1,462 @@
+"""Persistent JPEG photos and asynchronous MP4 recording from Go2 ROS images.
+
+Keeps the Q5 vision_capture action/ACP contract while sharing the existing
+camera publisher instead of opening the physical camera a second time.
+"""
+
+from datetime import datetime
+import json
+import logging
+import os
+from pathlib import Path
+import select
+import shutil
+import ssl
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.request
+from uuid import uuid4
+
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from sensor_msgs.msg import CompressedImage
+
+
+_FIRST_FRAME_TIMEOUT_S = 5.0
+_MAX_FRAME_AGE_S = 3.0
+log = logging.getLogger(__name__)
+
+
+class VisionCapturePlugin:
+    PREFIX = "vision_capture"
+
+    def __init__(self, plugin_config, namespace, executor, external_camera=None):
+        self._front_topic = f"/{namespace}/camera/front"
+        self._external_camera = external_camera
+        self._camera = plugin_config.get("camera", "front")
+        self._external_instance_id = plugin_config.get("external_instance_id", "")
+        if self._camera not in ("front", "external"):
+            raise ValueError("camera must be front or external")
+        self._output_dir = Path(plugin_config.get(
+            "output_dir", "/opt/phanthy-motus/data/vision_capture")).expanduser()
+        self._fps = max(1, min(15, int(plugin_config.get("fps", 15))))
+        self._max_duration_s = max(1, min(30, int(plugin_config.get("max_duration_s", 30))))
+        self._condition = threading.Condition()
+        self._streams = {}
+        self._recording_lock = threading.Lock()
+        self._active_recording = None
+        self._last_recording = None
+        self._node = Node("go2_vision_capture")
+        executor.add_node(self._node)
+
+    def get_tool(self):
+        camera_property = {"type": "string", "enum": ["front", "external"],
+                           "oneOf": [{"const": "front", "title": "front"},
+                                     {"const": "external", "title": "external (only rgb)"}],
+                           "description": "摄像头：front 内置前置，external 外接（only rgb）；省略时使用卡片配置。"}
+        return {
+            "name": self.PREFIX, "type": "actuator", "multiInstance": False,
+            "description": "Save a Go2 RGB JPEG photo or record a silent H.264 MP4 video to persistent storage.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string", "enum": [
+                        "start", "capture_photo", "record_video", "list_cameras", "info", "stop"]},
+                    "camera": camera_property,
+                    "duration_s": {"type": "integer", "minimum": 1,
+                                   "maximum": self._max_duration_s,
+                                   "default": min(5, self._max_duration_s)},
+                },
+                "required": ["action"], "additionalProperties": False,
+                "x-action-params": {
+                    "start": {"params": [], "description": "订阅配置的相机 RGB 图像。"},
+                    "capture_photo": {"params": ["camera"], "description": "保存所选相机的 RGB 照片为 JPG。"},
+                    "record_video": {"params": ["duration_s", "camera"], "description": "录制所选相机的 RGB 视频，默认 5 秒。"},
+                    "list_cameras": {"params": [], "description": "列出内置相机和已启动的外接相机实例。"},
+                    "info": {"params": [], "description": "查看图像来源、保存目录和录像结果。"},
+                    "stop": {"params": [], "description": "取消当前录像并删除未完成文件。"},
+                },
+                "x-completion": {"actions": ["record_video"],
+                                 "timeout": self._max_duration_s + 20},
+            },
+            "configSchema": {"type": "object", "properties": {
+                "camera": {**camera_property, "default": "front"},
+            }},
+        }
+
+    def _sources(self):
+        sources = [{"camera": "front", "name": "Go2 内置前置相机", "topic": self._front_topic}]
+        if self._external_camera is not None:
+            info = self._external_camera.dispatch("info", {})
+            for instance_id in info.get("active_instances", []):
+                status = self._external_camera.dispatch("info", {"instance_id": instance_id})
+                if status.get("state") != "running" or status.get("channel", "rgb") != "rgb":
+                    continue
+                for output in status.get("topic_out", []):
+                    if output.get("format") == "image/jpeg" and output.get("topic"):
+                        sources.append({"camera": "external", "external_instance_id": instance_id,
+                                        "name": status.get("device_name") or instance_id,
+                                        "device_path": status.get("device_path"), "topic": output["topic"]})
+        return sources
+
+    def _resolve_source(self, args):
+        camera = args.get("camera", self._camera)
+        if camera == "front":
+            source = {"camera": "front", "name": "Go2 内置前置相机", "topic": self._front_topic}
+        elif camera == "external":
+            instance_id = args.get("external_instance_id", self._external_instance_id)
+            if instance_id and self._external_camera is not None:
+                status = self._external_camera.dispatch("info", {"instance_id": instance_id})
+                channel = status.get("channel", "rgb")
+                if channel != "rgb":
+                    raise ValueError(f"External camera instance '{instance_id}' uses channel '{channel}'; "
+                                     "vision_capture currently supports only RGB. Select a channel=rgb instance.")
+            candidates = [source for source in self._sources() if source["camera"] == "external"
+                          and (not instance_id or source["external_instance_id"] == instance_id)]
+            if not candidates:
+                raise ValueError("No running RGB external camera matches the selection; "
+                                 "start an ext_camera instance with channel=rgb and use its instance_id")
+            if len(candidates) != 1:
+                raise ValueError("Multiple RGB external cameras are running; keep only the intended RGB instance running before capture")
+            source = candidates[0]
+        else:
+            raise ValueError("camera must be front or external")
+        topic = source["topic"]
+        with self._condition:
+            if topic not in self._streams:
+                self._streams[topic] = {"latest": None, "sequence": 0}
+                try:
+                    self._streams[topic]["subscription"] = self._node.create_subscription(
+                        CompressedImage, topic, lambda msg: self._on_frame(topic, msg), qos_profile_sensor_data)
+                except Exception:
+                    del self._streams[topic]
+                    raise
+        return source
+
+    def _on_frame(self, topic, msg):
+        data = bytes(msg.data)
+        if "jpeg" not in msg.format.lower() and "jpg" not in msg.format.lower():
+            return
+        if not data.startswith(b"\xff\xd8") or not data.endswith(b"\xff\xd9"):
+            return
+        stamp = msg.header.stamp
+        timestamp = stamp.sec + stamp.nanosec / 1e9
+        now = self._node.get_clock().now().nanoseconds / 1e9
+        # Both built-in and external Go2 publishers stamp their frames. Reject
+        # delayed DDS data as well as a locally stale cache; allow unstamped JPEG.
+        age = now - timestamp if timestamp else 0.0
+        if age > _MAX_FRAME_AGE_S or age < -_MAX_FRAME_AGE_S:
+            return
+        with self._condition:
+            stream = self._streams[topic]
+            stream["sequence"] += 1
+            stream["latest"] = (data, time.monotonic() - max(0.0, age), stream["sequence"])
+            self._condition.notify_all()
+
+    def _frame(self, source, after_sequence=None, timeout_s=_FIRST_FRAME_TIMEOUT_S, cancel=None):
+        deadline = time.monotonic() + timeout_s
+        with self._condition:
+            while True:
+                if cancel is not None and cancel.is_set():
+                    raise RuntimeError("Video recording was cancelled")
+                frame = self._streams[source["topic"]]["latest"]
+                if (frame is not None and time.monotonic() - frame[1] <= _MAX_FRAME_AGE_S
+                        and (after_sequence is None or frame[2] > after_sequence)):
+                    return frame
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise RuntimeError(f"No fresh JPEG frame on {source['topic']}; start the source camera and check ROS connectivity")
+                self._condition.wait(min(0.1, remaining))
+
+    def _info(self):
+        with self._recording_lock:
+            try:
+                source = self._resolve_source({})
+                message = ""
+            except ValueError as exc:
+                source, message = None, str(exc)
+            active = self._active_recording
+            public = ({key: active[key] for key in (
+                "action_id", "state", "duration_s", "started_at", "source")} if active else None)
+            last = self._last_recording
+            camera, instance_id = self._camera, self._external_instance_id
+        with self._condition:
+            frame = self._streams[source["topic"]]["latest"] if source else None
+            age = time.monotonic() - frame[1] if frame else None
+        ready = age is not None and age <= _MAX_FRAME_AGE_S
+        return {"ok": ready, "state": "ready" if ready else "waiting_for_camera",
+                "source": source, "camera": camera, "external_instance_id": instance_id,
+                "message": message, "output_dir": str(self._output_dir),
+                "photos_dir": str(self._output_dir / "photos"),
+                "videos_dir": str(self._output_dir / "videos"),
+                "fps": self._fps, "max_duration_s": self._max_duration_s,
+                "latest_frame_age_s": round(age, 3) if age is not None else None,
+                "encoder_available": shutil.which("ffmpeg") is not None,
+                "active_recording": public, "last_recording": last}
+
+    def start(self):
+        # Bundle startup precedes executor spinning: do not wait here for DDS.
+        return self._info()
+
+    def _new_path(self, directory, prefix, suffix):
+        target = self._output_dir / directory
+        target.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+        return target / f"{prefix}_{stamp}_{uuid4().hex[:8]}{suffix}"
+
+    def _capture_photo(self, args):
+        path = None
+        try:
+            with self._recording_lock:
+                source = self._resolve_source(args)
+            # Every photo is a frame received after this request, including after
+            # switching cameras. Cached data from the other camera cannot leak.
+            with self._condition:
+                sequence = self._streams[source["topic"]]["sequence"]
+            data, received, _ = self._frame(source, sequence)
+            path = self._new_path("photos", "IMG", ".jpg")
+            path.write_bytes(data)
+            return {"ok": True, "media_type": "photo", "file_path": str(path), "source": source,
+                    "captured_at": datetime.now().isoformat(timespec="seconds"),
+                    "frame_age_s": round(time.monotonic() - received, 3)}
+        except Exception as exc:
+            if path is not None:
+                self._remove_partial(path)
+            return {"ok": False, "code": "CAPTURE_FAILED", "message": str(exc)}
+
+    @staticmethod
+    def _remove_partial(path):
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            log.error("[vision_capture] Could not remove incomplete file %s: %s", path, exc)
+            return str(exc)
+        return None
+
+    @staticmethod
+    def _write_frame(process, data, cancel):
+        # Never block indefinitely on a wedged encoder or hold a Python buffered
+        # stdin lock that would prevent stop() from cancelling the recording.
+        pending = memoryview(data)
+        deadline = time.monotonic() + 3
+        while pending:
+            if cancel.is_set():
+                raise RuntimeError("Video recording was cancelled")
+            if process.poll() is not None:
+                raise RuntimeError("ffmpeg exited while recording")
+            if time.monotonic() >= deadline:
+                raise RuntimeError("ffmpeg input timed out")
+            if select.select([], [process.stdin], [], 0.1)[1]:
+                try:
+                    pending = pending[os.write(process.stdin.fileno(), pending):]
+                except BlockingIOError:
+                    pass
+
+    def _record_video(self, active):
+        cancel = active["cancel"]
+        source = active["source"]
+        process = None
+        path = None
+        completed = False
+        try:
+            # Start from a frame arriving after the request, not a cached image.
+            with self._condition:
+                sequence = self._streams[source["topic"]]["sequence"]
+            frame = self._frame(source, sequence, cancel=cancel)
+            path = self._new_path("videos", "video", ".mp4")
+            with tempfile.TemporaryFile() as errors:
+                process = subprocess.Popen([
+                    "ffmpeg", "-nostdin", "-y", "-loglevel", "error",
+                    "-use_wallclock_as_timestamps", "1", "-f", "mjpeg",
+                    "-probesize", "32", "-analyzeduration", "0",
+                    "-framerate", str(self._fps), "-i", "pipe:0", "-an",
+                    "-c:v", "libx264", "-preset", "ultrafast", "-threads", "2",
+                    # Normalize the timeline, retain real-time playback at a
+                    # constant output rate, and extend the last frame to the
+                    # requested endpoint. VFR alone can end one tick early
+                    # (e.g. 4.934s for a 5s request).
+                    "-vf", ("scale=out_range=tv,pad=ceil(iw/2)*2:ceil(ih/2)*2,"
+                            f"setpts=PTS-STARTPTS,fps={self._fps},tpad=stop_mode=clone:stop=-1"),
+                    "-frames:v", str(self._fps * active["duration_s"]),
+                    "-pix_fmt", "yuv420p", "-color_range", "tv", "-vsync", "vfr",
+                    "-movflags", "+faststart", str(path),
+                ], stdin=subprocess.PIPE, stdout=subprocess.DEVNULL, stderr=errors, bufsize=0)
+                os.set_blocking(process.stdin.fileno(), False)
+                with self._recording_lock:
+                    active["process"] = process
+                started = time.monotonic()
+                deadline = started + active["duration_s"]
+                frames = 0
+                while True:
+                    tick = time.monotonic()
+                    self._write_frame(process, frame[0], cancel)
+                    frames += 1
+                    cancel.wait(min(max(0, 1 / self._fps - (time.monotonic() - tick)),
+                                    max(0, deadline - time.monotonic())))
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    try:
+                        frame = self._frame(source, frame[2], min(remaining, _MAX_FRAME_AGE_S), cancel)
+                    except RuntimeError:
+                        # A healthy low-fps source may have no final frame exactly
+                        # at the deadline. A stalled source must still fail.
+                        if (not cancel.is_set() and time.monotonic() >= deadline
+                                and time.monotonic() - frame[1] < _MAX_FRAME_AGE_S):
+                            break
+                        raise
+                if frames < min(2, self._fps * active["duration_s"]):
+                    raise RuntimeError("Not enough fresh frames to record video")
+                process.stdin.close()
+                encode_deadline = time.monotonic() + 10
+                while process.poll() is None:
+                    if cancel.wait(0.1):
+                        raise RuntimeError("Video recording was cancelled")
+                    if time.monotonic() >= encode_deadline:
+                        raise RuntimeError("ffmpeg finalization timed out")
+                if process.returncode != 0 or not path.exists() or path.stat().st_size == 0:
+                    errors.seek(0)
+                    raise RuntimeError(errors.read(4096).decode("utf-8", "replace") or "ffmpeg failed to create MP4")
+            if cancel.is_set():
+                raise RuntimeError("Video recording was cancelled")
+            completed = True
+            return {"ok": True, "media_type": "video", "file_path": str(path), "source": source,
+                    "recorded_duration_s": active["duration_s"], "frames": frames,
+                    "encoded_frames": self._fps * active["duration_s"],
+                    "captured_at": datetime.now().isoformat(timespec="seconds")}
+        except Exception as exc:
+            return {"ok": False, "code": "RECORD_CANCELLED" if cancel.is_set() else "RECORD_FAILED",
+                    "message": str(exc)}
+        finally:
+            if process is not None:
+                if process.poll() is None:
+                    process.kill()
+                    process.wait(timeout=2)
+                if not process.stdin.closed:
+                    process.stdin.close()
+            with self._recording_lock:
+                active["process"] = None
+            if not completed and path is not None:
+                self._remove_partial(path)
+
+    def _notify_complete(self, action_id, status, result):
+        payload = json.dumps({"action_id": action_id, "status": status,
+                              "result": result, "tool": self.PREFIX, "ts": time.time()}).encode()
+        url = os.environ.get("AGENT_CORE_URL", "https://localhost:15678").rstrip("/")
+        ctx = ssl.create_default_context()
+        if url.startswith(("https://localhost:", "https://127.0.0.1:")):
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+        try:
+            request = urllib.request.Request(url + "/api/acp/complete", data=payload,
+                                             headers={"Content-Type": "application/json"})
+            with urllib.request.urlopen(request, timeout=3, context=ctx):
+                pass
+        except Exception as exc:
+            log.warning("[vision_capture] ACP completion delivery failed: %s", exc)
+
+    def _record_video_async(self, active):
+        try:
+            result = self._record_video(active)
+        except Exception as exc:
+            result = {"ok": False, "code": "RECORD_FAILED", "message": str(exc)}
+        with self._recording_lock:
+            # stop() may race with successful encoding; cancellation wins until
+            # the terminal result is committed under this same lock.
+            if active["cancel"].is_set():
+                cleanup_error = None
+                if result.get("ok"):
+                    cleanup_error = self._remove_partial(Path(result["file_path"]))
+                result = {"ok": False, "code": "RECORD_CANCELLED", "message": "Video recording was cancelled"}
+                if cleanup_error:
+                    result["cleanup_error"] = cleanup_error
+            status = "completed" if result.get("ok") else (
+                "cancelled" if result.get("code") == "RECORD_CANCELLED" else "error")
+            self._last_recording = {"action_id": active["action_id"], "status": status, "result": result}
+            active["state"] = status
+            active["finished"] = True
+        # The worker owns the only terminal notification, including shutdown.
+        try:
+            self._notify_complete(active["action_id"], status, result)
+        finally:
+            with self._recording_lock:
+                self._active_recording = None
+
+    def _start_video_recording(self, args):
+        requested = args.get("duration_s", min(5, self._max_duration_s))
+        if type(requested) is not int or not 1 <= requested <= self._max_duration_s:
+            return {"ok": False, "code": "INVALID_DURATION",
+                    "message": f"duration_s must be an integer between 1 and {self._max_duration_s}"}
+        if shutil.which("ffmpeg") is None:
+            return {"ok": False, "code": "RECORD_FAILED", "message": "ffmpeg is not installed"}
+        with self._recording_lock:
+            if self._active_recording is not None:
+                return {"ok": False, "code": "RECORD_IN_PROGRESS", "message": "A video recording is already in progress"}
+            try:
+                source = self._resolve_source(args)
+            except ValueError as exc:
+                return {"ok": False, "code": "RECORD_FAILED", "message": str(exc)}
+            action_id = f"vision_capture_record_video_{uuid4().hex}"
+            active = {"action_id": action_id, "state": "recording", "duration_s": requested,
+                      "started_at": datetime.now().isoformat(timespec="seconds"),
+                      "cancel": threading.Event(), "process": None, "source": source}
+            thread = threading.Thread(target=self._record_video_async, args=(active,),
+                                      daemon=True, name="go2_vision_capture_record_video")
+            active["thread"] = thread
+            self._active_recording = active
+            try:
+                thread.start()
+            except Exception:
+                self._active_recording = None
+                raise
+        return {"ok": True, "state": "queued", "action_id": action_id,
+                "media_type": "video", "requested_duration_s": requested, "source": source}
+
+    def stop(self):
+        with self._recording_lock:
+            active = self._active_recording
+            if active is None:
+                return {"ok": True, "state": "idle"}
+            if not active.get("finished"):
+                active["cancel"].set()
+                active["state"] = "stopping"
+            process = active["process"]
+        with self._condition:
+            self._condition.notify_all()
+        if process is not None and process.poll() is None:
+            try:
+                process.terminate()
+            except ProcessLookupError:
+                pass
+        active["thread"].join(timeout=6)
+        with self._recording_lock:
+            stopping = self._active_recording is active
+        return {"ok": True, "state": "stopping" if stopping else "idle", "action_id": active["action_id"]}
+
+    def dispatch(self, action, args):
+        if action == "config":
+            with self._recording_lock:
+                camera = args.get("camera", self._camera)
+                instance_id = args.get("external_instance_id", self._external_instance_id)
+                if camera not in ("front", "external") or not isinstance(instance_id, str):
+                    return {"ok": False, "code": "INVALID_CAMERA", "message": "Invalid camera configuration"}
+                if (self._active_recording is not None
+                        and (camera, instance_id) != (self._camera, self._external_instance_id)):
+                    return {"ok": False, "code": "RECORD_IN_PROGRESS", "message": "Stop recording before changing camera configuration"}
+                self._camera, self._external_instance_id = camera, instance_id
+            return {"ok": True, "camera": camera, "external_instance_id": instance_id}
+        if action == "start":
+            return self.start()
+        if action == "info":
+            return self._info()
+        if action == "capture_photo":
+            return self._capture_photo(args)
+        if action == "record_video":
+            return self._start_video_recording(args)
+        if action == "stop":
+            return self.stop()
+        if action == "list_cameras":
+            return {"ok": True, "cameras": self._sources()}
+        return None


### PR DESCRIPTION
为 Go2 新增与 Q5 同名的 `vision_capture` 卡片，将 RGB 相机画面保存为可下载检查的 JPG 照片和无声 H.264 MP4。复用已有 ROS JPEG 数据流，不重复打开相机设备。

## 卡片能力

- `capture_photo`：等待新鲜图像并保存 JPG，同步返回路径、来源和帧龄。
- `record_video`：录制 1–30 秒视频，默认 5 秒（随配置的 `max_duration_s` 收窄）；立即同步返回 `state: recording`、唯一 `action_id`、`queued_at` 和目标 `file_path`——路径预生成，即最终保存路径，与 `capture_photo` 的路径暴露方式一致。
- **文件就绪后才发送 ACP 结束信号**：等待 FFmpeg 成功退出，再用 ffprobe 检查 MP4 与视频流的实际时长、编码帧数。验证通过才回调 `completed`；失败、取消在清理后回调相应终态。`info.last_recording` 可独立查询结果。schema 声明 `x-completion`（`timeout = max_duration_s + 15`），Core 据此注册 pending 并在下一个执行器调用前等待 barrier——完成信号仅用于该编排。
- 成片按真实输入时间轴输出固定帧率并补齐末帧。5 秒 / 15fps 的 MP4 为 **5.000000 秒、75 帧**；`frames` 是新鲜源帧数。输入断流仍然报错。
- `camera` 仅选择 `front` 或 `external`，描述中明确外接源只支持 RGB；卡片不展示 `external_instance_id`。自动选择唯一运行中的 RGB 实例，排除深度与红外；多个 RGB 实例时明确要求只保留目标实例，不随意选择设备。
- 支持 `start`（返回执行器生命周期 `{"state": "ready"}`，相机就绪细节在 `info`）、`stop`、`info`、`list_cameras`。取消删除未完成的 MP4，来源相机预览继续运行。

## 结果字段

成功的录像结果只携带与 Q5 对齐的精简字段集：

| 字段 | 含义 |
| --- | --- |
| `ok` / `media_type` | 成功标志与 `video` 媒体类型 |
| `file_path` | Go2 主机上成片的绝对路径 |
| `recorded_duration_s` | ffprobe 实测的成片时长 |
| `frames` | 编码的新鲜源帧数 |
| `captured_at` | 编码完成时的文件系统 ISO 时间戳（带时区） |

失败与取消结果只携带 `ok`、`code`、`message`。`info.last_recording` 以 `{action_id, status, result}` 保留最近一次终态，供 `info` 独立查询。

## 集成边界

- 配置默认启用卡片；Dockerfile 安装 FFmpeg/ffprobe（base 镜像不携带，仅本卡片使用，`--no-install-recommends` 并保留 apt 清理）并复制插件。
- 默认保存到 `/opt/phanthy-motus/data/vision_capture/{photos,videos}`，沿用 Go2 已有持久化挂载。与 Q5 一致，仅返回文件路径，可用 SCP 下载检查，不增加图片/视频内嵌预览。
- 基于已包含 #248 的上游 main 集成，不修改已合并的 `ext_camera`、导航或其他 driver 功能。
- **不要求任何 Core 修改**。目标 `file_path` 在准入响应同步返回；文件校验与 ACP 终态信号由 driver 完成，使用现有 `/api/acp/complete` 接口，回调结果不承载展示专用字段。
- 完整说明见 [VISION_CAPTURE.md](https://github.com/He2y/phanthymotus-driver/blob/codex/go2-vision-capture/unitree/go2/VISION_CAPTURE.md)。

## 验证

- 本地 Go2 检查 **32 项通过**（采集契约 31 项 + 子进程 logsafe 契约 1 项），包括准入即含 `file_path`、验证文件结束前禁止发送 completed、时长不符报错、取消及清理、全部子进程入口安装 logsafe。
- 2026-09-09 真机前置相机与 D435i RGB 各录制 5 秒：独立 ffprobe 解码验证，文件与视频流时长均为 **5.000000 秒、75 帧**；ACP 在文件就绪约 0.1 秒后到达 Core。
- 真实取消信号通过验证，临时外接相机实例已停止。此前还验证过两路 1280×720 照片，以及前置/RGB/深度/红外并行有效数据。
- 2026-09-11 画布验证：`record_video` 的 mcp result 立即携带 `file_path`，录制结束不依赖任何 Core 侧渲染。

按要求，**不提交本地测试脚本、部署脚本或媒体产物**。PR 仅含 Go2 插件、入口、配置、Dockerfile 和使用说明。

## 同步 file_path 与 ACP 编排

目标 `file_path` 在 `record_video` 的准入响应中同步返回（路径预生成，即最终保存路径），浏览器日志立即可见完整文件名和保存地址，不依赖 Core 的 ACP `file_path` 渲染。ACP 终态信号（`completed`/`cancelled`/`error`）仅用于编排：释放 Core 的 pending barrier，保证物理动作顺序。全部在 driver 侧完成，Core 文件不包含在本 driver PR 中。
