### PR TITLE
feat(adam): add read-only hand state sensor

### DIFF
--- a/pndbotics/adam/config.yaml
+++ b/pndbotics/adam/config.yaml
@@ -63,5 +63,9 @@ plugins:
     thumb_close_min_flex_position: 100
     open_positions: [1000, 1000, 1000, 1000, 1000, 0, 1000, 1000, 1000, 1000, 1000, 0]
     close_positions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+  hand_state:
+    enabled: true
+    publish_rate_hz: 5
+    state_timeout_sec: 1.0
   model:
     enabled: true

--- a/pndbotics/adam/device.py
+++ b/pndbotics/adam/device.py
@@ -176,16 +176,21 @@ def _normalize_hand_state_positions(position) -> list[int]:
     except (TypeError, ValueError):
         raw_positions = []
 
-    try:
-        positions = _coerce_hand_positions(
-            raw_positions,
-            limit=HAND_POSITION_MAX,
-            expected=len(raw_positions),
-        )
-    except ValueError:
-        positions = []
-    if len(positions) < HAND_POSITION_COUNT:
-        positions.extend([HAND_POSITION_MIN] * (HAND_POSITION_COUNT - len(positions)))
+    positions = []
+    for raw in raw_positions:
+        if isinstance(raw, bool):
+            positions.append(HAND_POSITION_MIN)
+            continue
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            positions.append(HAND_POSITION_MIN)
+            continue
+        if not math.isfinite(value):
+            positions.append(HAND_POSITION_MIN)
+            continue
+        positions.append(int(max(HAND_POSITION_MIN, min(HAND_POSITION_MAX, round(value)))))
+    positions.extend([HAND_POSITION_MIN] * (HAND_POSITION_COUNT - len(positions)))
     return positions[:HAND_POSITION_COUNT]
 
 
@@ -212,6 +217,51 @@ def _hand_state_payload(position, received_at_ms: int, *, fresh: bool) -> dict:
         "position": positions,
         "left": side(positions[:6]),
         "right": side(positions[6:12]),
+    }
+
+
+def _hand_position_label(position: int) -> str:
+    ratio = position / HAND_POSITION_MAX
+    if ratio >= 0.95:
+        return "fully_open"
+    if ratio >= 0.75:
+        return "almost_open"
+    if ratio >= 0.25:
+        return "half_closed"
+    if ratio >= 0.05:
+        return "almost_closed"
+    return "fully_closed"
+
+
+def _hand_state_sensor_payload(snapshot: dict) -> dict:
+    """Present Adam's 12-channel feedback in the hand sensor card format."""
+    def hand_block(values):
+        fingers = []
+        for index, (name, position) in enumerate(zip(HAND_CHANNEL_NAMES, values), start=1):
+            fingers.append({
+                "id": index,
+                "name": name,
+                "label": HAND_CHANNEL_LABELS[name],
+                "position": position,
+                "position_label": _hand_position_label(position),
+            })
+        return {
+            "fingers": fingers,
+            "finger_count": 5,
+            "motor_channel_count": 6,
+        }
+
+    return {
+        "hands": {
+            "left": hand_block(snapshot["left"]["position"]),
+            "right": hand_block(snapshot["right"]["position"]),
+        },
+        "timestamp_ms": snapshot["timestamp_ms"],
+        "received_at_ms": snapshot["received_at_ms"],
+        "age_ms": snapshot["age_ms"],
+        "fresh": snapshot["fresh"],
+        "position_max": snapshot["position_max"],
+        "source_topic": "rt/handstate",
     }
 
 
@@ -385,6 +435,117 @@ class HandStateCache:
         if last_read_error:
             result["last_read_error"] = last_read_error
         return result
+
+
+class _HandStatePublisherNode(Node):
+    """Publishes snapshots supplied by the shared Adam hand-state cache."""
+
+    def __init__(self, namespace: str, publish_rate_hz: float, cache, timeout_sec: float):
+        super().__init__("adam_hand_state_publisher")
+        self._topic = f"/{namespace}/state/hand_state"
+        self._cache = cache
+        self._timeout_sec = timeout_sec
+        self._active = False
+        self._lock = threading.Lock()
+        self._pub = self.create_publisher(String, self._topic, _best_effort_qos())
+        self._timer = self.create_timer(1.0 / publish_rate_hz, self._publish)
+
+    def set_active(self, active: bool):
+        with self._lock:
+            self._active = bool(active)
+
+    def _publish(self):
+        with self._lock:
+            active = self._active
+        if not active:
+            return
+        snapshot = self._cache.snapshot(self._timeout_sec)
+        if snapshot is None:
+            return
+        msg = String()
+        msg.data = json.dumps(_hand_state_sensor_payload(snapshot))
+        self._pub.publish(msg)
+
+
+class HandStatePlugin:
+    """Read-only sensor card backed by Adam's shared ``rt/handstate`` cache."""
+
+    PREFIX = "hand_state"
+
+    def __init__(self, plugin_config: dict, namespace: str, executor, state_cache=None, **kwargs):
+        self._cache = state_cache or HandStateCache()
+        self._owns_cache = state_cache is None
+        self._executor = executor
+        self._running = False
+        try:
+            rate = float(plugin_config.get("publish_rate_hz", 30))
+        except (TypeError, ValueError):
+            rate = 30.0
+        try:
+            self._timeout_sec = float(plugin_config.get("state_timeout_sec", 1.0))
+        except (TypeError, ValueError):
+            self._timeout_sec = 1.0
+        rate = rate if rate > 0 else 30.0
+        self._timeout_sec = self._timeout_sec if self._timeout_sec > 0 else 1.0
+        self._node = _HandStatePublisherNode(namespace, rate, self._cache, self._timeout_sec)
+        executor.add_node(self._node)
+
+    def get_tool(self) -> dict:
+        return {
+            "name": "hand_state",
+            "type": "sensor",
+            "multiInstance": False,
+            "readOnly": True,
+            "description": "Adam hand feedback from DDS rt/handstate (left and right six-channel hands)",
+            "inputSchema": {"type": "object", "properties": {}},
+            "topic_out": [{"topic": self._node._topic, "format": "data/json"}],
+        }
+
+    def _read(self) -> dict:
+        snapshot = self._cache.snapshot(self._timeout_sec)
+        if snapshot is not None:
+            return _hand_state_sensor_payload(snapshot)
+        status = self._cache.status(self._timeout_sec)
+        return {
+            "state": "unavailable" if not status["reader_available"] else "waiting",
+            "fresh": False,
+            "reader_available": status["reader_available"],
+            "source_topic": "rt/handstate",
+            "message": "DDS hand state reader is unavailable" if not status["reader_available"] else "No hand state received yet",
+        }
+
+    def start(self):
+        self._running = True
+        self._cache.start()
+        self._node.set_active(True)
+
+    def stop(self):
+        self._running = False
+        self._node.set_active(False)
+        if self._owns_cache:
+            self._cache.stop()
+
+    def close(self):
+        self.stop()
+        _destroy_ros_node(self._executor, self._node)
+        if self._owns_cache:
+            self._cache.close()
+
+    def dispatch(self, action: str, args: dict) -> dict:
+        if action in ("read", "get_hand_state"):
+            return self._read()
+        if action == "start":
+            self.start()
+        elif action == "stop":
+            self.stop()
+        elif action != "info":
+            return {"state": "error", "error": "INVALID_ARGUMENT", "message": f"unknown action: {action}"}
+        return {
+            "state": "running" if self._running else "idle",
+            "topic_out": [{"topic": self._node._topic, "format": "data/json"}],
+            **self._cache.status(self._timeout_sec),
+        }
+
 
 # ROS2 JointState joint names for upper body control (used by ArmPlugin)
 ROS2_UPPER_BODY_JOINTS = [
@@ -2346,9 +2507,10 @@ class AdamDeviceBundle:
             and (ros2_enabled is None or ros2_enabled)
         )
         hand_enabled = plugins_cfg.get("hand", {}).get("enabled", True)
+        hand_state_enabled = plugins_cfg.get("hand_state", {}).get("enabled", False)
         self._hand_state_cache = (
             HandStateCache(dds_handstate_sub)
-            if hand_enabled else None
+            if hand_enabled or hand_state_enabled else None
         )
 
         # StatePlugin
@@ -2387,6 +2549,14 @@ class AdamDeviceBundle:
             p = HandPlugin(plugins_cfg.get("hand", {}), namespace, executor,
                            dds_hand_pub=dds_hand_pub,
                            state_cache=self._hand_state_cache)
+            self._plugins.append(p)
+
+        # HandStatePlugin
+        if hand_state_enabled and self._ros2_enabled:
+            p = HandStatePlugin(
+                plugins_cfg.get("hand_state", {}), namespace, executor,
+                state_cache=self._hand_state_cache,
+            )
             self._plugins.append(p)
 
         # ModelPlugin

--- a/pndbotics/adam/device.py
+++ b/pndbotics/adam/device.py
@@ -292,7 +292,9 @@ class HandStateCache:
         self._latest_position = None
         self._received_at_ms = 0
         self._received_monotonic = None
+        self._sample_count = 0
         self._last_read_error = None
+        self._last_sample_position = None
 
     def start(self) -> bool:
         with self._lifecycle_lock:
@@ -376,6 +378,8 @@ class HandStateCache:
                         self._latest_position = position
                         self._received_at_ms = int(time.time() * 1000)
                         self._received_monotonic = time.monotonic()
+                        self._sample_count += 1
+                        self._last_sample_position = _normalize_hand_state_positions(position)
                         self._last_read_error = None
                 elif stop_event.wait(0.01):
                     break
@@ -423,6 +427,7 @@ class HandStateCache:
             received_at_ms = self._received_at_ms
             received_monotonic = self._received_monotonic
             last_read_error = self._last_read_error
+            sample_count = self._sample_count
         fresh = self._fresh(received_monotonic, timeout_sec)
         result = {
             "reader_available": reader_available,
@@ -431,6 +436,7 @@ class HandStateCache:
                 max(0, int(time.time() * 1000) - received_at_ms)
                 if received_monotonic is not None else None
             ),
+            "sample_count": sample_count,
         }
         if last_read_error:
             result["last_read_error"] = last_read_error
@@ -445,7 +451,12 @@ class _HandStatePublisherNode(Node):
         self._topic = f"/{namespace}/state/hand_state"
         self._cache = cache
         self._timeout_sec = timeout_sec
-        self._active = False
+        # Sensor topics are live outputs; card actions must not be required to
+        # start the publisher after the driver has registered the tool.
+        self._active = True
+        self._publish_count = 0
+        self._last_publish_at_ms = 0
+        self._last_publish_error = None
         self._lock = threading.Lock()
         self._pub = self.create_publisher(String, self._topic, _best_effort_qos())
         self._timer = self.create_timer(1.0 / publish_rate_hz, self._publish)
@@ -464,7 +475,27 @@ class _HandStatePublisherNode(Node):
             return
         msg = String()
         msg.data = json.dumps(_hand_state_sensor_payload(snapshot))
-        self._pub.publish(msg)
+        try:
+            self._pub.publish(msg)
+        except Exception as exc:
+            with self._lock:
+                self._last_publish_error = str(exc)
+            return
+        with self._lock:
+            self._publish_count += 1
+            self._last_publish_at_ms = int(time.time() * 1000)
+            self._last_publish_error = None
+
+    def metrics(self) -> dict:
+        with self._lock:
+            result = {
+                "publish_count": self._publish_count,
+                "last_publish_at_ms": self._last_publish_at_ms or None,
+                "active": self._active,
+            }
+            if self._last_publish_error:
+                result["last_publish_error"] = self._last_publish_error
+            return result
 
 
 class HandStatePlugin:
@@ -544,6 +575,7 @@ class HandStatePlugin:
             "state": "running" if self._running else "idle",
             "topic_out": [{"topic": self._node._topic, "format": "data/json"}],
             **self._cache.status(self._timeout_sec),
+            **self._node.metrics(),
         }
 
 

--- a/pndbotics/adam/driver.yaml
+++ b/pndbotics/adam/driver.yaml
@@ -22,6 +22,7 @@ cards:
   - { name: loco,               type: actuator }
   - { name: arm,                type: actuator }
   - { name: hand,                type: actuator }
+  - { name: hand_state,          type: sensor }
   - { name: camera_head,         type: sensor }
   - { name: camera_depth,        type: sensor }
   - { name: camera_pointcloud,   type: sensor }

--- a/pndbotics/adam/main.py
+++ b/pndbotics/adam/main.py
@@ -216,7 +216,10 @@ def main():
     dds_hand_pub = None
     plugins_cfg = cfg.get("plugins", {})
     need_lowstate = plugins_cfg.get("state", {}).get("enabled", True)
-    need_handstate = plugins_cfg.get("hand", {}).get("enabled", True)
+    need_handstate = (
+        plugins_cfg.get("hand", {}).get("enabled", True)
+        or plugins_cfg.get("hand_state", {}).get("enabled", False)
+    )
     need_hand_pub = plugins_cfg.get("hand", {}).get("enabled", True)
     try:
         from pndbotics_sdk_py.core.channel import ChannelSubscriber, ChannelPublisher

--- a/pndbotics/adam/tests/test_hand_state.py
+++ b/pndbotics/adam/tests/test_hand_state.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import time
+import types
+import unittest
+from pathlib import Path
+
+
+class FakePublisher:
+    def __init__(self):
+        self.messages = []
+
+    def publish(self, message):
+        self.messages.append(message)
+
+
+class FakeNode:
+    def __init__(self, *args, **kwargs):
+        self.publishers = []
+
+    def create_publisher(self, *args):
+        publisher = FakePublisher()
+        self.publishers.append(publisher)
+        return publisher
+
+    def create_timer(self, *args):
+        return object()
+
+    def destroy_node(self):
+        pass
+
+
+def load_device():
+    numpy = types.ModuleType("numpy")
+    rclpy = types.ModuleType("rclpy")
+    rclpy.node = types.ModuleType("rclpy.node")
+    rclpy.node.Node = FakeNode
+    rclpy.qos = types.ModuleType("rclpy.qos")
+    rclpy.qos.QoSProfile = lambda **kwargs: kwargs
+    rclpy.qos.ReliabilityPolicy = types.SimpleNamespace(BEST_EFFORT=1)
+    rclpy.qos.HistoryPolicy = types.SimpleNamespace(KEEP_LAST=1)
+    sensor_msgs = types.ModuleType("sensor_msgs")
+    sensor_msgs.msg = types.ModuleType("sensor_msgs.msg")
+    sensor_msgs.msg.JointState = object
+    std_msgs = types.ModuleType("std_msgs")
+    std_msgs.msg = types.ModuleType("std_msgs.msg")
+
+    class String:
+        data = ""
+
+    std_msgs.msg.String = String
+    old_modules = {name: sys.modules.get(name) for name in (
+        "numpy", "rclpy", "rclpy.node", "rclpy.qos", "sensor_msgs", "sensor_msgs.msg", "std_msgs", "std_msgs.msg",
+    )}
+    sys.modules.update({
+        "numpy": numpy,
+        "rclpy": rclpy, "rclpy.node": rclpy.node, "rclpy.qos": rclpy.qos,
+        "sensor_msgs": sensor_msgs, "sensor_msgs.msg": sensor_msgs.msg,
+        "std_msgs": std_msgs, "std_msgs.msg": std_msgs.msg,
+    })
+    try:
+        path = Path(__file__).parents[1] / "device.py"
+        module = types.ModuleType("adam_device_test")
+        module.__file__ = str(path)
+        source = "from __future__ import annotations\n" + path.read_text(encoding="utf-8")
+        exec(compile(source, str(path), "exec"), module.__dict__)
+        return module
+    finally:
+        for name, old_module in old_modules.items():
+            if old_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = old_module
+
+
+class FakeExecutor:
+    def __init__(self):
+        self.nodes = []
+
+    def add_node(self, node):
+        self.nodes.append(node)
+
+    def remove_node(self, node):
+        self.nodes.remove(node)
+
+
+class FakeCache:
+    def __init__(self, snapshot=None, reader_available=True):
+        self.snapshot_value = snapshot
+        self.reader_available = reader_available
+        self.starts = 0
+        self.stops = 0
+
+    def snapshot(self, timeout_sec):
+        return self.snapshot_value
+
+    def status(self, timeout_sec):
+        return {"reader_available": self.reader_available, "fresh": False, "last_sample_age_ms": None}
+
+    def start(self):
+        self.starts += 1
+        return self.reader_available
+
+    def stop(self):
+        self.stops += 1
+
+
+class HandStateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.device = load_device()
+
+    def test_payload_normalizes_short_and_malformed_positions(self):
+        payload = self.device._hand_state_payload([100, "bad", 2000], 10, fresh=True)
+        self.assertEqual(payload["position"], [100, 0, 1000] + [0] * 9)
+        self.assertEqual(payload["left"]["channels"]["pinky"], 100)
+        self.assertEqual(payload["right"]["position"], [0] * 6)
+
+    def test_sensor_payload_has_tianyi_style_hands(self):
+        snapshot = self.device._hand_state_payload(range(0, 1200, 100), 10, fresh=True)
+        payload = self.device._hand_state_sensor_payload(snapshot)
+        self.assertEqual(len(payload["hands"]["left"]["fingers"]), 6)
+        self.assertEqual(payload["hands"]["right"]["fingers"][5]["name"], "thumb_rotate")
+        self.assertEqual(payload["hands"]["left"]["fingers"][0]["position_label"], "fully_closed")
+
+    def test_cache_reports_missing_and_stale_samples(self):
+        cache = self.device.HandStateCache()
+        self.assertIsNone(cache.snapshot(1.0))
+        self.assertFalse(cache.status(1.0)["reader_available"])
+        cache._latest_position = [1] * 12
+        cache._received_at_ms = int(time.time() * 1000) - 2000
+        cache._received_monotonic = time.monotonic() - 2
+        self.assertFalse(cache.snapshot(0.1)["fresh"])
+
+    def test_sensor_is_read_only_and_never_uses_command_writer(self):
+        executor = FakeExecutor()
+        snapshot = self.device._hand_state_payload([500] * 12, int(time.time() * 1000), fresh=True)
+        cache = FakeCache(snapshot)
+        plugin = self.device.HandStatePlugin({"publish_rate_hz": 30}, "adam", executor, state_cache=cache)
+        tool = plugin.get_tool()
+        self.assertEqual(tool["type"], "sensor")
+        self.assertTrue(tool["readOnly"])
+        self.assertFalse(tool["multiInstance"])
+        self.assertEqual(tool["topic_out"][0], {"topic": "/adam/state/hand_state", "format": "data/json"})
+        plugin.start()
+        plugin._node._publish()
+        published = json.loads(plugin._node._pub.messages[0].data)
+        self.assertEqual(published["hands"]["left"]["fingers"][0]["position"], 500)
+        self.assertEqual(cache.starts, 1)
+        self.assertFalse(hasattr(plugin, "_hand_pub"))
+
+    def test_sensor_reports_waiting_when_reader_has_no_sample(self):
+        plugin = self.device.HandStatePlugin({}, "adam", FakeExecutor(), state_cache=FakeCache())
+        self.assertEqual(plugin.dispatch("read", {})["state"], "waiting")
+        unavailable = self.device.HandStatePlugin({}, "adam", FakeExecutor(), state_cache=FakeCache(reader_available=False))
+        self.assertEqual(unavailable.dispatch("read", {})["state"], "unavailable")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pndbotics/adam/tests/test_hand_state.py
+++ b/pndbotics/adam/tests/test_hand_state.py
@@ -135,6 +135,14 @@ class HandStateTests(unittest.TestCase):
         cache._received_monotonic = time.monotonic() - 2
         self.assertFalse(cache.snapshot(0.1)["fresh"])
 
+    def test_publisher_is_live_without_start_action(self):
+        executor = FakeExecutor()
+        snapshot = self.device._hand_state_payload([250] * 12, int(time.time() * 1000), fresh=True)
+        plugin = self.device.HandStatePlugin({}, "adam", executor, state_cache=FakeCache(snapshot))
+        plugin._node._publish()
+        self.assertEqual(len(plugin._node._pub.messages), 1)
+        self.assertEqual(plugin._node.metrics()["publish_count"], 1)
+
     def test_sensor_is_read_only_and_never_uses_command_writer(self):
         executor = FakeExecutor()
         snapshot = self.device._hand_state_payload([500] * 12, int(time.time() * 1000), fresh=True)


### PR DESCRIPTION
## Summary
- Add Adam's read-only `hand_state` sensor card backed by native DDS `rt/handstate` feedback.
- Publish Tianyi-style left/right six-channel JSON state at 5 Hz without using `rt/handcmd`.
- Add normalization, unavailable/stale handling, registration metadata, and focused tests.

## Test plan
- [x] `python3 pndbotics/adam/tests/test_hand_state.py`
- [x] `python3 -m py_compile pndbotics/adam/device.py pndbotics/adam/main.py`