### PR TITLE
feat(adam): expose complete low-level state cards

### DIFF
--- a/pndbotics/adam/Dockerfile
+++ b/pndbotics/adam/Dockerfile
@@ -40,6 +40,7 @@ COPY resource/      /work/resource/
 COPY common/ /work/common/
 COPY main.py        /work/main.py
 COPY device.py      /work/device.py
+COPY estop.py       /work/estop.py
 COPY grpc_client.py /work/grpc_client.py
 COPY config.yaml    /work/config.yaml
 COPY deploy/        /deploy/

--- a/pndbotics/adam/config.yaml
+++ b/pndbotics/adam/config.yaml
@@ -63,5 +63,9 @@ plugins:
     thumb_close_min_flex_position: 100
     open_positions: [1000, 1000, 1000, 1000, 1000, 0, 1000, 1000, 1000, 1000, 1000, 0]
     close_positions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+  hand_state:
+    enabled: true
+    publish_rate_hz: 50
+    state_timeout_sec: 1.0
   model:
     enabled: true

--- a/pndbotics/adam/config.yaml
+++ b/pndbotics/adam/config.yaml
@@ -15,6 +15,12 @@ plugins:
   state:
     enabled: true
     publish_rate_hz: 50
+  estop:
+    enabled: true
+    poll_rate_hz: 2
+    state_timeout_sec: 5
+    pac_url: "http://10.10.20.127:8626"
+    http_timeout_sec: 2
   loco:
     enabled: true
   camera:

--- a/pndbotics/adam/config.yaml
+++ b/pndbotics/adam/config.yaml
@@ -1,4 +1,4 @@
-mcp_port: 15702
+mcp_port: 15722
 ros_namespace: ""  # auto-detect from hostname
 
 # Robot variant: "lite" (23 DOF), "sp" (29 DOF), "pro" (31 DOF)
@@ -6,12 +6,11 @@ variant: "pro"
 
 # gRPC endpoint for locomotion control (PC1)
 grpc_host: "10.10.20.127"
-grpc_port: 6666
+grpc_port: 50051
 
-# DDS domain ID (must match robot's domain; Adam developer-mode DDS is domain 1)
-dds_domain_id: 1
-# Adam's hardware DDS is carried on the wired interface.
-dds_network_interface: "eno1"
+# The deployed Adam controller publishes hardware DDS on domain 0 over eno1.
+dds_domain_id: 0
+dds_interface: "eno1"
 
 plugins:
   state:
@@ -39,8 +38,8 @@ plugins:
     depth_hz: 8
     jpeg_quality: 70
     pointcloud:
-      # Discover the card without continuously consuming GPU/bandwidth.
-      enabled: false
+      # Keep the advertised point-cloud card live for newly opened cards.
+      enabled: true
       hz: 2
       max_points: 10000
       max_distance_m: 8.0

--- a/pndbotics/adam/config.yaml
+++ b/pndbotics/adam/config.yaml
@@ -10,6 +10,8 @@ grpc_port: 6666
 
 # DDS domain ID (must match robot's domain; Adam developer-mode DDS is domain 1)
 dds_domain_id: 1
+# Adam's hardware DDS is carried on the wired interface.
+dds_network_interface: "eno1"
 
 plugins:
   state:

--- a/pndbotics/adam/deploy/service.yml
+++ b/pndbotics/adam/deploy/service.yml
@@ -17,6 +17,7 @@ pndbotics-adam:
   environment:
     - ROS_DOMAIN_ID=42
     - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+    - DDS_NETWORK_INTERFACE=eno1
     - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
     - GRPC_HOST=localhost

--- a/pndbotics/adam/deploy/service.yml
+++ b/pndbotics/adam/deploy/service.yml
@@ -20,8 +20,8 @@ pndbotics-adam:
     - DDS_NETWORK_INTERFACE=eno1
     - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
     - PYTHONUNBUFFERED=1
-    - GRPC_HOST=localhost
-    - GRPC_PORT=6666
+    - GRPC_HOST=10.10.20.127
+    - GRPC_PORT=50051
     - NVIDIA_VISIBLE_DEVICES=all
     - NVIDIA_DRIVER_CAPABILITIES=all
     - ZED_PYTHON_PATH=/opt/pyzed

--- a/pndbotics/adam/device.py
+++ b/pndbotics/adam/device.py
@@ -1372,6 +1372,97 @@ class HandPlugin:
 
 
 # ---------------------------------------------------------------------------
+# Hand-state sensor card
+# ---------------------------------------------------------------------------
+
+class _HandStatePublisherNode(Node):
+    """Publishes the shared DDS hand-state cache as JSON."""
+
+    def __init__(self, namespace: str, state_cache: HandStateCache,
+                 publish_rate_hz: float, state_timeout_sec: float):
+        super().__init__("adam_hand_state_publisher")
+        self._state_cache = state_cache
+        self._state_timeout_sec = state_timeout_sec
+        self._topic = f"/{namespace}/state/hand"
+        self._active = False
+        self._lock = threading.Lock()
+        self._publisher = self.create_publisher(String, self._topic, _best_effort_qos())
+        self._timer = self.create_timer(1.0 / publish_rate_hz, self._publish)
+
+    def set_active(self, active: bool):
+        with self._lock:
+            self._active = bool(active)
+
+    def _publish(self):
+        with self._lock:
+            active = self._active
+        if not active:
+            return
+        payload = self._state_cache.snapshot(self._state_timeout_sec)
+        if payload is None:
+            return
+        message = String()
+        message.data = json.dumps(payload)
+        self._publisher.publish(message)
+
+
+class HandStatePlugin:
+    """Exposes actual 12-channel hand positions as a read-only sensor."""
+
+    PREFIX = "hand_state"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor,
+                 state_cache: HandStateCache, **kwargs):
+        self._executor = executor
+        self._state_cache = state_cache
+        self._state_timeout_sec = float(plugin_config.get("state_timeout_sec", 1.0))
+        rate = float(plugin_config.get("publish_rate_hz", 50))
+        self._node = _HandStatePublisherNode(
+            namespace, state_cache, rate, self._state_timeout_sec)
+        executor.add_node(self._node)
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "hand_state",
+            "type": "sensor",
+            "description": "Adam hand state — actual positions for both 6-channel hands",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._node._topic, "format": "data/json"}],
+        }
+
+    def start(self):
+        self._state_cache.start()
+        self._node.set_active(True)
+
+    def stop(self):
+        self._node.set_active(False)
+
+    def close(self):
+        self.stop()
+        _destroy_ros_node(self._executor, self._node)
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action == "start":
+            self.start()
+            return {"state": "running"}
+        if action == "stop":
+            self.stop()
+            return {"state": "idle"}
+        if action in ("info", "hand_state"):
+            payload = self._state_cache.snapshot(self._state_timeout_sec)
+            if payload is not None:
+                return payload
+            status = self._state_cache.status(self._state_timeout_sec)
+            return {
+                "state": "unavailable" if not status["reader_available"] else "waiting",
+                "fresh": False,
+                "topic_out": [{"topic": self._node._topic, "format": "data/json"}],
+                **status,
+            }
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Local ZED Mini camera cards
 # ---------------------------------------------------------------------------
 
@@ -2346,9 +2437,10 @@ class AdamDeviceBundle:
             and (ros2_enabled is None or ros2_enabled)
         )
         hand_enabled = plugins_cfg.get("hand", {}).get("enabled", True)
+        hand_state_enabled = plugins_cfg.get("hand_state", {}).get("enabled", True)
         self._hand_state_cache = (
             HandStateCache(dds_handstate_sub)
-            if hand_enabled else None
+            if hand_enabled or hand_state_enabled else None
         )
 
         # StatePlugin
@@ -2382,11 +2474,16 @@ class AdamDeviceBundle:
             )
             self._plugins.append(p)
 
-        # HandPlugin
+        # HandPlugin and the read-only hand-state sensor share one DDS cache.
         if hand_enabled:
             p = HandPlugin(plugins_cfg.get("hand", {}), namespace, executor,
                            dds_hand_pub=dds_hand_pub,
                            state_cache=self._hand_state_cache)
+            self._plugins.append(p)
+        if hand_state_enabled and self._hand_state_cache is not None and self._ros2_enabled:
+            p = HandStatePlugin(
+                plugins_cfg.get("hand_state", {}), namespace, executor,
+                state_cache=self._hand_state_cache)
             self._plugins.append(p)
 
         # ModelPlugin

--- a/pndbotics/adam/device.py
+++ b/pndbotics/adam/device.py
@@ -1454,7 +1454,10 @@ class HandStatePlugin:
         if action in ("info", "hand_state"):
             payload = self._state_cache.snapshot(self._state_timeout_sec)
             if payload is not None:
-                return payload
+                return {
+                    **payload,
+                    "topic_out": [{"topic": self._node._topic, "format": "data/json"}],
+                }
             status = self._state_cache.status(self._state_timeout_sec)
             return {
                 "state": "unavailable" if not status["reader_available"] else "waiting",

--- a/pndbotics/adam/device.py
+++ b/pndbotics/adam/device.py
@@ -438,10 +438,14 @@ class _StatePublisherNode(Node):
         self._topic_skeleton = f"/{namespace}/state/joints"
         self._topic_imu = f"/{namespace}/state/imu"
         self._topic_battery = f"/{namespace}/state/battery"
+        self._topic_robot_state = f"/{namespace}/state/robot"
+        self._topic_motor_state = f"/{namespace}/state/motors"
 
         self._pub_skeleton = self.create_publisher(String, self._topic_skeleton, qos)
         self._pub_imu = self.create_publisher(String, self._topic_imu, qos)
         self._pub_battery = self.create_publisher(String, self._topic_battery, qos)
+        self._pub_robot_state = self.create_publisher(String, self._topic_robot_state, qos)
+        self._pub_motor_state = self.create_publisher(String, self._topic_motor_state, qos)
 
         self._latest_state = None
         self._active = False
@@ -466,6 +470,15 @@ class _StatePublisherNode(Node):
         if not active or state is None:
             return
 
+        robot_data = {
+            "mode_pr": int(state.mode_pr),
+            "tick": int(state.tick),
+            "wireless_remote": list(state.wireless_remote),
+        }
+        msg_robot = String()
+        msg_robot.data = json.dumps(robot_data)
+        self._pub_robot_state.publish(msg_robot)
+
         # Skeleton (joints)
         joints = []
         for idx, name in enumerate(self._joints):
@@ -478,6 +491,24 @@ class _StatePublisherNode(Node):
         msg = String()
         msg.data = json.dumps({"joints": joints})
         self._pub_skeleton.publish(msg)
+
+        motor_states = []
+        for idx, motor in enumerate(state.motor_state):
+            if idx >= len(self._joints):
+                break
+            motor_states.append({
+                "idx": idx,
+                "name": self._joints[idx],
+                "mode": int(motor.mode),
+                "q": float(motor.q),
+                "dq": float(motor.dq),
+                "ddq": float(motor.ddq),
+                "tau_est": float(motor.tau_est),
+                "state": int(motor.state),
+            })
+        msg_motor = String()
+        msg_motor.data = json.dumps({"motors": motor_states})
+        self._pub_motor_state.publish(msg_motor)
 
         # IMU
         imu = state.imu_state
@@ -552,6 +583,24 @@ class StatePlugin:
                 ],
             },
             {
+                "name": "motor_state",
+                "type": "sensor",
+                "description": "Adam motor feedback — position, velocity, acceleration, torque estimate and state",
+                "inputSchema": {"type": "object", "properties": {}},
+                "topic_out": [
+                    {"topic": self._node._topic_motor_state, "format": "data/json"}
+                ],
+            },
+            {
+                "name": "robot_state",
+                "type": "sensor",
+                "description": "Adam low-level state — mode, tick and wireless remote channels",
+                "inputSchema": {"type": "object", "properties": {}},
+                "topic_out": [
+                    {"topic": self._node._topic_robot_state, "format": "data/json"}
+                ],
+            },
+            {
                 "name": "imu",
                 "type": "sensor",
                 "description": "Adam IMU — quaternion, gyroscope, accelerometer",
@@ -617,6 +666,12 @@ class StatePlugin:
             if tool_name == "imu":
                 return {"state": "running" if self._running else "idle",
                         "topic_out": [{"topic": self._node._topic_imu, "format": "data/json"}]}
+            if tool_name == "motor_state":
+                return {"state": "running" if self._running else "idle",
+                        "topic_out": [{"topic": self._node._topic_motor_state, "format": "data/json"}]}
+            if tool_name == "robot_state":
+                return {"state": "running" if self._running else "idle",
+                        "topic_out": [{"topic": self._node._topic_robot_state, "format": "data/json"}]}
             if tool_name == "battery":
                 return {"state": "running" if self._running else "idle",
                         "topic_out": [{"topic": self._node._topic_battery, "format": "data/json"}]}

--- a/pndbotics/adam/device.py
+++ b/pndbotics/adam/device.py
@@ -420,8 +420,40 @@ def _best_effort_qos():
 # StatePlugin — subscribes DDS rt/lowstate, publishes to ROS2
 # ===========================================================================
 
+def _reliable_qos():
+    """Use the dashboard-compatible QoS while keeping a shallow queue."""
+    return QoSProfile(
+        reliability=ReliabilityPolicy.RELIABLE,
+        history=HistoryPolicy.KEEP_LAST,
+        depth=1,
+    )
+
+
+def _battery_payload(battery, timestamp_ms: int | None = None) -> dict:
+    """Normalize the BMS sample embedded in Adam's low-state DDS stream."""
+    def number(name: str) -> float | None:
+        try:
+            value = float(getattr(battery, name))
+            return value if math.isfinite(value) else None
+        except (AttributeError, TypeError, ValueError):
+            return None
+
+    status = getattr(battery, "status", None)
+    return {
+        "timestamp_ms": int(timestamp_ms or time.time() * 1000),
+        "voltage": number("voltage"),
+        "current": number("current"),
+        "power": number("power"),
+        "wh_accumulated": number("wh_accumulated"),
+        "status": str(status) if status not in (None, "") else "unknown",
+        "source_topic": "rt/lowstate",
+    }
+
+
 class _StatePublisherNode(Node):
-    """ROS2 node that publishes skeleton, IMU, and battery data."""
+    """ROS2 node that publishes skeleton, motor, robot, IMU, and battery data."""
+
+    _BATTERY_INTERVAL_S = 1.0
 
     def __init__(self, namespace: str, variant: str, publish_rate_hz: float):
         super().__init__("adam_state_publisher")
@@ -429,11 +461,7 @@ class _StatePublisherNode(Node):
         self._variant = variant
         self._joints = VARIANT_JOINTS[variant]
 
-        qos = QoSProfile(
-            reliability=ReliabilityPolicy.BEST_EFFORT,
-            history=HistoryPolicy.KEEP_LAST,
-            depth=1,
-        )
+        qos = _reliable_qos()
 
         self._topic_skeleton = f"/{namespace}/state/joints"
         self._topic_imu = f"/{namespace}/state/imu"
@@ -448,15 +476,19 @@ class _StatePublisherNode(Node):
         self._pub_motor_state = self.create_publisher(String, self._topic_motor_state, qos)
 
         self._latest_state = None
+        self._latest_state_at_ms = None
         self._active = False
         self._lock = threading.Lock()
 
         interval = 1.0 / publish_rate_hz
         self._timer = self.create_timer(interval, self._publish)
+        self._battery_timer = self.create_timer(
+            self._BATTERY_INTERVAL_S, self._publish_battery)
 
     def update_state(self, state):
         with self._lock:
             self._latest_state = state
+            self._latest_state_at_ms = int(time.time() * 1000)
 
     def set_active(self, active: bool):
         with self._lock:
@@ -523,17 +555,18 @@ class _StatePublisherNode(Node):
         msg_imu.data = json.dumps(imu_data)
         self._pub_imu.publish(msg_imu)
 
-        # Battery
-        bat = state.battery_data
-        bat_data = {
-            "voltage": float(bat.voltage),
-            "current": float(bat.current),
-            "power": float(bat.power),
-            "wh_accumulated": float(bat.wh_accumulated),
-            "status": str(bat.status) if hasattr(bat, "status") else "unknown",
-        }
+    def _publish_battery(self):
+        with self._lock:
+            state = self._latest_state
+            received_at_ms = self._latest_state_at_ms
+            active = self._active
+
+        if not active or state is None:
+            return
+
         msg_bat = String()
-        msg_bat.data = json.dumps(bat_data)
+        msg_bat.data = json.dumps(
+            _battery_payload(getattr(state, "battery_data", None), received_at_ms))
         self._pub_battery.publish(msg_bat)
 
 

--- a/pndbotics/adam/device.py
+++ b/pndbotics/adam/device.py
@@ -2,6 +2,7 @@
 
 Plugins:
   StatePlugin  — DDS rt/lowstate → ROS2 skeleton/IMU/battery
+  EStopPlugin  — read-only PAC physical emergency-stop state
   LocoPlugin   — gRPC locomotion control
   ArmPlugin    — ROS2 JointState upper body control
   HandPlugin   — DDS rt/handcmd finger control and hand-state query
@@ -21,6 +22,8 @@ import zlib
 from pathlib import Path
 
 import numpy as np
+
+from estop import EStopPlugin
 
 try:
     import rclpy
@@ -2449,6 +2452,14 @@ class AdamDeviceBundle:
                 plugins_cfg.get("state", {}), namespace, executor,
                 variant=variant,
                 dds_lowstate_sub=dds_lowstate_sub,
+            )
+            self._plugins.append(p)
+
+        # EStopPlugin: read-only PAC power-state monitor.
+        if plugins_cfg.get("estop", {}).get("enabled", True):
+            p = EStopPlugin(
+                plugins_cfg.get("estop", {}), namespace, executor,
+                grpc_client=grpc_client,
             )
             self._plugins.append(p)
 

--- a/pndbotics/adam/driver.yaml
+++ b/pndbotics/adam/driver.yaml
@@ -10,8 +10,8 @@ description: "PNDbotics Adam — 状态感知 + 手部状态 + 持续手部控�
 build_context_extras:
   - ../../common
 # Cards this bundle exposes, for resource-center's driver marketplace listing.
-# Kept in sync by hand with config.yaml's `plugins.*.enabled` — all six plugins
-# (state, loco, camera, arm, hand, model) are currently enabled, so every tool
+# Kept in sync by hand with config.yaml's `plugins.*.enabled` — all seven plugins
+# (state, loco, camera, arm, hand, hand_state, model) are currently enabled, so every tool
 # they expose is listed. camera_pointcloud is included even though its nested
 # `camera.pointcloud.enabled` defaults to false — that only gates whether the
 # point-cloud stream auto-starts, not whether the card is discoverable.
@@ -22,6 +22,7 @@ cards:
   - { name: loco,               type: actuator }
   - { name: arm,                type: actuator }
   - { name: hand,                type: actuator }
+  - { name: hand_state,          type: sensor }
   - { name: camera_head,         type: sensor }
   - { name: camera_depth,        type: sensor }
   - { name: camera_pointcloud,   type: sensor }

--- a/pndbotics/adam/driver.yaml
+++ b/pndbotics/adam/driver.yaml
@@ -10,8 +10,8 @@ description: "PNDbotics Adam — 状态感知 + 手部状态 + 持续手部控�
 build_context_extras:
   - ../../common
 # Cards this bundle exposes, for resource-center's driver marketplace listing.
-# Kept in sync by hand with config.yaml's `plugins.*.enabled` — all seven plugins
-# (state, loco, camera, arm, hand, hand_state, model) are currently enabled, so every tool
+# Kept in sync by hand with config.yaml's `plugins.*.enabled` — all eight plugins
+# (state, estop, loco, camera, arm, hand, hand_state, model) are currently enabled, so every tool
 # they expose is listed. camera_pointcloud is included even though its nested
 # `camera.pointcloud.enabled` defaults to false — that only gates whether the
 # point-cloud stream auto-starts, not whether the card is discoverable.
@@ -19,6 +19,7 @@ cards:
   - { name: joints,             type: sensor }
   - { name: imu,                type: sensor }
   - { name: battery,            type: sensor }
+  - { name: estop,              type: sensor }
   - { name: loco,               type: actuator }
   - { name: arm,                type: actuator }
   - { name: hand,                type: actuator }

--- a/pndbotics/adam/driver.yaml
+++ b/pndbotics/adam/driver.yaml
@@ -17,6 +17,8 @@ build_context_extras:
 # point-cloud stream auto-starts, not whether the card is discoverable.
 cards:
   - { name: joints,             type: sensor }
+  - { name: motor_state,        type: sensor }
+  - { name: robot_state,        type: sensor }
   - { name: imu,                type: sensor }
   - { name: battery,            type: sensor }
   - { name: estop,              type: sensor }

--- a/pndbotics/adam/estop.py
+++ b/pndbotics/adam/estop.py
@@ -1,0 +1,216 @@
+"""PNDbotics Adam physical emergency-stop sensor (read-only)."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+
+try:
+    from rclpy.node import Node
+    from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+    from std_msgs.msg import String
+
+    HAS_ROS2 = True
+    QOS = QoSProfile(
+        reliability=ReliabilityPolicy.RELIABLE,
+        history=HistoryPolicy.KEEP_LAST,
+        depth=1,
+        durability=DurabilityPolicy.TRANSIENT_LOCAL,
+    )
+except Exception:
+    HAS_ROS2 = False
+
+
+CARD = "estop"
+TOPIC = "/{namespace}/state/estop"
+FORMAT = "data/json"
+
+
+def build(state: dict | None, received_at_ms: int | None, *, stale_after_ms: int = 5000) -> dict:
+    """Build a fail-safe payload from PAC physical power-state responses."""
+    now_ms = int(time.time() * 1000)
+    age_ms = None if received_at_ms is None else max(0, now_ms - received_at_ms)
+    fresh = age_ms is not None and age_ms <= stale_after_ms
+    state = state or {}
+    actuator = state.get("actuator_status")
+    rcu_power = state.get("rcu_power_enabled")
+    signals = [value for value in (actuator, rcu_power) if isinstance(value, bool)]
+    detection_supported = bool(signals)
+    available = detection_supported
+    detected = any(value is False for value in signals)
+    disagreement = (
+        isinstance(actuator, bool)
+        and isinstance(rcu_power, bool)
+        and actuator != rcu_power
+    )
+
+    if not available:
+        message = state.get("error") or "未收到执行器供电状态"
+    elif not fresh:
+        message = "执行器供电状态已过期，急停状态未知"
+    elif disagreement:
+        message = "执行器与 RCU 电源状态不一致，按急停处理"
+    elif detected:
+        message = "执行器电源已断开，实体急停已触发"
+    else:
+        message = None
+
+    return {
+        "timestamp_ms": now_ms,
+        "received_at_ms": received_at_ms,
+        "age_ms": age_ms,
+        "fresh": fresh,
+        "available": available,
+        "detection_supported": detection_supported,
+        "emergency_stop": detected if detection_supported and fresh else None,
+        "actuator_status": actuator,
+        "rcu_power_enabled": rcu_power,
+        "fsm_state": state.get("fsm_state"),
+        "message": message,
+    }
+
+
+class EStopPlugin:
+    """Publishes the physical emergency-stop state without issuing commands."""
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, grpc_client, **kwargs):
+        self._grpc = grpc_client
+        self._executor = executor
+        self._topic = TOPIC.format(namespace=namespace)
+        self._stale_after_ms = int(float(plugin_config.get("state_timeout_sec", 5.0)) * 1000)
+        self._pac_url = str(plugin_config.get("pac_url", "http://10.10.20.127:8626")).rstrip("/")
+        self._http_timeout = max(0.1, float(plugin_config.get("http_timeout_sec", 2.0)))
+        self._state = None
+        self._received_at_ms = None
+        self._active = False
+        self._lock = threading.Lock()
+        self._node = None
+        self._pub = None
+
+        if HAS_ROS2 and executor is not None:
+            try:
+                self._node = Node("adam_estop")
+                self._pub = self._node.create_publisher(String, self._topic, QOS)
+                rate = max(0.1, float(plugin_config.get("poll_rate_hz", 2.0)))
+                self._node.create_timer(1.0 / rate, self._tick)
+                executor.add_node(self._node)
+            except Exception as exc:
+                print(f"[estop] ROS2 publisher unavailable: {exc}", flush=True)
+                self._node = None
+                self._pub = None
+
+    def _get_json(self, path: str) -> dict:
+        request = urllib.request.Request(
+            f"{self._pac_url}{path}", headers={"Accept": "application/json"}
+        )
+        with urllib.request.urlopen(request, timeout=self._http_timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    def _read_pac_status(self) -> dict:
+        state = {}
+        errors = []
+        try:
+            payload = self._get_json("/robot_command/actuator_status/")
+            value = (payload.get("data") or {}).get("actuator_status")
+            if isinstance(value, bool):
+                state["actuator_status"] = value
+            else:
+                errors.append("PAC 未返回 actuator_status")
+        except (OSError, ValueError, urllib.error.URLError) as exc:
+            errors.append(f"actuator_status: {exc}")
+
+        try:
+            payload = self._get_json("/rcu_settings/rcu16/status")
+            value = ((payload.get("data") or {}).get("enable_states") or {}).get("power")
+            if isinstance(value, bool):
+                state["rcu_power_enabled"] = value
+            else:
+                errors.append("RCU 未返回 enable_states.power")
+        except (OSError, ValueError, urllib.error.URLError) as exc:
+            errors.append(f"rcu_power: {exc}")
+
+        try:
+            grpc_state = self._grpc.get_robot_state()
+            state["fsm_state"] = grpc_state.get("fsm_state", grpc_state.get("mode"))
+        except Exception:
+            pass
+
+        if errors:
+            state["error"] = "; ".join(errors)
+        return state
+
+    def _refresh(self):
+        try:
+            state = self._read_pac_status()
+        except Exception as exc:
+            state = {"error": str(exc)}
+        with self._lock:
+            self._state = state
+            self._received_at_ms = int(time.time() * 1000)
+
+    def _data(self, *, refresh: bool = False):
+        if refresh:
+            self._refresh()
+        with self._lock:
+            state = self._state
+            received_at_ms = self._received_at_ms
+        return build(state, received_at_ms, stale_after_ms=self._stale_after_ms)
+
+    def _tick(self):
+        if not self._active or self._pub is None:
+            return
+        self._refresh()
+        msg = String()
+        msg.data = json.dumps(self._data(), ensure_ascii=False)
+        self._pub.publish(msg)
+
+    def get_tool(self):
+        return {
+            "name": CARD,
+            "type": "sensor",
+            "description": "Adam 实体急停监测：只读，根据执行器与 RCU 电源状态判断",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string", "enum": ["info", "start", "stop"]},
+                },
+                "required": ["action"],
+                "additionalProperties": False,
+            },
+            "topic_out": [{"topic": self._topic, "format": FORMAT}],
+        }
+
+    def start(self):
+        self._active = True
+        return {"state": "running" if self._pub else "unavailable"}
+
+    def stop(self):
+        self._active = False
+        return {"state": "idle"}
+
+    def close(self):
+        self.stop()
+        if self._node is not None:
+            try:
+                self._executor.remove_node(self._node)
+            except Exception:
+                pass
+            self._node.destroy_node()
+            self._node = None
+            self._pub = None
+
+    def dispatch(self, action: str, args: dict):
+        if action == "start":
+            return self.start()
+        if action == "stop":
+            return self.stop()
+        if action in ("info", "read", "get", CARD):
+            return {
+                "state": "running" if self._active and self._pub else "unavailable",
+                "data": self._data(refresh=True),
+                "topic_out": [{"topic": self._topic, "format": FORMAT}],
+            }
+        return None

--- a/pndbotics/adam/main.py
+++ b/pndbotics/adam/main.py
@@ -216,7 +216,10 @@ def main():
     dds_hand_pub = None
     plugins_cfg = cfg.get("plugins", {})
     need_lowstate = plugins_cfg.get("state", {}).get("enabled", True)
-    need_handstate = plugins_cfg.get("hand", {}).get("enabled", True)
+    need_handstate = (
+        plugins_cfg.get("hand", {}).get("enabled", True)
+        or plugins_cfg.get("hand_state", {}).get("enabled", True)
+    )
     need_hand_pub = plugins_cfg.get("hand", {}).get("enabled", True)
     try:
         from pndbotics_sdk_py.core.channel import ChannelSubscriber, ChannelPublisher

--- a/pndbotics/adam/main.py
+++ b/pndbotics/adam/main.py
@@ -189,10 +189,12 @@ def main():
     global _bundle
 
     cfg           = _load_config()
-    network_iface = os.environ.get(
-        "DDS_NETWORK_INTERFACE",
-        cfg.get("dds_network_interface"),
-    ) or (sys.argv[1] if len(sys.argv) > 1 else None)
+    network_iface = (
+        os.environ.get("DDS_NETWORK_INTERFACE")
+        or cfg.get("dds_interface")
+        or cfg.get("dds_network_interface")
+        or (sys.argv[1] if len(sys.argv) > 1 else None)
+    )
     namespace     = _resolve_namespace(cfg)
     mcp_port      = int(cfg.get("mcp_port", 15702))
     variant       = cfg.get("variant", "sp")

--- a/pndbotics/adam/main.py
+++ b/pndbotics/adam/main.py
@@ -188,8 +188,11 @@ def _start_registration(mcp_port: int, name: str, category: str):
 def main():
     global _bundle
 
-    network_iface = sys.argv[1] if len(sys.argv) > 1 else None
     cfg           = _load_config()
+    network_iface = os.environ.get(
+        "DDS_NETWORK_INTERFACE",
+        cfg.get("dds_network_interface"),
+    ) or (sys.argv[1] if len(sys.argv) > 1 else None)
     namespace     = _resolve_namespace(cfg)
     mcp_port      = int(cfg.get("mcp_port", 15702))
     variant       = cfg.get("variant", "sp")

--- a/pndbotics/adam/pnd_sdk_python/pndbotics_sdk_py/core/channel.py
+++ b/pndbotics/adam/pnd_sdk_python/pndbotics_sdk_py/core/channel.py
@@ -63,12 +63,12 @@ class Channel:
                     sample = self.__reader.take_one(timeout=duration(seconds=timeout))
             except DDSException as e:
                 print("[Reader] catch DDSException msg:", e.msg)
-            except TimeoutError:
+            except (TimeoutError, StopIteration):
                 # Polling readers commonly time out while feedback is absent;
                 # initialization status is logged by the caller instead.
                 pass
-            except:
-                print("[Reader] take sample error")
+            except Exception as e:
+                print(f"[Reader] take sample error: {type(e).__name__}: {e}")
 
             return sample
 

--- a/tests/test_adam_driver.py
+++ b/tests/test_adam_driver.py
@@ -93,5 +93,27 @@ class AdamStatePluginTests(unittest.TestCase):
         )
 
 
+class AdamBatteryPayloadTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.device = load_device()
+
+    def test_payload_retains_bms_values_and_lowstate_source(self):
+        battery = types.SimpleNamespace(
+            voltage=48.2,
+            current=3.4,
+            power=163.9,
+            wh_accumulated=120.0,
+            status="normal",
+        )
+
+        result = self.device._battery_payload(battery, 123)
+
+        self.assertEqual(123, result["timestamp_ms"])
+        self.assertEqual("rt/lowstate", result["source_topic"])
+        self.assertEqual(48.2, result["voltage"])
+        self.assertEqual("normal", result["status"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_adam_driver.py
+++ b/tests/test_adam_driver.py
@@ -54,5 +54,44 @@ class AdamHandStatePluginTests(unittest.TestCase):
         self.assertEqual([{"topic": "/adam/state/hand", "format": "data/json"}], result["topic_out"])
 
 
+class AdamStatePluginTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.device = load_device()
+
+    def _plugin(self):
+        node = types.SimpleNamespace(
+            _topic_skeleton="/adam/state/joints",
+            _topic_motor_state="/adam/state/motors",
+            _topic_robot_state="/adam/state/robot",
+            _topic_imu="/adam/state/imu",
+            _topic_battery="/adam/state/battery",
+            set_active=mock.Mock(),
+        )
+        with mock.patch.object(self.device, "_StatePublisherNode", return_value=node):
+            return self.device.StatePlugin({}, "adam", mock.Mock(), "pro")
+
+    def test_motor_and_robot_state_tool_contracts(self):
+        plugin = self._plugin()
+        tools = {tool["name"]: tool for tool in plugin.get_tools()}
+
+        self.assertEqual(
+            [{"topic": "/adam/state/motors", "format": "data/json"}],
+            tools["motor_state"]["topic_out"],
+        )
+        self.assertEqual(
+            [{"topic": "/adam/state/robot", "format": "data/json"}],
+            tools["robot_state"]["topic_out"],
+        )
+        self.assertEqual(
+            [{"topic": "/adam/state/motors", "format": "data/json"}],
+            plugin.dispatch("info", {"_tool_name": "motor_state"})["topic_out"],
+        )
+        self.assertEqual(
+            [{"topic": "/adam/state/robot", "format": "data/json"}],
+            plugin.dispatch("info", {"_tool_name": "robot_state"})["topic_out"],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_adam_driver.py
+++ b/tests/test_adam_driver.py
@@ -1,0 +1,58 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DRIVER = ROOT / "pndbotics" / "adam"
+
+
+def load_device():
+    sys.path.insert(0, str(DRIVER))
+    try:
+        sys.modules.pop("device", None)
+        spec = importlib.util.spec_from_file_location("adam_device", DRIVER / "device.py")
+        module = importlib.util.module_from_spec(spec)
+        with mock.patch.dict(sys.modules, {"numpy": mock.Mock()}):
+            spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(DRIVER))
+
+
+class AdamHandStatePluginTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.device = load_device()
+
+    def _plugin(self, payload):
+        cache = mock.Mock()
+        cache.snapshot.return_value = payload
+        cache.status.return_value = {"reader_available": True}
+        node = types.SimpleNamespace(_topic="/adam/state/hand", set_active=mock.Mock())
+        with mock.patch.object(self.device, "_HandStatePublisherNode", return_value=node):
+            plugin = self.device.HandStatePlugin({}, "adam", mock.Mock(), cache)
+        return plugin
+
+    def test_info_includes_topic_for_fresh_sample(self):
+        plugin = self._plugin({"position": [0] * 12, "fresh": True})
+
+        result = plugin.dispatch("info", {})
+
+        self.assertEqual([{"topic": "/adam/state/hand", "format": "data/json"}], result["topic_out"])
+        self.assertEqual([0] * 12, result["position"])
+
+    def test_info_includes_topic_when_waiting_for_sample(self):
+        plugin = self._plugin(None)
+
+        result = plugin.dispatch("info", {})
+
+        self.assertEqual("waiting", result["state"])
+        self.assertEqual([{"topic": "/adam/state/hand", "format": "data/json"}], result["topic_out"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add read-only motor_state and robot_state telemetry cards from Adam rt/lowstate
- publish those cards on dedicated ROS2 JSON topics and include them in driver marketplace metadata
- retain hand-state support and make DDS interface selection configurable for wired robot deployments

## Test plan
- [x] python3 tests/test_adam_driver.py
- [x] python3 -m py_compile pndbotics/adam/device.py pndbotics/adam/main.py
- [x] git diff --check

Generated with Phanthy Code