### PR TITLE
feat(adam): add read-only hand_state sensor card for Adam Pro

### DIFF
--- a/pndbotics/adam/config.yaml
+++ b/pndbotics/adam/config.yaml
@@ -63,5 +63,9 @@ plugins:
     thumb_close_min_flex_position: 100
     open_positions: [1000, 1000, 1000, 1000, 1000, 0, 1000, 1000, 1000, 1000, 1000, 0]
     close_positions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+  hand_state:
+    enabled: true
+    publish_rate_hz: 30
+    state_timeout_sec: 1.0
   model:
     enabled: true

--- a/pndbotics/adam/device.py
+++ b/pndbotics/adam/device.py
@@ -7,6 +7,7 @@ Plugins:
   HandPlugin   — DDS rt/handcmd finger control and hand-state query
   ModelPlugin  — URDF resource for 3D visualization
 """
+from __future__ import annotations
 
 import json
 import io
@@ -619,6 +620,159 @@ class StatePlugin:
                         "topic_out": [{"topic": self._node._topic_battery, "format": "data/json"}]}
             return {"state": "running" if self._running else "idle",
                     "topic_out": [{"topic": self._node._topic_skeleton, "format": "sensor/skeleton"}]}
+        return None
+
+
+# ===========================================================================
+# HandStatePlugin — ROS2 hand-state sensor card (read-only)
+# ===========================================================================
+
+class _HandStatePublisherNode(Node):
+    """ROS2 node that publishes hand-state JSON from HandStateCache."""
+
+    def __init__(self, namespace: str, publish_rate_hz: float):
+        super().__init__("adam_hand_state_publisher")
+        self._namespace = namespace
+        qos = QoSProfile(
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1,
+        )
+        self._topic_hand_state = f"/{namespace}/state/hand_state"
+        self._pub_hand_state = self.create_publisher(String, self._topic_hand_state, qos)
+        self._latest_payload = None
+        self._active = False
+        self._lock = threading.Lock()
+        interval = 1.0 / publish_rate_hz
+        self._timer = self.create_timer(interval, self._publish)
+
+    def update_payload(self, payload):
+        with self._lock:
+            self._latest_payload = payload
+
+    def set_active(self, active: bool):
+        with self._lock:
+            self._active = bool(active)
+
+    def _publish(self):
+        with self._lock:
+            payload = self._latest_payload
+            active = self._active
+        if not active or payload is None:
+            return
+        msg = String()
+        msg.data = json.dumps(payload)
+        self._pub_hand_state.publish(msg)
+
+
+class HandStatePlugin:
+    """Read-only hand-state sensor card powered by HandStateCache.
+
+    Publishes JSON snapshots of the 12-channel hand feedback to a ROS2 topic.
+    Does NOT write to ``rt/handcmd`` — it is purely observational.
+    """
+
+    PREFIX = "hand_state"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor,
+                 state_cache=None, **kwargs):
+        self._namespace = namespace
+        self._running = False
+        self._executor = executor
+        self._state_cache = state_cache or HandStateCache()
+        try:
+            self._publish_rate_hz = float(plugin_config.get("publish_rate_hz", 30))
+        except (TypeError, ValueError):
+            self._publish_rate_hz = 30.0
+        if self._publish_rate_hz <= 0:
+            self._publish_rate_hz = 30.0
+        try:
+            self._state_timeout_sec = float(plugin_config.get("state_timeout_sec", 1.0))
+        except (TypeError, ValueError):
+            self._state_timeout_sec = 1.0
+        if self._state_timeout_sec <= 0:
+            self._state_timeout_sec = 1.0
+        self._node = _HandStatePublisherNode(namespace, self._publish_rate_hz)
+        executor.add_node(self._node)
+        self._poll_lifecycle_lock = threading.Lock()
+        self._poll_thread = None
+        self._poll_stop_event = None
+
+    def _poll_loop(self, stop_event: threading.Event):
+        """Poll HandStateCache and push snapshots to the ROS2 publisher."""
+        while not stop_event.is_set():
+            snapshot = self._state_cache.snapshot(self._state_timeout_sec)
+            if snapshot is not None:
+                self._node.update_payload(snapshot)
+            elif stop_event.wait(0.05):
+                break
+
+    def get_tools(self) -> list:
+        return [
+            {
+                "name": "hand_state",
+                "type": "sensor",
+                "multiInstance": False,
+                "description": (
+                    "Adam hand state — real-time 12-channel hand feedback "
+                    "(left/right, 6 motors each). Publishes to "
+                    f"{self._node._topic_hand_state}"
+                ),
+                "inputSchema": {"type": "object", "properties": {}},
+                "topic_out": [
+                    {"topic": self._node._topic_hand_state, "format": "data/json"}
+                ],
+            },
+        ]
+
+    def start(self):
+        self._running = True
+        self._node.set_active(True)
+        self._state_cache.start()
+        with self._poll_lifecycle_lock:
+            if self._poll_thread is None or not self._poll_thread.is_alive():
+                stop_event = threading.Event()
+                self._poll_stop_event = stop_event
+                self._poll_thread = threading.Thread(
+                    target=self._poll_loop,
+                    args=(stop_event,),
+                    daemon=True,
+                    name="adam_hand_state_poll",
+                )
+                self._poll_thread.start()
+
+    def stop(self):
+        self._running = False
+        self._node.set_active(False)
+        with self._poll_lifecycle_lock:
+            thread = self._poll_thread
+            stop_event = self._poll_stop_event
+            if stop_event is not None:
+                stop_event.set()
+            if thread is not None and thread is not threading.current_thread():
+                thread.join(1.5)
+            if thread is None or not thread.is_alive():
+                self._poll_thread = None
+                self._poll_stop_event = None
+
+    def close(self):
+        self.stop()
+        _destroy_ros_node(self._executor, self._node)
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action == "start":
+            self.start()
+            return {"state": "running"}
+        if action == "stop":
+            self.stop()
+            return {"state": "idle"}
+        if action == "info":
+            return {
+                "state": "running" if self._running else "idle",
+                "topic_out": [
+                    {"topic": self._node._topic_hand_state, "format": "data/json"}
+                ],
+            }
         return None
 
 
@@ -2346,9 +2500,10 @@ class AdamDeviceBundle:
             and (ros2_enabled is None or ros2_enabled)
         )
         hand_enabled = plugins_cfg.get("hand", {}).get("enabled", True)
+        hand_state_enabled = plugins_cfg.get("hand_state", {}).get("enabled", True)
         self._hand_state_cache = (
             HandStateCache(dds_handstate_sub)
-            if hand_enabled else None
+            if (hand_enabled or hand_state_enabled) else None
         )
 
         # StatePlugin
@@ -2387,6 +2542,12 @@ class AdamDeviceBundle:
             p = HandPlugin(plugins_cfg.get("hand", {}), namespace, executor,
                            dds_hand_pub=dds_hand_pub,
                            state_cache=self._hand_state_cache)
+            self._plugins.append(p)
+
+        # HandStatePlugin — read-only sensor card
+        if hand_state_enabled and self._ros2_enabled:
+            p = HandStatePlugin(plugins_cfg.get("hand_state", {}), namespace, executor,
+                                state_cache=self._hand_state_cache)
             self._plugins.append(p)
 
         # ModelPlugin

--- a/pndbotics/adam/driver.yaml
+++ b/pndbotics/adam/driver.yaml
@@ -11,7 +11,7 @@ build_context_extras:
   - ../../common
 # Cards this bundle exposes, for resource-center's driver marketplace listing.
 # Kept in sync by hand with config.yaml's `plugins.*.enabled` — all six plugins
-# (state, loco, camera, arm, hand, model) are currently enabled, so every tool
+# (state, loco, camera, arm, hand, hand_state, model) are currently enabled, so every tool
 # they expose is listed. camera_pointcloud is included even though its nested
 # `camera.pointcloud.enabled` defaults to false — that only gates whether the
 # point-cloud stream auto-starts, not whether the card is discoverable.
@@ -22,6 +22,7 @@ cards:
   - { name: loco,               type: actuator }
   - { name: arm,                type: actuator }
   - { name: hand,                type: actuator }
+  - { name: hand_state,           type: sensor }
   - { name: camera_head,         type: sensor }
   - { name: camera_depth,        type: sensor }
   - { name: camera_pointcloud,   type: sensor }

--- a/pndbotics/adam/main.py
+++ b/pndbotics/adam/main.py
@@ -216,7 +216,7 @@ def main():
     dds_hand_pub = None
     plugins_cfg = cfg.get("plugins", {})
     need_lowstate = plugins_cfg.get("state", {}).get("enabled", True)
-    need_handstate = plugins_cfg.get("hand", {}).get("enabled", True)
+    need_handstate = plugins_cfg.get("hand", {}).get("enabled", True) or plugins_cfg.get("hand_state", {}).get("enabled", True)
     need_hand_pub = plugins_cfg.get("hand", {}).get("enabled", True)
     try:
         from pndbotics_sdk_py.core.channel import ChannelSubscriber, ChannelPublisher

--- a/pndbotics/adam/tests/test_hand_state.py
+++ b/pndbotics/adam/tests/test_hand_state.py
@@ -1,0 +1,325 @@
+"""Focused tests for Adam hand-state sensor card (HandStatePlugin).
+
+Covers:
+- Valid 12-value feedback produces correct payload
+- Short / malformed feedback gets normalised safely
+- Stale sample is marked not fresh
+- Reader unavailable returns unavailable status
+- hand_state tool is separate from hand tool and never calls DDS command writer
+"""
+import sys
+import threading
+import time
+import types
+import unittest
+
+# ---------------------------------------------------------------------------
+# Minimal numpy mock so device.py can load without the actual package
+# ---------------------------------------------------------------------------
+_np_mod = types.ModuleType("numpy")
+_np_mod.ndarray = object
+_np_mod.float = float
+_np_mod.int = int
+sys.modules["numpy"] = _np_mod
+
+# ---------------------------------------------------------------------------
+# Minimal ROS2 mock so we can import device.py without a full ROS2 runtime
+# ---------------------------------------------------------------------------
+_ros2_mod = types.ModuleType("rclpy")
+_ros2_mod.ok = lambda: False
+_rclpy_node = types.ModuleType("rclpy.node")
+
+
+class _MockNode:
+    """Minimal Node mock that accepts __init__ args and tracks created publishers/timers."""
+
+    def __init__(self, *args, **kwargs):
+        self._publishers = []
+        self._timers = []
+        self._topic_hand_state = None
+
+    def create_publisher(self, msg_type, topic, qos):
+        self._publishers.append((msg_type, topic, qos))
+        return types.SimpleNamespace(publish=lambda m: None)
+
+    def create_timer(self, timer_period_sec, callback):
+        self._timers.append((timer_period_sec, callback))
+        return types.SimpleNamespace(cancel=lambda: None)
+
+    def destroy_publisher(self, pub):
+        pass
+
+    def destroy_timer(self, timer):
+        pass
+
+
+_rclpy_node.Node = _MockNode
+_qos = types.ModuleType("rclpy.qos")
+
+
+class _QoSProfile:
+    def __init__(self, *, reliability, history, depth):
+        self.reliability = reliability
+        self.history = history
+        self.depth = depth
+
+
+_qos.QoSProfile = _QoSProfile
+_qos.ReliabilityPolicy = types.SimpleNamespace(BEST_EFFORT=1)
+_qos.HistoryPolicy = types.SimpleNamespace(KEEP_LAST=1)
+
+_joint_msgs = types.ModuleType("sensor_msgs.msg")
+_joint_msgs.JointState = object
+_std_msgs = types.ModuleType("std_msgs.msg")
+_std_msgs.String = object
+
+sys.modules["rclpy"] = _ros2_mod
+sys.modules["rclpy.node"] = _rclpy_node
+sys.modules["rclpy.qos"] = _qos
+sys.modules["sensor_msgs"] = types.ModuleType("sensor_msgs")
+sys.modules["sensor_msgs.msg"] = _joint_msgs
+sys.modules["std_msgs"] = types.ModuleType("std_msgs")
+sys.modules["std_msgs.msg"] = _std_msgs
+
+# ---------------------------------------------------------------------------
+# Now import the module under test
+# ---------------------------------------------------------------------------
+device_path = (
+    "/tmp/claude/phanthymotus-driver-adam/pndbotics/adam/device.py"
+)
+import importlib.util
+
+# ---------------------------------------------------------------------------
+# Load device.py directly without requiring pndbotics package
+# ---------------------------------------------------------------------------
+device_path = "/tmp/claude/phanthymotus-driver-adam/pndbotics/adam/device.py"
+spec = importlib.util.spec_from_file_location("device", device_path)
+_device = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(_device)
+
+HandStateCache = _device.HandStateCache
+HandStatePlugin = _device.HandStatePlugin
+_hand_state_payload = _device._hand_state_payload
+_normalize_hand_state_positions = _device._normalize_hand_state_positions
+_coerce_hand_positions = _device._coerce_hand_positions
+HAND_POSITION_MAX = _device.HAND_POSITION_MAX
+HAND_POSITION_COUNT = _device.HAND_POSITION_COUNT
+HandPlugin = _device.HandPlugin
+
+
+class MockExecutor:
+    """Tiny executor stub that stores added nodes."""
+
+    def __init__(self):
+        self.nodes = []
+
+    def add_node(self, node):
+        self.nodes.append(node)
+
+
+class MockSubscriber:
+    """DDS subscriber stub that yields controlled samples."""
+
+    def __init__(self, samples=None, fail=False):
+        self.samples = samples or []
+        self.fail = fail
+        self.read_count = 0
+
+    def Read(self, timeout=0.2):
+        if self.fail:
+            raise RuntimeError("simulated DDS read error")
+        idx = self.read_count
+        self.read_count += 1
+        if idx < len(self.samples):
+            sample = self.samples[idx]
+            if isinstance(sample, Exception):
+                raise sample
+            return sample
+        return None
+
+
+class MockHandStateMsg:
+    def __init__(self, position):
+        self.position = position
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestNormalizeHandStatePositions(unittest.TestCase):
+    def test_valid_12_values(self):
+        pos = list(range(12))
+        result = _normalize_hand_state_positions(pos)
+        self.assertEqual(len(result), 12)
+        self.assertEqual(result, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+
+    def test_short_array(self):
+        result = _normalize_hand_state_positions([100, 200])
+        self.assertEqual(len(result), 12)
+        # short values fill, rest are 0
+        self.assertEqual(result[:2], [100, 200])
+
+    def test_empty_array(self):
+        result = _normalize_hand_state_positions([])
+        self.assertEqual(len(result), 12)
+        self.assertEqual(result, [0] * 12)
+
+    def test_exceeds_12(self):
+        result = _normalize_hand_state_positions(list(range(20)))
+        self.assertEqual(len(result), 12)
+
+
+class TestCoerceHandPositions(unittest.TestCase):
+    def test_clamps_to_max(self):
+        result = _coerce_hand_positions([2000] * 12, limit=1000)
+        self.assertEqual(result, [1000] * 12)
+
+    def test_rejects_bool(self):
+        with self.assertRaises(ValueError):
+            _coerce_hand_positions([True] * 12, limit=1000)
+
+    def test_rejects_wrong_length(self):
+        with self.assertRaises(ValueError):
+            _coerce_hand_positions([100] * 11, limit=1000)
+
+    def test_rejects_nan(self):
+        with self.assertRaises(ValueError):
+            _coerce_hand_positions([float("nan")] * 12, limit=1000)
+
+
+class TestHandStatePayload(unittest.TestCase):
+    def test_valid_payload_structure(self):
+        pos = [100, 200] + [500] * 10
+        ts = int(time.time() * 1000)
+        payload = _hand_state_payload(pos, ts, fresh=True)
+        self.assertIn("timestamp_ms", payload)
+        self.assertIn("received_at_ms", payload)
+        self.assertIn("age_ms", payload)
+        self.assertTrue(payload["fresh"])
+        self.assertEqual(payload["position"], pos)
+        self.assertEqual(len(payload["left"]["channels"]), 6)
+        self.assertEqual(len(payload["right"]["channels"]), 6)
+        self.assertEqual(payload["position_max"], HAND_POSITION_MAX)
+
+    def test_unfresh_payload(self):
+        pos = [0] * 12
+        ts = int(time.time() * 1000)
+        payload = _hand_state_payload(pos, ts, fresh=False)
+        self.assertFalse(payload["fresh"])
+
+
+class TestHandStateCache(unittest.TestCase):
+    def test_fresh_positions(self):
+        msg = MockHandStateMsg([500] * 12)
+        sub = MockSubscriber(samples=[msg])
+        cache = HandStateCache(sub)
+        self.assertTrue(cache.start())
+        time.sleep(0.5)
+        positions = cache.fresh_positions(timeout_sec=1.0)
+        self.assertEqual(positions, [500] * 12)
+        cache.close()
+
+    def test_snapshot_returns_none_before_any_read(self):
+        cache = HandStateCache(None)
+        cache.start()
+        time.sleep(0.2)
+        snapshot = cache.snapshot(timeout_sec=0.5)
+        self.assertIsNone(snapshot)
+        cache.close()
+
+    def test_status_reader_unavailable(self):
+        cache = HandStateCache(None)
+        cache.start()
+        time.sleep(0.2)
+        status = cache.status(timeout_sec=1.0)
+        self.assertFalse(status["reader_available"])
+        cache.close()
+
+    def test_stale_sample(self):
+        """Cache holds old sample; timeout makes it stale."""
+        msg = MockHandStateMsg([100] * 12)
+        sub = MockSubscriber(samples=[msg])
+        cache = HandStateCache(sub)
+        self.assertTrue(cache.start())
+        # Wait for sample to arrive
+        time.sleep(0.5)
+        # Now wait for it to become stale
+        time.sleep(2.0)
+        positions = cache.fresh_positions(timeout_sec=0.5)
+        self.assertIsNone(positions)
+        cache.close()
+
+
+class TestHandStatePlugin(unittest.TestCase):
+    """Test the plugin layer without requiring real DDS/ROS2."""
+
+    def test_tool_registration(self):
+        """hand_state tool appears as sensor with topic_out."""
+        cache = HandStateCache(None)
+        cache.start()
+        executor = MockExecutor()
+        plugin = HandStatePlugin({"publish_rate_hz": 10, "state_timeout_sec": 0.5},
+                                 "test", executor, state_cache=cache)
+        tools = plugin.get_tools()
+        self.assertEqual(len(tools), 1)
+        tool = tools[0]
+        self.assertEqual(tool["name"], "hand_state")
+        self.assertEqual(tool["type"], "sensor")
+        self.assertIn("topic_out", tool)
+        self.assertEqual(tool["topic_out"][0]["format"], "data/json")
+        plugin.close()
+
+    def test_dispatch_info(self):
+        cache = HandStateCache(None)
+        cache.start()
+        executor = MockExecutor()
+        plugin = HandStatePlugin({}, "test", executor, state_cache=cache)
+        result = plugin.dispatch("info", {"_tool_name": "hand_state"})
+        self.assertEqual(result["state"], "idle")
+        self.assertIn("topic_out", result)
+        plugin.close()
+
+    def test_hand_tool_separate_from_hand_state(self):
+        """hand_state does not interfere with hand actuator tool."""
+        cache = HandStateCache(None)
+        cache.start()
+        executor = MockExecutor()
+        hand_plugin = HandPlugin({}, "test", executor,
+                                 dds_hand_pub=None, state_cache=cache)
+        hand_state_plugin = HandStatePlugin({}, "test", executor,
+                                            state_cache=cache)
+
+        hand_tools = hand_plugin.get_tool()
+        hand_state_tools = hand_state_plugin.get_tools()
+
+        self.assertEqual(hand_tools["name"], "hand")
+        self.assertEqual(hand_tools["type"], "actuator")
+        self.assertEqual(hand_state_tools[0]["name"], "hand_state")
+        self.assertEqual(hand_state_tools[0]["type"], "sensor")
+
+        hand_plugin.close()
+        hand_state_plugin.close()
+        cache.close()
+
+    def test_hand_state_plugin_does_not_create_publisher(self):
+        """hand_state sensor is read-only and never invokes DDS command writer."""
+        cache = HandStateCache(None)
+        cache.start()
+        executor = MockExecutor()
+        plugin = HandStatePlugin({}, "test", executor, state_cache=cache)
+
+        # Start plugin and poll briefly
+        plugin.start()
+        time.sleep(0.3)
+        plugin.stop()
+        plugin.close()
+
+        # Cache should still be functioning for hand actuator
+        # snapshot is None because there's no real DDS reader, but cache is alive
+        self.assertIsNone(cache.snapshot(timeout_sec=0.5))
+        cache.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a standalone `hand_state` sensor card (type: sensor) that publishes 12-channel hand feedback JSON to ROS2 topic `/<namespace>/state/hand_state`
- Modeled after G1 sensor-card pattern; follows existing Adam StatePlugin conventions
- Reuses the existing `HandStateCache` as the single `rt/handstate` DDS reader — no duplicate DDS readers
- Does NOT write to `rt/handcmd` — purely observational, safe to drag onto canvas
- Share `HandStateCache` between `hand` actuator and `hand_state` sensor
- Enable DDS `rt/handstate` reader when either `hand` or `hand_state` is enabled
- Add `plugins.hand_state` config block (30 Hz publish rate, enabled by default)
- Register `hand_state` in `driver.yaml` marketplace cards
- 18 focused unit tests covering payload normalization, cache freshness, plugin registration, and tool separation

## Changes
| File | Description |
|------|-------------|
| `pndbotics/adam/device.py` | New `HandStatePlugin` + `_HandStatePublisherNode` (+163 lines) |
| `pndbotics/adam/main.py` | Extend `need_handstate` predicate to include `hand_state` (+1 line) |
| `pndbotics/adam/config.yaml` | Add `plugins.hand_state` block (+4 lines) |
| `pndbotics/adam/driver.yaml` | Register `hand_state` sensor card in marketplace (+2 lines) |
| `pndbotics/adam/tests/test_hand_state.py` | 18 unit tests for hand-state functionality (+325 lines) |

## Test
All 18 tests pass: `python3 tests/test_hand_state.py`