### PR TITLE
drivers: add on_notify hook binding to every tts tool

### DIFF
--- a/README_dev.md
+++ b/README_dev.md
@@ -1227,6 +1227,14 @@ Each hook entry maps a `hook_id` to an action + params that will be called direc
 | `on_interrupt_speak` | User barge-in (speech) | Stop TTS |
 | `on_interrupt_motion` | Emergency stop | Stop locomotion |
 | `on_interrupt_all` | Full interrupt | Stop all outputs |
+| `on_notify` | LLM produced a notify-worthy content string | Speak it (`{"action": "speak"}`), or flash/blink if no speaker |
+
+`on_notify` fires with `extra_params={"text": "..."}` — the text is merged into whatever static
+`action`/`params` your binding declares. A speech-capable tool typically just needs `{"action":
+"speak"}` (the merged `text` key lines up with its own `speak` action). A device with no speaker
+(e.g. a drone) can bind its LED tool instead, e.g. `{"action": "set_effect", "params": {"pattern":
+"notify_blink"}}` — the unused `text` key in the merged args is harmless (hook calls skip schema
+validation) and the LED just blinks per its own fixed pattern.
 
 ### Key Differences from Normal Tools
 

--- a/agibot/AimDK_X2/device.py
+++ b/agibot/AimDK_X2/device.py
@@ -921,6 +921,7 @@ class TtsPlugin:
                 "interrupt": {"type": "boolean", "default": False, "description": "是否打断同等优先级播报"},
             },
             "required": ["text"],
+            "x-hooks": {"on_notify": {}},
         })
 
     def start(self):

--- a/engineai/t800/device.py
+++ b/engineai/t800/device.py
@@ -4879,7 +4879,8 @@ class TtsPlugin:
             "inputSchema": {"type": "object", "properties": {
                 "text": {"type": "string"}, "language": {"type": "string"},
                 "speaker": {"type": "string"}, "rate": {"type": "integer", "minimum": 50, "maximum": 300}},
-                "required": ["text"]},
+                "required": ["text"],
+                "x-hooks": {"on_notify": {}}},
         }
 
     def start(self) -> None:

--- a/unitree/g1/device.py
+++ b/unitree/g1/device.py
@@ -274,6 +274,9 @@ class NativeTtsPlugin:
                     "get_volume": {"params": [],                 "description": "Get current speaker volume"},
                     "set_volume": {"params": ["volume"],         "description": "Set speaker volume (0-100)"},
                 },
+                "x-hooks": {
+                    "on_notify": {"action": "speak"},
+                },
             },
         }
 

--- a/unitree/r1/device.py
+++ b/unitree/r1/device.py
@@ -267,6 +267,9 @@ class NativeTtsPlugin:
                     "get_volume": {"params": [],                 "description": "Get current speaker volume"},
                     "set_volume": {"params": ["volume"],         "description": "Set speaker volume (0-100)"},
                 },
+                "x-hooks": {
+                    "on_notify": {"action": "speak"},
+                },
             },
         }
 

--- a/x-humanoid/tianyi2.0/device.py
+++ b/x-humanoid/tianyi2.0/device.py
@@ -4586,6 +4586,7 @@ class TtsPlugin:
                 },
                 "x-hooks": {
                     "on_interrupt_speak": {"action": "interrupt"},
+                    "on_notify": {"action": "speak"},
                 },
             },
         }


### PR DESCRIPTION
## Summary
- Part of the auto-notify redesign (`phanthymotus` `feat/progress-notification-prompt` + `feat/on-notify-hook`): agent-core now fires an `on_notify` hook whenever the LLM produces narratable content, replacing prose-based prompt instructions that didn't reliably get followed.
- Adds the sibling `on_notify` x-hooks binding to every driver's `tts` tool (unitree/g1, unitree/r1, x-humanoid/tianyi2.0, engineai/t800, agibot/AimDK_X2), mirroring `on_interrupt_speak` where it already exists.
- Documents `on_notify` in the README's x-hooks table, including the speaker-less/LED case.

## Test plan
- [x] `python3 -m py_compile` on all 5 edited device.py files
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest engineai/t800/tests` — 250 passed
- [ ] Live check on Tianyi 2.0: `POST /api/hooks/fire {"hook": "on_notify", "extra_params": {"text": "测试播报"}}` produces audible speech