### PR TITLE
fix(noetix/bumi): release camera from app streaming

### DIFF
--- a/noetix/bumi/Dockerfile
+++ b/noetix/bumi/Dockerfile
@@ -19,8 +19,7 @@ RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
         libasound2-dev \
         libssl-dev \
         libeigen3-dev \
-        libboost-dev \
-        util-linux && \
+        libboost-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Realsense SDK (D435i camera)

--- a/noetix/bumi/Dockerfile
+++ b/noetix/bumi/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get -o Acquire::AllowInsecureRepositories=true update && \
         libasound2-dev \
         libssl-dev \
         libeigen3-dev \
-        libboost-dev && \
+        libboost-dev \
+        util-linux && \
     rm -rf /var/lib/apt/lists/*
 
 # Realsense SDK (D435i camera)

--- a/noetix/bumi/README.md
+++ b/noetix/bumi/README.md
@@ -2,6 +2,31 @@
 
 The bundle exposes the original Bumi sensor, locomotion, audio and camera cards plus one higher-level motion-state card backed by documented Noetix SDK APIs. All card implementations are kept in `device.py`.
 
+## App 图传与 Phanthy Camera Card
+
+Bumi 的官方 App 图传服务 `noetix-video-capture.service` 会占用 RealSense。
+因此，官方 App 图传与本 Driver 的 `camera` / `depth` Card 不能同时使用。
+
+要让 Phanthy Dashboard 直接调用相机，设定
+`plugins.camera.disable_vendor_capture_service: true`（提供的 Bumi 配置已
+开启）。Driver 在初始化相机前，会利用部署配置中的宿主机 PID namespace 和
+特权能力，在机器人宿主机执行：
+
+```bash
+systemctl disable --now noetix-video-capture.service
+```
+
+该设置会跨机器人重启生效：Phanthy 的 `camera` / `depth` Card 优先使用
+RealSense，但官方 App 图传不可用。操作失败只会记录日志，不会阻止其他 Bumi
+Card 启动。
+
+要恢复官方 App 图传，请在机器人宿主机显式执行：
+
+```bash
+sudo systemctl enable noetix-video-capture.service
+sudo systemctl start noetix-video-capture.service
+```
+
 ## `vision_capture` card
 
 Persistent RGB photo/video capture, with the card/action names and file layout

--- a/noetix/bumi/config.yaml
+++ b/noetix/bumi/config.yaml
@@ -12,6 +12,12 @@ plugins:
     enabled: true
   camera:
     enabled: true
+    # Bumi supports either official App video transfer or Phanthy's direct
+    # camera/depth Cards. To use these Cards, the Bumi deployment enters the
+    # host mount namespace and runs:
+    #   systemctl disable --now noetix-video-capture.service
+    # Set false only when official App video transfer must retain the camera.
+    disable_vendor_capture_service: true
   motion_state:
     enabled: true
     # 2 Hz: sufficient for Agent-facing motion telemetry without excessive DDS reads.

--- a/noetix/bumi/main.py
+++ b/noetix/bumi/main.py
@@ -56,6 +56,65 @@ def _resolve_namespace(cfg: dict) -> str:
 
 # ── Bundle ────────────────────────────────────────────────────────────────────
 
+# The factory App video-transfer service opens Bumi's RealSense device before
+# this driver starts. librealsense then cannot negotiate the RGB+depth profile
+# and the camera worker exits with "Couldn't resolve requests". Bumi supports
+# either App video transfer or this driver's direct camera Card, not both. The
+# service deployment shares the host PID namespace and is privileged, so nsenter
+# can invoke the host's systemctl rather than a non-existent systemd here.
+_VENDOR_VIDEO_CAPTURE_SERVICE = "noetix-video-capture.service"
+
+
+def _disable_vendor_video_capture_service(cfg: dict) -> None:
+    """Stop and disable the host service that monopolizes the RealSense camera.
+
+    This is best-effort: failing to access the host's systemd must not prevent
+    the non-camera Bumi cards from registering. The service name is fixed in
+    code instead of accepting an arbitrary command from YAML.
+    """
+    camera_cfg = cfg.get("plugins", {}).get("camera", {})
+    if not camera_cfg.get("enabled", False):
+        return
+    if not camera_cfg.get("disable_vendor_capture_service", False):
+        return
+
+    command = [
+        "nsenter", "--target", "1", "--mount", "--",
+        "systemctl", "disable", "--now", "--no-ask-password",
+        _VENDOR_VIDEO_CAPTURE_SERVICE,
+    ]
+    try:
+        result = subprocess.run(
+            command, capture_output=True, text=True, timeout=15, check=False,
+        )
+    except FileNotFoundError:
+        print(
+            "[camera] WARNING: nsenter is unavailable; cannot release host "
+            f"camera service {_VENDOR_VIDEO_CAPTURE_SERVICE}", flush=True,
+        )
+        return
+    except subprocess.TimeoutExpired:
+        print(
+            "[camera] WARNING: timed out while releasing host camera service "
+            f"{_VENDOR_VIDEO_CAPTURE_SERVICE}", flush=True,
+        )
+        return
+
+    if result.returncode == 0:
+        print(
+            "[camera] App video-transfer service stopped and disabled; "
+            "Phanthy camera/depth Cards may now use the RealSense directly: "
+            f"{_VENDOR_VIDEO_CAPTURE_SERVICE}", flush=True,
+        )
+        return
+
+    detail = (result.stderr or result.stdout).strip()
+    print(
+        "[camera] WARNING: could not stop/disable host camera service "
+        f"{_VENDOR_VIDEO_CAPTURE_SERVICE} (exit {result.returncode}): {detail}",
+        flush=True,
+    )
+
 class BumiDeviceBundle:
     def __init__(self, cfg: dict, namespace: str, executor, high_ctrl, media_ctrl):
         self._plugins: list = []
@@ -275,6 +334,9 @@ def main():
     mcp_port  = int(cfg.get("mcp_port", 15704))
 
     print(f"[bundle] namespace={namespace} mcp_port={mcp_port}")
+
+    # Must happen before the CameraPlugin creates its RealSense pipeline.
+    _disable_vendor_video_capture_service(cfg)
 
     # ── Initialize Noetix SDK ──
     high_ctrl = None


### PR DESCRIPTION
Bumi 官方 App 图传服务 noetix-video-capture.service 会占用 RealSense。

本 PR 在 Bumi Driver 启动时停用该服务，使 Phanthy 的 camera/depth Card 能直接获取 RGB 与深度流。

- 通过 nsenter 在宿主机执行 systemctl disable --now
- 仅在 camera 启用且配置项开启时执行
- 补充 App 图传与 Phanthy Camera Card 的互斥说明

影响：启用后官方 App 图传不可用；可通过 enable + start noetix-video-capture.service 恢复。