### PR TITLE
fix(q5): restore TTS media bridge transport

### DIFF
--- a/robotera/q5_bundle/Dockerfile
+++ b/robotera/q5_bundle/Dockerfile
@@ -59,6 +59,7 @@ COPY joints_state.py /work/joints_state.py
 COPY joints.py /work/joints.py
 COPY robot_ready.py /work/robot_ready.py
 COPY battery.py /work/battery.py
+COPY imu.py /work/imu.py
 COPY system_health.py /work/system_health.py
 COPY hand_state.py /work/hand_state.py
 COPY estop.py /work/estop.py

--- a/robotera/q5_bundle/config.yaml
+++ b/robotera/q5_bundle/config.yaml
@@ -23,6 +23,8 @@ plugins:
     enabled: false  # merged into robot_status
   battery:
     enabled: true
+  imu:
+    enabled: true
   system_health:
     enabled: false  # merged into robot_status
   hand_state:

--- a/robotera/q5_bundle/driver.yaml
+++ b/robotera/q5_bundle/driver.yaml
@@ -18,6 +18,7 @@ cards:
   - { name: joints,            type: sensor }
   - { name: joints_state,      type: sensor }
   - { name: battery,           type: sensor }
+  - { name: imu,               type: sensor }
   - { name: hand_state,        type: sensor }
   - { name: mic,               type: sensor }
   - { name: speaker,           type: actuator }

--- a/robotera/q5_bundle/imu.py
+++ b/robotera/q5_bundle/imu.py
@@ -1,0 +1,125 @@
+"""Q5 compact IMU (accelerometer + gyroscope) state card.
+
+Publishes a normalized, self-describing JSON payload on
+``/{ns}/q5/imu``.  The raw accelerometer/gyroscope vectors are already
+subscribed by the Q5 SDK client (``q5_accel`` and ``q5_gyro``); this card is a
+thin, stable view over the shared ``imu`` snapshot so it never depends on the
+SDK's internal topic names or field layout.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+from sensor_contract import topic_out
+
+try:
+    from rclpy.node import Node
+    from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+    from std_msgs.msg import String
+
+    _HAS_ROS2 = True
+    _QOS = QoSProfile(
+        reliability=ReliabilityPolicy.BEST_EFFORT,
+        history=HistoryPolicy.KEEP_LAST,
+        depth=1,
+        durability=DurabilityPolicy.VOLATILE,
+    )
+except Exception:
+    _HAS_ROS2 = False
+
+CARD = "imu"
+TYPE = "sensor"
+TOPIC = "/{ns}/q5/imu"
+FMT = "data/json"
+HZ = 2.0
+NODE = "q5_imu"
+DESC = "Q5 IMU：线加速度（加速度计）和角速度（陀螺仪），2Hz 发布"
+
+
+class Plugin:
+    def __init__(self, plugin_config, namespace, executor, client):
+        self._client = client
+        self._topic = TOPIC.format(ns=namespace)
+        self._node = None
+        self._pub = None
+        if _HAS_ROS2 and executor is not None:
+            try:
+                self._node = Node(NODE)
+                self._pub = self._node.create_publisher(String, self._topic, _QOS)
+                self._node.create_timer(1.0 / HZ, self._tick)
+                executor.add_node(self._node)
+            except Exception as e:
+                print(f"[{CARD}] ROS2 publisher unavailable: {e}", flush=True)
+                self._node = None
+                self._pub = None
+
+    def _data(self) -> dict:
+        """Normalized, SDK-agnostic IMU snapshot.
+
+        Every field is read with a default so a partial or changed SDK snapshot
+        can never raise; an unread sensor simply reports ``available=False``.
+        """
+        snap = self._client.sensor_snapshot("imu")
+        return {
+            "available": bool(snap.get("available", False)),
+            "fresh": bool(snap.get("fresh", False)),
+            "age_ms": snap.get("age_ms"),
+            "linear_acceleration": snap.get("linear_acceleration"),
+            "angular_velocity": snap.get("angular_velocity"),
+            "received_at_ms": snap.get("received_at_ms"),
+            "message_timestamp_ms": snap.get("message_timestamp_ms"),
+        }
+
+    def _tick(self):
+        if self._pub is None:
+            return
+        try:
+            payload = json.dumps(self._data(), ensure_ascii=False)
+        except Exception:
+            return
+        msg = String()
+        msg.data = payload
+        self._pub.publish(msg)
+
+    def get_tool(self):
+        return {
+            "name": CARD,
+            "type": TYPE,
+            "multiInstance": False,
+            "description": DESC,
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["info", "start", "stop"],
+                        "description": "info=读一次; start=2Hz 发布; stop=停止发布。",
+                    }
+                },
+                "required": ["action"],
+                "additionalProperties": False,
+            },
+            "topic_out": topic_out(self._topic, FMT),
+        }
+
+    def dispatch(self, action, args):
+        running = self._pub is not None
+        if action == "start":
+            return {"state": "running" if running else "unavailable"}
+        if action == "stop":
+            return {"state": "idle"}
+        if action in ("info", "read", "get", "show", CARD):
+            return {
+                "state": "running" if running else "unavailable",
+                "available": bool(self._data().get("available", False)),
+                "fresh": bool(self._data().get("fresh", False)),
+                "topic_out": topic_out(self._topic, FMT),
+                "data": self._data(),
+            }
+        return None
+
+
+def make_plugin(plugin_config, namespace, executor, client):
+    return Plugin(plugin_config, namespace, executor, client)

--- a/robotera/q5_bundle/main.py
+++ b/robotera/q5_bundle/main.py
@@ -39,12 +39,28 @@ import yaml
 
 from control_contract import prepare_call_args
 
-try:
-    import rclpy
-    import rclpy.executors
-    _HAS_ROS2 = True
-except Exception:
-    _HAS_ROS2 = False
+rclpy = None
+_HAS_ROS2 = None
+
+
+def _load_rclpy() -> bool:
+    """Import rclpy only in the vendor-side parent process.
+
+    BridgeWorker uses multiprocessing's spawn context, which re-imports this
+    module in its child. Delaying this import lets that child select Fast DDS
+    before its own first rclpy import.
+    """
+    global rclpy, _HAS_ROS2
+    if _HAS_ROS2 is not None:
+        return _HAS_ROS2
+    try:
+        import rclpy as _rclpy
+        import rclpy.executors
+        rclpy = _rclpy
+        _HAS_ROS2 = True
+    except Exception:
+        _HAS_ROS2 = False
+    return _HAS_ROS2
 
 
 def _load_config() -> dict:
@@ -231,7 +247,7 @@ def main():
     print(f"[bundle] namespace={namespace} mcp_port={mcp_port}")
 
     executor = None
-    if _HAS_ROS2:
+    if _load_rclpy():
         try:
             if not rclpy.ok():
                 rclpy.init()

--- a/robotera/q5_bundle/q5_media_bridge.py
+++ b/robotera/q5_bundle/q5_media_bridge.py
@@ -29,6 +29,23 @@ import queue
 import sys
 import threading
 import time
+from pathlib import Path
+
+
+DEFAULT_FASTDDS_PROFILE = Path(__file__).with_name("resource") / "fastdds_udp_only.xml"
+
+
+def configure_fastdds_transport() -> str:
+    """Select one UDP-capable Fast DDS profile for the typed media bridge."""
+    profile = (os.environ.get("FASTDDS_DEFAULT_PROFILES_FILE")
+               or os.environ.get("FASTRTPS_DEFAULT_PROFILES_FILE"))
+    if not profile:
+        if not DEFAULT_FASTDDS_PROFILE.is_file():
+            raise RuntimeError(f"Fast DDS UDP profile is missing: {DEFAULT_FASTDDS_PROFILE}")
+        profile = str(DEFAULT_FASTDDS_PROFILE)
+    os.environ["FASTDDS_DEFAULT_PROFILES_FILE"] = profile
+    os.environ["FASTRTPS_DEFAULT_PROFILES_FILE"] = profile
+    return profile
 
 
 class BridgeWorker:
@@ -134,8 +151,11 @@ def _run_bridge_subprocess(cmd_q: mp.Queue, sensor_q: mp.Queue, media_qs: dict[s
     os.environ["ROS_DOMAIN_ID"] = "42"
     os.environ["RMW_IMPLEMENTATION"] = "rmw_fastrtps_cpp"
     os.environ.setdefault("PYTHONUNBUFFERED", "1")
-    # UDP-only transport for Docker host networking (shared-memory won't work)
-    os.environ.setdefault("FASTDDS_BUILTIN_TRANSPORTS", "DEFAULT")
+    # The bridge is in a separate Docker process from Agent Core. Fast DDS's
+    # default shared-memory transport discovers a topic but cannot receive its
+    # samples across that boundary, so select one UDP-capable profile before
+    # importing rclpy.
+    profile = configure_fastdds_transport()
 
     import hashlib
     import json

--- a/robotera/q5_bundle/test_q5_bus_bridge.py
+++ b/robotera/q5_bundle/test_q5_bus_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 from pathlib import Path
@@ -9,6 +10,7 @@ import unittest
 from unittest import mock
 
 import q5_bus_bridge
+import q5_media_bridge
 from sensor_contract import topic_out
 
 
@@ -50,6 +52,68 @@ class Q5BusBridgeTests(unittest.TestCase):
         self.assertIn('"pointcloud": self._ctx.Queue(maxsize=2)', source)
         self.assertIn("for media_q in media_qs.values():", source)
         self.assertIn("media_q.get_nowait()", source)
+
+    def test_main_defers_rclpy_import_for_spawned_media_bridge(self):
+        source = Path(__file__).with_name("main.py").read_text()
+        tree = ast.parse(source)
+        module_imports = [
+            alias.name
+            for node in tree.body
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        ]
+        module_from_imports = [
+            node.module
+            for node in tree.body
+            if isinstance(node, ast.ImportFrom)
+        ]
+        self.assertNotIn("rclpy", module_imports)
+        self.assertNotIn("rclpy", module_from_imports)
+        self.assertIn("def _load_rclpy()", source)
+        self.assertIn("if _load_rclpy():", source)
+
+    def test_media_bridge_sets_fastdds_before_importing_rclpy(self):
+        source = Path(q5_media_bridge.__file__).read_text()
+        worker_start = source.index("def _run_bridge_subprocess")
+        worker_source = source[worker_start:]
+        self.assertLess(worker_source.index('os.environ["ROS_DOMAIN_ID"] = "42"'),
+                        worker_source.index("import rclpy"))
+        self.assertLess(worker_source.index('os.environ["RMW_IMPLEMENTATION"] = "rmw_fastrtps_cpp"'),
+                        worker_source.index("import rclpy"))
+        self.assertLess(worker_source.index("configure_fastdds_transport()"),
+                        worker_source.index("import rclpy"))
+
+    def test_media_bridge_uses_bundled_udp_profile_by_default(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            profile = q5_media_bridge.configure_fastdds_transport()
+            self.assertEqual(profile, str(q5_media_bridge.DEFAULT_FASTDDS_PROFILE))
+            self.assertEqual(os.environ["FASTDDS_DEFAULT_PROFILES_FILE"], profile)
+            self.assertEqual(os.environ["FASTRTPS_DEFAULT_PROFILES_FILE"], profile)
+
+    def test_media_bridge_promotes_legacy_profile_to_canonical_name(self):
+        with mock.patch.dict(os.environ, {
+            "FASTRTPS_DEFAULT_PROFILES_FILE": "/etc/fastdds/legacy.xml",
+        }, clear=True):
+            profile = q5_media_bridge.configure_fastdds_transport()
+            self.assertEqual(profile, "/etc/fastdds/legacy.xml")
+            self.assertEqual(os.environ["FASTDDS_DEFAULT_PROFILES_FILE"], profile)
+            self.assertEqual(os.environ["FASTRTPS_DEFAULT_PROFILES_FILE"], profile)
+
+    def test_media_bridge_prefers_canonical_profile_over_stale_legacy_value(self):
+        with mock.patch.dict(os.environ, {
+            "FASTDDS_DEFAULT_PROFILES_FILE": "/etc/fastdds/canonical.xml",
+            "FASTRTPS_DEFAULT_PROFILES_FILE": "/etc/fastdds/stale.xml",
+        }, clear=True):
+            profile = q5_media_bridge.configure_fastdds_transport()
+            self.assertEqual(profile, "/etc/fastdds/canonical.xml")
+            self.assertEqual(os.environ["FASTRTPS_DEFAULT_PROFILES_FILE"], profile)
+
+    def test_media_bridge_rejects_missing_default_udp_profile(self):
+        missing = Path("/missing/q5-fastdds-udp.xml")
+        with mock.patch.dict(os.environ, {}, clear=True), \
+                mock.patch.object(q5_media_bridge, "DEFAULT_FASTDDS_PROFILE", missing):
+            with self.assertRaisesRegex(RuntimeError, "Fast DDS UDP profile is missing"):
+                q5_media_bridge.configure_fastdds_transport()
 
     def test_sensor_topic_contract_does_not_depend_on_vendor_side_publisher(self):
         declared = topic_out("/nvidia_desktop/q5/battery", "data/json")


### PR DESCRIPTION
## Summary

- Add the Q5 IMU state card.
- Restore the Q5 TTS media bridge transport.
- Verify the repaired image on Q5 and confirm `tts.speak` produces audio.

## Test plan

- [x] Q5 deployment completed with `q5-bundle-liujiankai:tts-rmw-fix`
- [x] Q5 `tts.speak` audio playback verified
- [x] Existing Q5 camera, microphone, and base-drive plugins started successfully