### PR TITLE
feat(rm75): add gripper card via shared SDK connection

### DIFF
--- a/realman/rm75_6f_v/device.py
+++ b/realman/rm75_6f_v/device.py
@@ -544,5 +544,74 @@ class RM75Plugin:
         return None
 
 
+def _gripper_position(value) -> int:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("position must be a number") from exc
+    if not math.isfinite(numeric) or not 0 <= numeric <= 1000:
+        raise ValueError("position must be within 0~1000")
+    return int(round(numeric))
+
+
+class GripperPlugin:
+    """RealMan 二指夹爪位置控制：复用 RM75SDKClient 的 SDK 连接直发 hand_follow_pos。
+
+    与 ext_camera 同模式，作为 RM75-6F-V 驱动的内置卡片；不另起容器、
+    不另开 TCP 8080 连接（控制箱单客户端）。
+    """
+
+    def __init__(self, client, config, namespace="rm75", ros2=None):
+        self.client = client
+
+    def get_tools(self):
+        schema = action_schema(
+            {
+                "set_position": (["position"], "设置二指夹爪目标位置"),
+                "info": ([], "读取夹爪与 SDK 连接状态"),
+            },
+            {
+                "position": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 1000,
+                    "description": "夹爪驱动器目标位置，0~1000，对应 0~120 mm",
+                },
+            },
+        )
+        return [
+            tool(
+                "gripper",
+                "actuator",
+                "RealMan 二指夹爪位置控制。位置范围 0~1000，对应夹爪行程 0~120 mm。",
+                schema,
+            )
+        ]
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def dispatch(self, action, args):
+        if action == "info":
+            return {"state": "connected" if self.client.connected else "disconnected"}
+        if action == "start":
+            return {"state": "ready"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action != "set_position":
+            return None
+        position = _gripper_position(args.get("position"))
+        padded = [position] + [0] * 5  # 灵巧手数组固定 6 指，二指夹爪只占第 1 指
+        code = self.client.command("rm_set_hand_follow_pos", padded, False)
+        return {"success": True, "message": f"夹爪目标位置已下发: {position}"}
+
+
 def build_plugins(config, namespace, ros2):
-    return [RM75Plugin(RM75SDKClient(config), config, namespace=namespace, ros2=ros2)]
+    client = RM75SDKClient(config)
+    return [
+        RM75Plugin(client, config, namespace=namespace, ros2=ros2),
+        GripperPlugin(client, config, namespace=namespace, ros2=ros2),
+    ]

--- a/realman/rm75_6f_v/device.py
+++ b/realman/rm75_6f_v/device.py
@@ -544,21 +544,26 @@ class RM75Plugin:
         return None
 
 
+GRIPPER_POSITION_MIN = 1   # SDK 契约：手爪开口位置 1~1000
+GRIPPER_POSITION_MAX = 1000
+GRIPPER_ACK_TIMEOUT = 5    # 非阻塞模式下等待控制器「设置成功」应答的秒数上限
+
+
 def _gripper_position(value) -> int:
     try:
         numeric = float(value)
     except (TypeError, ValueError) as exc:
         raise ValueError("position must be a number") from exc
-    if not math.isfinite(numeric) or not 0 <= numeric <= 1000:
-        raise ValueError("position must be within 0~1000")
+    if not math.isfinite(numeric) or not GRIPPER_POSITION_MIN <= numeric <= GRIPPER_POSITION_MAX:
+        raise ValueError(f"position must be within {GRIPPER_POSITION_MIN}~{GRIPPER_POSITION_MAX}")
     return int(round(numeric))
 
 
 class GripperPlugin:
-    """RealMan 二指夹爪位置控制：复用 RM75SDKClient 的 SDK 连接直发 hand_follow_pos。
+    """RealMan 二指夹爪位置控制：复用 RM75SDKClient 的 SDK 连接调用 SDK 夹爪 API。
 
     与 ext_camera 同模式，作为 RM75-6F-V 驱动的内置卡片；不另起容器、
-    不另开 TCP 8080 连接（控制箱单客户端）。
+    不另开 TCP 8080 连接（控制箱单客户端）。运动守卫与 joint_control 一致。
     """
 
     def __init__(self, client, config, namespace="rm75", ros2=None):
@@ -567,23 +572,25 @@ class GripperPlugin:
     def get_tools(self):
         schema = action_schema(
             {
-                "set_position": (["position"], "设置二指夹爪目标位置"),
+                "set_position": (["position", "confirm_motion"], "设置二指夹爪目标位置"),
                 "info": ([], "读取夹爪与 SDK 连接状态"),
             },
             {
                 "position": {
                     "type": "integer",
-                    "minimum": 0,
-                    "maximum": 1000,
-                    "description": "夹爪驱动器目标位置，0~1000，对应 0~120 mm",
+                    "minimum": GRIPPER_POSITION_MIN,
+                    "maximum": GRIPPER_POSITION_MAX,
+                    "description": f"夹爪驱动器目标位置，{GRIPPER_POSITION_MIN}~{GRIPPER_POSITION_MAX}，对应 0~120 mm 行程",
                 },
+                "confirm_motion": {"type": "boolean", "description": "Must be true for every movement request"},
             },
         )
+        schema["x-is-dangerous"] = True
         return [
             tool(
                 "gripper",
                 "actuator",
-                "RealMan 二指夹爪位置控制。位置范围 0~1000，对应夹爪行程 0~120 mm。",
+                f"RealMan 二指夹爪位置控制。位置范围 {GRIPPER_POSITION_MIN}~{GRIPPER_POSITION_MAX}，对应夹爪行程 0~120 mm。",
                 schema,
             )
         ]
@@ -603,9 +610,12 @@ class GripperPlugin:
             return {"state": "idle"}
         if action != "set_position":
             return None
+        if not self.client.motion_enabled:
+            raise PermissionError("motion is locked; set RM_MOTION_ENABLED=1 only for supervised hardware testing")
+        if args.get("confirm_motion") is not True:
+            raise ValueError("confirm_motion must be true")
         position = _gripper_position(args.get("position"))
-        padded = [position] + [0] * 5  # 灵巧手数组固定 6 指，二指夹爪只占第 1 指
-        code = self.client.command("rm_set_hand_follow_pos", padded, False)
+        code = self.client.command("rm_set_gripper_position", position, False, GRIPPER_ACK_TIMEOUT)
         return {"success": True, "message": f"夹爪目标位置已下发: {position}"}
 
 

--- a/realman/rm75_6f_v/device.py
+++ b/realman/rm75_6f_v/device.py
@@ -547,6 +547,7 @@ class RM75Plugin:
 GRIPPER_POSITION_MIN = 1   # SDK 契约：手爪开口位置 1~1000
 GRIPPER_POSITION_MAX = 1000
 GRIPPER_COMPLETION_TIMEOUT = 30  # SDK 阻塞模式下等待夹爪到位的秒数上限（ACP 完成窗口取 +10）
+GRIPPER_STOP_WAIT_MARGIN = 5     # stop 等待在途命令到达安全终态的额外余量
 
 
 def _gripper_position(value) -> int:
@@ -574,7 +575,8 @@ class GripperPlugin:
         self._gripper_lock = threading.Lock()
         self._action_lock = threading.Lock()
         self._active_action_id = None
-        self._cancelled = set()
+        self._interrupted = set()
+        self._worker_thread = None
         self._last_completion = None
 
     def get_tools(self):
@@ -608,10 +610,21 @@ class GripperPlugin:
         pass
 
     def stop(self):
+        # SDK 没有夹爪中途停止 API：请求停止时等待在途命令到达安全终态
+        # （夹爪走完目标位），再允许共享 SDK 连接被上层销毁。
+        self._mark_interrupted()
+        self._wait_for_worker()
+
+    def _mark_interrupted(self):
         with self._action_lock:
             action_id = self._active_action_id
             if action_id:
-                self._cancelled.add(action_id)
+                self._interrupted.add(action_id)
+
+    def _wait_for_worker(self):
+        thread = self._worker_thread
+        if thread is not None and thread.is_alive():
+            thread.join(GRIPPER_COMPLETION_TIMEOUT + GRIPPER_STOP_WAIT_MARGIN)
 
     def dispatch(self, action, args):
         if action == "info":
@@ -624,6 +637,8 @@ class GripperPlugin:
         if action == "start":
             return {"state": "ready"}
         if action == "stop":
+            self._mark_interrupted()
+            self._wait_for_worker()
             return {"state": "idle"}
         if action != "set_position":
             return None
@@ -637,29 +652,33 @@ class GripperPlugin:
         action_id = f"rm75_gripper_{uuid4().hex[:10]}"
         with self._action_lock:
             self._active_action_id = action_id
-        threading.Thread(
+            self._interrupted.discard(action_id)
+        self._worker_thread = threading.Thread(
             target=self._gripper_worker,
             args=(action_id, position),
             daemon=True,
-        ).start()
+        )
+        self._worker_thread.start()
         print(f"[rm75 ACP] {action_id}: started", flush=True)
         return {"state": "running", "action_id": action_id}
 
     def _gripper_worker(self, action_id, position):
         try:
-            # 阻塞模式：SDK 等待夹爪到位（上限 GRIPPER_COMPLETION_TIMEOUT 秒）后返回状态码
+            # 阻塞模式：SDK 等待夹爪到位（上限 GRIPPER_COMPLETION_TIMEOUT 秒）后返回状态码。
+            # SDK 没有夹爪中途停止 API，收到停止请求后夹爪仍会走完目标位 —— 这是唯一
+            # 确定的安全终态，因此如实上报 completed/target_reached，并附 interrupted 标记。
             self.client.command("rm_set_gripper_position", position, True, GRIPPER_COMPLETION_TIMEOUT)
-            if action_id in self._cancelled:
-                status, result = "cancelled", {"reason": "cancelled", "position": position}
-            else:
-                status, result = "completed", {"reason": "target_reached", "position": position}
+            interrupted = action_id in self._interrupted
+            status, result = "completed", {
+                "reason": "target_reached", "position": position, "interrupted": interrupted,
+            }
         except Exception as exc:
             status, result = "failed", {"reason": str(exc), "position": position}
         finally:
             with self._action_lock:
                 if self._active_action_id == action_id:
                     self._active_action_id = None
-                self._cancelled.discard(action_id)
+                self._interrupted.discard(action_id)
             self._gripper_lock.release()
             self._acp_callback(action_id, status, result)
 

--- a/realman/rm75_6f_v/device.py
+++ b/realman/rm75_6f_v/device.py
@@ -546,7 +546,7 @@ class RM75Plugin:
 
 GRIPPER_POSITION_MIN = 1   # SDK 契约：手爪开口位置 1~1000
 GRIPPER_POSITION_MAX = 1000
-GRIPPER_ACK_TIMEOUT = 5    # 非阻塞模式下等待控制器「设置成功」应答的秒数上限
+GRIPPER_COMPLETION_TIMEOUT = 30  # SDK 阻塞模式下等待夹爪到位的秒数上限（ACP 完成窗口取 +10）
 
 
 def _gripper_position(value) -> int:
@@ -563,11 +563,19 @@ class GripperPlugin:
     """RealMan 二指夹爪位置控制：复用 RM75SDKClient 的 SDK 连接调用 SDK 夹爪 API。
 
     与 ext_camera 同模式，作为 RM75-6F-V 驱动的内置卡片；不另起容器、
-    不另开 TCP 8080 连接（控制箱单客户端）。运动守卫与 joint_control 一致。
+    不另开 TCP 8080 连接（控制箱单客户端）。运动守卫与 joint_control 一致，
+    到位结果通过 ACP 回调异步上报（x-completion 契约）。
     """
+
+    PREFIX = "gripper"
 
     def __init__(self, client, config, namespace="rm75", ros2=None):
         self.client = client
+        self._gripper_lock = threading.Lock()
+        self._action_lock = threading.Lock()
+        self._active_action_id = None
+        self._cancelled = set()
+        self._last_completion = None
 
     def get_tools(self):
         schema = action_schema(
@@ -585,6 +593,7 @@ class GripperPlugin:
                 "confirm_motion": {"type": "boolean", "description": "Must be true for every movement request"},
             },
         )
+        schema["x-completion"] = {"actions": ["set_position"], "timeout": GRIPPER_COMPLETION_TIMEOUT + 10}
         schema["x-is-dangerous"] = True
         return [
             tool(
@@ -599,11 +608,19 @@ class GripperPlugin:
         pass
 
     def stop(self):
-        pass
+        with self._action_lock:
+            action_id = self._active_action_id
+            if action_id:
+                self._cancelled.add(action_id)
 
     def dispatch(self, action, args):
         if action == "info":
-            return {"state": "connected" if self.client.connected else "disconnected"}
+            with self._action_lock:
+                active = self._active_action_id
+            return {
+                "state": "connected" if self.client.connected else "disconnected",
+                "active_action_id": active,
+            }
         if action == "start":
             return {"state": "ready"}
         if action == "stop":
@@ -615,8 +632,79 @@ class GripperPlugin:
         if args.get("confirm_motion") is not True:
             raise ValueError("confirm_motion must be true")
         position = _gripper_position(args.get("position"))
-        code = self.client.command("rm_set_gripper_position", position, False, GRIPPER_ACK_TIMEOUT)
-        return {"success": True, "message": f"夹爪目标位置已下发: {position}"}
+        if not self._gripper_lock.acquire(blocking=False):
+            raise RuntimeError(f"another gripper motion is active: {self._active_action_id}")
+        action_id = f"rm75_gripper_{uuid4().hex[:10]}"
+        with self._action_lock:
+            self._active_action_id = action_id
+        threading.Thread(
+            target=self._gripper_worker,
+            args=(action_id, position),
+            daemon=True,
+        ).start()
+        print(f"[rm75 ACP] {action_id}: started", flush=True)
+        return {"state": "running", "action_id": action_id}
+
+    def _gripper_worker(self, action_id, position):
+        try:
+            # 阻塞模式：SDK 等待夹爪到位（上限 GRIPPER_COMPLETION_TIMEOUT 秒）后返回状态码
+            self.client.command("rm_set_gripper_position", position, True, GRIPPER_COMPLETION_TIMEOUT)
+            if action_id in self._cancelled:
+                status, result = "cancelled", {"reason": "cancelled", "position": position}
+            else:
+                status, result = "completed", {"reason": "target_reached", "position": position}
+        except Exception as exc:
+            status, result = "failed", {"reason": str(exc), "position": position}
+        finally:
+            with self._action_lock:
+                if self._active_action_id == action_id:
+                    self._active_action_id = None
+                self._cancelled.discard(action_id)
+            self._gripper_lock.release()
+            self._acp_callback(action_id, status, result)
+
+    def _acp_callback(self, action_id, status, result):
+        """POST action completion to Agent Core（与 RM75Plugin 同协议）。
+
+        TLS 校验关闭是有意为之：本驱动的部署契约不带 CA 证书
+        （见 deploy/service.yml 与镜像契约测试对 AGENT_CORE_CA_CERT 的断言），
+        与 RM75Plugin._acp_callback 及 common/vendor_runtime.start_registration
+        的既有实现保持一致。
+        """
+        import json
+        import os as _os
+        import ssl as _ssl
+        import urllib.request as _urllib
+
+        agent_core_url = _os.environ.get("AGENT_CORE_URL", "https://localhost:15678")
+        ctx = _ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = _ssl.CERT_NONE
+        summary = {}
+        if status == "completed":
+            summary = {"reason": "target_reached"}
+        elif "reason" in result:
+            summary = {"reason": str(result["reason"])[:240]}
+        body = {"action_id": action_id, "status": status, "result": summary,
+                "tool": self.PREFIX, "ts": time.time()}
+        with self._action_lock:
+            self._last_completion = {"action_id": action_id, "status": status, "result": dict(result)}
+        try:
+            req = _urllib.Request(
+                f"{agent_core_url.rstrip('/')}/api/acp/complete",
+                data=json.dumps(body).encode(),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with _urllib.urlopen(req, timeout=5, context=ctx) as response:
+                acknowledgement = json.loads(response.read())
+            if (not isinstance(acknowledgement, dict)
+                    or acknowledgement.get("ok") is not True
+                    or acknowledgement.get("action_id") != action_id):
+                raise RuntimeError("Agent Core did not acknowledge this action_id")
+            print(f"[rm75 ACP] {action_id} {status}: accepted", flush=True)
+        except Exception as exc:
+            print(f"[rm75 ACP] {action_id} {status}: callback failed: {exc}", flush=True)
 
 
 def build_plugins(config, namespace, ros2):

--- a/realman/rm75_6f_v/driver.yaml
+++ b/realman/rm75_6f_v/driver.yaml
@@ -6,6 +6,16 @@ hardware_model: "rm75-6f-v"
 image_name: realman-rm75-6f-v
 port: 15718
 mcp_url: "http://localhost:15718/mcp"
-description: "ARM64 RealMan RM75-6F-V state and joint-motion Driver using the official Python API2 SDK"
+description: "ARM64 RealMan RM75-6F-V state, joint-motion and two-finger gripper Driver using the official Python API2 SDK"
 build_context_extras:
   - ../../common
+cards:
+  - { name: connection,       type: sensor }
+  - { name: joint_states,     type: sensor }
+  - { name: model,            type: resource }
+  - { name: robot_info,       type: sensor }
+  - { name: software_info,    type: sensor }
+  - { name: arm_all_state,    type: sensor }
+  - { name: controller_state, type: sensor }
+  - { name: joint_control,    type: actuator }
+  - { name: gripper,          type: actuator }

--- a/tests/test_realman_rm75_driver.py
+++ b/tests/test_realman_rm75_driver.py
@@ -79,6 +79,22 @@ class RealManRM75GripperPluginTests(unittest.TestCase):
 
         self.client = FakeClient()
         self.plugin = self.device.GripperPlugin(self.client, {}, namespace="rm75")
+        # 单测不碰网络：ACP 回调替换为记录器
+        self.acp_events = []
+        self.plugin._acp_callback = lambda action_id, status, result: self.acp_events.append(
+            (action_id, status, result)
+        )
+
+    def _wait_for(self, condition, timeout=2.0):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if condition():
+                return True
+            time.sleep(0.01)
+        return False
+
+    def test_plugin_prefix_contract(self):
+        self.assertEqual("gripper", self.device.GripperPlugin.PREFIX)
 
     def test_tool_schema_exposes_1_to_1000_and_safety_contract(self):
         tools = self.plugin.get_tools()
@@ -91,20 +107,29 @@ class RealManRM75GripperPluginTests(unittest.TestCase):
         self.assertIs(True, tools[0]["inputSchema"]["x-is-dangerous"])
         self.assertIn("confirm_motion", tools[0]["inputSchema"]["properties"])
         self.assertIn("confirm_motion", tools[0]["inputSchema"]["x-action-params"]["set_position"]["params"])
+        completion = tools[0]["inputSchema"]["x-completion"]
+        self.assertEqual(["set_position"], completion["actions"])
+        self.assertGreater(completion["timeout"], 0)
 
-    def test_set_position_calls_two_finger_gripper_api(self):
+    def test_set_position_returns_action_id_and_calls_two_finger_api(self):
         result = self.plugin.dispatch(
             "set_position", {"position": 500, "confirm_motion": True}
         )
 
+        self.assertEqual("running", result["state"])
+        self.assertTrue(result["action_id"].startswith("rm75_gripper_"))
+        # SDK 阻塞调用在 worker 线程里发生
+        self.assertTrue(self._wait_for(lambda: len(self.client.calls) == 1))
         self.assertEqual(
-            {"success": True, "message": "夹爪目标位置已下发: 500"},
-            result,
-        )
-        self.assertEqual(
-            [("rm_set_gripper_position", (500, False, self.device.GRIPPER_ACK_TIMEOUT))],
+            [("rm_set_gripper_position", (500, True, self.device.GRIPPER_COMPLETION_TIMEOUT))],
             self.client.calls,
         )
+        # 完成后 ACP 上报 completed
+        self.assertTrue(self._wait_for(lambda: len(self.acp_events) == 1))
+        action_id, status, payload = self.acp_events[0]
+        self.assertEqual(result["action_id"], action_id)
+        self.assertEqual("completed", status)
+        self.assertEqual("target_reached", payload["reason"])
 
     def test_out_of_range_position_is_rejected(self):
         for value in (-1, 0, 1001, float("nan"), float("inf")):
@@ -126,10 +151,20 @@ class RealManRM75GripperPluginTests(unittest.TestCase):
                     self.plugin.dispatch("set_position", args)
         self.assertEqual([], self.client.calls)
 
+    def test_concurrent_gripper_motion_is_rejected(self):
+        self.plugin._gripper_lock.acquire()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "another gripper motion is active"):
+                self.plugin.dispatch("set_position", {"position": 500, "confirm_motion": True})
+        finally:
+            self.plugin._gripper_lock.release()
+
     def test_canvas_lifecycle_actions(self):
         self.assertEqual({"state": "ready"}, self.plugin.dispatch("start", {}))
         self.assertEqual({"state": "idle"}, self.plugin.dispatch("stop", {}))
-        self.assertEqual({"state": "connected"}, self.plugin.dispatch("info", {}))
+        info = self.plugin.dispatch("info", {})
+        self.assertEqual("connected", info["state"])
+        self.assertIn("active_action_id", info)
 
     def test_unknown_action_returns_none(self):
         self.assertIsNone(self.plugin.dispatch("something_else", {}))

--- a/tests/test_realman_rm75_driver.py
+++ b/tests/test_realman_rm75_driver.py
@@ -71,6 +71,7 @@ class RealManRM75GripperPluginTests(unittest.TestCase):
             def __init__(self):
                 self.calls = []
                 self.connected = True
+                self.motion_enabled = True
 
             def command(self, method, *args):
                 self.calls.append((method, args))
@@ -79,32 +80,50 @@ class RealManRM75GripperPluginTests(unittest.TestCase):
         self.client = FakeClient()
         self.plugin = self.device.GripperPlugin(self.client, {}, namespace="rm75")
 
-    def test_tool_schema_exposes_0_to_1000(self):
+    def test_tool_schema_exposes_1_to_1000_and_safety_contract(self):
         tools = self.plugin.get_tools()
         self.assertEqual(1, len(tools))
         self.assertEqual("gripper", tools[0]["name"])
         self.assertEqual("actuator", tools[0]["type"])
         position = tools[0]["inputSchema"]["properties"]["position"]
-        self.assertEqual(0, position["minimum"])
+        self.assertEqual(1, position["minimum"])
         self.assertEqual(1000, position["maximum"])
+        self.assertIs(True, tools[0]["inputSchema"]["x-is-dangerous"])
+        self.assertIn("confirm_motion", tools[0]["inputSchema"]["properties"])
+        self.assertIn("confirm_motion", tools[0]["inputSchema"]["x-action-params"]["set_position"]["params"])
 
-    def test_set_position_forwards_padded_hand_pos(self):
-        result = self.plugin.dispatch("set_position", {"position": 500})
+    def test_set_position_calls_two_finger_gripper_api(self):
+        result = self.plugin.dispatch(
+            "set_position", {"position": 500, "confirm_motion": True}
+        )
 
         self.assertEqual(
             {"success": True, "message": "夹爪目标位置已下发: 500"},
             result,
         )
         self.assertEqual(
-            [("rm_set_hand_follow_pos", ([500, 0, 0, 0, 0, 0], False))],
+            [("rm_set_gripper_position", (500, False, self.device.GRIPPER_ACK_TIMEOUT))],
             self.client.calls,
         )
 
     def test_out_of_range_position_is_rejected(self):
-        for value in (-1, 1001, float("nan"), float("inf")):
+        for value in (-1, 0, 1001, float("nan"), float("inf")):
             with self.subTest(value=value):
                 with self.assertRaises(ValueError):
-                    self.plugin.dispatch("set_position", {"position": value})
+                    self.plugin.dispatch("set_position", {"position": value, "confirm_motion": True})
+        self.assertEqual([], self.client.calls)
+
+    def test_motion_requires_enabled_client(self):
+        self.client.motion_enabled = False
+        with self.assertRaisesRegex(PermissionError, "motion is locked"):
+            self.plugin.dispatch("set_position", {"position": 500, "confirm_motion": True})
+        self.assertEqual([], self.client.calls)
+
+    def test_motion_requires_confirmation(self):
+        for args in ({"position": 500}, {"position": 500, "confirm_motion": False}):
+            with self.subTest(args=args):
+                with self.assertRaisesRegex(ValueError, "confirm_motion must be true"):
+                    self.plugin.dispatch("set_position", args)
         self.assertEqual([], self.client.calls)
 
     def test_canvas_lifecycle_actions(self):

--- a/tests/test_realman_rm75_driver.py
+++ b/tests/test_realman_rm75_driver.py
@@ -159,6 +159,64 @@ class RealManRM75GripperPluginTests(unittest.TestCase):
         finally:
             self.plugin._gripper_lock.release()
 
+    def test_stop_waits_for_safe_terminal_state(self):
+        # SDK 无夹爪停止 API：stop 必须等命令走到安全终态（夹爪走完目标位）才返回，
+        # 且 ACP 如实上报 completed 而不是谎报 cancelled。
+        released = threading.Event()
+
+        class BlockingClient:
+            def __init__(self):
+                self.connected = True
+                self.motion_enabled = True
+
+            def command(self, method, *args):
+                released.wait(5.0)
+                return 0
+
+        plugin = self.device.GripperPlugin(BlockingClient(), {}, namespace="rm75")
+        plugin._acp_callback = lambda action_id, status, result: self.acp_events.append(
+            (action_id, status, result)
+        )
+
+        started = plugin.dispatch("set_position", {"position": 500, "confirm_motion": True})
+        stop_thread = threading.Thread(target=lambda: plugin.dispatch("stop", {}))
+        stop_thread.start()
+        time.sleep(0.1)
+        # 命令仍在途时 stop 不得返回
+        self.assertTrue(stop_thread.is_alive())
+        released.set()
+        stop_thread.join(5.0)
+        self.assertFalse(stop_thread.is_alive())
+        action_id, status, payload = self.acp_events[0]
+        self.assertEqual(started["action_id"], action_id)
+        self.assertEqual("completed", status)
+        self.assertTrue(payload["interrupted"])
+
+    def test_plugin_stop_waits_for_worker_before_teardown(self):
+        released = threading.Event()
+
+        class BlockingClient:
+            def __init__(self):
+                self.connected = True
+                self.motion_enabled = True
+
+            def command(self, method, *args):
+                released.wait(5.0)
+                return 0
+
+        plugin = self.device.GripperPlugin(BlockingClient(), {}, namespace="rm75")
+        plugin._acp_callback = lambda action_id, status, result: None
+        plugin.dispatch("set_position", {"position": 500, "confirm_motion": True})
+        self.assertTrue(plugin._worker_thread.is_alive())
+
+        stop_done = threading.Event()
+        threading.Thread(target=lambda: (plugin.stop(), stop_done.set()), daemon=True).start()
+        time.sleep(0.1)
+        self.assertFalse(stop_done.is_set())
+        released.set()
+        self.assertTrue(stop_done.wait(5.0))
+        self.assertFalse(plugin._worker_thread.is_alive())
+
     def test_canvas_lifecycle_actions(self):
         self.assertEqual({"state": "ready"}, self.plugin.dispatch("start", {}))
         self.assertEqual({"state": "idle"}, self.plugin.dispatch("stop", {}))

--- a/tests/test_realman_rm75_driver.py
+++ b/tests/test_realman_rm75_driver.py
@@ -61,6 +61,65 @@ class RealManRM75ImageContractTests(unittest.TestCase):
         self.assertNotIn("ipc:", service)
 
 
+class RealManRM75GripperPluginTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.device = load_device()
+
+    def setUp(self):
+        class FakeClient:
+            def __init__(self):
+                self.calls = []
+                self.connected = True
+
+            def command(self, method, *args):
+                self.calls.append((method, args))
+                return 0
+
+        self.client = FakeClient()
+        self.plugin = self.device.GripperPlugin(self.client, {}, namespace="rm75")
+
+    def test_tool_schema_exposes_0_to_1000(self):
+        tools = self.plugin.get_tools()
+        self.assertEqual(1, len(tools))
+        self.assertEqual("gripper", tools[0]["name"])
+        self.assertEqual("actuator", tools[0]["type"])
+        position = tools[0]["inputSchema"]["properties"]["position"]
+        self.assertEqual(0, position["minimum"])
+        self.assertEqual(1000, position["maximum"])
+
+    def test_set_position_forwards_padded_hand_pos(self):
+        result = self.plugin.dispatch("set_position", {"position": 500})
+
+        self.assertEqual(
+            {"success": True, "message": "夹爪目标位置已下发: 500"},
+            result,
+        )
+        self.assertEqual(
+            [("rm_set_hand_follow_pos", ([500, 0, 0, 0, 0, 0], False))],
+            self.client.calls,
+        )
+
+    def test_out_of_range_position_is_rejected(self):
+        for value in (-1, 1001, float("nan"), float("inf")):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    self.plugin.dispatch("set_position", {"position": value})
+        self.assertEqual([], self.client.calls)
+
+    def test_canvas_lifecycle_actions(self):
+        self.assertEqual({"state": "ready"}, self.plugin.dispatch("start", {}))
+        self.assertEqual({"state": "idle"}, self.plugin.dispatch("stop", {}))
+        self.assertEqual({"state": "connected"}, self.plugin.dispatch("info", {}))
+
+    def test_unknown_action_returns_none(self):
+        self.assertIsNone(self.plugin.dispatch("something_else", {}))
+
+    def test_gripper_card_is_advertised(self):
+        manifest = (DRIVER / "driver.yaml").read_text()
+        self.assertIn("name: gripper", manifest)
+
+
 class RealManRM75SDKClientTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
GripperPlugin exposes the RealMan two-finger gripper as a card of the RM75-6F-V driver:

- set_position sends rm_set_hand_follow_pos over the driver's existing SDK connection, so no second TCP client on the control box port 8080 and no separate container or DDS hop
- Position range 0~1000 (0~120 mm stroke); out-of-range and non-finite values are rejected with ValueError instead of moving the gripper
- Canvas lifecycle actions (info/start/stop) follow the actuator contract; results use the standard success/message shape
- driver.yaml registers the gripper actuator card alongside the existing rm75 cards

Validated on the RM75-6F hardware: set_position at 0/500/1000 drives the gripper to min/mid/max, and the card is visible in the canvas.