### PR TITLE
feat(teleopit): 新增卡片控制的 G1 动作仿真与预览

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Each driver is a standalone [MCP](https://modelcontextprotocol.io) HTTP server t
 | Driver | Hardware | Port | Description |
 |--------|----------|------|-------------|
 | `unitree/g1` | Unitree G1 Humanoid | 15701 | Locomotion, arm control, mic, speaker, LED, state monitoring |
+| [`generic/teleopit`](generic/teleopit/README.md) | Teleopit G1 29DoF simulation | 15719 | BVH/PICO whole-body input, MuJoCo preview and joint diagnostics; no hardware output |
 | `unitree/go1` | Unitree Go1 (EDU) Quadruped | 15715 | State, locomotion, camera (RGB/depth/pointcloud), ext peripherals, URDF |
 | `unitree/go2` | Unitree Go2 Quadruped | 15703 | Locomotion, obstacle avoidance, voice, video, navigation |
 | `unitree/r1` | Unitree R1 (EDU) Humanoid | 15702 | Mic, TTS, LED, locomotion, stereo camera, state monitoring |

--- a/README_zh.md
+++ b/README_zh.md
@@ -11,6 +11,7 @@
 | 驱动 | 硬件 | 端口 | 说明 |
 |------|------|------|------|
 | `unitree/g1` | Unitree G1 人形机器人 | 15701 | 运动控制、机械臂、麦克风、扬声器、LED、状态监控 |
+| [`generic/teleopit`](generic/teleopit/README.md) | Teleopit G1 29DoF 仿真 | 15719 | BVH/PICO 全身输入、MuJoCo 画面和关节诊断；不含真机输出 |
 | `engineai/t800` | 众擎 T800 开发版 | 15708 | ROS2/Native SDK、全身状态、舞蹈/手势序列、虚拟手柄、运动与高低层控制 |
 | `deep_robotics/lynx_m20` | 云深处山猫 M20 | 15716 | 官方 ROS 2/Fast DDS 接口与 basic_server TCP/UDP 原生控制，隔离标准版和 Pro 能力 |
  | `qianxing/qianjiao2_pro` | 潜行科技潜蛟 2.0 Pro ROV | 15739 | MAVLink v1/UDP 6DOF 运动控制、锁定/解锁、心跳和连接状态 |

--- a/generic/teleopit/Dockerfile
+++ b/generic/teleopit/Dockerfile
@@ -1,0 +1,27 @@
+ARG ROS_BASE_IMAGE=bj-warehouse.tencentcloudcr.com/phanthy-motus/ros-base:latest
+FROM ${ROS_BASE_IMAGE}
+
+WORKDIR /work
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git python3-pip python3-venv libosmesa6 libgl1 \
+    && rm -rf /var/lib/apt/lists/*
+RUN python3 -m pip install --no-cache-dir PyYAML==6.0.3
+
+COPY common/ /work/common/
+COPY main.py plugin.py manager.py worker.py backend.py upstream.py /work/
+COPY setup_teleopit.py requirements*.txt prepare_runtime.sh /work/
+COPY config.yaml driver.yaml /work/
+COPY deploy/ /deploy/
+
+# Source, checkpoints and sample data are intentionally not redistributed in the
+# image. An operator explicitly provisions this persistent runtime after reviewing
+# third-party terms. The MCP server remains usable for preflight before setup.
+ENV PYTHONPATH=/work \
+    PYTHONUNBUFFERED=1 \
+    TELEOPIT_ROOT=/opt/teleopit-runtime/source \
+    TELEOPIT_PYTHON=/opt/teleopit-runtime/venv/bin/python \
+    MUJOCO_GL=osmesa \
+    ROS_DOMAIN_ID=42 \
+    RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+EXPOSE 15719
+CMD ["/bin/bash", "-c", "source /opt/ros/humble/setup.bash && python3 /work/main.py"]

--- a/generic/teleopit/README.md
+++ b/generic/teleopit/README.md
@@ -1,0 +1,104 @@
+# Teleopit 动作仿真 Driver
+
+在 PhanthyMotus 画布内启动 BVH/PICO 全身动作输入，查看 **G1 29DoF MuJoCo 仿真**、关节目标和处理耗时。控制和画面都走已有卡片，不需要另开遥操作网页。
+
+此 Driver 是额外的可选后端，不替换既有 OpenXR/WebXR 双臂链路。实际复用 [Teleopit 0.5.0](https://github.com/BotRunner64/Teleopit/tree/v0.5.0) 的 `TeleopPipeline`：输入 → GMR 重定向/IK → ONNX 策略 → MuJoCo；这里新增的代码负责卡片、进程会话、配置、诊断和图像发布，没有自写替代算法。
+
+## 这一版能做什么
+
+| 卡片 | 可操作/可看到的结果 |
+| --- | --- |
+| `teleopit_sim`（执行器） | 配置输入、预检查、显式运行、暂停、恢复、停止；停止可取消模型加载和等待头显 |
+| `teleopit_state`（传感器） | 会话、输入新鲜度、29 个关节目标/仿真测量值、各阶段计算耗时、错误原因 |
+| `teleopit_preview`（传感器） | 640×480 MuJoCo JPEG 画面，最高约 5 Hz，直接由 Core 的图像卡渲染 |
+
+不启动仿真也能启动 Driver、查看卡片及缺失依赖。启用控制卡的 `start` 只返回 ready；点击 `run` 才启动独立子进程。停止预览/状态卡不会停止仿真；停止控制卡会结束会话。`config` 和卡片齿轮设置作用于**下次运行**。
+
+只有 `source=bvh|pico`；没有 live 开关，也不加载 Unitree SDK、G1 Bridge 或真机电机发布器。仿真状态不会被转发为机器人命令。现成策略面向 G1 29DoF，不能直接用于此前联调的 G1_23；真机适配和 PICO 设备验收不在本版已验证结果之内。
+
+## 本地安装与启动
+
+仿真环境使用 Python 3.10–3.12，建议与 ROS 2 的解释器分开。先阅读下文的第三方许可说明，再显式安装。源码/模型下载只在安装脚本执行；卡片不自动安装代码。
+
+```bash
+# 在 phanthymotus-driver 仓库根目录执行；工作目录可自选，不要放入待提交源码树。
+uv venv --python 3.11 --seed /tmp/phanthy-teleopit-venv
+/tmp/phanthy-teleopit-venv/bin/python generic/teleopit/setup_teleopit.py \
+  --root /tmp/phanthy-teleopit-source --accept-third-party-licenses
+
+export TELEOPIT_ROOT=/tmp/phanthy-teleopit-source
+export TELEOPIT_PYTHON=/tmp/phanthy-teleopit-venv/bin/python
+
+# 无 ROS 的开发机：只提供 MCP，状态可通过 info 查询；不宣称卡片已收到 DDS 画面。
+"$TELEOPIT_PYTHON" generic/teleopit/main.py --no-ros --no-register
+```
+
+有 ROS 2/Core 的主机使用已配置 ROS 2 的 Python 启动 `generic/teleopit/main.py`（不加 `--no-ros`）；仿真仍由 `TELEOPIT_PYTHON` 执行。MCP 默认只监听 `127.0.0.1:15719`，通过已有本机 Core 注册和代理访问。Core DDS Domain 默认 42；与 Core 使用相同 DDS 配置。此 Driver 不创建机器人 DDS Domain 的参与者。
+
+资产最小下载约 44 MB（不含 Python 依赖）：官方 `track_g1.onnx`、机器人模型、BVH 样例。安装器固定源码 commit `f9263865c581802ad531854b8e547e2403a945f3` 与资产 revision `94cf996444fea6894b87c28e86606cd4c2f1408f`，核对大小和 SHA-256，拒绝覆盖已有不同内容，拒绝归档路径穿越和链接。G1 不需要另下载 365 MB 的其他 GMR 资源。
+
+## 在画布上验证
+
+1. 添加并启动 `teleopit_state`、`teleopit_preview`，再添加 `teleopit_sim`。
+2. 控制卡选择 `source=bvh`，`bvh_path` 留空用固定样例，`max_steps=500`，`render=true`。启动卡片后执行 `preflight`，确认 `ready=true`。
+3. 执行 `run`。状态会从 starting 变为 running；`snapshot.step` 和 `sim_time_s` 增长，画面与关节数据更新。默认最多 500 个策略步，也会在 BVH 结束时完成。
+4. 执行 `pause`，等到 paused 后确认步数冻结；`resume` 后继续。`stop` 后为 idle，子进程和输入资源释放。再次测试需重新 `start` 控制卡。
+
+`policy_hz=50` 是策略的目标频率，不代表当前主机实际达到 50 Hz。`step_compute_ms` 是重定向、观测、推理和物理计算耗时之和，**不是 VR→真机端到端延迟**；不含输入等待、渲染、传输和卡片显示。慢帧不补发追帧。`snapshot_age_ms` 用于识别陈旧数据；画面仅用于仿真观察，不是头显实时视频回传。
+
+无需 ROS 的 MCP 检查示例（状态/关节可以使用，图像推送需要 ROS 2）：
+
+```bash
+curl -s http://127.0.0.1:15719/mcp -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"teleopit_sim","arguments":{"action":"start"}}}'
+curl -s http://127.0.0.1:15719/mcp -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"teleopit_sim","arguments":{"action":"run","source":"bvh","max_steps":50,"render":false}}}'
+curl -s http://127.0.0.1:15719/mcp -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"teleopit_sim","arguments":{"action":"info"}}}'
+```
+
+## PICO Ultra 输入
+
+此入口使用 [pico-bridge 0.2.1](https://github.com/BotRunner64/pico-bridge/releases/tag/v0.2.1) 的全身骨架数据，**不是**原有只传头部/控制器位姿的 OpenXR 客户端。按照 [Teleopit PICO 仿真教程](https://github.com/BotRunner64/Teleopit/blob/v0.5.0/docs/docs/tutorials/pico-sim2sim.md) 配置头显、全身追踪及对应 Motion Trackers，并安装匹配 APK。
+
+1. 在同一虚拟环境重跑安装脚本，加 `--pico` 安装固定版本 Python bridge；不会安装真机 SDK。
+2. PICO 和 Driver 主机使用互通的局域网。接收端默认绑定 `0.0.0.0:63901`；多网卡时，在卡片填写 `pico_advertise_host` 为头显可达的主机 IP。允许 bridge 所需的局域网流量。
+3. 头显完成应用启动、授权和全身追踪校准后，卡片选择 `source=pico`、`max_steps=0`，执行 `preflight` → `run`。
+4. 仿真开始/暂停/恢复/结束由卡片负责，不依赖头显的 Y/A/B 按钮。头显首次授权、应用启动和追踪校准仍需按 PICO 应用要求完成。
+
+`running` 只说明后端已启动；必须看到 `snapshot.step` 增长才说明已完成输入→算法→仿真。`backend.waiting_for_input=true` 表示还没收到可用骨架。超过 0.5 秒未更新标记 `input_stale`，超过配置的 `input_timeout_s`（默认 10 秒）结束会话并返回错误；不会默默宣称连接成功。本地测试覆盖解析、超时和控制隔离，PICO 实机待连接验收。
+
+## 容器部署
+
+```bash
+./build.sh generic/teleopit
+```
+
+镜像只包含 Driver 和 ROS 运行时，不内置第三方 Teleopit 源码、策略和样例。按 `deploy/service.yml` 挂载持久化 `/opt/phanthy-motus/teleopit-runtime` 后，由操作者在已启动容器里显式准备独立后端环境：
+
+```bash
+docker exec embodied-teleopit-simulation bash /work/prepare_runtime.sh \
+  --accept-third-party-licenses --pico
+```
+
+首次准备完成后可直接在卡片 `preflight` / `run`，无需重启 Core。默认使用 CPU 推理与 OSMesa 无显示器渲染，不需要 privileged、机器人设备挂载或 GPU。镜像中的 ROS Python 负责发布，持久化 venv 负责仿真。Linux ARM64 镜像构建和真实 ROS/Core 渲染仍需部署环境验证；不要把本地 Intel Mac 仿真测试视为这两项已通过。
+
+## 验证命令
+
+```bash
+# 轻量契约/生命周期/安装器测试；真实仿真测试默认明确跳过。
+"$TELEOPIT_PYTHON" -m pip install pytest
+"$TELEOPIT_PYTHON" -m pytest generic/teleopit/tests -q
+
+# 实际加载固定 Teleopit、官方 BVH/模型/ONNX，检查真实 worker 与 HTTP 控制。
+TELEOPIT_TEST_ROOT="$TELEOPIT_ROOT" \
+  "$TELEOPIT_PYTHON" -m pytest generic/teleopit/tests -q
+```
+
+本地验证包括真实 GMR→ONNX→MuJoCo、29 关节输出、有效 JPEG、HTTP 控制及停止/重启；不包含 PICO 实机、G1 真机和 ROS/Core 浏览器端验收。`diagnostics` 列表中 `code=preview_unavailable` 的记录表示 OpenGL/OSMesa 不可用，计算仍可继续，但不能把无画面认作预览成功。
+
+## 第三方来源与许可
+
+Teleopit 根目录为 Apache-2.0，固定模型仓库元数据标注 MIT；**不能据此推断所有第三方代码、模型和样例都适用相同许可**。上游 `teleopit/retargeting/gmr/utils/lafan_vendor/license.txt` 写明 CC-BY-NC-ND-4.0，默认示例来自 LAFAN1；解包后的 `assets/robots/unitree_g1/LICENSE` 是 Unitree BSD-3-Clause，保留其声明。商业部署、修改或再分发前应核对对应材料的授权范围；本 Driver 不替第三方授予许可。
+
+Driver 仓库不提交这些外部源码/资产，不在默认镜像中打包它们；安装必须由操作者阅读提示并显式确认。后续若要产品化全身真机控制，还需确认具体 G1 型号、匹配模型/策略、现场验收及上述授权问题。

--- a/generic/teleopit/backend.py
+++ b/generic/teleopit/backend.py
@@ -1,0 +1,372 @@
+"""Card-controlled adapter for the pinned Teleopit 0.5.0 simulation pipeline.
+
+No imitation policy, IK solver or physics loop is implemented here. The real
+``TeleopPipeline.run`` owns all of them. Hooks at its existing message-bus and
+policy-step seams provide measurements, cancellation and card controls. This
+module deliberately has no dependency on Teleopit's sim2real / DDS bridge.
+Heavy dependencies are loaded only inside the isolated worker's run call.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import io
+import math
+from pathlib import Path
+import sys
+import time
+from typing import Any, Callable
+
+
+UPSTREAM_VERSION = "0.5.0"
+UPSTREAM_COMMIT = "f9263865c581802ad531854b8e547e2403a945f3"
+JOINT_COUNT = 29
+POLICY_HZ = 50.0
+STALE_AFTER_S = 0.5
+
+
+class _Stopped(Exception):
+    """Local cancellation; unwinds through Teleopit's resource cleanup."""
+
+
+def _number(value: Any, name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a finite number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _vector(value: Any, size: int, name: str) -> list[float]:
+    """Reject wrong-size/nonfinite data, never pad/trim an upstream output."""
+    if hasattr(value, "shape") and tuple(value.shape) != (size,):
+        raise ValueError(f"{name} must have shape ({size},), got {value.shape}")
+    try:
+        result = [_number(item, name) for item in value]
+    except (TypeError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain {size} finite numbers") from exc
+    if len(result) != size:
+        raise ValueError(f"{name} has {len(result)} entries, expected {size}")
+    return result
+
+
+class _Gate:
+    def __init__(self, stop_event: Any, pause_event: Any,
+                 emit: Callable[[dict], None], *, clock: Callable[[], float] = time.monotonic) -> None:
+        self.stop_event = stop_event
+        self.pause_event = pause_event
+        self.emit = emit
+        self.clock = clock
+        self.cycle_start = clock()
+
+    def check(self) -> bool:
+        """Wait without advancing physics; return whether a pause occurred."""
+        if self.stop_event.is_set():
+            raise _Stopped()
+        paused = self.pause_event.is_set()
+        if paused:
+            self.emit({"event": "paused"})
+            while self.pause_event.is_set():
+                if self.stop_event.wait(0.05):
+                    raise _Stopped()
+            if self.stop_event.is_set():
+                raise _Stopped()
+            self.emit({"event": "resumed"})
+            self.cycle_start = self.clock()
+        return paused
+
+    def next_step(self) -> None:
+        paused = self.check()
+        # Pace relative to the last actual cycle, never to accumulated simulated
+        # time: a slow IK step or card pause must not cause a catch-up burst.
+        if not paused:
+            remaining = self.cycle_start + 1.0 / POLICY_HZ - self.clock()
+            if remaining > 0 and self.stop_event.wait(remaining):
+                raise _Stopped()
+        self.check()
+        self.cycle_start = self.clock()
+
+
+class _PicoInput:
+    """Observe upstream packets, strip headset controls, expose input freshness."""
+
+    def __init__(self, provider: Any, gate: _Gate, timeout_s: float) -> None:
+        self.provider = provider
+        self.gate = gate
+        self.timeout_s = timeout_s
+        self.timestamp: float | None = None
+        self.seq: int | None = None
+        self._get_packet = provider.get_realtime_input_packet
+
+    def read(self) -> Any:
+        deadline = self.gate.clock() + self.timeout_s
+        while not self.provider.has_frame():
+            if self.gate.check():
+                deadline = self.gate.clock() + self.timeout_s
+            if not self.provider.is_available():
+                raise RuntimeError("PICO receiver stopped before a body-tracking frame arrived")
+            if self.gate.clock() >= deadline:
+                raise TimeoutError("No PICO full-body tracking data received; enable body tracking and connect pico-bridge")
+            if self.gate.stop_event.wait(0.02):
+                raise _Stopped()
+        self.gate.check()
+        packet = self._get_packet()
+        self.timestamp = _number(packet.timestamp_s, "PICO packet timestamp")
+        self.seq = int(packet.seq)
+        age = max(0.0, self.gate.clock() - self.timestamp)
+        if age > self.timeout_s:
+            raise TimeoutError(f"PICO body-tracking input stopped updating for {age:.1f}s")
+        # v0.5.0's factory does not forward arms_button=None. Strip ALL controller
+        # events at the packet seam so card state remains the single owner of
+        # pause/resume and headset buttons cannot silently change simulation mode.
+        return dataclasses.replace(packet, control_events=())
+
+    def freshness(self) -> dict[str, Any]:
+        age = None if self.timestamp is None else max(0.0, self.gate.clock() - self.timestamp)
+        return {
+            "input_sequence": self.seq,
+            "input_age_ms": None if age is None else round(age * 1000.0, 3),
+            "input_stale": age is None or age > STALE_AFTER_S,
+        }
+
+
+def _make_pipeline(options: dict[str, Any]) -> Any:
+    """Load the installed, pinned upstream source and its own Hydra configs."""
+    root = Path(options["upstream_root"]).resolve()
+    package = root / "teleopit"
+    if not (package / "pipeline.py").is_file():
+        raise FileNotFoundError(f"Teleopit source is missing under {root}; run bootstrap first")
+    sys.path.insert(0, str(root))
+    upstream = importlib.import_module("teleopit")
+    actual = Path(upstream.__file__).resolve().parent
+    if actual != package:
+        raise RuntimeError(f"Wrong Teleopit import: {actual}; expected pinned source at {package}")
+
+    from hydra import compose, initialize_config_dir
+    from omegaconf import open_dict
+    from teleopit.pipeline import TeleopPipeline
+    from teleopit.runtime.console import PlainConsole
+
+    source = options["source"]
+    if source not in ("bvh", "pico"):
+        raise ValueError("source must be bvh or pico")
+    with initialize_config_dir(config_dir=str(package / "configs"), version_base=None):
+        cfg = compose(config_name="pico4_sim" if source == "pico" else "default")
+    with open_dict(cfg):
+        cfg.viewers = "none"
+        cfg.realtime = False
+        cfg.keyboard = {"enabled": False}
+        cfg.playback = {"pause_on_end": False, "keyboard": {"enabled": False}}
+        cfg.debug_trace_path = None
+        cfg.policy_hz = POLICY_HZ
+        cfg.pd_hz = 200.0
+        cfg.controller.policy_path = str(Path(options["policy_path"]).resolve())
+        cfg.controller.device = "cpu"
+        cfg.input.human_height = float(options.get("human_height", 1.75))
+        if source == "bvh":
+            cfg.input.bvh_file = str(Path(options["bvh_path"]).resolve())
+        else:
+            cfg.input.pico4_timeout = float(options.get("input_timeout_s", 10.0))
+            cfg.input.bridge_start_timeout = float(options.get("input_timeout_s", 10.0))
+            cfg.input.bridge_host = options.get("pico_host", "0.0.0.0")
+            cfg.input.bridge_port = int(options.get("pico_port", 63901))
+            cfg.input.bridge_advertise_ip = options.get("pico_advertise_host") or None
+            cfg.input.pause_button = None
+            cfg.input.arms_button = None
+            cfg.input.video.enabled = False
+    return TeleopPipeline(cfg, console=PlainConsole(title="Teleopit Driver", enabled=False))
+
+
+def _joint_names(robot: Any) -> list[str]:
+    model = robot.model
+    by_address = {}
+    for i in range(model.njnt):
+        address = int(model.jnt_qposadr[i])
+        if 7 <= address < 7 + JOINT_COUNT:
+            by_address[address] = str(model.joint(i).name)
+    names = [by_address.get(address, "") for address in range(7, 7 + JOINT_COUNT)]
+    if len(set(names)) != JOINT_COUNT or any(not name for name in names):
+        raise ValueError("Teleopit robot model must expose 29 named scalar joints in qpos order")
+    return names
+
+
+class _Preview:
+    """Optional 5 Hz view; missing EGL/OpenGL is reported, never hidden."""
+
+    def __init__(self, robot: Any, enabled: bool, emit: Callable[[dict], None]) -> None:
+        self.robot = robot
+        self.emit = emit
+        self.renderer = None
+        self.enabled = enabled
+        self.next_at = 0.0
+        self.camera = None
+
+    def image(self) -> bytes | None:
+        now = time.monotonic()
+        if not self.enabled or now < self.next_at:
+            return None
+        self.next_at = now + 0.2
+        try:
+            import mujoco
+            from PIL import Image
+
+            if self.renderer is None:
+                self.renderer = mujoco.Renderer(self.robot.model, height=480, width=640)
+                self.camera = mujoco.MjvCamera()
+                self.camera.distance = 3.0
+                self.camera.azimuth = 135
+                self.camera.elevation = -20
+            self.camera.lookat[:] = self.robot.data.qpos[:3]
+            self.renderer.update_scene(self.robot.data, camera=self.camera)
+            data = io.BytesIO()
+            Image.fromarray(self.renderer.render()).save(data, format="JPEG", quality=75)
+            return data.getvalue()
+        except Exception as exc:
+            self.enabled = False
+            self.close()
+            self.emit({"event": "diagnostic", "code": "preview_unavailable", "message": str(exc)})
+            return None
+
+    def close(self) -> None:
+        renderer, self.renderer = self.renderer, None
+        if renderer is not None:
+            try:
+                renderer.close()
+            except Exception as exc:
+                self.emit({"event": "diagnostic", "code": "preview_close_failed", "message": str(exc)})
+
+
+def run_backend(options: dict, emit: Callable[[dict], None], stop_event: Any,
+                pause_event: Any) -> None:
+    """Run real Teleopit until completed/stopped; errors propagate to supervisor.
+
+    ``event=ready`` means the simulation pipeline exists, not that PICO body data
+    has arrived. Only ``event=frame`` proves a real GMR/ONNX/MuJoCo step. The
+    optional JPEG is a bytes sibling of the finite-JSON snapshot. Computation
+    measurements exclude pacing/input waiting and are NOT end-to-end latency.
+    """
+    gate = _Gate(stop_event, pause_event, emit)
+    pipeline = None
+    preview = None
+    steps = 0
+    compute_sum_ms = 0.0
+    compute_max_ms = 0.0
+    last_snapshot: dict = {}
+    reason = "completed"
+    try:
+        gate.check()
+        pipeline = _make_pipeline(options)
+        robot = pipeline.robot
+        if int(robot.num_actions) != JOINT_COUNT or int(robot.model.nq) != 7 + JOINT_COUNT:
+            raise ValueError("Only the upstream G1 29DoF MuJoCo model is supported")
+        joint_names = _joint_names(robot)
+        target = _vector(robot.default_dof_pos, JOINT_COUNT, "default joint positions")
+        stage_ms = {"retarget_ms": 0.0, "observation_ms": 0.0, "policy_ms": 0.0, "physics_ms": 0.0}
+
+        def timed(owner: Any, name: str, key: str, size: int | None = None) -> None:
+            original = getattr(owner, name)
+
+            def call(*args: Any, **kwargs: Any) -> Any:
+                start = time.perf_counter()
+                result = original(*args, **kwargs)
+                stage_ms[key] += (time.perf_counter() - start) * 1000.0
+                if size is not None:
+                    _vector(result, size, name)
+                return result
+
+            setattr(owner, name, call)
+
+        runner = pipeline.loop._step_runner
+        timed(pipeline.retargeter, "retarget", "retarget_ms", 7 + JOINT_COUNT)
+        observation_size = int(getattr(pipeline.controller, "_expected_obs_dim", 167) or 167)
+        timed(runner, "build_observation", "observation_ms", observation_size)
+        timed(pipeline.controller, "compute_action", "policy_ms", JOINT_COUNT)
+        timed(runner, "apply_control", "physics_ms")
+        original_target = runner.compute_target_dof_pos
+
+        def capture_target(action: Any) -> Any:
+            nonlocal target
+            result = original_target(action)
+            target = _vector(result, JOINT_COUNT, "target joint positions")
+            return result
+
+        runner.compute_target_dof_pos = capture_target
+        pico = None
+        if options["source"] == "pico":
+            pico = _PicoInput(pipeline.input_provider, gate, float(options.get("input_timeout_s", 10.0)))
+            pipeline.input_provider.get_realtime_input_packet = pico.read
+        preview = _Preview(robot, bool(options.get("render", False)), emit)
+
+        def observe(state: Any) -> None:
+            nonlocal steps, last_snapshot, compute_sum_ms, compute_max_ms
+            steps += 1
+            compute_ms = sum(stage_ms.values())
+            compute_sum_ms += compute_ms
+            compute_max_ms = max(compute_max_ms, compute_ms)
+            last_snapshot = {
+                "step": steps,
+                "source": options["source"],
+                "mode": "simulation",
+                "robot_profile": "unitree_g1_29dof",
+                "sim_time_s": _number(state.timestamp, "simulation time"),
+                "policy_hz": POLICY_HZ,
+                "step_compute_ms": round(compute_ms, 3),
+                "target_positions": list(target),
+                "joint_positions": _vector(state.qpos, JOINT_COUNT, "joint positions"),
+                "joint_names": joint_names,
+                "root_position": _vector(state.base_pos, 3, "root position"),
+                "root_orientation_wxyz": _vector(state.quat, 4, "root orientation"),
+                "input_age_ms": None,
+                "input_stale": False,
+                "hardware_output": False,
+                **{key: round(value, 3) for key, value in stage_ms.items()},
+            }
+            if pico is not None:
+                last_snapshot.update(pico.freshness())
+            event = {"event": "frame", "snapshot": last_snapshot}
+            jpeg = preview.image()
+            if jpeg is not None:
+                event["preview_jpeg"] = jpeg
+            emit(event)
+            for key in stage_ms:
+                stage_ms[key] = 0.0
+            gate.next_step()
+
+        from teleopit.bus.topics import TOPIC_ROBOT_STATE
+
+        pipeline.bus.subscribe(TOPIC_ROBOT_STATE, observe)
+        # Heavy model loading may have outlived a stop request. Do not publish a
+        # late "ready" transition for a session that has already been cancelled.
+        gate.check()
+        emit({
+            "event": "ready", "upstream_version": UPSTREAM_VERSION,
+            "upstream_commit": UPSTREAM_COMMIT, "robot_profile": "unitree_g1_29dof",
+            "source": options["source"], "joint_names": joint_names,
+            "policy_hz": POLICY_HZ, "hardware_output": False,
+            "waiting_for_input": options["source"] == "pico",
+        })
+        gate.check()
+        gate.cycle_start = gate.clock()
+        default_steps = 0 if options["source"] == "pico" else 500
+        pipeline.run(num_steps=int(options.get("max_steps", default_steps)))
+    except _Stopped:
+        reason = "stopped"
+    finally:
+        if preview is not None:
+            preview.close()
+        if pipeline is not None:
+            close = getattr(pipeline.input_provider, "close", None)
+            if callable(close):
+                close()
+    emit({
+        "event": "complete",
+        "summary": {
+            "reason": reason, "steps": steps,
+            "sim_time_s": last_snapshot.get("sim_time_s", 0.0),
+            "mean_step_compute_ms": round(compute_sum_ms / max(steps, 1), 3),
+            "max_step_compute_ms": round(compute_max_ms, 3),
+            "hardware_output": False,
+        },
+    })

--- a/generic/teleopit/config.yaml
+++ b/generic/teleopit/config.yaml
@@ -1,0 +1,20 @@
+mcp_port: 15719
+name: Teleopit 动作仿真
+bind_host: 127.0.0.1
+ros_namespace: ""
+ros:
+  core_domain_id: 42
+teleopit:
+  # 管理员先显式安装上游；留空时读取 TELEOPIT_ROOT / TELEOPIT_PYTHON。
+  upstream_root: ""
+  worker_python: ""
+  policy_path: ""
+  source: bvh
+  bvh_path: ""
+  max_steps: 500
+  human_height: 1.75
+  render: true
+  pico_host: 0.0.0.0
+  pico_port: 63901
+  pico_advertise_host: ""
+  input_timeout_s: 10

--- a/generic/teleopit/deploy/service.yml
+++ b/generic/teleopit/deploy/service.yml
@@ -1,0 +1,20 @@
+teleopit-simulation:
+  image: __IMAGE__
+  container_name: embodied-teleopit-simulation
+  network_mode: host
+  volumes:
+    - /opt/phanthy-motus/dds-local.xml:/opt/phanthy-motus/dds-local.xml:ro
+    - /opt/phanthy-motus/teleopit-runtime:/opt/teleopit-runtime
+  environment:
+    - AGENT_CORE_URL=https://localhost:15678
+    - ROS_DOMAIN_ID=42
+    - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+    - FASTRTPS_DEFAULT_PROFILES_FILE=/opt/phanthy-motus/dds-local.xml
+    - MUJOCO_GL=osmesa
+    - PYTHONUNBUFFERED=1
+  logging:
+    driver: local
+    options:
+      max-size: 10m
+      max-file: "3"
+  restart: unless-stopped

--- a/generic/teleopit/driver.yaml
+++ b/generic/teleopit/driver.yaml
@@ -1,0 +1,15 @@
+id: teleopit-driver
+name: Teleopit 动作仿真
+category: driver
+hardware_provider: generic
+hardware_model: teleopit-g1-29-simulation
+image_name: teleopit-simulation
+port: 15719
+mcp_url: http://localhost:15719/mcp
+description: "Teleopit 0.5.0：BVH/PICO 全身输入、G1 29DoF MuJoCo 仿真、关节状态和画面预览；不含真机输出"
+build_context_extras:
+  - ../../common
+cards:
+  - { name: teleopit_sim, type: actuator }
+  - { name: teleopit_state, type: sensor }
+  - { name: teleopit_preview, type: sensor }

--- a/generic/teleopit/main.py
+++ b/generic/teleopit/main.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Teleopit simulation cards, served through the existing MCP/Core contracts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Repository checkout and image layout both put common/ above this directory.
+for _parent in Path(__file__).resolve().parents:
+    if (_parent / "common" / "vendor_runtime.py").is_file():
+        sys.path.insert(0, str(_parent))
+        break
+
+from common import logsafe
+
+logsafe.install()
+
+import argparse
+import os
+import signal
+import threading
+from http.server import ThreadingHTTPServer
+
+from common.vendor_runtime import (
+    DriverBundle, load_config, make_handler, resolve_namespace, start_registration,
+)
+
+from plugin import CoreTopicPublisher, TeleopitPlugin
+
+
+DRIVER_ID = "teleopit-driver"
+SERVER_NAME = "teleopit-simulation"
+
+
+def build_bundle(config: dict, manager=None, publisher=None) -> DriverBundle:
+    """Build a ROS/Teleopit-import-free bundle when collaborators are supplied."""
+    if manager is None:
+        from manager import SimulationManager
+        manager = SimulationManager(config.get("teleopit", {}))
+    plugin = TeleopitPlugin(config, resolve_namespace(config), manager, publisher)
+    bundle = DriverBundle([plugin])
+    bundle.manager = manager
+    bundle.plugin = plugin
+    return bundle
+
+
+def create_server(config: dict, bundle: DriverBundle, host=None, port=None) -> ThreadingHTTPServer:
+    base = make_handler(lambda: bundle, SERVER_NAME, DRIVER_ID)
+
+    class Handler(base):
+        def log_message(self, fmt, *args):
+            msg = fmt % args
+            if '"POST /mcp' not in msg or "200" not in msg:
+                safe = msg.encode("unicode_escape").decode("ascii")[:200]
+                print(f"[mcp] {self.address_string()} {safe}", flush=True)
+
+        def do_POST(self):
+            # The shared handler remains the owner of JSON-RPC framing. Bound
+            # request size here because this card needs no large input payloads.
+            try:
+                length = int(self.headers.get("Content-Length", "0"))
+            except ValueError:
+                length = -1
+            if length <= 0 or length > 65536:
+                self.close_connection = True
+                self.send_json(413 if length > 65536 else 400,
+                               {"error": "Content-Length must be between 1 and 65536"})
+                return
+            self.connection.settimeout(5)
+            super().do_POST()
+
+    bind_host = host if host is not None else os.environ.get("MCP_BIND_HOST", config.get("bind_host", "127.0.0.1"))
+    bind_port = int(port if port is not None else config.get("mcp_port", 15719))
+    return ThreadingHTTPServer((bind_host, bind_port), Handler)
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description="Teleopit G1 29DoF 仿真 Driver（无真机输出）")
+    parser.add_argument("--no-ros", action="store_true", help="仅提供 MCP，不发布 Core 状态/画面话题")
+    parser.add_argument("--no-register", action="store_true", help="不自动向 Agent Core 注册")
+    parser.add_argument("--host", help="MCP 监听地址，默认 127.0.0.1")
+    parser.add_argument("--port", type=int, help="MCP 监听端口，默认 15719")
+    args = parser.parse_args(argv)
+    config = load_config(__file__)
+    namespace = resolve_namespace(config)
+    publisher = None
+    if not args.no_ros:
+        try:
+            publisher = CoreTopicPublisher(namespace, config.get("ros", {}).get("core_domain_id", 42))
+        except Exception as exc:
+            print(f"[teleopit] ROS 2 unavailable; MCP remains available: {exc}", flush=True)
+    bundle = build_bundle(config, publisher=publisher)
+    server = None
+    stopping = threading.Event()
+
+    def shutdown(signum, _frame):
+        if stopping.is_set():
+            return
+        stopping.set()
+        print(f"[teleopit] signal {signum}; stopping", flush=True)
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    try:
+        server = create_server(config, bundle, args.host, args.port)
+        bundle.start_all()
+        if not args.no_register:
+            start_registration(server.server_address[1], config, DRIVER_ID)
+        signal.signal(signal.SIGTERM, shutdown)
+        signal.signal(signal.SIGINT, shutdown)
+        print(f"[teleopit] MCP={server.server_address} namespace={namespace} hardware_output=false", flush=True)
+        server.serve_forever()
+    finally:
+        bundle.stop_all()
+        bundle.manager.close()
+        if server is not None:
+            server.server_close()
+        if publisher is not None:
+            publisher.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/generic/teleopit/manager.py
+++ b/generic/teleopit/manager.py
@@ -1,0 +1,343 @@
+"""Bounded, cancellable simulation sessions. No robot SDK lives in this process."""
+
+from __future__ import annotations
+
+import base64
+import collections
+import copy
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+import threading
+import time
+import uuid
+
+from upstream import inspect_installation
+
+
+USER_OPTIONS = frozenset({
+    "source", "bvh_path", "max_steps", "human_height", "render", "pico_advertise_host",
+})
+ACTIVE_STATES = frozenset({"starting", "running", "pausing", "paused", "resuming", "finishing", "stopping"})
+
+
+def validate_options(options: dict) -> dict:
+    """Validate controls independently of JSON Schema (MCP callers may bypass it)."""
+    if not isinstance(options, dict):
+        raise ValueError("遥操作设置必须是对象")
+    unknown = set(options) - USER_OPTIONS
+    if unknown:
+        raise ValueError(f"不支持的仿真设置: {', '.join(sorted(unknown))}")
+    result = dict(options)
+    if "source" in result and result["source"] not in {"bvh", "pico"}:
+        raise ValueError("source 只能是 bvh 或 pico；此 Driver 不提供真机输出")
+    if "max_steps" in result:
+        value = result["max_steps"]
+        if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= 180000:
+            raise ValueError("max_steps 必须是 0–180000 的整数（0 表示直到停止）")
+    if "human_height" in result:
+        value = result["human_height"]
+        if isinstance(value, bool) or not isinstance(value, (float, int)) or not math.isfinite(value) or not 0.8 <= value <= 2.5:
+            raise ValueError("human_height 必须是 0.8–2.5 米的有限数值")
+    if "render" in result and not isinstance(result["render"], bool):
+        raise ValueError("render 必须是布尔值")
+    for name in ("bvh_path", "pico_advertise_host"):
+        if name in result and (not isinstance(result[name], str) or len(result[name]) > 4096 or any(ord(c) < 32 for c in result[name])):
+            raise ValueError(f"{name} 必须是单行字符串")
+    return result
+
+
+class SimulationManager:
+    """One subprocess per run, generation-fenced so stop preempts slow startup."""
+
+    def __init__(self, config: dict | None = None):
+        self.config = dict(config or {})
+        self._lock = threading.RLock()
+        self._stop_lock = threading.Lock()
+        self._generation = 0
+        self._state = "idle"
+        self._process: subprocess.Popen | None = None
+        self._session_id: str | None = None
+        self._snapshot: dict = {}
+        self._preview: bytes | None = None
+        self._snapshot_at: float | None = None
+        self._error: str | None = None
+        self._logs: collections.deque[str] = collections.deque(maxlen=24)
+        self._last_preflight: dict | None = None
+        self._backend: dict = {}
+        self._diagnostics: collections.deque[dict] = collections.deque(maxlen=12)
+        self._closed = False
+
+    def _options(self, supplied: dict | None) -> dict:
+        supplied = validate_options(supplied or {})
+        defaults = {"source": "bvh", "bvh_path": "", "max_steps": 500,
+                    "human_height": 1.75, "render": True, "pico_advertise_host": ""}
+        defaults.update({k: v for k, v in self.config.items() if k in USER_OPTIONS})
+        defaults.update(supplied)
+        validate_options(defaults)
+        root = self.config.get("upstream_root") or os.environ.get("TELEOPIT_ROOT", "")
+        return {**defaults, "upstream_root": str(Path(root).expanduser().resolve()) if root else "",
+                "policy_path": self.config.get("policy_path") or "",
+                "pico_host": self.config.get("pico_host", "0.0.0.0"),
+                "pico_port": self.config.get("pico_port", 63901),
+                "input_timeout_s": self.config.get("input_timeout_s", 10.0)}
+
+    def _python(self) -> str:
+        return str(self.config.get("worker_python") or os.environ.get("TELEOPIT_PYTHON") or sys.executable)
+
+    def _check(self, options: dict) -> dict:
+        if not options["upstream_root"]:
+            return {"ready": False, "errors": ["尚未安装 Teleopit；先运行 setup_teleopit.py 并配置 TELEOPIT_ROOT"], "paths": {}}
+        result = inspect_installation(
+            Path(options["upstream_root"]), policy_path=options["policy_path"] or None,
+            bvh_path=options["bvh_path"] or None, source=options["source"],
+        )
+        result = dict(result)
+        errors = list(result.get("errors", []))
+        if result.get("ready"):
+            # Probe in the selected interpreter, not the ROS2/Core interpreter.
+            modules = ["teleopit", "mujoco", "mink", "onnxruntime", "torch", "omegaconf", "daqp",
+                       "hydra", "scipy", "qpsolvers", "numpy", "h5py", "zmq", "msgpack",
+                       "rich", "loop_rate_limiters", "imageio"]
+            versions = {"teleopit": "0.5.0", "mujoco": "3.2.7", "mink": "0.0.13",
+                        "onnxruntime": "1.23.2", "torch": "2.2.2", "numpy": "1.26.4",
+                        "hydra-core": "1.3.6", "omegaconf": "2.3.1"}
+            if options["render"]:
+                modules.append("PIL")
+            if options["source"] == "pico":
+                modules.append("pico_bridge")
+                versions["pico-bridge"] = "0.2.1"
+            probe = ("import importlib.util,importlib.metadata,json; "
+                     f"names={modules!r}; versions={versions!r}; "
+                     "installed={d.metadata['Name'].lower():d.version for d in importlib.metadata.distributions() if d.metadata['Name']}; "
+                     "print(json.dumps({'missing':[n for n in names if importlib.util.find_spec(n) is None],"
+                     "'version_mismatches':[n+': '+installed.get(n,'missing')+' != '+v for n,v in versions.items() if installed.get(n,'').split('+')[0]!=v],"
+                     "'origin':str(importlib.util.find_spec('teleopit').origin) if importlib.util.find_spec('teleopit') else ''}))")
+            try:
+                proc = subprocess.run([self._python(), "-c", probe], capture_output=True, text=True, timeout=10, check=True)
+                data = json.loads(proc.stdout)
+                if data["missing"]:
+                    errors.append("仿真解释器缺少依赖: " + ", ".join(data["missing"]))
+                if data["version_mismatches"]:
+                    errors.append("仿真依赖与已验证版本不匹配: " + ", ".join(data["version_mismatches"]))
+                expected = Path(options["upstream_root"]) / "teleopit" / "__init__.py"
+                if data["origin"] and Path(data["origin"]).resolve() != expected.resolve():
+                    errors.append("仿真解释器导入了另一份 teleopit；请对选定源码目录执行 editable 安装")
+            except (OSError, subprocess.SubprocessError, ValueError, KeyError) as exc:
+                errors.append(f"无法检查仿真解释器 {self._python()}: {exc}")
+        result.update(ready=not errors, errors=errors, worker_python=self._python())
+        return result
+
+    def preflight(self, options: dict | None = None) -> dict:
+        try:
+            result = self._check(self._options(options))
+        except (ValueError, OSError) as exc:
+            result = {"ready": False, "errors": [str(exc)], "paths": {}}
+        return {**result, "state": "ready" if result["ready"] else "error",
+                "hardware_output": False, "profile": "g1_29_sim"}
+
+    def run(self, options: dict | None = None) -> dict:
+        resolved = self._options(options)
+        with self._lock:
+            if self._closed:
+                raise ValueError("Driver 已关闭")
+            if self._state in ACTIVE_STATES or self._process is not None:
+                return {**self.info(), "accepted": False, "reason": "已有仿真会话；请先停止"}
+            self._generation += 1
+            generation = self._generation
+            self._state = "starting"
+            self._session_id = uuid.uuid4().hex
+            self._snapshot = {}
+            self._preview = None
+            self._snapshot_at = None
+            self._error = None
+            self._last_preflight = None
+            self._backend = {}
+            self._diagnostics.clear()
+            self._logs.clear()
+            threading.Thread(target=self._launch, args=(generation, resolved), name="teleopit-launch", daemon=True).start()
+            return {**self.info(), "accepted": True}
+
+    def _launch(self, generation: int, options: dict) -> None:
+        read_fd = write_fd = None
+        try:
+            check = self._check(options)
+            with self._lock:
+                if generation != self._generation:
+                    return
+                self._last_preflight = check
+                if not check["ready"]:
+                    self._state = "error"
+                    self._error = "; ".join(check["errors"])
+                    return
+                paths = check["paths"]
+                options.update(upstream_root=str(paths.get("root", options["upstream_root"])),
+                               policy_path=str(paths.get("policy", options["policy_path"])),
+                               bvh_path=str(paths.get("bvh") or options["bvh_path"]))
+                read_fd, write_fd = os.pipe()
+                process = subprocess.Popen(
+                    [self._python(), str(Path(__file__).with_name("worker.py")), "--event-fd", str(write_fd)],
+                    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                    text=True, encoding="utf-8", errors="replace", bufsize=1,
+                    pass_fds=(write_fd,), start_new_session=True,
+                )
+                self._process = process
+                os.close(write_fd)
+                write_fd = None
+                process.stdin.write(json.dumps(options, allow_nan=False) + "\n")
+                process.stdin.flush()
+            threading.Thread(target=self._read_logs, args=(generation, process), daemon=True, name="teleopit-logs").start()
+            with os.fdopen(read_fd, encoding="utf-8") as stream:
+                read_fd = None
+                for line in stream:
+                    self._receive(generation, json.loads(line))
+            return_code = process.wait()
+            if process.stdin:
+                process.stdin.close()
+            with self._lock:
+                if generation == self._generation:
+                    self._process = None
+                    if self._state == "finishing" and return_code == 0:
+                        self._state = "completed"
+                    elif self._state in ACTIVE_STATES:
+                        self._state = "error"
+                        self._error = f"仿真子进程意外退出（code={return_code}），未收到完成事件"
+                    elif return_code != 0 and self._state == "completed":
+                        self._state = "error"
+                        self._error = f"仿真子进程退出失败（code={return_code}）"
+        except Exception as exc:
+            error = f"启动/读取 Teleopit 失败: {exc}"
+            with self._lock:
+                if generation == self._generation:
+                    process = self._process
+                    self._state = "stopping" if process is not None else "error"
+                    self._error = error
+                else:
+                    process = None
+            self._terminate(process)
+            with self._lock:
+                if generation == self._generation:
+                    self._process = None
+                    self._state = "error"
+        finally:
+            for fd in (read_fd, write_fd):
+                if fd is not None:
+                    os.close(fd)
+
+    def _read_logs(self, generation: int, process: subprocess.Popen) -> None:
+        if process.stdout:
+            with process.stdout:
+                for line in process.stdout:
+                    with self._lock:
+                        if generation == self._generation:
+                            self._logs.append(line.rstrip()[:1024])
+
+    def _receive(self, generation: int, event: dict) -> None:
+        with self._lock:
+            if generation != self._generation:
+                return
+            kind = event.get("event")
+            if kind == "ready":
+                self._state = "running"
+                self._backend = {key: value for key, value in event.items() if key != "event"}
+            elif kind == "paused":
+                self._state = "paused"
+            elif kind == "resumed":
+                self._state = "running"
+            elif kind == "frame":
+                snapshot = event["snapshot"]
+                json.dumps(snapshot, allow_nan=False)
+                self._snapshot = snapshot
+                self._backend["waiting_for_input"] = False
+                self._snapshot_at = time.monotonic()
+                if event.get("preview_jpeg_b64"):
+                    self._preview = base64.b64decode(event["preview_jpeg_b64"], validate=True)
+            elif kind == "complete":
+                self._state = "finishing"
+                self._snapshot = {**self._snapshot, "summary": event.get("summary", {})}
+            elif kind == "error":
+                self._state = "error"
+                self._error = event.get("error", "Teleopit 仿真失败")
+            elif kind == "diagnostic":
+                self._diagnostics.append({key: value for key, value in event.items() if key != "event"})
+
+    def _command(self, command: str) -> bool:
+        process = self._process
+        if process is None or process.poll() is not None or process.stdin is None:
+            return False
+        try:
+            process.stdin.write(json.dumps({"command": command}) + "\n")
+            process.stdin.flush()
+            return True
+        except (BrokenPipeError, OSError, ValueError):
+            return False
+
+    def pause(self) -> dict:
+        with self._lock:
+            if self._state == "running" and self._command("pause"):
+                self._state = "pausing"
+            return self.info()
+
+    def resume(self) -> dict:
+        with self._lock:
+            if self._state == "paused" and self._command("resume"):
+                self._state = "resuming"
+            return self.info()
+
+    @staticmethod
+    def _terminate(process: subprocess.Popen | None) -> None:
+        if process is None:
+            return
+        if process.poll() is None:
+            try:
+                process.wait(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                process.terminate()
+                try:
+                    process.wait(timeout=1.0)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=2.0)
+        if process.stdin:
+            try:
+                process.stdin.close()
+            except OSError:
+                pass
+
+    def stop(self) -> dict:
+        # A second concurrent stop must not announce idle while the first is
+        # still reaping its child (which may own the PICO receiver port).
+        with self._stop_lock:
+            with self._lock:
+                self._command("stop")
+                self._generation += 1
+                generation = self._generation
+                process, self._process = self._process, None
+                self._state = "stopping"
+            self._terminate(process)
+            with self._lock:
+                if generation == self._generation:
+                    self._state = "idle"
+                    self._preview = None
+                return self.info()
+
+    def info(self) -> dict:
+        with self._lock:
+            return {"state": self._state, "session_id": self._session_id,
+                    "profile": "g1_29_sim", "hardware_output": False,
+                    "snapshot": copy.deepcopy(self._snapshot), "error": self._error,
+                    "snapshot_age_ms": round((time.monotonic() - self._snapshot_at) * 1000, 1) if self._snapshot_at else None,
+                    "preflight": copy.deepcopy(self._last_preflight), "logs": list(self._logs),
+                    "backend": copy.deepcopy(self._backend), "diagnostics": copy.deepcopy(list(self._diagnostics))}
+
+    def preview(self) -> bytes | None:
+        with self._lock:
+            return self._preview
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+        self.stop()

--- a/generic/teleopit/plugin.py
+++ b/generic/teleopit/plugin.py
@@ -1,0 +1,302 @@
+"""Stock PhanthyMotus cards for an isolated Teleopit simulation session.
+
+Only the supervisor is called here. Teleopit, MuJoCo and PICO dependencies are
+loaded by the worker process, never by the MCP server or the Core DDS context.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import threading
+import time
+from typing import Any
+
+from common.vendor_runtime import action_schema, jsonable, tool
+from manager import validate_options
+
+
+OPTION_PROPERTIES = {
+    "source": {
+        "type": "string", "enum": ["bvh", "pico"], "default": "bvh",
+        "description": "输入来源：BVH 动作回放，或安装 pico-bridge 的 PICO 全身追踪",
+    },
+    "bvh_path": {
+        "type": "string", "default": "",
+        "description": "Driver 主机上的 BVH 文件路径；留空使用已安装的官方示例",
+    },
+    "max_steps": {
+        "type": "integer", "minimum": 0, "maximum": 180000, "default": 500,
+        "description": "最大策略步数（50 Hz）；0 表示持续运行，直到点击停止",
+    },
+    "human_height": {
+        "type": "number", "minimum": 0.8, "maximum": 2.5, "default": 1.75,
+        "description": "操作者身高（米），用于动作重定向",
+    },
+    "render": {
+        "type": "boolean", "default": True,
+        "description": "生成 MuJoCo 仿真画面，由仿真预览卡显示",
+    },
+    "pico_advertise_host": {
+        "type": "string", "default": "", "x-sensitive": True,
+        "description": "PICO 可达的 Driver 主机局域网 IP；留空由 pico-bridge 自动选择",
+    },
+}
+
+
+def _options(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Validate only user-editable options; server paths are not MCP arguments."""
+    return validate_options({key: value for key, value in arguments.items()
+                             if key not in {"instance_id", "_tool_name"}})
+
+
+class CoreTopicPublisher:
+    """JSON/JPEG publishers in the Core domain only; no robot DDS participant."""
+
+    def __init__(self, namespace: str, core_domain_id: int = 42):
+        import rclpy
+        from rclpy.context import Context
+        from rclpy.node import Node
+        from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+        from sensor_msgs.msg import CompressedImage
+        from std_msgs.msg import String
+
+        self._rclpy = rclpy
+        self._string_type = String
+        self._image_type = CompressedImage
+        self._context = Context()
+        self._node = None
+        try:
+            rclpy.init(context=self._context, domain_id=int(core_domain_id))
+            self._node = Node("teleopit_simulation", context=self._context)
+            qos = QoSProfile(reliability=ReliabilityPolicy.RELIABLE,
+                             history=HistoryPolicy.KEEP_LAST, depth=1,
+                             durability=DurabilityPolicy.VOLATILE)
+            prefix = f"/{namespace}/teleopit"
+            self._state = self._node.create_publisher(String, f"{prefix}/state", qos)
+            self._preview = self._node.create_publisher(CompressedImage, f"{prefix}/preview", qos)
+        except Exception:
+            self.close()
+            raise
+
+    def publish_state(self, payload: dict[str, Any]) -> None:
+        message = self._string_type()
+        message.data = json.dumps(jsonable(payload), ensure_ascii=False, allow_nan=False)
+        self._state.publish(message)
+
+    def publish_preview(self, jpeg: bytes) -> None:
+        message = self._image_type()
+        message.header.stamp = self._node.get_clock().now().to_msg()
+        message.header.frame_id = "teleopit_simulation"
+        message.format = "jpeg"
+        message.data = jpeg
+        self._preview.publish(message)
+
+    def close(self) -> None:
+        if self._node is not None:
+            self._node.destroy_node()
+            self._node = None
+        if self._rclpy.ok(context=self._context):
+            self._rclpy.shutdown(context=self._context)
+
+
+class TeleopitPlugin:
+    """One simulation controller and two independently controlled sensor cards."""
+
+    def __init__(self, config: dict, namespace: str, manager: Any, publisher: Any = None):
+        self.manager = manager
+        self.publisher = publisher
+        self._lock = threading.RLock()
+        self._ready = False
+        self._stopping = False
+        self._configured: dict[str, Any] = {}
+        self._active = {"teleopit_state": False, "teleopit_preview": False}
+        self._topics = {
+            "teleopit_state": [{"topic": f"/{namespace}/teleopit/state", "format": "data/json"}],
+            "teleopit_preview": [{"topic": f"/{namespace}/teleopit/preview", "format": "image/jpeg"}],
+        }
+        self._defaults = {key: value for key, value in config.get("teleopit", {}).items()
+                          if key in OPTION_PROPERTIES and key != "pico_advertise_host"}
+        self._publish_error: str | None = None
+        self._closed = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def get_tools(self) -> list[dict]:
+        properties = copy.deepcopy(OPTION_PROPERTIES)
+        for name, value in self._defaults.items():
+            properties[name]["default"] = value
+        options = list(properties)
+        actions = {
+            "start": (options, "启用控制卡并保存配置，不启动仿真"),
+            "run": (options, "启动 Teleopit G1 29 自由度 MuJoCo 仿真，绝不向真机输出"),
+            "stop": ([], "停止仿真并取消正在进行的模型加载或 PICO 等待"),
+            "pause": ([], "暂停当前仿真"),
+            "resume": ([], "继续当前仿真"),
+            "preflight": (options, "检查 Teleopit、模型、示例动作及输入依赖，不启动仿真"),
+            "info": ([], "读取仿真状态、关节目标、延迟和错误原因"),
+            "config": (options, "保存下一次运行的设置；不修改正在运行的会话"),
+        }
+        simulation = tool(
+            "teleopit_sim", "actuator",
+            "Teleopit 动作仿真：BVH/PICO 全身输入 → 重定向 → 策略推理 → MuJoCo。"
+            "仅支持 G1 29 自由度仿真；不控制 G1 真机。启动卡片后点击 run。",
+            action_schema(actions, properties),
+        )
+        simulation["inputSchema"]["additionalProperties"] = False
+        simulation["configSchema"] = {
+            "type": "object", "properties": copy.deepcopy(properties),
+            "additionalProperties": False,
+        }
+        sensors = []
+        for name, description in (
+            ("teleopit_state", "Teleopit 仿真状态：会话、29 关节目标、实测仿真关节和处理延迟"),
+            ("teleopit_preview", "Teleopit 仿真预览：在卡片内显示 MuJoCo JPEG 画面；需启用 render"),
+        ):
+            schema = action_schema({
+                "start": ([], "开启本卡片数据推送，不启动仿真"),
+                "stop": ([], "关闭本卡片数据推送，不停止仿真"),
+                "info": ([], "读取推送状态和仿真信息"),
+            }, {})
+            schema["additionalProperties"] = False
+            sensors.append(tool(name, "sensor", description, schema, topic_out=self._topics[name]))
+        return [simulation, *sensors]
+
+    def start(self) -> dict:
+        # Driver startup is deliberately cheap and never calls manager.run().
+        with self._lock:
+            if self._closed.is_set():
+                return {"state": "error", "error": "Driver 已关闭"}
+            self._ready = True
+            if self.publisher is not None and self._thread is None:
+                self._thread = threading.Thread(target=self._publish_loop, daemon=True,
+                                                name="teleopit-card-publisher")
+                self._thread.start()
+        return {"state": "ready", "hardware_output": False}
+
+    def stop(self) -> dict:
+        """Bundle shutdown, not a single card's stop action."""
+        self._closed.set()
+        with self._lock:
+            self._ready = False
+            self._active = {key: False for key in self._active}
+            thread = self._thread
+        result = self.manager.stop()
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=2)
+        return result
+
+    def _info(self) -> dict:
+        info = dict(self.manager.info())
+        with self._lock:
+            info.update({
+                "card_state": "ready" if self._ready else "idle",
+                "configured_options": dict(self._configured),
+                "streams": dict(self._active),
+                "ros_available": self.publisher is not None,
+                "publish_error": self._publish_error,
+            })
+        info["hardware_output"] = False
+        info["profile"] = "g1_29_sim"
+        return info
+
+    def _sensor(self, name: str, action: str) -> dict | None:
+        if action not in ("start", "stop", "info"):
+            return None
+        with self._lock:
+            if action == "start":
+                if self._closed.is_set():
+                    return {"state": "error", "error": "Driver 已关闭"}
+                if self.publisher is None:
+                    return {"state": "unavailable", "ok": False,
+                            "error": "ROS 2 推送不可用；请在已配置 Core DDS 的环境中启动 Driver。"
+                                     "无 ROS 模式仍可通过控制卡 info 查询仿真。",
+                            "topic_out": self._topics[name]}
+                self._active[name] = True
+            elif action == "stop":
+                self._active[name] = False
+            running = self._active[name]
+        result = {"state": "running" if running else "idle", "topic_out": self._topics[name],
+                  "hardware_output": False, "ros_available": self.publisher is not None}
+        if action == "info":
+            result["simulation"] = self._info()
+            if name == "teleopit_preview":
+                result["preview_available"] = self.manager.preview() is not None
+        return result
+
+    def dispatch(self, action: str, args: dict) -> dict | None:
+        name = args.get("_tool_name", "teleopit_sim")
+        if name in self._active:
+            return self._sensor(name, action)
+        if name != "teleopit_sim":
+            return None
+        if action in ("start", "config"):
+            options = _options(args)
+            with self._lock:
+                if self._stopping:
+                    return {"state": "stopping", "adapter_ok": False,
+                            "error": "正在停止仿真，请等待停止完成"}
+                self._configured.update(options)
+                if action == "start":
+                    if self._closed.is_set():
+                        return {"state": "error", "error": "Driver 已关闭"}
+                    self._ready = True
+                return {"state": "ready" if self._ready else "idle", "adapter_ok": True,
+                        "configured_options": dict(self._configured), "hardware_output": False}
+        if action in ("run", "preflight"):
+            overrides = _options(args)
+            with self._lock:
+                ready = self._ready and not self._stopping and not self._closed.is_set()
+                options = {**self._configured, **overrides}
+                if action == "run":
+                    if not ready:
+                        return {"state": "idle", "ok": False, "error": "请先启动 Teleopit 控制卡"}
+                    # The manager only schedules work here. Hold the small
+                    # lifecycle lock until scheduling, so stop cannot be
+                    # overtaken by an already-admitted run request.
+                    return self.manager.run(options)
+            if action == "preflight":
+                return self.manager.preflight(options)
+        if action == "stop":
+            with self._lock:
+                self._ready = False
+                self._stopping = True
+            try:
+                return self.manager.stop()
+            finally:
+                with self._lock:
+                    self._stopping = False
+        if action == "pause":
+            return self.manager.pause()
+        if action == "resume":
+            return self.manager.resume()
+        if action == "info":
+            return self._info()
+        return None
+
+    def publish_once(self) -> None:
+        """One producer → Core transport pass, also usable by deterministic tests."""
+        with self._lock:
+            active = dict(self._active)
+        if self.publisher is None or self._closed.is_set():
+            return
+        if active["teleopit_state"]:
+            payload = self._info()
+            payload["published_at_ms"] = int(time.time() * 1000)
+            self.publisher.publish_state(payload)
+        if active["teleopit_preview"]:
+            jpeg = self.manager.preview()
+            if jpeg is not None:
+                self.publisher.publish_preview(jpeg)
+
+    def _publish_loop(self) -> None:
+        while not self._closed.wait(0.2):
+            try:
+                self.publish_once()
+                with self._lock:
+                    self._publish_error = None
+            except Exception as exc:
+                with self._lock:
+                    previous = self._publish_error
+                    self._publish_error = str(exc)
+                if previous != str(exc):
+                    print(f"[teleopit] card publishing failed: {exc}", flush=True)

--- a/generic/teleopit/prepare_runtime.sh
+++ b/generic/teleopit/prepare_runtime.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Explicit operator action, never executed by Driver or card lifecycle.
+set -euo pipefail
+if [[ "${1:-}" != "--accept-third-party-licenses" ]]; then
+  printf '%s\n' '请先阅读 README.md 的第三方许可说明，然后传入 --accept-third-party-licenses。' >&2
+  exit 2
+fi
+shift
+teleopit_runtime_dir="${TELEOPIT_RUNTIME_DIR:-/opt/teleopit-runtime}"
+teleopit_script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+if [[ ! -x "${teleopit_runtime_dir}/venv/bin/python" ]]; then
+  python3 -m venv "${teleopit_runtime_dir}/venv"
+fi
+"${teleopit_runtime_dir}/venv/bin/python" "${teleopit_script_dir}/setup_teleopit.py" \
+  --root "${teleopit_runtime_dir}/source" --accept-third-party-licenses "$@"

--- a/generic/teleopit/requirements-pico.txt
+++ b/generic/teleopit/requirements-pico.txt
@@ -1,0 +1,7 @@
+# Optional pico-bridge only: no Teleopit sim2real extra, g1_bridge or Unitree SDK.
+# The release wheel was downloaded and verified when this integration was added.
+pico-bridge @ https://github.com/BotRunner64/pico-bridge/releases/download/v0.2.1/pico_bridge-0.2.1-py3-none-any.whl#sha256=7cf0fee07c76541fd06e2ee6bdeec3d11fec578cd4ef6b45179dec4af31b369f
+# Compatible with NumPy 1.26 and Python 3.10–3.12; video/device validation is separate.
+av==13.1.0
+aiortc==1.10.1
+rerun-sdk==0.18.2

--- a/generic/teleopit/requirements-sim.txt
+++ b/generic/teleopit/requirements-sim.txt
@@ -1,0 +1,23 @@
+# Optional CPU simulation environment; install in a dedicated Python 3.10–3.12 venv.
+# Direct dependency pins tested with the fixed Teleopit 0.5.0 source on Python 3.11.
+# Python 3.10's last compatible SciPy line is selected explicitly, not by a latest resolver.
+numpy==1.26.4
+torch==2.2.2
+mujoco==3.2.7
+mink==0.0.13
+qpsolvers[proxqp]==4.13.0
+proxsuite==0.7.3
+daqp==0.9.1
+scipy==1.17.1; python_version >= "3.11"
+scipy==1.15.3; python_version < "3.11"
+onnxruntime==1.23.2
+hydra-core==1.3.6
+omegaconf==2.3.1
+h5py==3.16.0
+pyzmq==27.2.0
+msgpack==1.2.2
+rich==15.0.0
+loop-rate-limiters==1.2.0
+imageio==2.37.4
+huggingface_hub==1.30.0
+Pillow==12.3.0

--- a/generic/teleopit/requirements.txt
+++ b/generic/teleopit/requirements.txt
@@ -1,0 +1,2 @@
+# Lightweight MCP server. Heavy simulation packages belong in a separate venv.
+PyYAML==6.0.3

--- a/generic/teleopit/setup_teleopit.py
+++ b/generic/teleopit/setup_teleopit.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Explicit, pinned installation of the optional simulation backend.
+
+Run inside a dedicated Python 3.10–3.12 virtual environment. This script never
+installs robot SDKs and is not called from the card or driver lifecycle.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path, PurePosixPath
+
+from upstream import (
+    ASSETS, ASSET_RECEIPT, ASSET_REVISION, SOURCE_REVISION, SOURCE_URL,
+    Asset, inspect_installation, inspect_source, sha256_file,
+)
+
+
+LICENSE_NOTICE = """Teleopit 根源码为 Apache-2.0，模型仓库标注 MIT；第三方材料另有条款。
+其中 lafan_vendor/license.txt 为 CC-BY-NC-ND-4.0，示例 BVH 来自 LAFAN1。
+本脚本不替第三方授予商业使用/再分发许可；商业部署前需单独核对组件和数据许可。
+不会把这些外部源码、模型或示例提交到 Driver 仓库。"""
+
+
+def ensure_checkout(root: Path) -> None:
+    """Create a pinned checkout, never reset an operator's existing one."""
+    if root.exists():
+        _, errors = inspect_source(root)
+        if errors:
+            raise ValueError("；".join(errors))
+        return
+    root.parent.mkdir(parents=True, exist_ok=True)
+    # Stage our own clone so a failed network operation leaves no partial root.
+    with tempfile.TemporaryDirectory(prefix=".teleopit-source-", dir=root.parent) as tmp:
+        staging = Path(tmp) / "source"
+        subprocess.run(["git", "clone", "--no-checkout", "--filter=blob:none",
+                        SOURCE_URL, str(staging)], check=True)
+        subprocess.run(["git", "-C", str(staging), "checkout", "--detach",
+                        SOURCE_REVISION], check=True)
+        _, errors = inspect_source(staging)
+        if errors:
+            raise ValueError("；".join(errors))
+        if root.exists():
+            raise FileExistsError(f"安装目录已被创建，未覆盖: {root}")
+        staging.rename(root)
+
+
+def download_asset(asset: Asset, cache: Path) -> Path:
+    """Download a revision-pinned file and verify size plus SHA-256."""
+    cache.mkdir(parents=True, exist_ok=True)
+    target = cache / f"{asset.sha256}-{Path(asset.remote_path).name}"
+    if target.exists():
+        if (target.is_symlink() or not target.is_file()
+                or target.stat().st_size != asset.size
+                or sha256_file(target) != asset.sha256):
+            raise ValueError(f"缓存文件校验失败，未覆盖: {target}")
+        return target
+    with tempfile.TemporaryDirectory(prefix=".download-", dir=cache) as tmp:
+        staged = Path(tmp) / "asset"
+        request = urllib.request.Request(asset.url, headers={"User-Agent": "phanthymotus-teleopit-setup/1"})
+        with urllib.request.urlopen(request, timeout=60) as response, staged.open("xb") as output:
+            count = 0
+            while block := response.read(1024 * 1024):
+                count += len(block)
+                if count > asset.size:
+                    raise ValueError(f"下载文件大于固定清单: {asset.name}")
+                output.write(block)
+        if staged.stat().st_size != asset.size or sha256_file(staged) != asset.sha256:
+            raise ValueError(f"下载文件 SHA-256 或大小不匹配: {asset.name}")
+        # Atomic no-overwrite publication, including concurrent installers.
+        os.link(staged, target)
+    return target
+
+
+def safe_extract(archive: Path, target: Path, *, max_bytes: int = 2_000_000_000) -> None:
+    """Extract regular files/directories only; reject links and unsafe paths.
+
+    Do not use extractall: Python 3.10's extraction filter is insufficient and
+    tar symlinks/hardlinks can escape a lexically safe member path.
+    """
+    target.mkdir(parents=True, exist_ok=False)
+    with tarfile.open(archive, "r:gz") as tar:
+        members = tar.getmembers()
+        total = 0
+        seen = set()
+        for member in members:
+            name = PurePosixPath(member.name)
+            if (name.is_absolute() or ".." in name.parts or "\\" in member.name
+                    or ":" in member.name or not (member.isdir() or member.isfile())):
+                raise ValueError(f"拒绝不安全的归档成员: {member.name}")
+            if str(name) in ("", "."):
+                if member.isdir():
+                    continue
+                raise ValueError("拒绝空归档文件名")
+            if name in seen:
+                raise ValueError(f"拒绝重复的归档成员: {member.name}")
+            seen.add(name)
+            total += member.size
+            if member.size < 0 or total > max_bytes:
+                raise ValueError("归档展开超过大小限制")
+        for member in members:
+            name = PurePosixPath(member.name)
+            if str(name) in ("", "."):
+                continue
+            destination = target.joinpath(*name.parts)
+            if member.isdir():
+                destination.mkdir(parents=True, exist_ok=True)
+            else:
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                source = tar.extractfile(member)
+                if source is None:
+                    raise ValueError(f"无法读取归档成员: {member.name}")
+                with source, destination.open("xb") as output:
+                    shutil.copyfileobj(source, output)
+
+
+def _tree_signature(path: Path) -> dict[str, str]:
+    if path.is_symlink():
+        raise ValueError(f"不覆盖符号链接: {path}")
+    if path.is_file():
+        return {".": sha256_file(path)}
+    if not path.is_dir():
+        raise ValueError(f"不是普通文件或目录: {path}")
+    result = {}
+    for item in sorted(path.rglob("*")):
+        if item.is_symlink():
+            raise ValueError(f"不接受资源符号链接: {item}")
+        if item.is_file():
+            result[item.relative_to(path).as_posix()] = sha256_file(item)
+        elif not item.is_dir():
+            raise ValueError(f"不接受特殊资源文件: {item}")
+    return result
+
+
+def install_asset(asset: Asset, downloaded: Path, root: Path) -> dict:
+    """Place assets without overwriting an existing, differing file/tree."""
+    if downloaded.stat().st_size != asset.size or sha256_file(downloaded) != asset.sha256:
+        raise ValueError(f"安装输入校验失败: {asset.name}")
+    destination = root / asset.local_path
+    ancestor = root
+    for part in Path(asset.local_path).parts:
+        ancestor = ancestor / part
+        if ancestor.is_symlink():
+            raise ValueError(f"不接受资源目录中的符号链接: {ancestor}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=".asset-", dir=destination.parent) as tmp:
+        staged = Path(tmp) / "asset"
+        if asset.archive:
+            safe_extract(downloaded, staged)
+        else:
+            shutil.copyfile(downloaded, staged)
+        signature = _tree_signature(staged)
+        if destination.exists() or destination.is_symlink():
+            if _tree_signature(destination) != signature:
+                raise ValueError(f"现有资源与固定版本不同，未覆盖: {destination}")
+        elif asset.archive:
+            staged.rename(destination)
+        else:
+            os.link(staged, destination)
+    return {"sha256": asset.sha256, "size": asset.size,
+            "local_path": asset.local_path, "files": signature}
+
+
+def install_dependencies(root: Path, *, pico: bool = False) -> None:
+    if not (3, 10) <= sys.version_info[:2] <= (3, 12):
+        raise ValueError("请使用 Python 3.10–3.12 虚拟环境安装已验证依赖")
+    if sys.prefix == sys.base_prefix:
+        raise ValueError("拒绝修改全局 Python；请先创建并激活专用虚拟环境")
+    if importlib.util.find_spec("pip") is None:
+        raise ValueError("虚拟环境缺少 pip；请用 uv venv --seed 或 python -m venv 创建环境")
+    pip = [sys.executable, "-m", "pip", "install"]
+    if platform.system() == "Linux" and platform.machine().lower() in ("x86_64", "amd64"):
+        # Avoid downloading CUDA dependencies for this CPU-only simulation driver.
+        subprocess.run(pip + ["--index-url", "https://download.pytorch.org/whl/cpu",
+                              "torch==2.2.2"], check=True)
+    requirements = Path(__file__).with_name("requirements-sim.txt")
+    subprocess.run(pip + ["-r", str(requirements)], check=True)
+    subprocess.run(pip + ["--no-deps", "-e", str(root)], check=True)
+    if pico:
+        subprocess.run(pip + ["-r", str(Path(__file__).with_name("requirements-pico.txt"))], check=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", required=True, type=Path, help="专用 Teleopit checkout 目录")
+    parser.add_argument("--cache", type=Path, help="下载缓存，默认 ROOT.parent/teleopit-asset-cache")
+    parser.add_argument("--check", action="store_true", help="只检查，不安装或访问网络")
+    parser.add_argument("--assets-only", action="store_true", help="只准备源码/资源，不修改 Python 环境")
+    parser.add_argument("--pico", action="store_true", help="另装固定 pico-bridge；不装真机 SDK")
+    parser.add_argument("--with-gmr", action="store_true", help="另装其他机器人 GMR 资源（约 365 MB；G1 不需要）")
+    parser.add_argument("--accept-third-party-licenses", action="store_true", help="已阅读第三方许可说明，确认本地安装用途合规")
+    args = parser.parse_args(argv)
+    root = args.root.expanduser().resolve()
+    if args.check:
+        report = inspect_installation(root, source="pico" if args.pico else "bvh")
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+        return 0 if report["ready"] else 1
+    print(LICENSE_NOTICE)
+    if not args.accept_third_party_licenses:
+        parser.error("请阅读以上许可说明后，显式提供 --accept-third-party-licenses")
+    cache = (args.cache or root.parent / "teleopit-asset-cache").expanduser().resolve()
+    try:
+        ensure_checkout(root)
+        receipt = {"source_revision": SOURCE_REVISION, "asset_revision": ASSET_REVISION, "assets": {}}
+        for asset in ASSETS:
+            if asset.name == "gmr" and not args.with_gmr:
+                continue
+            print(f"准备 {asset.name} ({asset.size / 1_000_000:.1f} MB): {asset.url}", flush=True)
+            receipt["assets"][asset.name] = install_asset(asset, download_asset(asset, cache), root)
+        # This generated receipt is owned solely by this installer, not source or assets.
+        receipt_path = root / ASSET_RECEIPT
+        if receipt_path.is_symlink():
+            raise ValueError(f"不覆盖符号链接: {receipt_path}")
+        receipt_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+        if not args.assets_only:
+            install_dependencies(root, pico=args.pico)
+        report = inspect_installation(root, source="pico" if args.pico else "bvh")
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+        return 0 if report["ready"] else 1
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        print(f"安装失败（未覆盖已有源码/资源）: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/generic/teleopit/tests/test_backend.py
+++ b/generic/teleopit/tests/test_backend.py
@@ -1,0 +1,320 @@
+"""Adapter contracts plus an opt-in REAL Teleopit / GMR / ONNX / MuJoCo smoke.
+
+Run lightweight checks with unittest discovery. Set TELEOPIT_TEST_ROOT to a
+bootstrapped v0.5.0 source root in its dependency environment to include the
+real three-policy-step smoke; a skipped smoke is NOT simulation evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+import threading
+import time
+from types import ModuleType, SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+
+SPEC = importlib.util.spec_from_file_location(
+    "teleopit_driver_backend", Path(__file__).resolve().parents[1] / "backend.py"
+)
+backend = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(backend)
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        return self.now
+
+
+class FakeEvent:
+    def __init__(self, clock, *, set_=False):
+        self.clock = clock
+        self.value = set_
+        self.waits = []
+
+    def is_set(self):
+        return self.value
+
+    def wait(self, seconds):
+        self.waits.append(seconds)
+        self.clock.now += seconds
+        return self.value
+
+
+class GateTests(unittest.TestCase):
+    def test_regular_pacing_is_50_hz(self):
+        clock = FakeClock()
+        stop = FakeEvent(clock)
+        gate = backend._Gate(stop, FakeEvent(clock), lambda event: None, clock=clock)
+        clock.now = 0.008
+        gate.next_step()
+        self.assertAlmostEqual(clock.now, 0.02)
+        self.assertEqual(len(stop.waits), 1)
+
+    def test_slow_step_resets_deadline_and_never_catches_up(self):
+        clock = FakeClock()
+        stop = FakeEvent(clock)
+        gate = backend._Gate(stop, FakeEvent(clock), lambda event: None, clock=clock)
+        clock.now = 10.0
+        gate.next_step()
+        self.assertEqual(stop.waits, [])
+        clock.now += 0.005
+        gate.next_step()
+        self.assertAlmostEqual(stop.waits[-1], 0.015)
+
+    def test_stop_preempts_pause(self):
+        clock = FakeClock()
+        gate = backend._Gate(FakeEvent(clock, set_=True), FakeEvent(clock, set_=True), lambda event: None)
+        with self.assertRaises(backend._Stopped):
+            gate.check()
+
+
+@dataclass(frozen=True)
+class Packet:
+    timestamp_s: float
+    seq: int = 1
+    control_events: tuple = ("toggle_arms", "toggle_pause")
+
+
+class PicoInputTests(unittest.TestCase):
+    def setUp(self):
+        self.clock = FakeClock()
+        self.gate = backend._Gate(FakeEvent(self.clock), FakeEvent(self.clock), lambda event: None, clock=self.clock)
+        self.packet = Packet(timestamp_s=0.0)
+        self.provider = SimpleNamespace(
+            has_frame=lambda: True,
+            is_available=lambda: True,
+            get_realtime_input_packet=lambda: self.packet,
+        )
+
+    def test_strips_headset_controls_without_changing_body_packet(self):
+        monitor = backend._PicoInput(self.provider, self.gate, 10.0)
+        packet = monitor.read()
+        self.assertEqual(packet.control_events, ())
+        self.assertEqual(packet.timestamp_s, self.packet.timestamp_s)
+        self.assertEqual(self.packet.control_events, ("toggle_arms", "toggle_pause"))
+        self.assertFalse(monitor.freshness()["input_stale"])
+
+    def test_reports_stale_then_times_out_if_stream_stops(self):
+        monitor = backend._PicoInput(self.provider, self.gate, 10.0)
+        monitor.read()
+        self.clock.now = 0.6
+        self.assertEqual(monitor.freshness()["input_age_ms"], 600.0)
+        self.assertTrue(monitor.freshness()["input_stale"])
+        self.clock.now = 10.1
+        with self.assertRaisesRegex(TimeoutError, "stopped updating"):
+            monitor.read()
+
+    def test_no_body_frame_times_out_while_remain_cancellable(self):
+        self.provider.has_frame = lambda: False
+        monitor = backend._PicoInput(self.provider, self.gate, 0.05)
+        with self.assertRaisesRegex(TimeoutError, "full-body tracking"):
+            monitor.read()
+        self.assertGreaterEqual(self.clock.now, 0.05)
+        self.assertLess(self.clock.now, 0.1)
+
+    def test_input_timestamp_must_be_finite(self):
+        self.packet = Packet(timestamp_s=float("nan"))
+        with self.assertRaisesRegex(ValueError, "finite"):
+            backend._PicoInput(self.provider, self.gate, 1.0).read()
+
+
+class FakeBus:
+    def __init__(self):
+        self.callbacks = {}
+
+    def subscribe(self, topic, callback):
+        self.callbacks[topic] = callback
+
+    def publish(self, topic, state):
+        self.callbacks[topic](state)
+
+
+class FakePipeline:
+    """Test double of the pinned bus/API seam, NOT an algorithm smoke."""
+
+    def __init__(self, *, bad_state=False, bad_action=False):
+        self.closed = False
+        self.state = SimpleNamespace(
+            qpos=[float("nan") if bad_state else 0.4] * 29,
+            quat=[1.0, 0.0, 0.0, 0.0], base_pos=[0.0, 0.0, 0.76], timestamp=0.0,
+        )
+        self.robot = SimpleNamespace(
+            num_actions=29, default_dof_pos=[0.0] * 29,
+            model=SimpleNamespace(nq=36, njnt=30, jnt_qposadr=[0] + list(range(7, 36)),
+                                  joint=lambda i: SimpleNamespace(name=f"joint_{i}")),
+        )
+        self.bus = FakeBus()
+        self.controller = SimpleNamespace(compute_action=lambda obs: [float("inf") if bad_action else 0.2] * 29)
+        self.retargeter = SimpleNamespace(retarget=lambda frame: [0.0] * 36)
+        self.input_provider = SimpleNamespace(close=self.close)
+        self.runner = SimpleNamespace(
+            build_observation=lambda: [0.0] * 167,
+            compute_target_dof_pos=lambda action: [0.7] * 29,
+            apply_control=self.apply_control,
+        )
+        self.loop = SimpleNamespace(_step_runner=self.runner)
+
+    def apply_control(self, target):
+        self.state.timestamp += 0.02
+        return [99.0] * 29, self.state
+
+    def close(self):
+        self.closed = True
+
+    def run(self, num_steps):
+        for _ in range(num_steps):
+            self.retargeter.retarget(None)
+            obs = self.runner.build_observation()
+            action = self.controller.compute_action(obs)
+            target = self.runner.compute_target_dof_pos(action)
+            _, state = self.runner.apply_control(target)
+            self.bus.publish("state", state)
+
+
+class PipelineAdapterTests(unittest.TestCase):
+    def setUp(self):
+        self.topics = ModuleType("teleopit.bus.topics")
+        self.topics.TOPIC_ROBOT_STATE = "state"
+        self.options = {"source": "bvh", "max_steps": 3, "render": False}
+        self.events = []
+        self.stop = threading.Event()
+        self.pause = threading.Event()
+
+    def run_fake(self, pipeline, emit=None):
+        with patch.object(backend, "_make_pipeline", return_value=pipeline), patch.dict(
+            sys.modules, {"teleopit.bus.topics": self.topics}
+        ):
+            backend.run_backend(self.options, emit or self.events.append, self.stop, self.pause)
+
+    def test_real_bus_seam_reports_targets_not_torques_or_measured_positions(self):
+        pipeline = FakePipeline()
+        self.run_fake(pipeline)
+        self.assertTrue(pipeline.closed)
+        self.assertEqual(self.events[0]["event"], "ready")
+        frames = [event["snapshot"] for event in self.events if event["event"] == "frame"]
+        self.assertEqual(len(frames), 3)
+        self.assertEqual(frames[-1]["target_positions"], [0.7] * 29)
+        self.assertEqual(frames[-1]["joint_positions"], [0.4] * 29)
+        self.assertEqual(frames[-1]["sim_time_s"], 0.06)
+        self.assertFalse(frames[-1]["hardware_output"])
+        self.assertEqual(self.events[-1]["summary"]["steps"], 3)
+        json.dumps(self.events, allow_nan=False)
+
+    def test_stop_from_first_frame_unwinds_and_reports_one_step(self):
+        def emit(event):
+            self.events.append(event)
+            if event["event"] == "frame":
+                self.stop.set()
+
+        pipeline = FakePipeline()
+        self.run_fake(pipeline, emit)
+        self.assertTrue(pipeline.closed)
+        self.assertEqual(self.events[-1]["summary"]["reason"], "stopped")
+        self.assertEqual(self.events[-1]["summary"]["steps"], 1)
+
+    def test_stop_before_init_does_not_load_dependencies(self):
+        self.stop.set()
+        with patch.object(backend, "_make_pipeline") as factory:
+            backend.run_backend(self.options, self.events.append, self.stop, self.pause)
+        factory.assert_not_called()
+        self.assertEqual(self.events[-1]["summary"]["reason"], "stopped")
+
+    def test_bad_policy_output_rejected_before_physics(self):
+        pipeline = FakePipeline(bad_action=True)
+        with self.assertRaisesRegex(ValueError, "finite"):
+            self.run_fake(pipeline)
+        self.assertEqual(pipeline.state.timestamp, 0.0)
+        self.assertTrue(pipeline.closed)
+
+    def test_bad_state_rejected_without_false_complete(self):
+        pipeline = FakePipeline(bad_state=True)
+        with self.assertRaisesRegex(ValueError, "finite"):
+            self.run_fake(pipeline)
+        self.assertTrue(pipeline.closed)
+        self.assertFalse(any(event["event"] == "complete" for event in self.events))
+
+    def test_pause_ack_freezes_physics_until_resume(self):
+        acknowledged = threading.Event()
+        pipeline = FakePipeline()
+        errors = []
+
+        def emit(event):
+            self.events.append(event)
+            if event["event"] == "frame" and event["snapshot"]["step"] == 1:
+                self.pause.set()
+            if event["event"] == "paused":
+                acknowledged.set()
+
+        def run():
+            try:
+                self.run_fake(pipeline, emit)
+            except Exception as exc:
+                errors.append(exc)
+
+        worker = threading.Thread(target=run)
+        worker.start()
+        try:
+            self.assertTrue(acknowledged.wait(1.0))
+            paused_at = pipeline.state.timestamp
+            time.sleep(0.06)
+            self.assertEqual(pipeline.state.timestamp, paused_at)
+            self.pause.clear()
+            worker.join(1.0)
+            self.assertFalse(worker.is_alive())
+            self.assertEqual(errors, [])
+            self.assertEqual([e["event"] for e in self.events].count("paused"), 1)
+            self.assertEqual([e["event"] for e in self.events].count("resumed"), 1)
+        finally:
+            self.stop.set()
+            self.pause.clear()
+            worker.join(1.0)
+
+
+class ValidationTests(unittest.TestCase):
+    def test_no_padding_or_truncation(self):
+        for count in (23, 28, 30):
+            with self.subTest(count=count), self.assertRaises(ValueError):
+                backend._vector([0.0] * count, 29, "target")
+
+    def test_nonfinite_vectors_rejected(self):
+        for value in (float("nan"), float("inf"), -float("inf"), True):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                backend._vector([value] * 29, 29, "target")
+
+
+@unittest.skipUnless(os.environ.get("TELEOPIT_TEST_ROOT"), "set TELEOPIT_TEST_ROOT for real GMR/ONNX/MuJoCo smoke")
+class RealUpstreamSmoke(unittest.TestCase):
+    def test_bvh_to_gmr_to_onnx_to_mujoco(self):
+        root = Path(os.environ["TELEOPIT_TEST_ROOT"]).resolve()
+        options = {
+            "upstream_root": str(root), "source": "bvh", "render": False,
+            "bvh_path": str(root / "data/sample_bvh/aiming1_subject1.bvh"),
+            "policy_path": str(root / "ckpt/track_g1.onnx"), "max_steps": 3,
+        }
+        events = []
+        backend.run_backend(options, events.append, threading.Event(), threading.Event())
+        frames = [event["snapshot"] for event in events if event["event"] == "frame"]
+        self.assertEqual(len(frames), 3)
+        self.assertEqual(events[-1]["summary"]["reason"], "completed")
+        self.assertAlmostEqual(frames[-1]["sim_time_s"], 0.06)
+        self.assertEqual(len(frames[-1]["target_positions"]), 29)
+        self.assertGreater(frames[-1]["policy_ms"], 0.0)
+        self.assertGreater(frames[-1]["physics_ms"], 0.0)
+        self.assertNotEqual(frames[0]["joint_positions"], frames[-1]["joint_positions"])
+        json.dumps(events, allow_nan=False)
+        forbidden = ("g1_bridge_sdk", "unitree_sdk2py", "teleopit.sim2real.unitree_g1")
+        self.assertFalse(any(module in sys.modules for module in forbidden))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleopit/tests/test_card.py
+++ b/generic/teleopit/tests/test_card.py
@@ -1,0 +1,340 @@
+"""Real MCP HTTP and stock card contract tests, without ROS/Teleopit installs."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import threading
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+DRIVER = Path(__file__).resolve().parents[1]
+REPO = DRIVER.parents[1]
+sys.path.insert(0, str(DRIVER))
+sys.path.insert(0, str(REPO))
+spec = importlib.util.spec_from_file_location("teleopit_card_entrypoint", DRIVER / "main.py")
+entrypoint = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(entrypoint)
+from plugin import CoreTopicPublisher, TeleopitPlugin
+
+
+class FakeManager:
+    def __init__(self):
+        self.state = "idle"
+        self.runs = []
+        self.preflights = []
+        self.stops = 0
+        self.jpeg = b"\xff\xd8test-jpeg\xff\xd9"
+
+    def info(self):
+        return {"state": self.state, "session_id": "test-session" if self.runs else None,
+                "snapshot": {"target_joint_pos": [0.0] * 29}, "error": None,
+                "hardware_output": False, "profile": "g1_29_sim"}
+
+    def preflight(self, options=None):
+        self.preflights.append(dict(options or {}))
+        return {"ok": True, "hardware_output": False, "checks": {"policy": True}}
+
+    def run(self, options=None):
+        self.runs.append(dict(options or {}))
+        self.state = "running"
+        return self.info()
+
+    def stop(self):
+        self.stops += 1
+        self.state = "idle"
+        return self.info()
+
+    def pause(self):
+        self.state = "paused"
+        return self.info()
+
+    def resume(self):
+        self.state = "running"
+        return self.info()
+
+    def preview(self):
+        return self.jpeg
+
+    def close(self):
+        self.stop()
+
+
+class FakePublisher:
+    def __init__(self):
+        self.states = []
+        self.frames = []
+
+    def publish_state(self, state):
+        self.states.append(json.loads(json.dumps(state, allow_nan=False)))
+
+    def publish_preview(self, jpeg):
+        self.frames.append(jpeg)
+
+
+class MCPCardTests(unittest.TestCase):
+    def setUp(self):
+        self.manager = FakeManager()
+        self.config = {"ros_namespace": "lab", "teleopit": {"max_steps": 123}}
+        self.bundle = entrypoint.build_bundle(self.config, manager=self.manager)
+        self.bundle.start_all()
+        self.server = entrypoint.create_server(self.config, self.bundle, host="127.0.0.1", port=0)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.url = f"http://127.0.0.1:{self.server.server_port}/mcp"
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+        self.bundle.stop_all()
+
+    def rpc(self, method, params=None):
+        data = json.dumps({"jsonrpc": "2.0", "id": 1, "method": method,
+                           "params": params or {}}).encode()
+        with urlopen(Request(self.url, data=data, headers={"Content-Type": "application/json"}), timeout=2) as response:
+            return json.load(response)
+
+    def call(self, name="teleopit_sim", action="info", **options):
+        response = self.rpc("tools/call", {"name": name, "arguments": {"action": action, **options}})
+        self.assertNotIn("error", response, response)
+        content = response["result"]["content"]
+        self.assertEqual(len(content), 1)
+        self.assertEqual(content[0]["type"], "text")
+        result = json.loads(content[0]["text"])
+        self.assertIsInstance(result, dict)
+        return result
+
+    def test_discovery_uses_stock_actuator_json_and_jpeg_cards(self):
+        initialized = self.rpc("initialize")
+        self.assertEqual(initialized["result"]["serverInfo"]["name"], "teleopit-simulation")
+        tools = {item["name"]: item for item in self.rpc("tools/list")["result"]["tools"]}
+        self.assertEqual(set(tools), {"teleopit_sim", "teleopit_state", "teleopit_preview"})
+        simulation = tools["teleopit_sim"]
+        self.assertEqual(simulation["type"], "actuator")
+        self.assertFalse(simulation["multiInstance"])
+        self.assertEqual(simulation["configSchema"]["properties"]["max_steps"]["default"], 123)
+        self.assertTrue(simulation["configSchema"]["properties"]["pico_advertise_host"]["x-sensitive"])
+        self.assertNotIn("upstream_root", simulation["configSchema"]["properties"])
+        self.assertIn("run", simulation["inputSchema"]["x-action-params"])
+        self.assertEqual(tools["teleopit_state"]["topic_out"],
+                         [{"topic": "/lab/teleopit/state", "format": "data/json"}])
+        self.assertEqual(tools["teleopit_preview"]["topic_out"],
+                         [{"topic": "/lab/teleopit/preview", "format": "image/jpeg"}])
+        self.assertEqual(self.manager.runs, [])
+
+    def test_core_config_start_run_pause_resume_stop_round_trip(self):
+        # Core sends config separately before start and before non-system actions.
+        configured = self.call(action="config", source="pico", max_steps=500, human_height=1.8)
+        self.assertTrue(configured["adapter_ok"])
+        self.assertEqual(self.call(action="start")["state"], "ready")
+        self.assertEqual(self.manager.runs, [])
+        self.assertTrue(self.call(action="preflight")["ok"])
+        self.assertEqual(self.manager.preflights[-1]["source"], "pico")
+        self.assertEqual(self.manager.runs, [])
+        result = self.call(action="run", max_steps=17)
+        self.assertEqual(result["state"], "running")
+        self.assertFalse(result["hardware_output"])
+        self.assertEqual(self.manager.runs, [{"source": "pico", "max_steps": 17, "human_height": 1.8}])
+        self.assertEqual(self.call(action="pause")["state"], "paused")
+        self.assertEqual(self.call(action="resume")["state"], "running")
+        self.call(action="config", source="bvh")
+        self.assertEqual(self.manager.state, "running")
+        self.assertEqual(len(self.manager.runs), 1)
+        self.assertEqual(self.call(action="info")["configured_options"]["source"], "bvh")
+        self.assertEqual(self.call(action="stop")["state"], "idle")
+        rejected = self.call(action="run")
+        self.assertFalse(rejected["ok"])
+        self.assertEqual(len(self.manager.runs), 1)
+        self.call(action="start")
+        self.call(action="run")
+        self.assertEqual(self.manager.runs[-1]["source"], "bvh")
+        self.assertEqual(self.manager.runs[-1]["max_steps"], 500)
+
+    def test_invalid_input_and_hidden_server_options_cannot_reach_worker(self):
+        for options in ({"source": "real"}, {"max_steps": True}, {"max_steps": -1},
+                        {"human_height": float("nan")}, {"render": "false"},
+                        {"upstream_root": "/tmp/untrusted"}, {"policy_path": "/tmp/model"},
+                        {"profile": "g1_23_live"}):
+            with self.subTest(options=options):
+                response = self.rpc("tools/call", {"name": "teleopit_sim",
+                                    "arguments": {"action": "run", **options}})
+                self.assertEqual(response["error"]["code"], -32602)
+        self.assertEqual(self.manager.runs, [])
+
+    def test_unknown_tool_or_action_is_explicit_jsonrpc_error(self):
+        for name, action in (("unknown", "run"), ("teleopit_sim", "live")):
+            response = self.rpc("tools/call", {"name": name, "arguments": {"action": action}})
+            self.assertEqual(response["error"]["code"], -32601)
+
+    def test_no_ros_mode_keeps_simulation_observable_and_reports_stream_gap(self):
+        result = self.call("teleopit_preview", "start")
+        self.assertEqual(result["state"], "unavailable")
+        self.assertFalse(result["ok"])
+        info = self.call(action="info")
+        self.assertFalse(info["ros_available"])
+        self.assertEqual(len(info["snapshot"]["target_joint_pos"]), 29)
+        self.assertEqual(self.call("teleopit_state", "stop")["state"], "idle")
+        self.assertEqual(self.manager.stops, 0)
+
+    def test_health_and_request_size_limit(self):
+        with urlopen(self.url.replace("/mcp", "/health"), timeout=2) as response:
+            self.assertEqual(json.load(response)["driver"], "teleopit-driver")
+        with self.assertRaises(HTTPError) as raised:
+            urlopen(Request(self.url, data=b"x" * 65537), timeout=2)
+        self.assertEqual(raised.exception.code, 413)
+
+
+class SensorLifecycleTests(unittest.TestCase):
+    def setUp(self):
+        self.manager = FakeManager()
+        self.publisher = FakePublisher()
+        self.plugin = TeleopitPlugin({}, "test", self.manager, self.publisher)
+
+    def call(self, name, action):
+        return self.plugin.dispatch(action, {"_tool_name": name})
+
+    def test_state_and_preview_producer_enable_disable_independently(self):
+        self.plugin.publish_once()
+        self.assertEqual(self.publisher.states, [])
+        self.assertEqual(self.publisher.frames, [])
+        self.call("teleopit_state", "start")
+        self.call("teleopit_preview", "start")
+        self.plugin.publish_once()
+        self.assertEqual(len(self.publisher.states), 1)
+        self.assertFalse(self.publisher.states[-1]["hardware_output"])
+        self.assertEqual(self.publisher.states[-1]["profile"], "g1_29_sim")
+        self.assertEqual(self.publisher.frames, [self.manager.jpeg])
+        self.call("teleopit_preview", "stop")
+        self.plugin.publish_once()
+        self.assertEqual(len(self.publisher.states), 2)
+        self.assertEqual(len(self.publisher.frames), 1)
+        self.call("teleopit_state", "stop")
+        self.plugin.publish_once()
+        self.assertEqual(len(self.publisher.states), 2)
+        self.assertEqual(self.manager.stops, 0)
+        self.assertEqual(self.manager.runs, [])
+
+    def test_no_frame_does_not_publish_placeholder(self):
+        self.manager.jpeg = None
+        self.call("teleopit_preview", "start")
+        self.plugin.publish_once()
+        self.assertEqual(self.publisher.frames, [])
+        self.assertFalse(self.call("teleopit_preview", "info")["preview_available"])
+
+    def test_shutdown_stops_simulation_and_publishers_without_restart(self):
+        self.plugin.start()
+        self.call("teleopit_state", "start")
+        self.plugin.stop()
+        self.plugin.publish_once()
+        self.assertFalse(self.plugin._thread.is_alive())
+        self.assertEqual(self.manager.stops, 1)
+        self.assertEqual(self.publisher.states, [])
+        self.assertEqual(self.plugin.start()["state"], "error")
+
+    def test_start_and_run_cannot_overtake_in_progress_stop(self):
+        self.plugin.start()
+        stopping = threading.Event()
+        finish = threading.Event()
+        original_stop = self.manager.stop
+
+        def slow_stop():
+            stopping.set()
+            if not finish.wait(2):
+                raise AssertionError("test did not release stop")
+            return original_stop()
+
+        self.manager.stop = slow_stop
+        thread = threading.Thread(target=lambda: self.call("teleopit_sim", "stop"))
+        thread.start()
+        try:
+            self.assertTrue(stopping.wait(1))
+            self.assertFalse(self.call("teleopit_sim", "start")["adapter_ok"])
+            self.assertFalse(self.call("teleopit_sim", "run")["ok"])
+            self.assertEqual(self.manager.runs, [])
+        finally:
+            finish.set()
+            thread.join(timeout=2)
+            self.plugin.stop()
+
+
+class CoreTransportTests(unittest.TestCase):
+    def test_ros_contract_is_core_domain_json_string_and_compressed_jpeg(self):
+        initialized = []
+        shutdown = []
+        publishers = {}
+
+        class Image:
+            def __init__(self):
+                self.header = SimpleNamespace(stamp=None, frame_id="")
+
+        class Node:
+            def __init__(self, name, context):
+                self.context = context
+
+            def create_publisher(self, message_type, topic, qos):
+                messages = []
+                publishers[topic] = (message_type, messages, qos)
+                return SimpleNamespace(publish=messages.append)
+
+            def get_clock(self):
+                return SimpleNamespace(now=lambda: SimpleNamespace(to_msg=lambda: "ros-stamp"))
+
+            def destroy_node(self):
+                pass
+
+        context = object()
+        modules = {
+            "rclpy": SimpleNamespace(init=lambda **kwargs: initialized.append(kwargs),
+                                     ok=lambda **kwargs: True,
+                                     shutdown=lambda **kwargs: shutdown.append(kwargs)),
+            "rclpy.context": SimpleNamespace(Context=lambda: context),
+            "rclpy.node": SimpleNamespace(Node=Node),
+            "rclpy.qos": SimpleNamespace(
+                DurabilityPolicy=SimpleNamespace(VOLATILE="volatile"),
+                HistoryPolicy=SimpleNamespace(KEEP_LAST="keep_last"),
+                ReliabilityPolicy=SimpleNamespace(RELIABLE="reliable"),
+                QoSProfile=lambda **kwargs: kwargs),
+            "sensor_msgs": SimpleNamespace(),
+            "sensor_msgs.msg": SimpleNamespace(CompressedImage=Image),
+            "std_msgs": SimpleNamespace(),
+            "std_msgs.msg": SimpleNamespace(String=SimpleNamespace),
+        }
+        with patch.dict(sys.modules, modules):
+            publisher = CoreTopicPublisher("lab", 42)
+            publisher.publish_state({"state": "running", "hardware_output": False})
+            publisher.publish_preview(b"jpeg-content")
+            publisher.close()
+        self.assertEqual(initialized, [{"context": context, "domain_id": 42}])
+        self.assertEqual(shutdown, [{"context": context}])
+        self.assertEqual(set(publishers), {"/lab/teleopit/state", "/lab/teleopit/preview"})
+        state_type, states, _ = publishers["/lab/teleopit/state"]
+        self.assertIs(state_type, SimpleNamespace)
+        self.assertEqual(json.loads(states[0].data), {"state": "running", "hardware_output": False})
+        image_type, images, qos = publishers["/lab/teleopit/preview"]
+        self.assertIs(image_type, Image)
+        self.assertEqual(images[0].data, b"jpeg-content")
+        self.assertEqual(images[0].format, "jpeg")
+        self.assertEqual(images[0].header.stamp, "ros-stamp")
+        self.assertEqual(qos["depth"], 1)
+
+
+class EntrypointTests(unittest.TestCase):
+    def test_help_requires_neither_ros_nor_teleopit(self):
+        result = subprocess.run([sys.executable, str(DRIVER / "main.py"), "--help"],
+                                capture_output=True, text=True, timeout=5)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--no-ros", result.stdout)
+        self.assertIn("--no-register", result.stdout)
+        self.assertIn("15719", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleopit/tests/test_e2e.py
+++ b/generic/teleopit/tests/test_e2e.py
@@ -1,0 +1,216 @@
+"""Opt-in REAL HTTP → manager → worker → Teleopit/GMR/ONNX/MuJoCo scenarios.
+
+TELEOPIT_TEST_ROOT must point to a bootstrapped, pinned Teleopit installation.
+Run this file with that installation's Python, or set TELEOPIT_TEST_PYTHON to
+its interpreter. If opted in, missing assets/dependencies/rendering FAIL; they
+do not silently skip. The publisher below captures the stock Core transport
+boundary only: these tests do not claim a running ROS/Core/browser was tested.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import os
+from pathlib import Path
+import sys
+import threading
+import time
+import unittest
+from urllib.request import Request, urlopen
+
+
+DRIVER = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(DRIVER))
+sys.path.insert(0, str(DRIVER.parents[1]))
+spec = importlib.util.spec_from_file_location("teleopit_e2e_entrypoint", DRIVER / "main.py")
+entrypoint = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(entrypoint)
+
+
+class CapturingPublisher:
+    """Capture actual worker output at the card's ROS message producer seam."""
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.states = []
+        self.frames = []
+
+    def publish_state(self, state):
+        # JSON serialization is part of the production Core-topic contract.
+        with self.lock:
+            self.states.append(json.loads(json.dumps(state, allow_nan=False)))
+            self.states[:] = self.states[-50:]
+
+    def publish_preview(self, jpeg):
+        with self.lock:
+            self.frames.append(bytes(jpeg))
+            self.frames[:] = self.frames[-50:]
+
+    def last_frame(self):
+        with self.lock:
+            return self.frames[-1] if self.frames else None
+
+
+@unittest.skipUnless(os.environ.get("TELEOPIT_TEST_ROOT"),
+                     "opt-in real scenario: set TELEOPIT_TEST_ROOT and use the Teleopit dependency interpreter")
+class RealTeleopitMCPTests(unittest.TestCase):
+    def setUp(self):
+        self.publisher = CapturingPublisher()
+        self.config = {
+            "ros_namespace": "teleopit_e2e",
+            "teleopit": {
+                "upstream_root": os.environ["TELEOPIT_TEST_ROOT"],
+                "worker_python": os.environ.get("TELEOPIT_TEST_PYTHON", sys.executable),
+                "source": "bvh", "render": False, "max_steps": 500,
+            },
+        }
+        self.bundle = entrypoint.build_bundle(self.config, publisher=self.publisher)
+        self.bundle.start_all()
+        self.server = entrypoint.create_server(self.config, self.bundle, host="127.0.0.1", port=0)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True,
+                                       name="teleopit-e2e-http")
+        self.thread.start()
+        self.url = f"http://127.0.0.1:{self.server.server_port}/mcp"
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+        self.bundle.stop_all()
+        self.bundle.manager.close()
+
+    def rpc(self, method, params=None):
+        payload = {"jsonrpc": "2.0", "id": 1, "method": method, "params": params or {}}
+        request = Request(self.url, data=json.dumps(payload).encode(),
+                          headers={"Content-Type": "application/json"})
+        with urlopen(request, timeout=20) as response:
+            result = json.load(response)
+        self.assertNotIn("error", result, result)
+        return result["result"]
+
+    def call(self, action="info", name="teleopit_sim", **options):
+        result = self.rpc("tools/call", {"name": name, "arguments": {"action": action, **options}})
+        content = result["content"]
+        self.assertEqual(len(content), 1)
+        self.assertEqual(content[0]["type"], "text")
+        parsed = json.loads(content[0]["text"])
+        self.assertIsInstance(parsed, dict)
+        return parsed
+
+    def wait_for(self, predicate, description, timeout=60):
+        deadline = time.monotonic() + timeout
+        last = {}
+        while time.monotonic() < deadline:
+            last = self.call()
+            self.assertNotEqual(last["state"], "error",
+                                f"{description}: {json.dumps(last, ensure_ascii=False)}")
+            if predicate(last):
+                return last
+            time.sleep(0.05)
+        self.fail(f"Timed out waiting for {description}: {json.dumps(last, ensure_ascii=False)}")
+
+    def assert_real_snapshot(self, snapshot):
+        self.assertEqual(snapshot["source"], "bvh")
+        self.assertEqual(snapshot["mode"], "simulation")
+        self.assertEqual(snapshot["robot_profile"], "unitree_g1_29dof")
+        self.assertFalse(snapshot["hardware_output"])
+        for key in ("target_positions", "joint_positions", "joint_names"):
+            self.assertEqual(len(snapshot[key]), 29, key)
+        self.assertEqual(len(set(snapshot["joint_names"])), 29)
+        for key in ("target_positions", "joint_positions"):
+            self.assertTrue(all(math.isfinite(value) for value in snapshot[key]), key)
+        for key in ("retarget_ms", "policy_ms", "physics_ms", "step_compute_ms"):
+            self.assertGreater(snapshot[key], 0.0, key)
+        self.assertGreater(snapshot["sim_time_s"], 0.0)
+        self.assertTrue(any(abs(value) > 1e-4 for value in snapshot["target_positions"]))
+        json.dumps(snapshot, allow_nan=False)
+
+    def test_bvh_pause_resume_stop_and_restart_over_real_mcp(self):
+        self.assertEqual(self.rpc("initialize")["serverInfo"]["name"], "teleopit-simulation")
+        tools = {tool["name"]: tool for tool in self.rpc("tools/list")["tools"]}
+        self.assertEqual(tools["teleopit_state"]["topic_out"][0]["format"], "data/json")
+        self.call("config", source="bvh", render=False, max_steps=500)
+        self.assertTrue(self.call("preflight")["ready"])
+        self.assertEqual(self.call("start")["state"], "ready")
+        idle = self.call()
+        self.assertEqual(idle["state"], "idle")
+        self.assertIsNone(idle["session_id"])
+        self.assertEqual(idle["snapshot"], {})
+        self.assertEqual(self.call("start", name="teleopit_state")["state"], "running")
+
+        began = time.monotonic()
+        accepted = self.call("run")
+        self.assertTrue(accepted["accepted"])
+        self.assertEqual(accepted["state"], "starting")
+        active = self.wait_for(lambda info: info["snapshot"].get("step", 0) >= 5,
+                               "at least five actual GMR/ONNX/MuJoCo frames")
+        startup_s = time.monotonic() - began
+        self.assert_real_snapshot(active["snapshot"])
+        first_session = active["session_id"]
+        self.call("pause")
+        paused = self.wait_for(lambda info: info["state"] == "paused", "worker pause acknowledgement", timeout=5)
+        paused_step = paused["snapshot"]["step"]
+        paused_sim_time = paused["snapshot"]["sim_time_s"]
+        time.sleep(0.35)
+        still_paused = self.call()
+        self.assertEqual(still_paused["state"], "paused")
+        self.assertEqual(still_paused["snapshot"]["step"], paused_step)
+        self.assertEqual(still_paused["snapshot"]["sim_time_s"], paused_sim_time)
+
+        # Turning a status card off cannot terminate or resume the simulation.
+        self.assertEqual(self.call("stop", name="teleopit_state")["state"], "idle")
+        self.assertEqual(self.call()["state"], "paused")
+        self.call("resume")
+        advanced = self.wait_for(lambda info: info["state"] == "running"
+                                 and info["snapshot"].get("step", 0) > paused_step,
+                                 "worker resume and advancing physics", timeout=5)
+        self.assertGreater(advanced["snapshot"]["sim_time_s"], paused_sim_time)
+        self.assertEqual(self.call("stop")["state"], "idle")
+
+        # A new short run must allocate a fresh child/session and complete.
+        self.call("start", source="bvh", render=False, max_steps=5)
+        restarted = self.call("run")
+        self.assertTrue(restarted["accepted"])
+        self.assertNotEqual(restarted["session_id"], first_session)
+        completed = self.wait_for(lambda info: info["state"] == "completed", "five-step restarted run completion")
+        self.assertEqual(completed["snapshot"]["step"], 5)
+        self.assertEqual(completed["snapshot"]["summary"]["steps"], 5)
+        self.assertEqual(completed["snapshot"]["summary"]["reason"], "completed")
+        self.assert_real_snapshot(completed["snapshot"])
+        print("[e2e] BVH HTTP lifecycle " + json.dumps({
+            "startup_to_five_frames_s": round(startup_s, 2),
+            "paused_step": paused_step, "resumed_step": advanced["snapshot"]["step"],
+            "restart_steps": completed["snapshot"]["step"],
+            "target_positions_first3": completed["snapshot"]["target_positions"][:3],
+            "step_compute_ms": completed["snapshot"]["step_compute_ms"],
+            "hardware_output": completed["hardware_output"],
+        }), flush=True)
+
+    def test_rendered_bvh_completion_reaches_card_jpeg_producer(self):
+        self.call("config", source="bvh", render=True, max_steps=10)
+        self.assertTrue(self.call("preflight")["ready"])
+        self.call("start")
+        self.assertEqual(self.call("start", name="teleopit_preview")["state"], "running")
+        self.assertTrue(self.call("run")["accepted"])
+        completed = self.wait_for(lambda info: info["state"] == "completed", "rendered BVH completion")
+        self.assertEqual(completed["snapshot"]["summary"]["steps"], 10)
+        self.assert_real_snapshot(completed["snapshot"])
+        self.wait_for(lambda info: self.publisher.last_frame() is not None,
+                      "actual MuJoCo JPEG at the card transport producer", timeout=3)
+        jpeg = self.publisher.last_frame()
+        self.assertTrue(jpeg.startswith(b"\xff\xd8"), "preview is not a JPEG")
+        self.assertTrue(jpeg.endswith(b"\xff\xd9"), "JPEG is truncated")
+        self.assertGreater(len(jpeg), 1000)
+        self.assertTrue(self.call("info", name="teleopit_preview")["preview_available"])
+        print("[e2e] BVH rendered HTTP run " + json.dumps({
+            "steps": completed["snapshot"]["step"],
+            "jpeg_bytes": len(jpeg), "captured_jpegs": len(self.publisher.frames),
+            "hardware_output": completed["hardware_output"],
+            "real_ros_core_tested": False,
+        }), flush=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleopit/tests/test_manager.py
+++ b/generic/teleopit/tests/test_manager.py
@@ -1,0 +1,226 @@
+"""Supervisor tests exercise cancellation and the actual child/event pipe seam."""
+
+import base64
+import json
+from pathlib import Path
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import manager
+from manager import SimulationManager, validate_options
+
+
+def until(predicate, timeout=5):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        value = predicate()
+        if value:
+            return value
+        time.sleep(0.01)
+    raise AssertionError("timed out waiting for supervisor state")
+
+
+@pytest.mark.parametrize("options", [
+    {"source": "live"}, {"max_steps": True}, {"max_steps": -1}, {"max_steps": 180001},
+    {"max_steps": 0.5}, {"human_height": float("nan")}, {"human_height": float("inf")},
+    {"render": "true"}, {"upstream_root": "/tmp"}, {"worker_python": "sh"},
+    {"policy_path": "/tmp/custom.onnx"}, {"bvh_path": "a\nb"},
+])
+def test_rejects_invalid_and_server_only_controls(options):
+    with pytest.raises(ValueError):
+        validate_options(options)
+
+
+def test_no_install_or_worker_on_lifecycle_info():
+    session = SimulationManager()
+    assert session.info()["state"] == "idle"
+    assert session.info()["hardware_output"] is False
+    assert session.preview() is None
+    assert session.preflight()["ready"] is False
+    assert session._process is None
+    session.close()
+    with pytest.raises(ValueError, match="关闭"):
+        session.run()
+
+
+def test_failed_preflight_never_launches(monkeypatch):
+    session = SimulationManager()
+    monkeypatch.setattr(session, "_check", lambda _: {"ready": False, "errors": ["missing policy"]})
+    monkeypatch.setattr(manager.subprocess, "Popen", lambda *a, **k: pytest.fail("must not spawn"))
+    assert session.run()["state"] == "starting"
+    until(lambda: session.info()["state"] == "error")
+    assert "missing policy" in session.info()["error"]
+    session.close()
+
+
+def test_stop_cancels_blocked_preflight_and_fences_old_frames(monkeypatch):
+    session = SimulationManager()
+    entered, release = threading.Event(), threading.Event()
+
+    def check(_):
+        entered.set()
+        assert release.wait(3)
+        return {"ready": True, "paths": {}}
+
+    monkeypatch.setattr(session, "_check", check)
+    monkeypatch.setattr(manager.subprocess, "Popen", lambda *a, **k: pytest.fail("cancelled launch"))
+    first = session.run()
+    assert entered.wait(1)
+    assert session.run()["accepted"] is False
+    old_generation = session._generation
+    assert session.stop()["state"] == "idle"
+    release.set()
+    session._receive(old_generation, {"event": "ready"})
+    session._receive(old_generation, {"event": "frame", "snapshot": {"step": 8}})
+    assert session.info()["snapshot"] == {}
+    assert first["session_id"] == session.info()["session_id"]
+    session.close()
+
+
+CHILD = """
+import base64,json,os,sys
+fd=int(sys.argv[1]); out=os.fdopen(fd,'w',buffering=1)
+def emit(value): out.write(json.dumps(value)+'\\n')
+json.loads(sys.stdin.readline())
+emit({'event':'ready'})
+emit({'event':'frame','snapshot':{'step':1,'joint_positions':[0]*29},'preview_jpeg_b64':base64.b64encode(b'jpeg').decode()})
+for line in sys.stdin:
+    command=json.loads(line)['command']
+    if command=='pause': emit({'event':'paused'})
+    if command=='resume': emit({'event':'resumed'})
+    if command=='stop': break
+emit({'event':'complete','summary':{'steps':1}})
+"""
+
+
+def setup_process(monkeypatch, child=CHILD):
+    session = SimulationManager()
+    monkeypatch.setattr(session, "_check", lambda _: {"ready": True, "paths": {}})
+    original = subprocess.Popen
+
+    def spawn(argv, **kwargs):
+        return original([sys.executable, "-u", "-c", child, argv[-1]], **kwargs)
+
+    monkeypatch.setattr(manager.subprocess, "Popen", spawn)
+    return session
+
+
+def test_real_pipe_pause_resume_stop_and_restart(monkeypatch):
+    session = setup_process(monkeypatch)
+    try:
+        first = session.run()
+        until(lambda: session.info()["snapshot"].get("step") == 1)
+        assert session.preview() == b"jpeg"
+        snapshot = session.info()["snapshot"]
+        snapshot["joint_positions"].clear()
+        assert len(session.info()["snapshot"]["joint_positions"]) == 29
+        assert session.pause()["state"] in {"pausing", "paused"}
+        until(lambda: session.info()["state"] == "paused")
+        session.resume()
+        until(lambda: session.info()["state"] == "running")
+        assert session.stop()["state"] == "idle"
+        assert session.preview() is None
+        second = session.run()
+        assert second["session_id"] != first["session_id"]
+        until(lambda: session.info()["state"] == "running")
+    finally:
+        session.close()
+
+
+def test_unexpected_exit_is_error(monkeypatch):
+    session = setup_process(monkeypatch, "import sys; sys.stdin.readline(); sys.exit(7)")
+    try:
+        session.run()
+        until(lambda: session.info()["state"] == "error")
+        assert "code=7" in session.info()["error"]
+    finally:
+        session.close()
+
+
+def test_kills_child_that_ignores_stop(monkeypatch):
+    session = setup_process(monkeypatch, "import sys,time; sys.stdin.readline(); time.sleep(30)")
+    session.run()
+    until(lambda: session._process is not None)
+    process = session._process
+    begin = time.monotonic()
+    assert session.stop()["state"] == "idle"
+    assert time.monotonic() - begin < 4
+    assert process.poll() is not None
+    session.close()
+
+
+def test_complete_waits_for_child_exit(monkeypatch):
+    child = """import json,os,sys,time
+out=os.fdopen(int(sys.argv[1]),'w',buffering=1)
+sys.stdin.readline()
+out.write(json.dumps({'event':'complete','summary':{'steps':2}})+'\\n')
+time.sleep(.25)
+"""
+    session = setup_process(monkeypatch, child)
+    try:
+        session.run()
+        until(lambda: session.info()["state"] == "finishing")
+        assert session.run()["accepted"] is False
+        until(lambda: session.info()["state"] == "completed")
+        assert session.info()["snapshot"]["summary"]["steps"] == 2
+    finally:
+        session.close()
+
+
+def test_concurrent_stops_cannot_reopen_while_reaping(monkeypatch):
+    session = SimulationManager()
+    entered, release = threading.Event(), threading.Event()
+
+    def terminate(_):
+        entered.set()
+        assert release.wait(3)
+
+    monkeypatch.setattr(session, "_terminate", terminate)
+    first = threading.Thread(target=session.stop)
+    second = threading.Thread(target=session.stop)
+    first.start()
+    assert entered.wait(1)
+    second.start()
+    assert session.info()["state"] == "stopping"
+    assert session.run()["accepted"] is False
+    release.set()
+    first.join(1)
+    second.join(1)
+    assert not first.is_alive() and not second.is_alive()
+    assert session.info()["state"] == "idle"
+
+
+def test_diagnostics_and_waiting_input_are_visible():
+    session = SimulationManager()
+    session._receive(0, {"event": "ready", "waiting_for_input": True, "source": "pico"})
+    assert session.info()["backend"]["waiting_for_input"] is True
+    session._receive(0, {"event": "diagnostic", "code": "preview_unavailable", "message": "missing GL"})
+    assert session.info()["diagnostics"][0]["code"] == "preview_unavailable"
+    session._receive(0, {"event": "frame", "snapshot": {"step": 1}})
+    assert session.info()["backend"]["waiting_for_input"] is False
+    session.close()
+
+
+def test_preflight_rejects_missing_hydra_or_old_pico_bridge(monkeypatch, tmp_path):
+    session = SimulationManager({"upstream_root": str(tmp_path)})
+    monkeypatch.setattr(manager, "inspect_installation", lambda *a, **k: {"ready": True, "errors": [], "paths": {}})
+
+    def probe(argv, **kwargs):
+        assert "hydra" in argv[-1] and "qpsolvers" in argv[-1] and "scipy" in argv[-1]
+        assert "pico-bridge" in argv[-1] and "0.2.1" in argv[-1]
+        return subprocess.CompletedProcess(argv, 0, stdout=json.dumps({
+            "missing": ["hydra"], "version_mismatches": ["pico-bridge: 0.2.0 != 0.2.1"],
+            "origin": str(tmp_path / "teleopit" / "__init__.py"),
+        }))
+
+    monkeypatch.setattr(manager.subprocess, "run", probe)
+    result = session.preflight({"source": "pico"})
+    assert result["ready"] is False
+    assert "hydra" in " ".join(result["errors"])
+    assert "pico-bridge" in " ".join(result["errors"])
+    session.close()

--- a/generic/teleopit/tests/test_upstream.py
+++ b/generic/teleopit/tests/test_upstream.py
@@ -1,0 +1,211 @@
+"""Pinned source/assets and safe operator-only setup contracts (no network)."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+DRIVER = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(DRIVER))
+
+import setup_teleopit as setup
+import upstream
+
+
+class SafeExtractionTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def archive(self, entries):
+        archive = self.root / "assets.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            for name, kind, data in entries:
+                entry = tarfile.TarInfo(name)
+                entry.type = kind
+                entry.size = len(data) if kind == tarfile.REGTYPE else 0
+                if kind in (tarfile.SYMTYPE, tarfile.LNKTYPE):
+                    entry.linkname = "../outside"
+                tar.addfile(entry, io.BytesIO(data))
+        return archive
+
+    def test_regular_files_extract_with_parent_directories(self):
+        archive = self.archive([("./unitree_g1/model.xml", tarfile.REGTYPE, b"model")])
+        setup.safe_extract(archive, self.root / "output")
+        self.assertEqual((self.root / "output/unitree_g1/model.xml").read_bytes(), b"model")
+
+    def test_rejects_traversal_absolute_windows_paths_links_and_devices(self):
+        entries = [
+            ("../outside", tarfile.REGTYPE), ("/outside", tarfile.REGTYPE),
+            ("x/../../outside", tarfile.REGTYPE), ("C:/outside", tarfile.REGTYPE),
+            ("x\\..\\outside", tarfile.REGTYPE), ("safe", tarfile.SYMTYPE),
+            ("safe", tarfile.LNKTYPE), ("safe", tarfile.CHRTYPE),
+            ("safe", tarfile.FIFOTYPE),
+        ]
+        for index, (name, kind) in enumerate(entries):
+            with self.subTest(name=name, kind=kind):
+                archive = self.archive([(name, kind, b"bad")])
+                with self.assertRaises(ValueError):
+                    setup.safe_extract(archive, self.root / f"out{index}")
+        self.assertFalse((self.root / "outside").exists())
+
+    def test_rejects_duplicate_members_and_expansion_limit_before_writing(self):
+        archive = self.archive([("a", tarfile.REGTYPE, b"one"),
+                                ("a", tarfile.REGTYPE, b"two")])
+        with self.assertRaises(ValueError):
+            setup.safe_extract(archive, self.root / "duplicates")
+        self.assertFalse((self.root / "duplicates/a").exists())
+        archive = self.archive([("a", tarfile.REGTYPE, b"long")])
+        with self.assertRaises(ValueError):
+            setup.safe_extract(archive, self.root / "limit", max_bytes=3)
+        self.assertFalse((self.root / "limit/a").exists())
+
+    def test_existing_different_assets_preserved_and_identical_install_is_idempotent(self):
+        archive = self.archive([("model.xml", tarfile.REGTYPE, b"model")])
+        asset = upstream.Asset("robots", "a.tar.gz", "assets/robots",
+                               upstream.sha256_file(archive), archive.stat().st_size, True)
+        first = setup.install_asset(asset, archive, self.root)
+        self.assertEqual(first, setup.install_asset(asset, archive, self.root))
+        installed = self.root / "assets/robots/model.xml"
+        installed.write_text("operator data")
+        with self.assertRaisesRegex(ValueError, "未覆盖"):
+            setup.install_asset(asset, archive, self.root)
+        self.assertEqual(installed.read_text(), "operator data")
+
+    def test_download_requires_pinned_digest_and_cache_is_not_overwritten(self):
+        data = b"test-model"
+        asset = upstream.Asset("policy", "test.onnx", "ckpt/test.onnx",
+                               hashlib.sha256(data).hexdigest(), len(data))
+        cache = self.root / "cache"
+        with patch("urllib.request.urlopen", return_value=io.BytesIO(data)) as request:
+            target = setup.download_asset(asset, cache)
+        self.assertIn(upstream.ASSET_REVISION, request.call_args.args[0].full_url)
+        with patch("urllib.request.urlopen") as request:
+            self.assertEqual(setup.download_asset(asset, cache), target)
+            request.assert_not_called()
+        target.write_bytes(b"operator")
+        with patch("urllib.request.urlopen") as request, self.assertRaises(ValueError):
+            setup.download_asset(asset, cache)
+        request.assert_not_called()
+        self.assertEqual(target.read_bytes(), b"operator")
+
+    def test_failed_download_leaves_no_published_asset(self):
+        asset = upstream.Asset("policy", "test.onnx", "test.onnx", "0" * 64, 3)
+        with patch("urllib.request.urlopen", return_value=io.BytesIO(b"bad")):
+            with self.assertRaises(ValueError):
+                setup.download_asset(asset, self.root / "cache")
+        self.assertEqual(list((self.root / "cache").iterdir()), [])
+
+    def test_rejects_existing_symlink_in_asset_parent(self):
+        source = self.root / "test-model"
+        source.write_bytes(b"model")
+        asset = upstream.Asset("policy", "model.onnx", "ckpt/model.onnx",
+                               upstream.sha256_file(source), source.stat().st_size)
+        outside = self.root / "operator-files"
+        outside.mkdir()
+        (self.root / "ckpt").symlink_to(outside, target_is_directory=True)
+        with self.assertRaises(ValueError):
+            setup.install_asset(asset, source, self.root)
+        self.assertEqual(list(outside.iterdir()), [])
+
+
+class InstallationInspectionTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.git("init", "--quiet")
+        self.git("config", "user.email", "teleopit-test@example.invalid")
+        self.git("config", "user.name", "Teleopit test")
+        files = ["teleopit/configs/default.yaml",
+                 "teleopit/retargeting/gmr/ik_configs/bvh_lafan1_to_g1.json",
+                 "teleopit/retargeting/gmr/ik_configs/pico_bridge_to_g1.json"]
+        for filename in files:
+            path = self.root / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("fixture")
+        self.git("add", "teleopit")
+        self.git("commit", "--quiet", "-m", "fixture")
+        self.revision = self.git("rev-parse", "HEAD")
+        self.addCleanup(patch.stopall)
+        patch.object(upstream, "SOURCE_REVISION", self.revision).start()
+        for filename in (upstream.DEFAULT_POLICY, upstream.DEFAULT_BVH, upstream.ROBOT_XML):
+            path = self.root / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("fixture")
+        policy = upstream.Asset("policy", "policy.onnx", upstream.DEFAULT_POLICY,
+                                hashlib.sha256(b"fixture").hexdigest(), 7)
+        patch.object(upstream, "ASSETS", (policy,)).start()
+
+    def git(self, *args):
+        return subprocess.run(["git", "-C", str(self.root), *args],
+                              capture_output=True, text=True, check=True).stdout.strip()
+
+    def test_reports_ready_paths_and_checks_policy_without_importing_simulator(self):
+        before = set(sys.modules)
+        report = upstream.inspect_installation(self.root)
+        self.assertTrue(report["ready"], report["errors"])
+        self.assertTrue(report["policy_verified"])
+        self.assertEqual(report["paths"]["bvh"], str((self.root / upstream.DEFAULT_BVH).resolve()))
+        self.assertFalse(report["receipt_present"])
+        self.assertNotIn("mujoco", set(sys.modules) - before)
+
+    def test_wrong_revision_and_modified_tracked_source_rejected(self):
+        with patch.object(upstream, "SOURCE_REVISION", "0" * 40):
+            self.assertFalse(upstream.inspect_installation(self.root)["ready"])
+        (self.root / "teleopit/configs/default.yaml").write_text("modified")
+        report = upstream.inspect_installation(self.root)
+        self.assertFalse(report["ready"])
+        self.assertTrue(any("本地修改" in error for error in report["errors"]))
+        with self.assertRaises(ValueError):
+            setup.ensure_checkout(self.root)
+        self.assertEqual((self.root / "teleopit/configs/default.yaml").read_text(), "modified")
+
+    def test_missing_bvh_does_not_block_pico_but_missing_policy_does(self):
+        (self.root / upstream.DEFAULT_BVH).unlink()
+        self.assertFalse(upstream.inspect_installation(self.root)["ready"])
+        self.assertTrue(upstream.inspect_installation(self.root, source="pico")["ready"])
+        (self.root / upstream.DEFAULT_POLICY).write_text("tampered")
+        self.assertFalse(upstream.inspect_installation(self.root, source="pico")["ready"])
+
+    def test_stale_or_nonobject_receipt_is_reported_without_false_provenance(self):
+        for receipt in ({"asset_revision": "stale"}, []):
+            with self.subTest(receipt=receipt):
+                (self.root / upstream.ASSET_RECEIPT).write_text(json.dumps(receipt))
+                report = upstream.inspect_installation(self.root)
+                self.assertFalse(report["receipt_present"])
+                self.assertTrue(any("凭据" in warning for warning in report["warnings"]))
+
+    def test_receipt_detects_modified_canonical_robot_xml(self):
+        receipt = {"source_revision": self.revision, "asset_revision": upstream.ASSET_REVISION,
+                   "assets": {"robots": {"files": {"unitree_g1/g1_29dof.xml":
+                              hashlib.sha256(b"fixture").hexdigest()}}}}
+        (self.root / upstream.ASSET_RECEIPT).write_text(json.dumps(receipt))
+        self.assertTrue(upstream.inspect_installation(self.root, source="pico")["ready"])
+        (self.root / upstream.ROBOT_XML).write_text("modified xml")
+        report = upstream.inspect_installation(self.root, source="pico")
+        self.assertFalse(report["ready"])
+        self.assertTrue(any("资源已改变" in error for error in report["errors"]))
+
+    def test_check_cli_is_read_only_and_refuses_missing_installation(self):
+        with (patch.object(setup, "ensure_checkout") as checkout,
+              patch.object(setup, "download_asset") as download,
+              patch("builtins.print")):
+            result = setup.main(["--root", str(self.root / "missing"), "--check"])
+        self.assertEqual(result, 1)
+        checkout.assert_not_called()
+        download.assert_not_called()
+        self.assertFalse((self.root / "missing").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/generic/teleopit/upstream.py
+++ b/generic/teleopit/upstream.py
@@ -1,0 +1,187 @@
+"""Lightweight, read-only checks for the optional Teleopit installation.
+
+This module never imports the simulator, installs packages, or contacts hardware.
+Downloads are available only through the operator-invoked setup_teleopit.py.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SOURCE_URL = "https://github.com/BotRunner64/Teleopit.git"
+SOURCE_VERSION = "0.5.0"
+SOURCE_REVISION = "f9263865c581802ad531854b8e547e2403a945f3"
+ASSET_REPOSITORY = "12e21/Teleopit-models"
+ASSET_REVISION = "94cf996444fea6894b87c28e86606cd4c2f1408f"
+DEFAULT_POLICY = "ckpt/track_g1.onnx"
+DEFAULT_BVH = "data/sample_bvh/aiming1_subject1.bvh"
+ROBOT_XML = "assets/robots/unitree_g1/g1_29dof.xml"
+ASSET_RECEIPT = ".phanthymotus-teleopit-assets.json"
+
+
+@dataclass(frozen=True)
+class Asset:
+    name: str
+    remote_path: str
+    local_path: str
+    sha256: str
+    size: int
+    archive: bool = False
+
+    @property
+    def url(self) -> str:
+        return (f"https://huggingface.co/{ASSET_REPOSITORY}/resolve/"
+                f"{ASSET_REVISION}/{self.remote_path}")
+
+
+# Digests and sizes are the Git LFS object identities from the immutable model
+# repository revision above, not hashes fetched dynamically at installation time.
+ASSETS = (
+    Asset("policy", "checkpoints/track_g1.onnx", DEFAULT_POLICY,
+          "1ebd341d9193e1c49a986450f6043ba1a9473ad46636ce0bcb1c7755c856e0de",
+          14_077_633),
+    Asset("robots", "archives/robot_assets.tar.gz", "assets/robots",
+          "fb5f1aeec3c57be6b26533c9a9aad0d095048a5fe8aa3c6915d8f6a67c35d4fc",
+          27_765_695, True),
+    Asset("bvh", "archives/sample_bvh.tar.gz", "data/sample_bvh",
+          "c6be528b094c4140285a3e7449303f5d65210223f16b896036eb86071505730e",
+          2_539_053, True),
+    # Not needed by G1: v0.5.0 GMR reuses the canonical assets/robots G1 model.
+    Asset("gmr", "archives/gmr_assets.tar.gz", "teleopit/retargeting/gmr/assets",
+          "538f52afaccbbe68bf35ec2d3289dbdb296c9270551b022f2a937a11ff841b04",
+          365_137_251, True),
+)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def inspect_source(root: Path) -> tuple[str | None, list[str]]:
+    """Reject other revisions and locally modified tracked upstream code."""
+    root = root.expanduser().resolve()
+    try:
+        def git(*args: str) -> str:
+            return subprocess.run(
+                ["git", "-C", str(root), *args], capture_output=True, text=True,
+                check=True, timeout=10,
+            ).stdout.strip()
+
+        if Path(git("rev-parse", "--show-toplevel")).resolve() != root:
+            return None, ["TELEOPIT_ROOT 必须指向独立的 Teleopit 源码仓库根目录"]
+        revision = git("rev-parse", "HEAD")
+        errors = []
+        if revision != SOURCE_REVISION:
+            errors.append(f"Teleopit 源码版本不匹配；要求 {SOURCE_REVISION}")
+        if git("status", "--porcelain", "--untracked-files=no"):
+            errors.append("Teleopit 已跟踪源码存在本地修改；请使用干净的固定版本 checkout")
+        return revision, errors
+    except (OSError, subprocess.SubprocessError):
+        return None, ["未找到可校验的 Teleopit Git checkout；请运行 setup_teleopit.py"]
+
+
+def _resolve_asset(root: Path, value: str | Path | None, default: str) -> Path:
+    path = Path(value or default).expanduser()
+    return (path if path.is_absolute() else root / path).resolve()
+
+
+def inspect_installation(
+    root: Path, policy_path: str | Path | None = None,
+    bvh_path: str | Path | None = None, source: str = "bvh",
+) -> dict:
+    """Inspect files/provenance without importing any optional Python package.
+
+    ``ready`` concerns source and assets only. The backend performs imports,
+    ONNX shape checks and simulator construction in its cancellable child process.
+    Custom BVH and ONNX paths are operator-owned; they are never downloaded here.
+    """
+    root = Path(root).expanduser().resolve()
+    revision, errors = inspect_source(root)
+    warnings = []
+    policy = _resolve_asset(root, policy_path, DEFAULT_POLICY)
+    bvh = _resolve_asset(root, bvh_path, DEFAULT_BVH)
+    xml = root / ROBOT_XML
+    required = {"policy": policy, "robot_xml": xml}
+    if source == "bvh":
+        required["bvh"] = bvh
+    elif source != "pico":
+        errors.append("source 必须为 bvh 或 pico")
+    required["config"] = root / "teleopit/configs/default.yaml"
+    required["retarget_config"] = root / (
+        "teleopit/retargeting/gmr/ik_configs/"
+        + ("pico_bridge_to_g1.json" if source == "pico" else "bvh_lafan1_to_g1.json")
+    )
+    for name, path in required.items():
+        try:
+            exists = path.is_file() and path.stat().st_size > 0
+        except OSError:
+            exists = False
+        if not exists:
+            errors.append(f"缺少 {name}: {path}")
+
+    policy_verified = False
+    if policy == (root / DEFAULT_POLICY).resolve() and policy.is_file():
+        try:
+            policy_verified = (policy.stat().st_size == ASSETS[0].size
+                               and sha256_file(policy) == ASSETS[0].sha256)
+        except OSError:
+            policy_verified = False
+        if not policy_verified:
+            errors.append("默认 G1 ONNX 策略 SHA-256 不匹配；请勿混用旧策略")
+    elif policy.is_file():
+        warnings.append("使用自定义 ONNX；其来源未由安装清单验证，仍需后端维度校验")
+
+    receipt = None
+    try:
+        receipt = json.loads((root / ASSET_RECEIPT).read_text(encoding="utf-8"))
+        if (not isinstance(receipt, dict) or receipt.get("asset_revision") != ASSET_REVISION
+                or receipt.get("source_revision") != SOURCE_REVISION
+                or not isinstance(receipt.get("assets"), dict)):
+            warnings.append("资源安装凭据版本不匹配；请用安装脚本重新校验")
+            receipt = None
+    except (OSError, ValueError):
+        warnings.append("未发现有效资源安装凭据；源码及策略已单独检查，网格由 MuJoCo 加载校验")
+    # Detect replacement of the selected canonical XML/BVH after installation.
+    # Meshes are not rehashed on every preflight; full trees are compared when the
+    # explicit installer is re-run. MuJoCo validates references and dimensions.
+    selected = {"robots": (xml, "unitree_g1/g1_29dof.xml")}
+    if source == "bvh" and bvh == (root / DEFAULT_BVH).resolve():
+        selected["bvh"] = (bvh, "aiming1_subject1.bvh")
+    if receipt:
+        for name, (path, relative) in selected.items():
+            asset_receipt = receipt["assets"].get(name, {})
+            files = asset_receipt.get("files", {}) if isinstance(asset_receipt, dict) else {}
+            expected = files.get(relative) if isinstance(files, dict) else None
+            if not isinstance(expected, str):
+                warnings.append(f"安装凭据缺少 {name} 的文件校验记录")
+            elif path.is_file():
+                try:
+                    if sha256_file(path) != expected:
+                        errors.append(f"安装后 {name} 资源已改变；请重新校验: {path}")
+                except OSError:
+                    errors.append(f"无法读取 {name} 资源: {path}")
+    return {
+        "ready": not errors,
+        "errors": errors,
+        "warnings": warnings,
+        "source_version": SOURCE_VERSION,
+        "source_revision": revision,
+        "expected_source_revision": SOURCE_REVISION,
+        "asset_revision": ASSET_REVISION,
+        "policy_verified": policy_verified,
+        "paths": {"root": str(root), "policy": str(policy), "bvh": str(bvh),
+                  "robot_xml": str(xml)},
+        "assets": {entry.name: {"sha256": entry.sha256, "size": entry.size,
+                                "local_path": entry.local_path}
+                   for entry in ASSETS if entry.name != "gmr"},
+        "receipt_present": receipt is not None,
+    }

--- a/generic/teleopit/worker.py
+++ b/generic/teleopit/worker.py
@@ -1,0 +1,68 @@
+"""Private child protocol: commands on stdin, structured events on an inherited pipe."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+from pathlib import Path
+import sys
+import threading
+import traceback
+
+# Source checkout and unified Docker build both make common/ available here.
+for _parent in Path(__file__).resolve().parents:
+    if (_parent / "common" / "logsafe.py").is_file():
+        sys.path.insert(0, str(_parent))
+        break
+try:
+    from common import logsafe
+    logsafe.install(check_fd=False)
+except ImportError:
+    pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event-fd", type=int, required=True)
+    args = parser.parse_args()
+    stop_event, pause_event = threading.Event(), threading.Event()
+    with os.fdopen(args.event_fd, "w", encoding="utf-8", buffering=1) as output:
+        def emit(event: dict) -> None:
+            event = dict(event)
+            preview = event.pop("preview_jpeg", None)
+            if preview is not None:
+                event["preview_jpeg_b64"] = base64.b64encode(preview).decode("ascii")
+            output.write(json.dumps(event, allow_nan=False, ensure_ascii=False) + "\n")
+            output.flush()
+
+        try:
+            options = json.loads(sys.stdin.readline())
+
+            def commands() -> None:
+                try:
+                    for line in sys.stdin:
+                        command = json.loads(line).get("command")
+                        if command == "pause":
+                            pause_event.set()
+                        elif command == "resume":
+                            pause_event.clear()
+                        elif command == "stop":
+                            break
+                finally:
+                    stop_event.set()
+                    pause_event.clear()
+
+            threading.Thread(target=commands, name="teleopit-commands", daemon=True).start()
+            from backend import run_backend
+            run_backend(options, emit, stop_event, pause_event)
+            return 0
+        except Exception as exc:
+            traceback.print_exc()
+            emit({"event": "error", "error": f"{type(exc).__name__}: {exc}"})
+            return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 可直接检验的结果

新增可选的 Teleopit 动作仿真 Driver，在 PhanthyMotus 画布内控制 G1 29DoF 仿真并查看关节状态和画面。作为额外后端提供，不替换已有遥操作链路。

- `teleopit_sim`：配置 BVH/PICO 输入，预检查、显式运行、暂停、恢复、停止；启用卡片不会自动运行仿真。
- `teleopit_state`：显示会话、29 关节目标和仿真测量值、输入新鲜度、分阶段计算耗时及错误原因。
- `teleopit_preview`：通过现有 `image/jpeg` 话题输出 640×480 MuJoCo 画面，无需单独打开遥操作网页。
- 停止可取消模型加载和等待头显；暂停后物理时间冻结，恢复后继续，停止后可重新启动新会话。

## 实现与改动范围

- 实际调用固定版本 Teleopit 0.5.0 的 `TeleopPipeline`，复用其 BVH/PICO 输入、GMR 重定向/IK、ONNX 策略和 MuJoCo 仿真，不用测试替身代替实际算法。
- 新增 `generic/teleopit/`，更新仓库中英文驱动目录。复用现有 MCP 和 Core 话题契约，没有修改 Core、共享运行时或已有机器人 Driver。
- 仿真运行在独立子进程；会话隔离、并发停止、输入超时和失败诊断由 Driver 管理。
- 安装由操作者显式执行，固定源码提交、资源版本及 SHA-256；拒绝覆盖不同资源和不安全归档。默认镜像不打包第三方 Teleopit 源码、模型和样例。

## 已完成验证

本地 Intel Mac、Python 3.11，安装固定 Teleopit 源码与官方模型/策略/BVH 后执行：

```bash
TELEOPIT_TEST_ROOT="$TELEOPIT_ROOT" \
  "$TELEOPIT_PYTHON" -m pytest generic/teleopit/tests -q
```

- 65 项测试、26 项子测试通过，包括真实 GMR → ONNX → MuJoCo 算法链路。
- 实际 HTTP → MCP → 会话管理 → 子进程 → Teleopit：启动、暂停步数冻结、恢复、停止和新会话重启通过。
- 真实仿真产生有限的 29 关节数据和有效 JPEG；另行连续运行 50 个策略步并生成 11 张预览画面。
- 卡片话题声明、配置保存、生命周期、资源校验、安全解包、依赖版本检查及并发停止测试通过。
- Python 编译检查、Shell 语法检查、差异空白检查通过。

## 草稿阶段的边界与待验收项

- [ ] PICO Ultra 实机输入、全身追踪校准与局域网连接验收。入口已接入固定 pico-bridge 0.2.1，尚未将头显实测计为通过。
- [ ] 真实 ROS 2/Core/浏览器画布的数据和图像显示验收。当前端到端测试到达卡片发布边界，不等于真实 Core 已验证。
- [ ] Linux ARM64 容器构建和部署验收。依赖解析已检查，本机没有完成 ARM64 镜像运行测试。
- 本版仅支持 **G1 29DoF 仿真**，没有真机输出开关，不安装或调用真机电机桥接；不能直接控制此前联调的 G1_23。
- `policy_hz=50` 是目标策略频率，`step_compute_ms` 是计算耗时，不是实际达到的帧率或 VR → 真机端到端延迟。
- 商业部署/再分发前需单独核对第三方许可：Teleopit 根源码 Apache-2.0、G1 模型 BSD-3-Clause；LAFAN 组件另有 CC-BY-NC-ND-4.0 条款，不能把全部材料统称为 Apache/MIT。

运行、安装和卡片验收步骤见 `generic/teleopit/README.md`。本 PR 保持草稿，待上述联调项补齐后再申请正式评审/合并。
